### PR TITLE
Optimize comparison kernels

### DIFF
--- a/benches/comparison_kernels.rs
+++ b/benches/comparison_kernels.rs
@@ -51,14 +51,14 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_op(&arr_a, &arr_b, Operator::Eq))
     });
     c.bench_function("eq scalar Float32", |b| {
-        b.iter(|| bench_op_scalar(&arr_a, 1.0, Operator::Eq))
+        b.iter(|| bench_op_scalar(&arr_a, 0.5, Operator::Eq))
     });
 
     c.bench_function("lt Float32", |b| {
         b.iter(|| bench_op(&arr_a, &arr_b, Operator::Lt))
     });
     c.bench_function("lt scalar Float32", |b| {
-        b.iter(|| bench_op_scalar(&arr_a, 1.0, Operator::Lt))
+        b.iter(|| bench_op_scalar(&arr_a, 0.5, Operator::Lt))
     });
 }
 

--- a/benches/comparison_kernels.rs
+++ b/benches/comparison_kernels.rs
@@ -23,26 +23,21 @@ use arrow2::array::*;
 use arrow2::util::bench_util::*;
 use arrow2::{compute::comparison::*, datatypes::DataType, types::NativeType};
 
-fn bench_eq<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
+fn bench_op<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>, op: Operator)
 where
     T: NativeType,
 {
-    compare(
-        criterion::black_box(arr_a),
-        criterion::black_box(arr_b),
-        Operator::Eq,
-    )
-    .unwrap();
+    compare(criterion::black_box(arr_a), criterion::black_box(arr_b), op).unwrap();
 }
 
-fn bench_eq_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T)
+fn bench_op_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T, op: Operator)
 where
     T: NativeType + std::cmp::PartialOrd,
 {
     primtive_compare_scalar(
         criterion::black_box(arr_a),
         criterion::black_box(value_b),
-        Operator::Eq,
+        op,
     )
     .unwrap();
 }
@@ -52,9 +47,18 @@ fn add_benchmark(c: &mut Criterion) {
     let arr_a = create_primitive_array::<f32>(size, DataType::Float32, 0.0);
     let arr_b = create_primitive_array::<f32>(size, DataType::Float32, 0.0);
 
-    c.bench_function("eq Float32", |b| b.iter(|| bench_eq(&arr_a, &arr_b)));
+    c.bench_function("eq Float32", |b| {
+        b.iter(|| bench_op(&arr_a, &arr_b, Operator::Eq))
+    });
     c.bench_function("eq scalar Float32", |b| {
-        b.iter(|| bench_eq_scalar(&arr_a, 1.0))
+        b.iter(|| bench_op_scalar(&arr_a, 1.0, Operator::Eq))
+    });
+
+    c.bench_function("lt Float32", |b| {
+        b.iter(|| bench_op(&arr_a, &arr_b, Operator::Lt))
+    });
+    c.bench_function("lt scalar Float32", |b| {
+        b.iter(|| bench_op_scalar(&arr_a, 1.0, Operator::Lt))
     });
 }
 

--- a/benches/comparison_kernels.rs
+++ b/benches/comparison_kernels.rs
@@ -44,8 +44,8 @@ where
 
 fn add_benchmark(c: &mut Criterion) {
     let size = 65536;
-    let arr_a = create_primitive_array::<f32>(size, DataType::Float32, 0.0);
-    let arr_b = create_primitive_array::<f32>(size, DataType::Float32, 0.0);
+    let arr_a = create_primitive_array_with_seed::<f32>(size, DataType::Float32, 0.0, 42);
+    let arr_b = create_primitive_array_with_seed::<f32>(size, DataType::Float32, 0.0, 43);
 
     c.bench_function("eq Float32", |b| {
         b.iter(|| bench_op(&arr_a, &arr_b, Operator::Eq))

--- a/src/util/bench_util.rs
+++ b/src/util/bench_util.rs
@@ -51,6 +51,30 @@ where
         .to(data_type)
 }
 
+pub fn create_primitive_array_with_seed<T>(
+    size: usize,
+    data_type: DataType,
+    null_density: f32,
+    seed: u64,
+) -> PrimitiveArray<T>
+where
+    T: NativeType,
+    Standard: Distribution<T>,
+{
+    let mut rng = StdRng::seed_from_u64(seed);
+
+    (0..size)
+        .map(|_| {
+            if rng.gen::<f32>() < null_density {
+                None
+            } else {
+                Some(rng.gen())
+            }
+        })
+        .collect::<Primitive<T>>()
+        .to(data_type)
+}
+
 /// Creates an random (but fixed-seeded) array of a given size and null density
 pub fn create_boolean_array(size: usize, null_density: f32, true_density: f32) -> BooleanArray
 where


### PR DESCRIPTION
This avoids the conditional jumps, which is faster when the pattern is not super predictable (which is the case for `%10`).

I also "fixed" the benchmarks, as they currently run on two arrays with equal elements as they use the same seed and introduced a `lt` version.

For arrays with a high "matching percentage" this has a huge performance impact (see lt benchmark, this is 5-10x faster), but a low matching percentage (eq on random floats) it  is slower to compare two arrays. The `eq` benchmark will now match probably never, so the CPU can predict those branches perfectly in the version on `main`.

```
Benchmarking eq Float32: Collecting 100 samples in estimated 5.1909 s (121k ite                                                                               eq Float32              time:   [41.836 us 41.890 us 41.947 us]
                        change: [+65.172% +65.623% +66.045%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking eq scalar Float32: Collecting 100 samples in estimated 5.0676 s (2                                                                               eq scalar Float32       time:   [20.758 us 20.789 us 20.826 us]
                        change: [-7.0110% -6.7414% -6.5092%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

Benchmarking lt Float32: Collecting 100 samples in estimated 5.1891 s (136k ite                                                                               lt Float32              time:   [37.666 us 37.725 us 37.789 us]
                        change: [-82.416% -82.241% -82.070%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking lt scalar Float32: Collecting 100 samples in estimated 5.0062 s (2                                                                               lt scalar Float32       time:   [21.252 us 21.272 us 21.290 us]
                        change: [-90.458% -90.437% -90.415%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe
```