### PR TITLE
Improved performance of primitive comparisons.

### DIFF
--- a/benches/comparison_kernels.rs
+++ b/benches/comparison_kernels.rs
@@ -19,28 +19,38 @@
 extern crate criterion;
 use criterion::Criterion;
 
-use arrow2::{compute::comparison::*, datatypes::DataType, types::NativeType};
+use arrow2::array::*;
 use arrow2::util::bench_util::*;
-use arrow2::{array::*};
+use arrow2::{compute::comparison::*, datatypes::DataType, types::NativeType};
 
 fn bench_eq<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
 where
     T: NativeType,
 {
-    compare(criterion::black_box(arr_a), criterion::black_box(arr_b), Operator::Eq).unwrap();
+    compare(
+        criterion::black_box(arr_a),
+        criterion::black_box(arr_b),
+        Operator::Eq,
+    )
+    .unwrap();
 }
 
 fn bench_eq_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T)
 where
     T: NativeType + std::cmp::PartialOrd,
 {
-    primtive_compare_scalar(criterion::black_box(arr_a), criterion::black_box(value_b), Operator::Eq).unwrap();
+    primtive_compare_scalar(
+        criterion::black_box(arr_a),
+        criterion::black_box(value_b),
+        Operator::Eq,
+    )
+    .unwrap();
 }
 
 fn add_benchmark(c: &mut Criterion) {
     let size = 65536;
     let arr_a = create_primitive_array::<f32>(size, DataType::Float32, 0.0);
-    let arr_b = create_primitive_array::<f32>(size, DataType::Float32,0.0);
+    let arr_b = create_primitive_array::<f32>(size, DataType::Float32, 0.0);
 
     c.bench_function("eq Float32", |b| b.iter(|| bench_eq(&arr_a, &arr_b)));
     c.bench_function("eq scalar Float32", |b| {


### PR DESCRIPTION
Implementation based on [this comment](https://github.com/apache/arrow/pull/9759#discussion_r598154125) from @yordan-pavlov.

Performance:

```
eq Float32              time:   [70.990 us 71.775 us 72.636 us]
                        change: [-12.665% -10.799% -8.9867%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

eq scalar Float32       time:   [26.832 us 27.174 us 27.540 us]
                        change: [-52.665% -51.655% -50.525%] (p = 0.00 < 0.05)
                        Performance has improved.
```