### PR TITLE
Improved sort of a single primitive column by -60%

### DIFF
--- a/benches/sort_kernel.rs
+++ b/benches/sort_kernel.rs
@@ -19,7 +19,7 @@
 extern crate criterion;
 use criterion::Criterion;
 
-use arrow2::compute::sort::{lexsort, sort, SortColumn};
+use arrow2::compute::sort::{lexsort, sort, SortColumn, SortOptions};
 use arrow2::util::bench_util::*;
 use arrow2::{array::*, datatypes::*};
 
@@ -44,7 +44,7 @@ fn bench_lexsort(arr_a: &dyn Array, array_b: &dyn Array) {
 }
 
 fn bench_sort(arr_a: &dyn Array) {
-    sort(criterion::black_box(arr_a), None).unwrap();
+    sort(criterion::black_box(arr_a), &SortOptions::default()).unwrap();
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/src/compute/sort/lex_sort.rs
+++ b/src/compute/sort/lex_sort.rs
@@ -210,14 +210,8 @@ mod tests {
     #[test]
     fn test_lex_sort_mixed_types2() {
         // test mix of string and in64 with option
-        let c1 = Primitive::<i64>::from(&[Some(0), Some(2), Some(-1), Some(0)])
-        .to(DataType::Int64);
-        let c2 = Utf8Array::<i32>::from(&vec![
-            Some("foo"),
-            Some("9"),
-            Some("7"),
-            Some("bar"),
-        ]);
+        let c1 = Primitive::<i64>::from(&[Some(0), Some(2), Some(-1), Some(0)]).to(DataType::Int64);
+        let c2 = Utf8Array::<i32>::from(&vec![Some("foo"), Some("9"), Some("7"), Some("bar")]);
         let input = vec![
             SortColumn {
                 values: &c1,
@@ -235,8 +229,15 @@ mod tests {
             },
         ];
         let expected = vec![
-            Box::new(Primitive::<i64>::from(&[Some(2), Some(0), Some(0), Some(-1)]).to(DataType::Int64)) as Box<dyn Array>,
-            Box::new(Utf8Array::<i32>::from(&vec![Some("9"), Some("foo"), Some("bar"), Some("7")])) as Box<dyn Array>,
+            Box::new(
+                Primitive::<i64>::from(&[Some(2), Some(0), Some(0), Some(-1)]).to(DataType::Int64),
+            ) as Box<dyn Array>,
+            Box::new(Utf8Array::<i32>::from(&vec![
+                Some("9"),
+                Some("foo"),
+                Some("bar"),
+                Some("7"),
+            ])) as Box<dyn Array>,
         ];
         test_lex_sort_arrays(input, expected);
     }

--- a/src/compute/sort/lex_sort.rs
+++ b/src/compute/sort/lex_sort.rs
@@ -89,7 +89,7 @@ pub fn lexsort_to_indices(columns: &[SortColumn]) -> Result<PrimitiveArray<i32>>
     if columns.len() == 1 {
         // fallback to non-lexical sort
         let column = &columns[0];
-        return sort_to_indices(column.values, column.options);
+        return sort_to_indices(column.values, &column.options.unwrap_or_default());
     }
 
     let row_count = columns[0].values.len();

--- a/src/compute/sort/primitive/indices.rs
+++ b/src/compute/sort/primitive/indices.rs
@@ -1,0 +1,199 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::{
+    array::{Array, PrimitiveArray},
+    buffer::MutableBuffer,
+    datatypes::DataType,
+    types::NativeType,
+};
+
+use super::super::SortOptions;
+
+/// # Safety
+/// `indices[i] < values.len()` for all i
+#[inline]
+unsafe fn sort_inner<T, F>(indices: &mut [i32], values: &[T], mut cmp: F, descending: bool)
+where
+    T: NativeType,
+    F: FnMut(&T, &T) -> std::cmp::Ordering,
+{
+    if descending {
+        indices.sort_by(|lhs, rhs| {
+            let lhs = values.get_unchecked(*lhs as usize);
+            let rhs = values.get_unchecked(*rhs as usize);
+            cmp(lhs, rhs).reverse()
+        })
+    } else {
+        indices.sort_by(|lhs, rhs| {
+            let lhs = values.get_unchecked(*lhs as usize);
+            let rhs = values.get_unchecked(*rhs as usize);
+            cmp(lhs, rhs)
+        })
+    }
+}
+
+pub fn indices_sorted_by<T, F>(
+    array: &PrimitiveArray<T>,
+    cmp: F,
+    options: &SortOptions,
+) -> PrimitiveArray<i32>
+where
+    T: NativeType,
+    F: Fn(&T, &T) -> std::cmp::Ordering,
+{
+    let descending = options.descending;
+    let values = array.values();
+    let validity = array.validity();
+
+    if let Some(validity) = validity {
+        let mut indices = MutableBuffer::<i32>::from_len_zeroed(array.len());
+
+        if options.nulls_first {
+            let mut nulls = 0;
+            let mut valids = 0;
+            validity
+                .iter()
+                .zip(0..array.len() as i32)
+                .for_each(|(x, index)| {
+                    if x {
+                        indices[validity.null_count() + valids] = index;
+                        valids += 1;
+                    } else {
+                        indices[nulls] = index;
+                        nulls += 1;
+                    }
+                });
+            // Soundness:
+            // all indices in `indices` are by construction `< array.len() == values.len()`
+            unsafe {
+                sort_inner(
+                    &mut indices.as_slice_mut()[validity.null_count()..],
+                    values,
+                    cmp,
+                    options.descending,
+                )
+            }
+        } else {
+            let last_valid_index = array.len() - validity.null_count();
+            let mut nulls = 0;
+            let mut valids = 0;
+            validity
+                .iter()
+                .zip(0..array.len() as i32)
+                .for_each(|(x, index)| {
+                    if x {
+                        indices[valids] = index;
+                        valids += 1;
+                    } else {
+                        indices[last_valid_index + nulls] = index;
+                        nulls += 1;
+                    }
+                });
+
+            // Soundness:
+            // all indices in `indices` are by construction `< array.len() == values.len()`
+            unsafe {
+                sort_inner(
+                    &mut indices.as_slice_mut()[..last_valid_index],
+                    values,
+                    cmp,
+                    options.descending,
+                )
+            };
+        }
+
+        PrimitiveArray::<i32>::from_data(DataType::Int32, indices.into(), None)
+    } else {
+        let mut indices = unsafe { MutableBuffer::from_trusted_len_iter(0..values.len() as i32) };
+
+        // Soundness:
+        // indices are by construction `< values.len()`
+        unsafe { sort_inner(&mut indices, values, cmp, descending) };
+
+        PrimitiveArray::<i32>::from_data(DataType::Int32, indices.into(), None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::ord;
+    use crate::array::Primitive;
+
+    fn test<T>(data: &[Option<T>], data_type: DataType, options: SortOptions, expected_data: &[i32])
+    where
+        T: NativeType + std::cmp::Ord,
+    {
+        let input = Primitive::<T>::from(data).to(data_type);
+        let expected = Primitive::<i32>::from_slice(&expected_data).to(DataType::Int32);
+        let output = indices_sorted_by(&input, ord::total_cmp, &options);
+        assert_eq!(output, expected)
+    }
+
+    #[test]
+    fn ascending_nulls_first() {
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: false,
+                nulls_first: true,
+            },
+            &[0, 5, 3, 1, 4, 2],
+        );
+    }
+
+    #[test]
+    fn ascending_nulls_last() {
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: false,
+                nulls_first: false,
+            },
+            &[3, 1, 4, 2, 0, 5],
+        );
+    }
+
+    #[test]
+    fn descending_nulls_first() {
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: true,
+                nulls_first: true,
+            },
+            &[0, 5, 2, 1, 4, 3],
+        );
+    }
+
+    #[test]
+    fn descending_nulls_last() {
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: true,
+                nulls_first: false,
+            },
+            &[2, 1, 4, 3, 0, 5],
+        );
+    }
+}

