### PR TITLE
Primitive arithmetic macro

### DIFF
--- a/src/array/primitive/from.rs
+++ b/src/array/primitive/from.rs
@@ -51,7 +51,7 @@ impl<T: NativeType> Primitive<T> {
         Self { values, validity }
     }
 
-    /// Creates a [`PrimitiveArray`] from an falible iterator of trusted length.
+    /// Creates a [`PrimitiveArray`] from an fallible iterator of trusted length.
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -176,4 +176,12 @@ mod tests {
         assert_eq!(array.values().len(), 0);
         assert_eq!(array.validity(), &None);
     }
+    #[test]
+    fn decimal() {
+        // Creates a decimal list with precision 5 and scale 2
+        // 55566 should be 555.66. The max number with these parameters is 999.99
+        let data = vec![Some(55566i128), None, Some(55500i128), Some(11100i128)];
+        let array = Primitive::<i128>::from(&data).to(DataType::Decimal(5, 2));
+        assert_eq!(format!("{}", array), "Decimal(5, 2)[55566, , 55500, 11100]");
+    }
 }

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -35,7 +35,7 @@ use super::utils::combine_validities;
 // is an error then an ArrowError is return with the data_type that cause it.
 // It returns the result from the arithmetic_primitive function evaluated with
 // the Operator selected
