### PR TITLE
Re-wrote the CSV to enable parallelism

### DIFF
--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -5,3 +5,5 @@
 - [Low level API](./low_level.md)
 - [High level API](./high_level.md)
 - [Foreign interfaces](./ffi.md)
+- IO
+    - [Read CSV](./csv_reader.md)

--- a/guide/src/csv_reader.md
+++ b/guide/src/csv_reader.md
@@ -1,0 +1,44 @@
+# CSV reader
+
+When compiled with feature `io_csv`, you can use this crate to read CSV files.
+This crate makes minimal assumptions on how you want to read a CSV, and offers a large degree of customization to it, along with a useful default.
+
+## Background
+
+There are two CPU-intensive tasks in reading a CSV file:
+* split the CSV file in rows, which includes parsing quotes and delimiters, and is necessary to `seek` to a given row.
+* parse a set of CSV rows (bytes) into a `RecordBatch`.
+
+Parsing bytes into values is more expensive than interpreting lines. As such, it is generally advantageous to have multiple readers of a single file that scan different parts of the file (within IO constraints).
+
+This crate relies on [the crate csv](https://crates.io/crates/csv) to scan and seek CSV files, and your code also needs such a dependency. With that said, `arrow2` makes no assumptions as to how to efficiently read the CSV: as a single reader per file or multiple readers.
+
+As an example, the following infers the schema and reads a CSV by re-using the same reader:
+
+```rust
+use csv::ReaderBuilder;
+use arrow2::io::csv::{infer_schema, read_batch, infer, DefaultParser};
+use arrow2::error::Result;
+
+fn read_path(path: &str) -> Result<()> {
+    let mut reader = ReaderBuilder::new().from_path(path)?;
+    let parser = DefaultParser::default();
+
+    let schema = infer_schema(&mut reader, None, true, &infer)?;
+
+    // 0: start from
+    // 100: up to (max batch size)
+    let batch = read_batch(&mut reader, &parser, 0, 100, schema, None)?;
+}
+```
+
+## Orchestration and parallelization
+
+Because `csv`'s API is syncronous, the functions above represent the "minimal unit of syncronous work". It is up to you to decide how you want to read the file efficiently:
+whether to read batches in sequence or in parallel, or whether IO supports multiple readers per file.
+
+## Customization
+
+In the code above, `parser` and `infer` allow for customization: they declare
+how rows of bytes should be infered (into a logical type), and processed (into a value of said type). They offer good default options, but you can customize the inference and parsing to your own needs. You can also of course decide to parse everything into memory as `Utf8Array` and delay
+any data transformation.

--- a/license.py
+++ b/license.py
@@ -30,6 +30,7 @@ own_license = '// ' + own_license.replace('\n', '\n// ')[:-3]
 
 own_compute = [
     "src/compute/arity.rs",
+    "src/compute/hash.rs",
     "src/compute/merge_sort",
 ]
 
@@ -43,14 +44,15 @@ def should_be_own_license(path: str) -> bool:
         path.startswith("src/docs") or \
         path.startswith("src/bits") or \
         path == "src/temporal_conversions.rs" or \
-        path.startswith("src/compute/merge_sort") or \
+        path.startswith("src/io/csv") or \
         any(path.startswith(x) for x in own_compute)
 
 
 def should_be_asf_license(path: str) -> bool:
     return path.startswith("src/alloc") or \
         (path.startswith("src/compute") and not any(path.startswith(x) for x in own_compute)) or \
-        path.startswith("src/io") or path == "src/record_batch.rs" or \
+        path.startswith("src/io") and not path.startswith("src/io/csv") or \
+        path == "src/record_batch.rs" or \
         path.startswith("src/datatypes/") or path.startswith("src/ffi/") or \
         path.startswith("src/util/")
 

--- a/src/array/utf8/from.rs
+++ b/src/array/utf8/from.rs
@@ -126,11 +126,12 @@ where
 
     let mut null = MutableBitmap::with_capacity(len);
     let mut offsets = MutableBuffer::<O>::with_capacity(len + 1);
-    offsets.push(O::default());
     let mut values = MutableBuffer::<u8>::new();
 
     let mut length = O::default();
     let mut dst = offsets.as_mut_ptr();
+    std::ptr::write(dst, length);
+    dst = dst.add(1);
     for item in iterator {
         if let Some(item) = item? {
             null.push(true);
@@ -145,10 +146,10 @@ where
     }
     assert_eq!(
         dst.offset_from(offsets.as_ptr()) as usize,
-        len,
+        len + 1,
         "Trusted iterator length was not accurately reported"
     );
-    offsets.set_len(len);
+    offsets.set_len(len + 1);
 
     Ok((null.into(), offsets.into(), values.into()))
 }

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -1,5 +1,3 @@
-
-
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -1,3 +1,5 @@
+
+
 use std::{
     collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},

--- a/src/datatypes/schema.rs
+++ b/src/datatypes/schema.rs
@@ -88,6 +88,10 @@ impl Schema {
         }
     }
 