--- a/src/compute/sort/primitive/mod.rs
+++ b/src/compute/sort/primitive/mod.rs
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+mod indices;
+mod sort;
+
+pub use indices::indices_sorted_by;
+pub use sort::sort_by;

--- a/src/compute/sort/primitive/sort.rs
+++ b/src/compute/sort/primitive/sort.rs
@@ -1,0 +1,167 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::buffer::MutableBuffer;
+use crate::{
+    array::{Array, PrimitiveArray},
+    bits::SlicesIterator,
+    buffer::MutableBitmap,
+    types::NativeType,
+};
+
+use super::super::SortOptions;
+
+fn sort_inner<T, F>(values: &mut [T], mut cmp: F, descending: bool)
+where
+    T: NativeType,
+    F: FnMut(&T, &T) -> std::cmp::Ordering,
+{
+    if descending {
+        values.sort_unstable_by(|x, y| cmp(x, y).reverse());
+    } else {
+        values.sort_unstable_by(cmp);
+    };
+}
+
+/// Sorts a [`PrimitiveArray`] according to `cmp` comparator and [`SortOptions`].
+pub fn sort_by<T, F>(array: &PrimitiveArray<T>, cmp: F, options: &SortOptions) -> PrimitiveArray<T>
+where
+    T: NativeType,
+    F: FnMut(&T, &T) -> std::cmp::Ordering,
+{
+    let values = array.values();
+    let validity = array.validity();
+
+    let (buffer, validity) = if let Some(validity) = validity {
+        let nulls = (0..validity.null_count()).map(|_| false);
+        let valids = (validity.null_count()..array.len()).map(|_| true);
+
+        let mut buffer = MutableBuffer::<T>::with_capacity(array.len());
+        let mut new_validity = MutableBitmap::with_capacity(array.len());
+        let slices = SlicesIterator::new(validity);
+
+        if options.nulls_first {
+            nulls
+                .chain(valids)
+                .for_each(|value| unsafe { new_validity.push_unchecked(value) });
+            (0..validity.null_count()).for_each(|_| buffer.push(T::default()));
+            for (start, len) in slices {
+                buffer.extend_from_slice(&values[start..start + len])
+            }
+            sort_inner(
+                &mut buffer.as_slice_mut()[validity.null_count()..],
+                cmp,
+                options.descending,
+            )
+        } else {
+            valids
+                .chain(nulls)
+                .for_each(|value| unsafe { new_validity.push_unchecked(value) });
+            for (start, len) in slices {
+                buffer.extend_from_slice(&values[start..start + len])
+            }
+            sort_inner(&mut buffer.as_slice_mut(), cmp, options.descending);
+
+            (0..validity.null_count()).for_each(|_| buffer.push(T::default()));
+        };
+
+        (buffer, new_validity.into())
+    } else {
+        let mut buffer = MutableBuffer::<T>::new();
+        buffer.extend_from_slice(values);
+
+        sort_inner(&mut buffer.as_slice_mut(), cmp, options.descending);
+
+        (buffer, None)
+    };
+    PrimitiveArray::<T>::from_data(array.data_type().clone(), buffer.into(), validity)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::array::ord;
+    use crate::array::Primitive;
+    use crate::datatypes::DataType;
+
+    fn test_sort_primitive_arrays<T>(
+        data: &[Option<T>],
+        data_type: DataType,
+        options: SortOptions,
+        expected_data: &[Option<T>],
+    ) where
+        T: NativeType + std::cmp::Ord,
+    {
+        let input = Primitive::<T>::from(data).to(data_type.clone());
+        let expected = Primitive::<T>::from(expected_data).to(data_type);
+        let output = sort_by(&input, ord::total_cmp, &options);
+        assert_eq!(expected, output)
+    }
+
+    #[test]
+    fn ascending_nulls_first() {
+        test_sort_primitive_arrays::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: false,
+                nulls_first: true,
+            },
+            &[None, None, Some(2), Some(3), Some(3), Some(5)],
+        );
+    }
+
+    #[test]
+    fn ascending_nulls_last() {
+        test_sort_primitive_arrays::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: false,
+                nulls_first: false,
+            },
+            &[Some(2), Some(3), Some(3), Some(5), None, None],
+        );
+    }
+
+    #[test]
+    fn descending_nulls_first() {
+        test_sort_primitive_arrays::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: true,
+                nulls_first: true,
+            },
+            &[None, None, Some(5), Some(3), Some(3), Some(2)],
+        );
+    }
+
+    #[test]
+    fn descending_nulls_last() {
+        test_sort_primitive_arrays::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: true,
+                nulls_first: false,
+            },
+            &[Some(5), Some(3), Some(3), Some(2), None, None],
+        );
+    }
+}


### PR DESCRIPTION
This improves performance of the `sort` of a single primitive column by refactoring it to allow the use of the unstable, in-place version of rust's sort.

There are 3 ideas here:
1. for a single array, there is not need to compute `indices + take` and we can instead perform the operation directly on a buffer.
2. Because indices are not needed and we define a total order, there is no need to use a stable sort
3. When indices are used (for multi-column sort), there is no need to use an auxiliary `Vec`; we can use a `Buffer<i32>` directly, which avoids a copy of the whole data.

The performance of multi-columns sort improved by -5%. Single columns improved by `-60%` for both with and without nulls, for `N = 2^12` slots. The higher the `N`, the lower the speedup, as sort is `O(N*log(N))` while a memcopy is `O(N)` and thus sort will always dominate.