### PR TITLE
Build guide on push and PR, but only deploy on main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,15 @@
 name: GitHub pages
+
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'guide/**'
+  pull_request:
+    paths:
+      - 'guide/**'
 
 jobs:
-  deploy:
+  guide:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -18,7 +22,9 @@ jobs:
       - run: mdbook build guide
 
       - name: Deploy
+        if: github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: ./guide/book
+


### PR DESCRIPTION
Issue #11 

Build the guide on pushes to any branch or when opening a PR. However, the pipeline only ever runs when files in `guide/**` changed. 
It should be noted that this applies also to `main`, so if a PR **without changes** to `guide/**` was successfully merged, the guide will not be built and deployed on `main`.

The guide is only deployed on `main`.