-macro_rules! arithmetic_match {
+macro_rules! primitive_arithmetic_match {
     ($lhs: expr, $rhs: expr, $op: expr, $primitive_array_type: ty, $data_type: expr) => {{
         let res_lhs = $lhs
             .as_any()
@@ -71,20 +71,22 @@ pub fn arithmetic(lhs: &dyn Array, op: Operator, rhs: &dyn Array) -> Result<Box<
         ));
     }
     match data_type {
-        DataType::Int8 => arithmetic_match!(lhs, rhs, op, Int8Array, data_type),
-        DataType::Int16 => arithmetic_match!(lhs, rhs, op, Int16Array, data_type),
-        DataType::Int32 => arithmetic_match!(lhs, rhs, op, Int32Array, data_type),
+        DataType::Int8 => primitive_arithmetic_match!(lhs, rhs, op, Int8Array, data_type),
+        DataType::Int16 => primitive_arithmetic_match!(lhs, rhs, op, Int16Array, data_type),
+        DataType::Int32 => primitive_arithmetic_match!(lhs, rhs, op, Int32Array, data_type),
         DataType::Int64 | DataType::Duration(_) => {
-            arithmetic_match!(lhs, rhs, op, Int64Array, data_type)
+            primitive_arithmetic_match!(lhs, rhs, op, Int64Array, data_type)
         }
-        DataType::UInt8 => arithmetic_match!(lhs, rhs, op, UInt8Array, data_type),
-        DataType::UInt16 => arithmetic_match!(lhs, rhs, op, UInt16Array, data_type),
-        DataType::UInt32 => arithmetic_match!(lhs, rhs, op, UInt32Array, data_type),
-        DataType::UInt64 => arithmetic_match!(lhs, rhs, op, UInt64Array, data_type),
+        DataType::UInt8 => primitive_arithmetic_match!(lhs, rhs, op, UInt8Array, data_type),
+        DataType::UInt16 => primitive_arithmetic_match!(lhs, rhs, op, UInt16Array, data_type),
+        DataType::UInt32 => primitive_arithmetic_match!(lhs, rhs, op, UInt32Array, data_type),
+        DataType::UInt64 => primitive_arithmetic_match!(lhs, rhs, op, UInt64Array, data_type),
         DataType::Float16 => unreachable!(),
-        DataType::Float32 => arithmetic_match!(lhs, rhs, op, Float32Array, data_type),
-        DataType::Float64 => arithmetic_match!(lhs, rhs, op, Float64Array, data_type),
-        DataType::Decimal(_, _) => arithmetic_match!(lhs, rhs, op, Int128Array, data_type),
+        DataType::Float32 => primitive_arithmetic_match!(lhs, rhs, op, Float32Array, data_type),
+        DataType::Float64 => primitive_arithmetic_match!(lhs, rhs, op, Float64Array, data_type),
+        DataType::Decimal(_, _) => {
+            primitive_arithmetic_match!(lhs, rhs, op, Int128Array, data_type)
+        }
         _ => Err(ArrowError::NotYetImplemented(format!(
             "Arithmetics between {:?} is not supported",
             data_type

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -40,18 +40,12 @@ macro_rules! primitive_arithmetic_match {
         let res_lhs = $lhs
             .as_any()
             .downcast_ref::<$primitive_array_type>()
-            .ok_or(ArrowError::DowncastError(format!(
-                "data type: {}",
-                $data_type
-            )))?;
+            .unwrap();
 
         let res_rhs = $rhs
             .as_any()
             .downcast_ref::<$primitive_array_type>()
-            .ok_or(ArrowError::DowncastError(format!(
-                "data type: {}",
-                $data_type
-            )))?;
+            .unwrap();
 
         arithmetic_primitive(res_lhs, $op, res_rhs)
             .map(Box::new)

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -125,6 +125,9 @@ pub enum DataType {
     /// arrays or a limited set of primitive types as integers.
     Dictionary(Box<DataType>, Box<DataType>),
     /// Decimal value with precision and scale
+    /// precision is the number of digits in the number and
+    /// scale is the number of decimal places.
+    /// The number 999.99 has a precision of 5 and scale of 2.
     Decimal(usize, usize),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,8 +20,6 @@ pub enum ArrowError {
     /// Error during import or export to/from a format
     ExternalFormat(String),
     DictionaryKeyOverflowError,
-    /// Error produced when unable to downcast an array
-    DowncastError(String),
     Other(String),
 }
 
@@ -63,9 +61,6 @@ impl Display for ArrowError {
             }
             ArrowError::DictionaryKeyOverflowError => {
                 write!(f, "Dictionary key bigger than the key type")
-            }
-            ArrowError::DowncastError(desc) => {
-                write!(f, "Error while downcasting array: {}", desc)
             }
             ArrowError::Other(message) => {
                 write!(f, "{}", message)

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,6 +20,8 @@ pub enum ArrowError {
     /// Error during import or export to/from a format
     ExternalFormat(String),
     DictionaryKeyOverflowError,
+    /// Error produced when unable to downcast an array
+    DowncastError(String),
     Other(String),
 }
 
@@ -61,6 +63,9 @@ impl Display for ArrowError {
             }
             ArrowError::DictionaryKeyOverflowError => {
                 write!(f, "Dictionary key bigger than the key type")
+            }
+            ArrowError::DowncastError(desc) => {
+                write!(f, "Error while downcasting array: {}", desc)
             }
             ArrowError::Other(message) => {
                 write!(f, "{}", message)

--- a/src/io/json/write/serialize.rs
+++ b/src/io/json/write/serialize.rs
@@ -205,10 +205,10 @@ fn write_array(array: &dyn Array) -> Value {
             jsonmaps.into_iter().map(Value::Object).collect()
         }
         _ => {
-            panic!(format!(
+            panic!(
                 "Unsupported datatype for array conversion: {:#?}",
                 array.data_type()
-            ));
+            );
         }
     })
 }
@@ -329,7 +329,7 @@ fn set_column_for_json_rows(
                 });
         }
         _ => {
-            panic!(format!("Unsupported datatype: {:#?}", array.data_type()));
+            panic!("Unsupported datatype: {:#?}", array.data_type());
         }
     }
 }

--- a/src/util/test_util.rs
+++ b/src/util/test_util.rs
@@ -36,7 +36,7 @@ use std::{env, error::Error, path::PathBuf};
 pub fn arrow_test_data() -> String {
     match get_data_dir("ARROW_TEST_DATA", "testing/arrow-testing/data") {
         Ok(pb) => pb.display().to_string(),
-        Err(err) => panic!(format!("failed to get arrow data dir: {}", err)),
+        Err(err) => panic!("failed to get arrow data dir: {}", err),
     }
 }
 


### PR DESCRIPTION
Definition of macro for primitive arithmetic matching. The macro is used to downcast `lhs` and `rhs` arrays to a primitive array type and executed the primitive arithmetic function with the results. 