+    pub const fn is_little_endian(&self) -> bool {
+        self.is_little_endian
+    }
+
     /// Merge schema into self if it is compatible. Struct fields will be merged recursively.
     ///
     /// Example:

--- a/src/io/csv/infer_schema.rs
+++ b/src/io/csv/infer_schema.rs
@@ -1,5 +1,3 @@
-
-
 use std::{
     collections::HashSet,
     io::{Read, Seek},

--- a/src/io/csv/infer_schema.rs
+++ b/src/io/csv/infer_schema.rs
@@ -1,19 +1,4 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+
 
 use std::{
     collections::HashSet,

--- a/src/io/csv/infer_schema.rs
+++ b/src/io/csv/infer_schema.rs
@@ -17,8 +17,7 @@
 
 use std::{
     collections::HashSet,
-    fs::File,
-    io::{Read, Seek, SeekFrom},
+    io::{Read, Seek},
 };
 
 use csv::StringRecord;
@@ -33,40 +32,30 @@ use crate::error::Result;
 /// If `max_read_records` is not set, the whole file is read to infer its schema.
 ///
 /// Return infered schema and number of records used for inference.
-pub fn infer_file_schema<R: Read + Seek, F: Fn(&str) -> DataType>(
-    reader: &mut R,
-    delimiter: u8,
+pub fn infer_schema<R: Read + Seek, F: Fn(&str) -> DataType>(
+    reader: &mut csv::Reader<R>,
     max_read_records: Option<usize>,
     has_header: bool,
     infer: &F,
-) -> Result<(Schema, usize)> {
-    let mut csv_reader = csv::ReaderBuilder::new()
-        .delimiter(delimiter)
-        .from_reader(reader);
-
+) -> Result<Schema> {
     // get or create header names
     // when has_header is false, creates default column names with column_ prefix
     let headers: Vec<String> = if has_header {
-        let headers = &csv_reader.headers()?.clone();
+        let headers = &reader.headers()?.clone();
         headers.iter().map(|s| s.to_string()).collect()
     } else {
-        let first_record_count = &csv_reader.headers()?.len();
+        let first_record_count = &reader.headers()?.len();
         (0..*first_record_count)
             .map(|i| format!("column_{}", i + 1))
             .collect()
     };
 
     // save the csv reader position after reading headers
-    let position = csv_reader.position().clone();
+    let position = reader.position().clone();
 
     let header_length = headers.len();
     // keep track of inferred field types
     let mut column_types: Vec<HashSet<DataType>> = vec![HashSet::new(); header_length];
-    // keep track of columns with nulls
-    let mut nulls: Vec<bool> = vec![false; header_length];
-
-    // return csv reader position to after headers
-    csv_reader.seek(position)?;
 
     let mut records_count = 0;
     let mut fields = vec![];
@@ -74,18 +63,14 @@ pub fn infer_file_schema<R: Read + Seek, F: Fn(&str) -> DataType>(
     let mut record = StringRecord::new();
     let max_records = max_read_records.unwrap_or(usize::MAX);
     while records_count < max_records {
-        if !csv_reader.read_record(&mut record)? {
+        if !reader.read_record(&mut record)? {
             break;
         }
         records_count += 1;
 
-        for i in 0..header_length {
+        for (i, column) in column_types.iter_mut().enumerate() {
             if let Some(string) = record.get(i) {
-                if string.is_empty() {
-                    nulls[i] = true;
-                } else {
-                    column_types[i].insert(infer(string));
-                }
+                column.insert(infer(string));
             }
         }
     }
@@ -93,7 +78,6 @@ pub fn infer_file_schema<R: Read + Seek, F: Fn(&str) -> DataType>(
     // build schema from inference results
     for i in 0..header_length {
         let possibilities = &column_types[i];
-        let has_validity = nulls[i];
         let field_name = &headers[i];
 
         // determine data type based on possible types
@@ -101,7 +85,7 @@ pub fn infer_file_schema<R: Read + Seek, F: Fn(&str) -> DataType>(
         match possibilities.len() {
             1 => {
                 for dtype in possibilities.iter() {
-                    fields.push(Field::new(&field_name, dtype.clone(), has_validity));
+                    fields.push(Field::new(&field_name, dtype.clone(), true));
                 }
             }
             2 => {
@@ -109,108 +93,18 @@ pub fn infer_file_schema<R: Read + Seek, F: Fn(&str) -> DataType>(
                     && possibilities.contains(&DataType::Float64)
                 {
                     // we have an integer and double, fall down to double
-                    fields.push(Field::new(&field_name, DataType::Float64, has_validity));
+                    fields.push(Field::new(&field_name, DataType::Float64, true));
                 } else {
                     // default to Utf8 for conflicting datatypes (e.g bool and int)
-                    fields.push(Field::new(&field_name, DataType::Utf8, has_validity));
+                    fields.push(Field::new(&field_name, DataType::Utf8, true));
                 }
             }
-            _ => fields.push(Field::new(&field_name, DataType::Utf8, has_validity)),
+            _ => fields.push(Field::new(&field_name, DataType::Utf8, true)),
         }
     }
 
     // return the reader seek back to the start
-    csv_reader.into_inner().seek(SeekFrom::Start(0))?;
+    reader.seek(position)?;
 
-    Ok((Schema::new(fields), records_count))
-}
-
-/// Infer schema from a list of CSV files by reading through first n records
-/// with `max_read_records` controlling the maximum number of records to read.
-///
-/// Files will be read in the given order untill n records have been reached.
-///
-/// If `max_read_records` is not set, all files will be read fully to infer the schema.
-pub fn infer_schema_from_files<F: Fn(&str) -> DataType>(
-    files: &[String],
-    delimiter: u8,
-    max_read_records: Option<usize>,
-    has_header: bool,
-    infer: F,
-) -> Result<Schema> {
-    let mut schemas = vec![];
-    let mut records_to_read = max_read_records.unwrap_or(std::usize::MAX);
-
-    for fname in files.iter() {
-        let (schema, records_read) = infer_file_schema(
-            &mut File::open(fname)?,
-            delimiter,
-            Some(records_to_read),
-            has_header,
-            &infer,
-        )?;
-        if records_read == 0 {
-            continue;
-        }
-        schemas.push(schema.clone());
-        records_to_read -= records_read;
-        if records_to_read == 0 {
-            break;
-        }
-    }
-
-    Schema::try_merge(schemas)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use std::io::Write;
-    use tempfile::NamedTempFile;
-
-    use crate::io::csv::reader::infer;
-
-    #[test]
-    fn test_infer_schema_from_multiple_files() -> Result<()> {
-        let mut csv1 = NamedTempFile::new()?;
-        let mut csv2 = NamedTempFile::new()?;
-        let csv3 = NamedTempFile::new()?; // empty csv file should be skipped
-        let mut csv4 = NamedTempFile::new()?;
-        writeln!(csv1, "c1,c2,c3")?;
-        writeln!(csv1, "1,\"foo\",0.5")?;
-        writeln!(csv1, "3,\"bar\",1")?;
-        // reading csv2 will set c2 to optional
-        writeln!(csv2, "c1,c2,c3,c4")?;
-        writeln!(csv2, "10,,3.14,true")?;
-        // reading csv4 will set c3 to optional
-        writeln!(csv4, "c1,c2,c3")?;
-        writeln!(csv4, "10,\"foo\",")?;
-
-        let schema = infer_schema_from_files(
-            &[
-                csv3.path().to_str().unwrap().to_string(),
-                csv1.path().to_str().unwrap().to_string(),
-                csv2.path().to_str().unwrap().to_string(),
-                csv4.path().to_str().unwrap().to_string(),
-            ],
-            b',',
-            Some(3), // only csv1 and csv2 should be read
-            true,
-            infer,
-        )?;
-
-        assert_eq!(schema.fields().len(), 4);
-        assert_eq!(false, schema.field(0).is_nullable());
-        assert_eq!(true, schema.field(1).is_nullable());
-        assert_eq!(false, schema.field(2).is_nullable());
-        assert_eq!(false, schema.field(3).is_nullable());
-
-        assert_eq!(&DataType::Int64, schema.field(0).data_type());
-        assert_eq!(&DataType::Utf8, schema.field(1).data_type());
-        assert_eq!(&DataType::Float64, schema.field(2).data_type());
-        assert_eq!(&DataType::Boolean, schema.field(3).data_type());
-
-        Ok(())
-    }
+    Ok(Schema::new(fields))
 }

--- a/src/io/csv/mod.rs
+++ b/src/io/csv/mod.rs
@@ -31,6 +31,12 @@ impl From<chrono::ParseError> for ArrowError {
     }
 }
 
+impl From<std::str::Utf8Error> for ArrowError {
+    fn from(error: std::str::Utf8Error) -> Self {
+        ArrowError::External("".to_string(), Box::new(error))
+    }
+}
+
 mod parser;
 mod reader;
 mod writer;
@@ -38,9 +44,12 @@ mod writer;
 mod infer_schema;
 mod read_boolean;
 mod read_primitive;
-pub use infer_schema::{infer_file_schema, infer_schema_from_files};
+mod read_utf8;
+pub use infer_schema::infer_schema;
+pub use parser::DefaultParser;
 pub use read_boolean::{new_boolean_array, BooleanParser};
 pub use read_primitive::{new_primitive_array, PrimitiveParser};
+pub use read_utf8::{new_utf8_array, Utf8Parser};
 
 pub use reader::*;
 pub use writer::{Writer, WriterBuilder};

--- a/src/io/csv/mod.rs
+++ b/src/io/csv/mod.rs
@@ -1,5 +1,3 @@
-
-
 //! Transfer data between the Arrow memory format and CSV (comma-separated values).
 
 use crate::error::ArrowError;

--- a/src/io/csv/mod.rs
+++ b/src/io/csv/mod.rs
@@ -1,19 +1,4 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+
 
 //! Transfer data between the Arrow memory format and CSV (comma-separated values).
 

--- a/src/io/csv/parser.rs
+++ b/src/io/csv/parser.rs
@@ -1,19 +1,4 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+
 
 use chrono::Datelike;
 

--- a/src/io/csv/parser.rs
+++ b/src/io/csv/parser.rs
@@ -1,5 +1,3 @@
-
-
 use chrono::Datelike;
 
 use crate::temporal_conversions::EPOCH_DAYS_FROM_CE;

--- a/src/io/csv/read_boolean.rs
+++ b/src/io/csv/read_boolean.rs
@@ -15,16 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use csv::StringRecord;
+use csv::ByteRecord;
 
 use crate::array::BooleanArray;
 
 /// default behavior is infalible: `None` if unable to parse
 pub trait BooleanParser<E> {
-    fn parse(&self, string: &str, _: usize) -> Result<Option<bool>, E> {
-        Ok(if string.eq_ignore_ascii_case("false") {
+    fn parse(&self, string: &[u8], _: usize) -> Result<Option<bool>, E> {
+        Ok(if string.eq_ignore_ascii_case(b"false") {
             Some(false)
-        } else if string.eq_ignore_ascii_case("true") {
+        } else if string.eq_ignore_ascii_case(b"true") {
             Some(true)
         } else {
             None
@@ -35,7 +35,7 @@ pub trait BooleanParser<E> {
 // parses a specific column (col_idx) into an Arrow Array.
 pub fn new_boolean_array<E, P: BooleanParser<E>>(
     line_number: usize,
-    rows: &[StringRecord],
+    rows: &[ByteRecord],
     col_idx: usize,
     parser: &P,
 ) -> Result<BooleanArray, E> {

--- a/src/io/csv/read_boolean.rs
+++ b/src/io/csv/read_boolean.rs
@@ -1,19 +1,4 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+
 
 use csv::ByteRecord;
 

--- a/src/io/csv/read_boolean.rs
+++ b/src/io/csv/read_boolean.rs
@@ -1,5 +1,3 @@
-
-
 use csv::ByteRecord;
 
 use crate::array::BooleanArray;

--- a/src/io/csv/read_primitive.rs
+++ b/src/io/csv/read_primitive.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use csv::StringRecord;
+use csv::ByteRecord;
 
 use crate::{
     array::{Primitive, PrimitiveArray},
@@ -24,9 +24,9 @@ use crate::{
 };
 
 pub trait PrimitiveParser<T: NativeType + lexical_core::FromLexical, E> {
-    fn parse(&self, string: &str, _: &DataType, _: usize) -> Result<Option<T>, E> {
+    fn parse(&self, bytes: &[u8], _: &DataType, _: usize) -> Result<Option<T>, E> {
         // default behavior is infalible: `None` if unable to parse
-        Ok(lexical_core::parse(string.as_bytes()).ok())
+        Ok(lexical_core::parse(bytes).ok())
     }
 }
 
@@ -36,7 +36,7 @@ pub fn new_primitive_array<
     P: PrimitiveParser<T, E>,
 >(
     line_number: usize,
-    rows: &[StringRecord],
+    rows: &[ByteRecord],
     col_idx: usize,
     data_type: &DataType,
     parser: &P,

--- a/src/io/csv/read_primitive.rs
+++ b/src/io/csv/read_primitive.rs
@@ -1,19 +1,4 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+
 
 use csv::ByteRecord;
 

--- a/src/io/csv/read_primitive.rs
+++ b/src/io/csv/read_primitive.rs
@@ -1,5 +1,3 @@
-
-
 use csv::ByteRecord;
 
 use crate::{

--- a/src/io/csv/read_utf8.rs
+++ b/src/io/csv/read_utf8.rs
@@ -1,0 +1,27 @@
+use csv::ByteRecord;
+
+use crate::array::{Offset, Utf8Array};
+
+pub trait Utf8Parser<E> {
+    fn parse<'a>(&self, bytes: &'a [u8], _: usize) -> Result<Option<&'a str>, E> {
+        // default behavior is infalible: `None` if unable to parse
+        Ok(std::str::from_utf8(bytes).ok())
+    }
+}
+
+pub fn new_utf8_array<O: Offset, E, P: Utf8Parser<E>>(
+    line_number: usize,
+    rows: &[ByteRecord],
+    col_idx: usize,
+    parser: &P,
+) -> Result<Utf8Array<O>, E> {
+    let iter = rows
+        .iter()
+        .enumerate()
+        .map(|(row_index, row)| match row.get(col_idx) {
+            Some(s) => parser.parse(s, line_number + row_index),
+            None => Ok(None),
+        });
+    // Soundness: slice is trusted len.
+    unsafe { Utf8Array::<O>::try_from_trusted_len_iter(iter) }
+}

--- a/src/io/csv/reader.rs
+++ b/src/io/csv/reader.rs
@@ -183,8 +183,7 @@ mod tests {
 
     #[test]
     fn test_read() -> Result<()> {
-        let builder = ReaderBuilder::new();
-        let mut reader = builder.from_path("test/data/uk_cities_with_headers.csv")?;
+        let mut reader = ReaderBuilder::new().from_path("test/data/uk_cities_with_headers.csv")?;
         let parser = DefaultParser::default();
 
         let schema = infer_schema(&mut reader, None, true, &infer)?;

--- a/src/io/csv/writer.rs
+++ b/src/io/csv/writer.rs
@@ -1,19 +1,4 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+
 
 //! CSV Writer
 //!

--- a/src/io/csv/writer.rs
+++ b/src/io/csv/writer.rs
@@ -1,5 +1,3 @@
-
-
 //! CSV Writer
 //!
 //! This CSV writer allows Arrow data (in record batches) to be written as CSV files.


### PR DESCRIPTION
This PR:

* removes the CSV reader and replaces it by a single function, `read_batch`, that reads a single `RecordBatch`; this allows downstream dependencies (DataFusion, Ballista, etc.) to have more control over how many cursors per file they wish, how each cursor should behave, thereby allowing them to control parallelism.

* made the parsing of CSV to be based on `&[u8]`, not `String`, thereby allowing much faster parsing of CSV.
