### PR TITLE
Add support to read from parquet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,13 @@ jobs:
           rustup toolchain install stable
           rustup default stable
           rustup component add rustfmt
+      - name: Setup parquet files
+        run: | 
+          apt update && apt install python3-pip python3-venv -y -q
+          python3 -m venv venv
+          venv/bin/pip install pip --upgrade
+          venv/bin/pip install pyarrow==3
+          venv/bin/python parquet_integration/write_parquet.py
       - name: Run
         run: |
           export CARGO_HOME="/github/home/.cargo"
@@ -91,7 +98,8 @@ jobs:
           rustup component add rustfmt
       - name: Run
         shell: bash
-        run: cargo test
+        # no need to run the whole thing. Rust guarantees interoperability
+        run: ARROW2_IGNORE_PARQUET= cargo test --lib
 
   clippy:
     name: Clippy
@@ -178,6 +186,13 @@ jobs:
           path: /home/runner/target
           # this key is not equal because coverage uses different compilation flags.
           key: ${{ runner.os }}-amd64-target-coverage-cache-stable-
+      - name: Setup parquet files
+        run: | 
+          apt update && apt install python3-pip python3-venv -y -q
+          python3 -m venv venv
+          venv/bin/pip install pip --upgrade
+          venv/bin/pip install pyarrow==3
+          venv/bin/python parquet_integration/write_parquet.py
       - name: Run coverage
         run: |
           export CARGO_HOME="/home/runner/.cargo"
@@ -257,4 +272,5 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          cargo build --target wasm32-unknown-unknown
+          # no need 
+          cargo build --no-default-features --features=merge_sort,io_ipc,io_csv,io_json --target wasm32-unknown-unknown

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target-tarpaulin
 venv
 lcov.info
 Cargo.lock
+fixtures

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "testing/arrow-testing"]
 	path = testing/arrow-testing
 	url = https://github.com/apache/arrow-testing
-[submodule "testing/parquet-testing"]
-	path = testing/parquet-testing
-	url = https://github.com/apache/parquet-testing.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,13 @@ rand = { version = "0.7", optional = true }
 
 itertools = { version = "^0.10", optional = true }
 
+[dependencies.parquet2]
+git = "https://github.com/jorgecarleitao/parquet2"
+rev = "a131dea41c5eefe8fab7c9effa4316063aaec1ab"
+default-features = false
+features = ["snappy", "gzip", "lz4", "zstd", "brotli"]
+optional = true
+
 [dev-dependencies]
 rand = "0.7"
 criterion = "0.3"
@@ -45,15 +52,22 @@ flate2 = "1"
 doc-comment = "0.3"
 
 [features]
-default = ["io_csv", "io_json", "io_ipc", "io_json_integration", "regex", "merge_sort", "benchmarks"]
+default = ["io_csv", "io_json", "io_ipc", "io_json_integration", "io_parquet", "regex", "merge_sort", "benchmarks"]
 merge_sort = ["itertools"]
 io_csv = ["csv", "lazy_static", "regex"]
 io_json = ["serde", "serde_derive", "serde_json", "indexmap"]
 io_ipc = ["flatbuffers"]
 io_json_integration = ["io_json", "hex"]
+io_parquet = ["parquet2"]
 benchmarks = ["rand"]
 
 [package.metadata.cargo-all-features]
+skip_feature_sets = [
+    ["benchmarks"],
+    ["merge_sort"],
+    ["io_json_integration"],
+]
+
 skip_optional_dependencies = true
 
 [[bench]]
@@ -90,4 +104,8 @@ harness = false
 
 [[bench]]
 name = "comparison_kernels"
+harness = false
+
+[[bench]]
+name = "read_parquet"
 harness = false

--- a/README.md
+++ b/README.md
@@ -20,13 +20,24 @@ Design documents about each of the parts of this repo are available on their res
 
 ## Run unit tests
 
+Some unit-tests depend on generating parquet files from pyarrow. These tests run by default.
+To not run them, pass `ARROW2_IGNORE_PARQUET` to the tests (the tests will be marked as OK/PASS).
+
 ```bash
 git clone git@github.com:jorgecarleitao/arrow2.git
 cd arrow2
-cargo test
+ARROW2_IGNORE_PARQUET= cargo test
 ```
 
 The test suite is a _superset_ of all integration tests that the original implementation has against golden files from the arrow project. It currently makes no attempt to test the implementation against other implementations in arrow's master; it assumes that arrow's golden files are sufficient to cover the specification. This crate uses both little and big endian golden files, as it supports both endianesses at IPC boundaries.
+
+To run the tests including integration with pyarrow's parquet writer, run
+
+```bash
+python3 -m venv venv
+venv/bin/pip install pyarrow==3
+venv/bin/python -m parquet_integration/write_parquet.py
+```
 
 ## Features in this crate and not in the original
 
@@ -41,7 +52,7 @@ The test suite is a _superset_ of all integration tests that the original implem
 
 ## Features in the original not availabe in this crate
 
-* Parquet IO
+* Parquet write
 * some compute kernels
 * SIMD (no plans to support: favor auto-vectorization instead)
 

--- a/benches/read_parquet.rs
+++ b/benches/read_parquet.rs
@@ -3,8 +3,8 @@ use std::{fs::File, path::PathBuf};
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use arrow2::error::Result;
-use parquet2::read::{get_page_iterator, read_metadata};
 use arrow2::io::parquet::read::page_iter_to_array;
+use parquet2::read::{get_page_iterator, read_metadata};
 
 fn read_decompressed_pages(size: usize, column: usize) -> Result<()> {
     // reads decompressed pages (i.e. CPU)

--- a/benches/read_parquet.rs
+++ b/benches/read_parquet.rs
@@ -9,7 +9,7 @@ use parquet2::read::{get_page_iterator, read_metadata};
 fn read_decompressed_pages(size: usize, column: usize) -> Result<()> {
     // reads decompressed pages (i.e. CPU)
     let dir = env!("CARGO_MANIFEST_DIR");
-    let path = PathBuf::from(dir).join(format!("fixtures/pyarrow3/basic_nulls_{}.parquet", size));
+    let path = PathBuf::from(dir).join(format!("fixtures/pyarrow3/v1/basic_nulls_{}.parquet", size));
     let mut file = File::open(path).unwrap();
 
     let metadata = read_metadata(&mut file)?;

--- a/benches/read_parquet.rs
+++ b/benches/read_parquet.rs
@@ -9,7 +9,8 @@ use parquet2::read::{get_page_iterator, read_metadata};
 fn read_decompressed_pages(size: usize, column: usize) -> Result<()> {
     // reads decompressed pages (i.e. CPU)
     let dir = env!("CARGO_MANIFEST_DIR");
-    let path = PathBuf::from(dir).join(format!("fixtures/pyarrow3/v1/basic_nulls_{}.parquet", size));
+    let path =
+        PathBuf::from(dir).join(format!("fixtures/pyarrow3/v1/basic_nulls_{}.parquet", size));
     let mut file = File::open(path).unwrap();
 
     let metadata = read_metadata(&mut file)?;

--- a/benches/read_parquet.rs
+++ b/benches/read_parquet.rs
@@ -1,0 +1,41 @@
+use std::{fs::File, path::PathBuf};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use arrow2::error::Result;
+use parquet2::read::{get_page_iterator, read_metadata};
+use arrow2::io::parquet::read::page_iter_to_array;
+
+fn read_decompressed_pages(size: usize, column: usize) -> Result<()> {
+    // reads decompressed pages (i.e. CPU)
+    let dir = env!("CARGO_MANIFEST_DIR");
+    let path = PathBuf::from(dir).join(format!("fixtures/pyarrow3/basic_nulls_{}.parquet", size));
+    let mut file = File::open(path).unwrap();
+
+    let metadata = read_metadata(&mut file)?;
+
+    let row_group = 0;
+    let iter = get_page_iterator(&metadata, row_group, column, &mut file)?;
+
+    let descriptor = &iter.descriptor().clone();
+    let _ = page_iter_to_array(iter, descriptor)?;
+    Ok(())
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    c.bench_function("read u64 10000", |b| {
+        b.iter(|| read_decompressed_pages(1000, 0))
+    });
+    c.bench_function("read u64 100000", |b| {
+        b.iter(|| read_decompressed_pages(10000, 0))
+    });
+    c.bench_function("read utf8 10000", |b| {
+        b.iter(|| read_decompressed_pages(1000, 2))
+    });
+    c.bench_function("read utf8 100000", |b| {
+        b.iter(|| read_decompressed_pages(10000, 2))
+    });
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/license.py
+++ b/license.py
@@ -46,6 +46,7 @@ def should_be_own_license(path: str) -> bool:
         path.startswith("src/bits") or \
         path == "src/temporal_conversions.rs" or \
         path.startswith("src/io/csv") or \
+        path.startswith("src/io/parquet") or \
         any(path.startswith(x) for x in own_compute)
 
 

--- a/parquet_integration/bench_pyarrow.py
+++ b/parquet_integration/bench_pyarrow.py
@@ -1,0 +1,14 @@
+import timeit
+
+import pyarrow.parquet
+
+def f(column):
+    pyarrow.parquet.read_table("fixtures/pyarrow3/basic_nulls_100000.parquet", columns=[column])
+
+seconds = timeit.Timer(lambda: f("int64")).timeit(number=512) / 512
+microseconds = seconds * 1000 * 1000
+print("read u64 100000     time: {:.2f} us".format(microseconds))
+
+seconds = timeit.Timer(lambda: f("string")).timeit(number=512) / 512
+microseconds = seconds * 1000 * 1000
+print("read utf8 100000    time: {:.2f} us".format(microseconds))

--- a/parquet_integration/write_parquet.py
+++ b/parquet_integration/write_parquet.py
@@ -18,6 +18,7 @@ def case1(size = 1):
         "string": string * size,
         "bool": boolean * size,
         "date": int64 * size,
+        "uint32": int64 * size,
     }, f"basic_nulls_{size*10}.parquet"
 
 def write_case1_pyarrow(size = 1):
@@ -29,6 +30,7 @@ def write_case1_pyarrow(size = 1):
         pa.field('string', pa.utf8()),
         pa.field('bool', pa.bool_()),
         pa.field('date', pa.timestamp('ms')),
+        pa.field('uint32', pa.uint32()),
     ]
     schema = pa.schema(fields)
 

--- a/parquet_integration/write_parquet.py
+++ b/parquet_integration/write_parquet.py
@@ -40,12 +40,9 @@ def write_case1_pyarrow(size = 1, page_version = 1):
     os.makedirs(base_path, exist_ok=True)
     pa.parquet.write_table(t, f"{base_path}/{path}", data_page_version=f"{page_version}.0")
 
-write_case1_pyarrow(1)
-write_case1_pyarrow(10)
-write_case1_pyarrow(100)
-write_case1_pyarrow(1000)
-write_case1_pyarrow(10000)
-write_case1_pyarrow(1, 2)
+for i in [1, 10, 100, 1000, 10000]:
+    write_case1_pyarrow(i)  # V1
+write_case1_pyarrow(1, 2)  # V2
 exit(0) # we are only testing against pyarrow in the code.
 
 def write_case1_pyspark():

--- a/parquet_integration/write_parquet.py
+++ b/parquet_integration/write_parquet.py
@@ -1,0 +1,66 @@
+import pyarrow
+import pyarrow.parquet
+import os
+import shutil
+
+PYARROW_PATH = "fixtures/pyarrow3"
+PYSPARK_PATH = "fixtures/pyspark3"
+
+def case1(size = 1):
+    int64 = [0, 1, None, 3, None, 5, 6, 7, None, 9]
+    float64 = [0.0, 1.0, None, 3.0, None, 5.0, 6.0, 7.0, None, 9.0]
+    string = ["Hello", None, "aa", "", None, "abc", None, None, "def", "aaa"]
+    boolean = [True, None, False, False, None, True, None, None, True, True]
+
+    return {
+        "int64": int64 * size,
+        "float64": float64 * size,
+        "string": string * size,
+        "bool": boolean * size,
+    }, f"basic_nulls_{size*10}.parquet"
+
+def write_case1_pyarrow(size = 1):
+    data, path = case1(size)
+    t = pyarrow.table(data)
+    os.makedirs(PYARROW_PATH, exist_ok=True)
+    pyarrow.parquet.write_table(t, f"{PYARROW_PATH}/{path}")
+
+write_case1_pyarrow(1)
+write_case1_pyarrow(10)
+write_case1_pyarrow(100)
+write_case1_pyarrow(1000)
+write_case1_pyarrow(10000)
+exit(0) # we are only testing against pyarrow in the code.
+
+def write_case1_pyspark():
+    data, path = case1()
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession \
+        .builder \
+        .getOrCreate()
+
+    columns = list(data.keys())
+    length = len(data[columns[0]])
+    # transpose
+    df = spark.createDataFrame([
+        [int64[i], float64[i]] for i in range(length)
+    ], schema=columns)
+
+    os.makedirs(PYSPARK_PATH, exist_ok=True)
+    # 1 is required here so that we convert it to a single parquet file
+    df.coalesce(1).write.parquet(f"{PYSPARK_PATH}/{FILE_NAME}")
+
+    def _single_file_spark(file_name: str):
+        """
+        converts a directiory with a single parquet "part" into a single parquet file.
+        """
+        files = os.listdir(f"{PYSPARK_PATH}/{file_name}")
+        part = [a for a in files if a.endswith(".parquet")]
+        assert len(path) == 1
+
+        os.rename(f"{PYSPARK_PATH}/{file_name}/{part[0]}", f"{PYSPARK_PATH}/tmp.parquet")
+        shutil.rmtree(f"{PYSPARK_PATH}/{file_name}")
+        os.rename(f"{PYSPARK_PATH}/tmp.parquet", f"{PYSPARK_PATH}/{file_name}")
+
+    _single_file_spark(FILE_NAME)

--- a/parquet_integration/write_parquet.py
+++ b/parquet_integration/write_parquet.py
@@ -1,4 +1,4 @@
-import pyarrow
+import pyarrow as pa
 import pyarrow.parquet
 import os
 import shutil
@@ -17,13 +17,24 @@ def case1(size = 1):
         "float64": float64 * size,
         "string": string * size,
         "bool": boolean * size,
+        "date": int64 * size,
     }, f"basic_nulls_{size*10}.parquet"
 
 def write_case1_pyarrow(size = 1):
     data, path = case1(size)
-    t = pyarrow.table(data)
+
+    fields = [
+        pa.field('int64', pa.int64()),
+        pa.field('float64', pa.float64()),
+        pa.field('string', pa.utf8()),
+        pa.field('bool', pa.bool_()),
+        pa.field('date', pa.timestamp('ms')),
+    ]
+    schema = pa.schema(fields)
+
+    t = pa.table(data, schema=schema)
     os.makedirs(PYARROW_PATH, exist_ok=True)
-    pyarrow.parquet.write_table(t, f"{PYARROW_PATH}/{path}")
+    pa.parquet.write_table(t, f"{PYARROW_PATH}/{path}")
 
 write_case1_pyarrow(1)
 write_case1_pyarrow(10)

--- a/parquet_integration/write_parquet.py
+++ b/parquet_integration/write_parquet.py
@@ -21,7 +21,7 @@ def case1(size = 1):
         "uint32": int64 * size,
     }, f"basic_nulls_{size*10}.parquet"
 
-def write_case1_pyarrow(size = 1):
+def write_case1_pyarrow(size = 1, page_version = 1):
     data, path = case1(size)
 
     fields = [
@@ -34,15 +34,18 @@ def write_case1_pyarrow(size = 1):
     ]
     schema = pa.schema(fields)
 
+    base_path = f"{PYARROW_PATH}/v{page_version}"
+
     t = pa.table(data, schema=schema)
-    os.makedirs(PYARROW_PATH, exist_ok=True)
-    pa.parquet.write_table(t, f"{PYARROW_PATH}/{path}")
+    os.makedirs(base_path, exist_ok=True)
+    pa.parquet.write_table(t, f"{base_path}/{path}", data_page_version=f"{page_version}.0")
 
 write_case1_pyarrow(1)
 write_case1_pyarrow(10)
 write_case1_pyarrow(100)
 write_case1_pyarrow(1000)
 write_case1_pyarrow(10000)
+write_case1_pyarrow(1, 2)
 exit(0) # we are only testing against pyarrow in the code.
 
 def write_case1_pyspark():

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -235,7 +235,6 @@ impl MutableBitmap {
     /// # Implementation
     /// This function splits the the iterator in 3 iterations:
     /// * a prefix, that is used finish a
-    #[inline]
     pub unsafe fn extend_from_trusted_len_iter<I: IntoIterator<Item = bool>>(
         &mut self,
         iterator: I,
@@ -292,7 +291,6 @@ impl MutableBitmap {
     /// Creates a new [`Bitmap`] from an iterator of booleans.
     /// # Safety
     /// The caller must guarantee that the iterator is `TrustedLen`.
-    #[inline]
     pub unsafe fn from_trusted_len_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = bool>,
@@ -310,7 +308,6 @@ impl MutableBitmap {
     /// Creates a new [`Bitmap`] from an falible iterator of booleans.
     /// # Safety
     /// The caller must guarantee that the iterator is `TrustedLen`.
-    #[inline]
     pub unsafe fn try_from_trusted_len_iter<E, I>(iter: I) -> std::result::Result<Self, E>
     where
         I: IntoIterator<Item = std::result::Result<bool, E>>,

--- a/src/buffer/mutable.rs
+++ b/src/buffer/mutable.rs
@@ -280,7 +280,6 @@ unsafe fn reallocate<T: NativeType>(
 }
 
 impl<A: NativeType> Extend<A> for MutableBuffer<A> {
-    #[inline]
     fn extend<T: IntoIterator<Item = A>>(&mut self, iter: T) {
         let iterator = iter.into_iter();
         self.extend_from_iter(iterator)
@@ -319,7 +318,6 @@ impl<T: NativeType> MutableBuffer<T> {
     /// # Safety
     /// This method assumes that the iterator's size is correct and is undefined behavior
     /// to use it on an iterator that reports an incorrect length.
-    #[inline]
     pub unsafe fn extend_from_trusted_len_iter<I: Iterator<Item = T>>(&mut self, iterator: I) {
         let (_, upper) = iterator.size_hint();
         let upper = upper.expect("trusted_len_iter requires an upper limit");
@@ -357,7 +355,6 @@ impl<T: NativeType> MutableBuffer<T> {
     // 1. there is no trait `TrustedLen` in stable rust and therefore
     //    we can't specialize `extend` for `TrustedLen` like `Vec` does.
     // 2. `from_trusted_len_iter` is faster.
-    #[inline]
     pub unsafe fn from_trusted_len_iter<I: Iterator<Item = T>>(iterator: I) -> Self {
         let mut buffer = MutableBuffer::new();
         buffer.extend_from_trusted_len_iter(iterator);
@@ -370,7 +367,6 @@ impl<T: NativeType> MutableBuffer<T> {
     /// # Safety
     /// This method assumes that the iterator's size is correct and is undefined behavior
     /// to use it on an iterator that reports an incorrect length.
-    #[inline]
     pub unsafe fn try_from_trusted_len_iter<E, I: Iterator<Item = std::result::Result<T, E>>>(
         iterator: I,
     ) -> std::result::Result<Self, E> {

--- a/src/compute/arity.rs
+++ b/src/compute/arity.rs
@@ -99,10 +99,11 @@ where
 
     let validity = combine_validities(lhs.validity(), rhs.validity());
 
-    let values =
-        lhs.values().iter().zip(rhs.values().iter()).map(|(l, r)| {
-            op(*l, *r).map_err(|error| ArrowError::from_external_error(Box::new(error)))
-        });
+    let values = lhs
+        .values()
+        .iter()
+        .zip(rhs.values().iter())
+        .map(|(l, r)| op(*l, *r).map_err(ArrowError::from_external_error));
     // JUSTIFICATION
     //  Benefit
     //      ~60% speedup

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,8 +25,8 @@ pub enum ArrowError {
 
 impl ArrowError {
     /// Wraps an external error in an `ArrowError`.
-    pub fn from_external_error(error: Box<dyn ::std::error::Error + Send + Sync>) -> Self {
-        Self::External("".to_string(), error)
+    pub fn from_external_error(error: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self::External("".to_string(), Box::new(error))
     }
 }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -26,3 +26,6 @@ pub mod ipc;
 
 #[cfg(feature = "io_json_integration")]
 pub mod json_integration;
+
+#[cfg(feature = "io_parquet")]
+pub mod parquet;

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -1,0 +1,9 @@
+use crate::error::ArrowError;
+
+pub mod read;
+
+impl From<parquet2::error::ParquetError> for ArrowError {
+    fn from(error: parquet2::error::ParquetError) -> Self {
+        ArrowError::External("".to_string(), Box::new(error))
+    }
+}

--- a/src/io/parquet/read/boolean.rs
+++ b/src/io/parquet/read/boolean.rs
@@ -1,0 +1,117 @@
+use crate::{
+    array::BooleanArray,
+    bitmap::{BitmapIter, MutableBitmap},
+    error::{ArrowError, Result},
+};
+
+use parquet2::{
+    encoding::{get_length, hybrid_rle, Encoding},
+    metadata::ColumnDescriptor,
+    read::{decompress_page, Page},
+};
+
+fn read_bitmap(
+    buffer: &[u8],
+    length: u32,
+    _has_validity: bool,
+    values: &mut MutableBitmap,
+    validity: &mut MutableBitmap,
+) {
+    let length = length as usize;
+
+    // split in two buffers: def_levels and data
+    let def_level_buffer_length = get_length(buffer) as usize;
+    let validity_buffer = &buffer[4..4 + def_level_buffer_length];
+    let values_buffer = &buffer[4 + def_level_buffer_length..];
+
+    let validity_iterator = hybrid_rle::Decoder::new(&validity_buffer, 1);
+
+    // in PLAIN, booleans are LSB bitpacked and thus we can read them as if they were a bitmap.
+    // note that `values_buffer` contains only non-null values.
+    // thus, at this point, it is not known how many values this buffer contains
+    // values_len is the upper bound. The actual number depends on how many nulls there is.
+    let values_len = values_buffer.len() * 8;
+    let mut values_iterator = BitmapIter::new(values_buffer, 0, values_len);
+
+    validity.reserve(length);
+    values.reserve(length);
+    for run in validity_iterator {
+        match run {
+            hybrid_rle::HybridEncoded::Bitpacked(packed) => {
+                // the pack may contain more items than needed.
+                let remaining = length - values.len();
+                let len = std::cmp::min(packed.len() * 8, remaining);
+                for is_valid in BitmapIter::new(packed, 0, len) {
+                    validity.push(is_valid);
+                    let value = if is_valid {
+                        values_iterator.next().unwrap()
+                    } else {
+                        false
+                    };
+                    values.push(value);
+                }
+            }
+            hybrid_rle::HybridEncoded::Rle(value, additional) => {
+                let is_set = value[0] == 1;
+                validity.extend_constant(additional, is_set);
+                if is_set {
+                    (0..additional).for_each(|_| {
+                        let value = values_iterator.next().unwrap();
+                        values.push(value)
+                    })
+                } else {
+                    values.extend_constant(additional, false)
+                }
+            }
+        }
+    }
+}
+
+pub fn iter_to_array<I, E>(mut iter: I, descriptor: &ColumnDescriptor) -> Result<BooleanArray>
+where
+    ArrowError: From<E>,
+    I: Iterator<Item = std::result::Result<Page, E>>,
+{
+    // todo: push metadata from the file to get this capacity
+    let capacity = 0;
+    let mut values = MutableBitmap::with_capacity(capacity);
+    let mut validity = MutableBitmap::with_capacity(capacity);
+    iter.try_for_each(|page| extend_from_page(page?, &descriptor, &mut values, &mut validity))?;
+
+    Ok(BooleanArray::from_data(values.into(), validity.into()))
+}
+
+fn extend_from_page(
+    page: Page,
+    descriptor: &ColumnDescriptor,
+    values: &mut MutableBitmap,
+    validity: &mut MutableBitmap,
+) -> Result<()> {
+    let page = decompress_page(page).map_err(ArrowError::from_external_error)?;
+    assert_eq!(descriptor.max_rep_level(), 0);
+    assert_eq!(descriptor.max_def_level(), 1);
+    let has_validity = descriptor.max_def_level() == 1;
+    match page {
+        Page::V1(page) => {
+            assert_eq!(page.def_level_encoding, Encoding::Rle);
+            match (&page.encoding, &page.dictionary_page) {
+                (Encoding::Plain, None) => {
+                    read_bitmap(&page.buf, page.num_values, has_validity, values, validity)
+                }
+                (encoding, None) => {
+                    return Err(ArrowError::NotYetImplemented(format!(
+                        "Encoding {:?} not yet implemented for Binary",
+                        encoding
+                    )))
+                }
+                _ => todo!(),
+            }
+        }
+        Page::V2(_) => {
+            return Err(ArrowError::NotYetImplemented(
+                "Reading booleans from V2 pages is not yet implemented".to_string(),
+            ))
+        }
+    };
+    Ok(())
+}

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -195,6 +195,13 @@ mod tests {
                 Primitive::<i64>::from(i64_values)
                     .to(DataType::Timestamp(TimeUnit::Millisecond, None)),
             ),
+            5 => {
+                let values = i64_values.iter().map(|x| x.map(|x| x as u32)).collect::<Vec<_>>();
+                Box::new(
+                    Primitive::<u32>::from(values)
+                        .to(DataType::UInt32),
+                )
+            }
             _ => unreachable!(),
         }
     }
@@ -281,6 +288,23 @@ mod tests {
             return Ok(());
         }
         let column = 4;
+        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let array = get_column(path, 0, column)?;
+
+        let expected = pyarrow_integration(column);
+
+        assert_eq!(expected.as_ref(), array.as_ref());
+
+        Ok(())
+    }
+
+    #[test]
+    #[ignore] // pyarrow issue; see https://issues.apache.org/jira/browse/ARROW-12201
+    fn pyarrow_integration_u32() -> Result<()> {
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
+            return Ok(());
+        }
+        let column = 5;
         let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
 

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -196,11 +196,11 @@ mod tests {
                     .to(DataType::Timestamp(TimeUnit::Millisecond, None)),
             ),
             5 => {
-                let values = i64_values.iter().map(|x| x.map(|x| x as u32)).collect::<Vec<_>>();
-                Box::new(
-                    Primitive::<u32>::from(values)
-                        .to(DataType::UInt32),
-                )
+                let values = i64_values
+                    .iter()
+                    .map(|x| x.map(|x| x as u32))
+                    .collect::<Vec<_>>();
+                Box::new(Primitive::<u32>::from(values).to(DataType::UInt32))
             }
             _ => unreachable!(),
         }
@@ -209,9 +209,8 @@ mod tests {
     fn get_column(path: &str, row_group: usize, column: usize) -> Result<Box<dyn Array>> {
         let mut file = File::open(path).unwrap();
 
-        let metadata = read_metadata(&mut file).map_err(ArrowError::from_external_error)?;
-        let iter = get_page_iterator(&metadata, row_group, column, &mut file)
-            .map_err(ArrowError::from_external_error)?;
+        let metadata = read_metadata(&mut file)?;
+        let iter = get_page_iterator(&metadata, row_group, column, &mut file)?;
 
         let descriptor = &iter.descriptor().clone();
 
@@ -251,7 +250,7 @@ mod tests {
     }
 
     #[test]
-    fn pyarrow_integration_v1_string() -> Result<()> {
+    fn pyarrow_integration_v1_utf8() -> Result<()> {
         if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
             return Ok(());
         }
@@ -306,6 +305,54 @@ mod tests {
         }
         let column = 5;
         let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
+        let array = get_column(path, 0, column)?;
+
+        let expected = pyarrow_integration(column);
+
+        assert_eq!(expected.as_ref(), array.as_ref());
+
+        Ok(())
+    }
+
+    #[test]
+    fn pyarrow_integration_v2_int64() -> Result<()> {
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
+            return Ok(());
+        }
+        let column = 0;
+        let path = "fixtures/pyarrow3/v2/basic_nulls_10.parquet";
+        let array = get_column(path, 0, column)?;
+
+        let expected = pyarrow_integration(column);
+
+        assert_eq!(expected.as_ref(), array.as_ref());
+
+        Ok(())
+    }
+
+    #[test]
+    fn pyarrow_integration_v2_utf8() -> Result<()> {
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
+            return Ok(());
+        }
+        let column = 2;
+        let path = "fixtures/pyarrow3/v2/basic_nulls_10.parquet";
+        let array = get_column(path, 0, column)?;
+
+        let expected = pyarrow_integration(column);
+
+        assert_eq!(expected.as_ref(), array.as_ref());
+
+        Ok(())
+    }
+
+    #[test]
+    fn pyarrow_integration_v2_boolean() -> Result<()> {
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
+            return Ok(());
+        }
+        let column = 3;
+        let path = "fixtures/pyarrow3/v2/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
 
         let expected = pyarrow_integration(column);

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -5,7 +5,7 @@ mod utils;
 
 use crate::{
     array::Array,
-    datatypes::DataType,
+    datatypes::{DataType, TimeUnit},
     error::{ArrowError, Result},
 };
 
@@ -13,8 +13,71 @@ use parquet2::{
     error::ParquetError,
     metadata::ColumnDescriptor,
     read::Page,
-    schema::types::{LogicalType, ParquetType, PhysicalType, PrimitiveConvertedType},
+    schema::{
+        types::{LogicalType, ParquetType, PhysicalType, PrimitiveConvertedType},
+        TimeUnit as ParquetTimeUnit, TimestampType,
+    },
 };
+
+fn page_iter_to_array_i64<I: Iterator<Item = std::result::Result<Page, ParquetError>>>(
+    iter: I,
+    descriptor: &ColumnDescriptor,
+    converted_type: &Option<PrimitiveConvertedType>,
+    logical_type: &Option<LogicalType>,
+) -> Result<Box<dyn Array>> {
+    let data_type = match (converted_type, logical_type) {
+        (None, None) => DataType::Int64,
+        (
+            _,
+            Some(LogicalType::TIMESTAMP(TimestampType {
+                is_adjusted_to_u_t_c,
+                unit,
+            })),
+        ) => {
+            let timezone = if *is_adjusted_to_u_t_c {
+                // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+                // A TIMESTAMP with isAdjustedToUTC=true is defined as [...] elapsed since the Unix epoch
+                Some("+00:00".to_string())
+            } else {
+                // PARQUET:
+                // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+                // A TIMESTAMP with isAdjustedToUTC=false represents [...] such
+                // timestamps should always be displayed the same way, regardless of the local time zone in effect
+                // ARROW:
+                // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+                // If the time zone is null or equal to an empty string, the data is "time
+                // zone naive" and shall be displayed *as is* to the user, not localized
+                // to the locale of the user.
+                None
+            };
+
+            match unit {
+                ParquetTimeUnit::MILLIS(_) => DataType::Timestamp(TimeUnit::Millisecond, timezone),
+                ParquetTimeUnit::MICROS(_) => DataType::Timestamp(TimeUnit::Microsecond, timezone),
+                ParquetTimeUnit::NANOS(_) => DataType::Timestamp(TimeUnit::Nanosecond, timezone),
+            }
+        }
+        // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
+        // *Backward compatibility:*
+        // TIME_MILLIS | TimeType (isAdjustedToUTC = true, unit = MILLIS)
+        // TIME_MICROS | TimeType (isAdjustedToUTC = true, unit = MICROS)
+        (Some(PrimitiveConvertedType::TimeMillis), None) => {
+            DataType::Timestamp(TimeUnit::Millisecond, Some("+00:00".to_string()))
+        }
+        (Some(PrimitiveConvertedType::TimeMicros), None) => {
+            DataType::Timestamp(TimeUnit::Microsecond, Some("+00:00".to_string()))
+        }
+        (c, l) => {
+            return Err(ArrowError::NotYetImplemented(format!(
+                "The conversion of (Int64, {:?}, {:?}) to arrow still not implemented",
+                c, l
+            )))
+        }
+    };
+
+    primitive::iter_to_array::<i64, _, _>(iter, descriptor, data_type)
+        .map(|x| Box::new(x) as Box<dyn Array>)
+}
 
 pub fn page_iter_to_array<I: Iterator<Item = std::result::Result<Page, ParquetError>>>(
     iter: I,
@@ -31,9 +94,9 @@ pub fn page_iter_to_array<I: Iterator<Item = std::result::Result<Page, ParquetEr
             (PhysicalType::Int32, None, None) => Ok(Box::new(
                 primitive::iter_to_array::<i32, _, _>(iter, descriptor, DataType::Int32)?,
             )),
-            (PhysicalType::Int64, None, None) => Ok(Box::new(
-                primitive::iter_to_array::<i64, _, _>(iter, descriptor, DataType::Int64)?,
-            )),
+            (PhysicalType::Int64, _, _) => {
+                page_iter_to_array_i64(iter, descriptor, converted_type, logical_type)
+            }
             (PhysicalType::Float, None, None) => Ok(Box::new(
                 primitive::iter_to_array::<f32, _, _>(iter, descriptor, DataType::Float32)?,
             )),
@@ -67,31 +130,28 @@ pub fn page_iter_to_array<I: Iterator<Item = std::result::Result<Page, ParquetEr
 mod tests {
     use std::fs::File;
 
-    use parquet2::{
-        read::{get_page_iterator, read_metadata},
-    };
+    use parquet2::read::{get_page_iterator, read_metadata};
 
     use crate::array::*;
 
     use super::*;
 
     fn pyarrow_integration(column: usize) -> Box<dyn Array> {
+        let i64_values = &[
+            Some(0),
+            Some(1),
+            None,
+            Some(3),
+            None,
+            Some(5),
+            Some(6),
+            Some(7),
+            None,
+            Some(9),
+        ];
+
         match column {
-            0 => Box::new(
-                Primitive::<i64>::from(&[
-                    Some(0),
-                    Some(1),
-                    None,
-                    Some(3),
-                    None,
-                    Some(5),
-                    Some(6),
-                    Some(7),
-                    None,
-                    Some(9),
-                ])
-                .to(DataType::Int64),
-            ),
+            0 => Box::new(Primitive::<i64>::from(i64_values).to(DataType::Int64)),
             1 => Box::new(
                 Primitive::<f64>::from(&[
                     Some(0.0),
@@ -131,6 +191,10 @@ mod tests {
                 Some(true),
                 Some(true),
             ])),
+            4 => Box::new(
+                Primitive::<i64>::from(i64_values)
+                    .to(DataType::Timestamp(TimeUnit::Millisecond, None)),
+            ),
             _ => unreachable!(),
         }
     }
@@ -149,7 +213,9 @@ mod tests {
 
     #[test]
     fn pyarrow_integration_int64() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() { return Ok(()); }
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
+            return Ok(());
+        }
         let column = 0;
         let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
@@ -163,7 +229,9 @@ mod tests {
 
     #[test]
     fn pyarrow_integration_float64() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() { return Ok(()); }
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
+            return Ok(());
+        }
         let column = 1;
         let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
@@ -177,7 +245,9 @@ mod tests {
 
     #[test]
     fn pyarrow_integration_string() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() { return Ok(()); }
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
+            return Ok(());
+        }
         let column = 2;
         let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
@@ -191,8 +261,26 @@ mod tests {
 
     #[test]
     fn pyarrow_integration_boolean() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() { return Ok(()); }
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
+            return Ok(());
+        }
         let column = 3;
+        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let array = get_column(path, 0, column)?;
+
+        let expected = pyarrow_integration(column);
+
+        assert_eq!(expected.as_ref(), array.as_ref());
+
+        Ok(())
+    }
+
+    #[test]
+    fn pyarrow_integration_timestamp() -> Result<()> {
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
+            return Ok(());
+        }
+        let column = 4;
         let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
 

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -219,12 +219,12 @@ mod tests {
     }
 
     #[test]
-    fn pyarrow_integration_int64() -> Result<()> {
+    fn pyarrow_integration_v1_int64() -> Result<()> {
         if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
             return Ok(());
         }
         let column = 0;
-        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
 
         let expected = pyarrow_integration(column);
@@ -235,12 +235,12 @@ mod tests {
     }
 
     #[test]
-    fn pyarrow_integration_float64() -> Result<()> {
+    fn pyarrow_integration_v1_float64() -> Result<()> {
         if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
             return Ok(());
         }
         let column = 1;
-        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
 
         let expected = pyarrow_integration(column);
@@ -251,12 +251,12 @@ mod tests {
     }
 
     #[test]
-    fn pyarrow_integration_string() -> Result<()> {
+    fn pyarrow_integration_v1_string() -> Result<()> {
         if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
             return Ok(());
         }
         let column = 2;
-        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
 
         let expected = pyarrow_integration(column);
@@ -267,12 +267,12 @@ mod tests {
     }
 
     #[test]
-    fn pyarrow_integration_boolean() -> Result<()> {
+    fn pyarrow_integration_v1_boolean() -> Result<()> {
         if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
             return Ok(());
         }
         let column = 3;
-        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
 
         let expected = pyarrow_integration(column);
@@ -283,12 +283,12 @@ mod tests {
     }
 
     #[test]
-    fn pyarrow_integration_timestamp() -> Result<()> {
+    fn pyarrow_integration_v1_timestamp() -> Result<()> {
         if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
             return Ok(());
         }
         let column = 4;
-        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
 
         let expected = pyarrow_integration(column);
@@ -300,12 +300,12 @@ mod tests {
 
     #[test]
     #[ignore] // pyarrow issue; see https://issues.apache.org/jira/browse/ARROW-12201
-    fn pyarrow_integration_u32() -> Result<()> {
+    fn pyarrow_integration_v1_u32() -> Result<()> {
         if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
             return Ok(());
         }
         let column = 5;
-        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
         let array = get_column(path, 0, column)?;
 
         let expected = pyarrow_integration(column);

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -1,0 +1,205 @@
+mod boolean;
+mod primitive;
+mod utf8;
+mod utils;
+
+use crate::{
+    array::Array,
+    datatypes::DataType,
+    error::{ArrowError, Result},
+};
+
+use parquet2::{
+    error::ParquetError,
+    metadata::ColumnDescriptor,
+    read::Page,
+    schema::types::{LogicalType, ParquetType, PhysicalType, PrimitiveConvertedType},
+};
+
+pub fn page_iter_to_array<I: Iterator<Item = std::result::Result<Page, ParquetError>>>(
+    iter: I,
+    descriptor: &ColumnDescriptor,
+) -> Result<Box<dyn Array>> {
+    match descriptor.type_() {
+        ParquetType::PrimitiveType {
+            physical_type,
+            converted_type,
+            logical_type,
+            ..
+        } => match (physical_type, converted_type, logical_type) {
+            // todo: apply conversion rules and the like
+            (PhysicalType::Int32, None, None) => Ok(Box::new(
+                primitive::iter_to_array::<i32, _, _>(iter, descriptor, DataType::Int32)?,
+            )),
+            (PhysicalType::Int64, None, None) => Ok(Box::new(
+                primitive::iter_to_array::<i64, _, _>(iter, descriptor, DataType::Int64)?,
+            )),
+            (PhysicalType::Float, None, None) => Ok(Box::new(
+                primitive::iter_to_array::<f32, _, _>(iter, descriptor, DataType::Float32)?,
+            )),
+            (PhysicalType::Double, None, None) => {
+                Ok(Box::new(primitive::iter_to_array::<f64, _, _>(
+                    iter,
+                    descriptor,
+                    DataType::Float64,
+                )?))
+            }
+            (PhysicalType::Boolean, None, None) => {
+                Ok(Box::new(boolean::iter_to_array(iter, descriptor)?))
+            }
+            (
+                PhysicalType::ByteArray,
+                Some(PrimitiveConvertedType::Utf8),
+                Some(LogicalType::STRING(_)),
+            ) => Ok(Box::new(utf8::iter_to_array::<i32, _, _>(
+                iter, descriptor,
+            )?)),
+            (p, c, l) => Err(ArrowError::NotYetImplemented(format!(
+                "The conversion of ({:?}, {:?}, {:?}) to arrow still not implemented",
+                p, c, l
+            ))),
+        },
+        _ => todo!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+
+    use parquet2::{
+        read::{get_page_iterator, read_metadata},
+    };
+
+    use crate::array::*;
+
+    use super::*;
+
+    fn pyarrow_integration(column: usize) -> Box<dyn Array> {
+        match column {
+            0 => Box::new(
+                Primitive::<i64>::from(&[
+                    Some(0),
+                    Some(1),
+                    None,
+                    Some(3),
+                    None,
+                    Some(5),
+                    Some(6),
+                    Some(7),
+                    None,
+                    Some(9),
+                ])
+                .to(DataType::Int64),
+            ),
+            1 => Box::new(
+                Primitive::<f64>::from(&[
+                    Some(0.0),
+                    Some(1.0),
+                    None,
+                    Some(3.0),
+                    None,
+                    Some(5.0),
+                    Some(6.0),
+                    Some(7.0),
+                    None,
+                    Some(9.0),
+                ])
+                .to(DataType::Float64),
+            ),
+            2 => Box::new(Utf8Array::<i32>::from(&vec![
+                Some("Hello".to_string()),
+                None,
+                Some("aa".to_string()),
+                Some("".to_string()),
+                None,
+                Some("abc".to_string()),
+                None,
+                None,
+                Some("def".to_string()),
+                Some("aaa".to_string()),
+            ])),
+            3 => Box::new(BooleanArray::from(&[
+                Some(true),
+                None,
+                Some(false),
+                Some(false),
+                None,
+                Some(true),
+                None,
+                None,
+                Some(true),
+                Some(true),
+            ])),
+            _ => unreachable!(),
+        }
+    }
+
+    fn get_column(path: &str, row_group: usize, column: usize) -> Result<Box<dyn Array>> {
+        let mut file = File::open(path).unwrap();
+
+        let metadata = read_metadata(&mut file).map_err(ArrowError::from_external_error)?;
+        let iter = get_page_iterator(&metadata, row_group, column, &mut file)
+            .map_err(ArrowError::from_external_error)?;
+
+        let descriptor = &iter.descriptor().clone();
+
+        page_iter_to_array(iter, descriptor)
+    }
+
+    #[test]
+    fn pyarrow_integration_int64() -> Result<()> {
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() { return Ok(()); }
+        let column = 0;
+        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let array = get_column(path, 0, column)?;
+
+        let expected = pyarrow_integration(column);
+
+        assert_eq!(expected.as_ref(), array.as_ref());
+
+        Ok(())
+    }
+
+    #[test]
+    fn pyarrow_integration_float64() -> Result<()> {
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() { return Ok(()); }
+        let column = 1;
+        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let array = get_column(path, 0, column)?;
+
+        let expected = pyarrow_integration(column);
+
+        assert_eq!(expected.as_ref(), array.as_ref());
+
+        Ok(())
+    }
+
+    #[test]
+    fn pyarrow_integration_string() -> Result<()> {
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() { return Ok(()); }
+        let column = 2;
+        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let array = get_column(path, 0, column)?;
+
+        let expected = pyarrow_integration(column);
+
+        assert_eq!(expected.as_ref(), array.as_ref());
+
+        Ok(())
+    }
+
+    #[test]
+    fn pyarrow_integration_boolean() -> Result<()> {
+        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() { return Ok(()); }
+        let column = 3;
+        let path = "fixtures/pyarrow3/basic_nulls_10.parquet";
+        let array = get_column(path, 0, column)?;
+
+        let expected = pyarrow_integration(column);
+
+        assert_eq!(expected.as_ref(), array.as_ref());
+
+        Ok(())
+    }
+}

--- a/src/io/parquet/read/primitive.rs
+++ b/src/io/parquet/read/primitive.rs
@@ -1,0 +1,194 @@
+use parquet2::{
+    encoding::{get_length, hybrid_rle, Encoding},
+    metadata::ColumnDescriptor,
+    read::{decompress_page, Page, PrimitivePageDict},
+    serialization::levels,
+    types,
+    types::NativeType,
+};
+
+use crate::{
+    array::PrimitiveArray,
+    bitmap::{BitmapIter, MutableBitmap},
+    buffer::MutableBuffer,
+    datatypes::DataType,
+    error::{ArrowError, Result},
+    types::NativeType as ArrowNativeType,
+};
+
+/// Assumptions: No rep levels
+fn read_dict_buffer<'a, T: NativeType + ArrowNativeType>(
+    buffer: &'a [u8],
+    length: u32,
+    dict: &'a PrimitivePageDict<T>,
+    _has_validity: bool,
+    values: &mut MutableBuffer<T>,
+    validity: &mut MutableBitmap,
+) {
+    let length = length as usize;
+    let dict_values = dict.values();
+
+    // split in two buffers: def_levels and data
+    let def_level_buffer_length = get_length(buffer) as usize;
+    let validity_buffer = &buffer[4..4 + def_level_buffer_length];
+    let indices_buffer = &buffer[4 + def_level_buffer_length..];
+
+    // SPEC: Data page format: the bit width used to encode the entry ids stored as 1 byte (max bit width = 32),
+    // SPEC: followed by the values encoded using RLE/Bit packed described above (with the given bit width).
+    let bit_width = indices_buffer[0];
+    let indices_buffer = &indices_buffer[1..];
+
+    let non_null_indices_len = (buffer.len() * 8 / bit_width as usize) as u32;
+    let mut indices =
+        levels::rle_decode(&indices_buffer, bit_width as u32, non_null_indices_len).into_iter();
+
+    let validity_iterator = hybrid_rle::Decoder::new(&validity_buffer, 1);
+
+    validity.reserve(length);
+    values.reserve(length);
+    for run in validity_iterator {
+        match run {
+            hybrid_rle::HybridEncoded::Bitpacked(packed) => {
+                let remaining = length - values.len();
+                let len = std::cmp::min(packed.len() * 8, remaining);
+                for is_valid in BitmapIter::new(packed, 0, len) {
+                    validity.push(is_valid);
+                    let value = if is_valid {
+                        dict_values[indices.next().unwrap() as usize]
+                    } else {
+                        T::default()
+                    };
+                    values.push(value);
+                }
+            }
+            hybrid_rle::HybridEncoded::Rle(value, additional) => {
+                let is_set = value[0] == 1;
+                validity.extend_constant(additional, is_set);
+                if is_set {
+                    (0..additional).for_each(|_| {
+                        let index = indices.next().unwrap() as usize;
+                        let value = dict_values[index];
+                        values.push(value)
+                    })
+                } else {
+                    values.extend_constant(additional, T::default())
+                }
+            }
+        }
+    }
+}
+
+fn read_buffer<T: NativeType + ArrowNativeType>(
+    buffer: &[u8],
+    length: u32,
+    _has_validity: bool,
+    values: &mut MutableBuffer<T>,
+    validity: &mut MutableBitmap,
+) {
+    let length = length as usize;
+
+    // split in two buffers: def_levels and data
+    let def_level_buffer_length = get_length(buffer) as usize;
+    let validity_buffer = &buffer[4..4 + def_level_buffer_length];
+    let values_buffer = &buffer[4 + def_level_buffer_length..];
+
+    let mut chunks = values_buffer[..length as usize * std::mem::size_of::<T>()]
+        .chunks_exact(std::mem::size_of::<T>());
+
+    let validity_iterator = hybrid_rle::Decoder::new(&validity_buffer, 1);
+
+    validity.reserve(length);
+    values.reserve(length);
+    for run in validity_iterator {
+        match run {
+            hybrid_rle::HybridEncoded::Bitpacked(packed) => {
+                // the pack may contain more items than needed.
+                let remaining = length - values.len();
+                let len = std::cmp::min(packed.len() * 8, remaining);
+                for is_valid in BitmapIter::new(packed, 0, len) {
+                    validity.push(is_valid);
+                    let value = if is_valid {
+                        types::decode(chunks.next().unwrap())
+                    } else {
+                        T::default()
+                    };
+                    values.push(value);
+                }
+            }
+            hybrid_rle::HybridEncoded::Rle(value, additional) => {
+                let is_set = value[0] == 1;
+                validity.extend_constant(additional, is_set);
+                if is_set {
+                    (0..additional).for_each(|_| {
+                        let value = types::decode(chunks.next().unwrap());
+                        values.push(value)
+                    })
+                } else {
+                    values.extend_constant(additional, T::default())
+                }
+            }
+        }
+    }
+}
+
+pub fn iter_to_array<T, I, E>(
+    mut iter: I,
+    descriptor: &ColumnDescriptor,
+    data_type: DataType,
+) -> Result<PrimitiveArray<T>>
+where
+    ArrowError: From<E>,
+    T: NativeType + ArrowNativeType,
+    I: Iterator<Item = std::result::Result<Page, E>>,
+{
+    // todo: push metadata from the file to get this capacity
+    let capacity = 0;
+    let mut values = MutableBuffer::<T>::with_capacity(capacity);
+    let mut validity = MutableBitmap::with_capacity(capacity);
+    iter.try_for_each(|page| extend_from_page(page?, &descriptor, &mut values, &mut validity))?;
+
+    Ok(PrimitiveArray::from_data(
+        data_type,
+        values.into(),
+        validity.into(),
+    ))
+}
+
+fn extend_from_page<T: NativeType + ArrowNativeType>(
+    page: Page,
+    descriptor: &ColumnDescriptor,
+    values: &mut MutableBuffer<T>,
+    validity: &mut MutableBitmap,
+) -> Result<()> {
+    let page = decompress_page(page)?;
+    assert_eq!(descriptor.max_rep_level(), 0);
+    assert_eq!(descriptor.max_def_level(), 1);
+    let has_validity = descriptor.max_def_level() == 1;
+    match page {
+        Page::V1(page) => {
+            assert_eq!(page.def_level_encoding, Encoding::Rle);
+            match (&page.encoding, &page.dictionary_page) {
+                (Encoding::PlainDictionary, Some(dict)) => read_dict_buffer::<T>(
+                    &page.buf,
+                    page.num_values,
+                    dict.as_any().downcast_ref().unwrap(),
+                    has_validity,
+                    values,
+                    validity,
+                ),
+                (Encoding::Plain, None) => {
+                    read_buffer::<T>(&page.buf, page.num_values, has_validity, values, validity)
+                }
+                (encoding, None) => {
+                    return Err(ArrowError::NotYetImplemented(format!(
+                        "Encoding {:?} not yet implemented",
+                        encoding
+                    )))
+                }
+                _ => todo!(),
+            }
+        }
+        Page::V2(_) => todo!(),
+    };
+    Ok(())
+}

--- a/src/io/parquet/read/primitive.rs
+++ b/src/io/parquet/read/primitive.rs
@@ -1,5 +1,5 @@
 use parquet2::{
-    encoding::{get_length, hybrid_rle, Encoding},
+    encoding::{hybrid_rle, Encoding},
     metadata::ColumnDescriptor,
     read::{decompress_page, Page, PrimitivePageDict},
     serialization::levels,
@@ -7,6 +7,7 @@ use parquet2::{
     types::NativeType,
 };
 
+use super::utils;
 use crate::{
     array::PrimitiveArray,
     bitmap::{BitmapIter, MutableBitmap},
@@ -17,10 +18,11 @@ use crate::{
 };
 
 /// Assumptions: No rep levels
-fn read_dict_buffer<'a, T: NativeType + ArrowNativeType>(
-    buffer: &'a [u8],
+fn read_dict_buffer<T: NativeType + ArrowNativeType>(
+    validity_buffer: &[u8],
+    indices_buffer: &[u8],
     length: u32,
-    dict: &'a PrimitivePageDict<T>,
+    dict: &PrimitivePageDict<T>,
     _has_validity: bool,
     values: &mut MutableBuffer<T>,
     validity: &mut MutableBitmap,
@@ -28,17 +30,12 @@ fn read_dict_buffer<'a, T: NativeType + ArrowNativeType>(
     let length = length as usize;
     let dict_values = dict.values();
 
-    // split in two buffers: def_levels and data
-    let def_level_buffer_length = get_length(buffer) as usize;
-    let validity_buffer = &buffer[4..4 + def_level_buffer_length];
-    let indices_buffer = &buffer[4 + def_level_buffer_length..];
-
     // SPEC: Data page format: the bit width used to encode the entry ids stored as 1 byte (max bit width = 32),
     // SPEC: followed by the values encoded using RLE/Bit packed described above (with the given bit width).
     let bit_width = indices_buffer[0];
     let indices_buffer = &indices_buffer[1..];
 
-    let non_null_indices_len = (buffer.len() * 8 / bit_width as usize) as u32;
+    let non_null_indices_len = (indices_buffer.len() * 8 / bit_width as usize) as u32;
     let mut indices =
         levels::rle_decode(&indices_buffer, bit_width as u32, non_null_indices_len).into_iter();
 
@@ -79,18 +76,14 @@ fn read_dict_buffer<'a, T: NativeType + ArrowNativeType>(
 }
 
 fn read_buffer<T: NativeType + ArrowNativeType>(
-    buffer: &[u8],
+    validity_buffer: &[u8],
+    values_buffer: &[u8],
     length: u32,
     _has_validity: bool,
     values: &mut MutableBuffer<T>,
     validity: &mut MutableBitmap,
 ) {
     let length = length as usize;
-
-    // split in two buffers: def_levels and data
-    let def_level_buffer_length = get_length(buffer) as usize;
-    let validity_buffer = &buffer[4..4 + def_level_buffer_length];
-    let values_buffer = &buffer[4 + def_level_buffer_length..];
 
     let mut chunks = values_buffer[..length as usize * std::mem::size_of::<T>()]
         .chunks_exact(std::mem::size_of::<T>());
@@ -167,18 +160,26 @@ fn extend_from_page<T: NativeType + ArrowNativeType>(
     match page {
         Page::V1(page) => {
             assert_eq!(page.def_level_encoding, Encoding::Rle);
+            let (validity_buffer, values_buffer) = utils::split_buffer_v1(&page.buf);
+
             match (&page.encoding, &page.dictionary_page) {
                 (Encoding::PlainDictionary, Some(dict)) => read_dict_buffer::<T>(
-                    &page.buf,
+                    validity_buffer,
+                    values_buffer,
                     page.num_values,
                     dict.as_any().downcast_ref().unwrap(),
                     has_validity,
                     values,
                     validity,
                 ),
-                (Encoding::Plain, None) => {
-                    read_buffer::<T>(&page.buf, page.num_values, has_validity, values, validity)
-                }
+                (Encoding::Plain, None) => read_buffer::<T>(
+                    validity_buffer,
+                    values_buffer,
+                    page.num_values,
+                    has_validity,
+                    values,
+                    validity,
+                ),
                 (encoding, None) => {
                     return Err(ArrowError::NotYetImplemented(format!(
                         "Encoding {:?} not yet implemented",
@@ -188,7 +189,37 @@ fn extend_from_page<T: NativeType + ArrowNativeType>(
                 _ => todo!(),
             }
         }
-        Page::V2(_) => todo!(),
+        Page::V2(page) => {
+            let def_level_buffer_length = page.header.definition_levels_byte_length as usize;
+            let (validity_buffer, values_buffer) =
+                utils::split_buffer_v2(&page.buf, def_level_buffer_length);
+            match (&page.header.encoding, &page.dictionary_page) {
+                (Encoding::PlainDictionary, Some(dict)) => read_dict_buffer::<T>(
+                    validity_buffer,
+                    values_buffer,
+                    page.header.num_values as u32,
+                    dict.as_any().downcast_ref().unwrap(),
+                    has_validity,
+                    values,
+                    validity,
+                ),
+                (Encoding::Plain, None) => read_buffer::<T>(
+                    validity_buffer,
+                    values_buffer,
+                    page.header.num_values as u32,
+                    has_validity,
+                    values,
+                    validity,
+                ),
+                (encoding, None) => {
+                    return Err(ArrowError::NotYetImplemented(format!(
+                        "Encoding {:?} not yet implemented",
+                        encoding
+                    )))
+                }
+                _ => todo!(),
+            }
+        }
     };
     Ok(())
 }

--- a/src/io/parquet/read/utf8.rs
+++ b/src/io/parquet/read/utf8.rs
@@ -1,0 +1,210 @@
+use parquet2::{
+    encoding::{get_length, hybrid_rle, Encoding},
+    metadata::ColumnDescriptor,
+    read::{decompress_page, BinaryPageDict, Page},
+    serialization::levels,
+};
+
+use crate::{
+    array::{Offset, Utf8Array},
+    bitmap::{BitmapIter, MutableBitmap},
+    buffer::MutableBuffer,
+    error::{ArrowError, Result},
+};
+
+use super::utils;
+
+/// Assumptions: No rep levels
+fn read_dict_buffer<O: Offset>(
+    buffer: &[u8],
+    length: u32,
+    dict: &BinaryPageDict,
+    _has_validity: bool,
+    offsets: &mut MutableBuffer<O>,
+    values: &mut MutableBuffer<u8>,
+    validity: &mut MutableBitmap,
+) {
+    let length = length as usize;
+    let dict_values = dict.values();
+    let dict_offsets = dict.offsets();
+    let mut last_offset = *offsets.as_slice_mut().last().unwrap();
+
+    // split in two buffers: def_levels and data
+    let def_level_buffer_length = get_length(buffer) as usize;
+    let validity_buffer = &buffer[4..4 + def_level_buffer_length];
+    let indices_buffer = &buffer[4 + def_level_buffer_length..];
+
+    // SPEC: Data page format: the bit width used to encode the entry ids stored as 1 byte (max bit width = 32),
+    // SPEC: followed by the values encoded using RLE/Bit packed described above (with the given bit width).
+    let bit_width = indices_buffer[0];
+    let indices_buffer = &indices_buffer[1..];
+
+    let non_null_indices_len = (buffer.len() * 8 / bit_width as usize) as u32;
+    let mut indices =
+        levels::rle_decode(&indices_buffer, bit_width as u32, non_null_indices_len).into_iter();
+
+    let validity_iterator = hybrid_rle::Decoder::new(&validity_buffer, 1);
+
+    validity.reserve(length);
+    values.reserve(length);
+    for run in validity_iterator {
+        match run {
+            hybrid_rle::HybridEncoded::Bitpacked(packed) => {
+                let remaining = length - values.len();
+                let len = std::cmp::min(packed.len() * 8, remaining);
+                for is_valid in BitmapIter::new(packed, 0, len) {
+                    validity.push(is_valid);
+                    if is_valid {
+                        let index = indices.next().unwrap() as usize;
+                        let dict_offset_i = dict_offsets[index] as usize;
+                        let dict_offset_ip1 = dict_offsets[index + 1] as usize;
+                        let length = dict_offset_ip1 - dict_offset_i;
+                        last_offset += O::from_usize(length).unwrap();
+                        values.extend_from_slice(&dict_values[dict_offset_i..dict_offset_ip1]);
+                    };
+                    offsets.push(last_offset);
+                }
+            }
+            hybrid_rle::HybridEncoded::Rle(value, additional) => {
+                let is_set = value[0] == 1;
+                validity.extend_constant(additional, is_set);
+                if is_set {
+                    (0..additional).for_each(|_| {
+                        let index = indices.next().unwrap() as usize;
+                        let dict_offset_i = dict_offsets[index] as usize;
+                        let dict_offset_ip1 = dict_offsets[index + 1] as usize;
+                        let length = dict_offset_ip1 - dict_offset_i;
+                        last_offset += O::from_usize(length).unwrap();
+                        values.extend_from_slice(&dict_values[dict_offset_i..dict_offset_ip1]);
+                    })
+                } else {
+                    offsets.extend_constant(additional, last_offset)
+                }
+            }
+        }
+    }
+}
+
+fn read_buffer<O: Offset>(
+    buffer: &[u8],
+    length: u32,
+    _has_validity: bool,
+    offsets: &mut MutableBuffer<O>,
+    values: &mut MutableBuffer<u8>,
+    validity: &mut MutableBitmap,
+) {
+    let length = length as usize;
+    let mut last_offset = *offsets.as_slice_mut().last().unwrap();
+
+    // split in two buffers: def_levels and data
+    let def_level_buffer_length = get_length(buffer) as usize;
+    let validity_buffer = &buffer[4..4 + def_level_buffer_length];
+    let values_buffer = &buffer[4 + def_level_buffer_length..];
+
+    // values_buffer: first 4 bytes are len, remaining is values
+    let mut values_iterator = utils::BinaryIter::new(values_buffer);
+
+    let validity_iterator = hybrid_rle::Decoder::new(&validity_buffer, 1);
+
+    validity.reserve(length);
+    values.reserve(length);
+    for run in validity_iterator {
+        match run {
+            hybrid_rle::HybridEncoded::Bitpacked(packed) => {
+                // the pack may contain more items than needed.
+                let remaining = length - values.len();
+                let len = std::cmp::min(packed.len() * 8, remaining);
+                for is_valid in BitmapIter::new(packed, 0, len) {
+                    validity.push(is_valid);
+                    let value = values_iterator.next().unwrap();
+                    last_offset += O::from_usize(value.len()).unwrap();
+                    offsets.push(last_offset);
+                    values.extend_from_slice(value);
+                }
+            }
+            hybrid_rle::HybridEncoded::Rle(value, additional) => {
+                let is_set = value[0] == 1;
+                validity.extend_constant(additional, is_set);
+                if is_set {
+                    (0..additional).for_each(|_| {
+                        let value = values_iterator.next().unwrap();
+                        last_offset += O::from_usize(value.len()).unwrap();
+                        offsets.push(last_offset);
+                        values.extend_from_slice(value)
+                    })
+                } else {
+                    offsets.extend_constant(additional, last_offset)
+                }
+            }
+        }
+    }
+}
+
+pub fn iter_to_array<O, I, E>(mut iter: I, descriptor: &ColumnDescriptor) -> Result<Utf8Array<O>>
+where
+    ArrowError: From<E>,
+    O: Offset,
+    I: Iterator<Item = std::result::Result<Page, E>>,
+{
+    // todo: push metadata from the file to get this capacity
+    let capacity = 0;
+    let mut values = MutableBuffer::<u8>::with_capacity(0);
+    let mut offsets = MutableBuffer::<O>::with_capacity(1 + capacity);
+    offsets.push(O::default());
+    let mut validity = MutableBitmap::with_capacity(capacity);
+    iter.try_for_each(|page| {
+        extend_from_page(page?, &descriptor, &mut offsets, &mut values, &mut validity)
+    })?;
+
+    Ok(Utf8Array::from_data(
+        offsets.into(),
+        values.into(),
+        validity.into(),
+    ))
+}
+
+fn extend_from_page<O: Offset>(
+    page: Page,
+    descriptor: &ColumnDescriptor,
+    offsets: &mut MutableBuffer<O>,
+    values: &mut MutableBuffer<u8>,
+    validity: &mut MutableBitmap,
+) -> Result<()> {
+    let page = decompress_page(page).map_err(ArrowError::from_external_error)?;
+    assert_eq!(descriptor.max_rep_level(), 0);
+    assert_eq!(descriptor.max_def_level(), 1);
+    let has_validity = descriptor.max_def_level() == 1;
+    match page {
+        Page::V1(page) => {
+            assert_eq!(page.def_level_encoding, Encoding::Rle);
+            match (&page.encoding, &page.dictionary_page) {
+                (Encoding::PlainDictionary, Some(dict)) => read_dict_buffer::<O>(
+                    &page.buf,
+                    page.num_values,
+                    dict.as_any().downcast_ref().unwrap(),
+                    has_validity,
+                    offsets,
+                    values,
+                    validity,
+                ),
+                (Encoding::Plain, None) => read_buffer::<O>(
+                    &page.buf,
+                    page.num_values,
+                    has_validity,
+                    offsets,
+                    values,
+                    validity,
+                ),
+                (encoding, None) => {
+                    return Err(ArrowError::NotYetImplemented(format!(
+                        "Encoding {:?} not yet implemented for Binary",
+                        encoding
+                    )))
+                }
+                _ => todo!(),
+            }
+        }
+        Page::V2(_) => todo!(),
+    };
+    Ok(())
+}

--- a/src/io/parquet/read/utils.rs
+++ b/src/io/parquet/read/utils.rs
@@ -25,3 +25,19 @@ impl<'a> Iterator for BinaryIter<'a> {
         Some(result)
     }
 }
+
+#[inline]
+pub fn split_buffer_v1(buffer: &[u8]) -> (&[u8], &[u8]) {
+    let def_level_buffer_length = get_length(&buffer) as usize;
+    (
+        &buffer[4..4 + def_level_buffer_length],
+        &buffer[4 + def_level_buffer_length..],
+    )
+}
+
+pub fn split_buffer_v2(buffer: &[u8], def_level_buffer_length: usize) -> (&[u8], &[u8]) {
+    (
+        &buffer[..def_level_buffer_length],
+        &buffer[def_level_buffer_length..],
+    )
+}

--- a/src/io/parquet/read/utils.rs
+++ b/src/io/parquet/read/utils.rs
@@ -1,0 +1,27 @@
+use parquet2::encoding::get_length;
+
+pub struct BinaryIter<'a> {
+    values: &'a [u8],
+}
+
+impl<'a> BinaryIter<'a> {
+    pub fn new(values: &'a [u8]) -> Self {
+        Self { values }
+    }
+}
+
+impl<'a> Iterator for BinaryIter<'a> {
+    type Item = &'a [u8];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.values.is_empty() {
+            return None;
+        }
+        let length = get_length(self.values) as usize;
+        self.values = &self.values[4..];
+        let result = &self.values[4..length as usize];
+        self.values = &self.values[4 + length..];
+        Some(result)
+    }
+}


### PR DESCRIPTION
This PR adds initial support to read from parquet.

This (and the whole [parquet2](https://github.com/jorgecarleitao/parquet2)) does not use `unsafe` and is ~10-20x faster than the official `parquet` crate. It also scales better with increasing size.

It supports all physical types but a very limited number of logical types. V2 pages are also not yet supported. It does support the two most common encodings (dict and RLE-bitpacking hybrid).

This PR also:

* adds Python code to generate parquet files from pyarrow, for the purposes of integration testing and benchmarking.
* adds interoperability tests against `pyarrow==3` for `i64`, `f64`, `bool` and `utf8`.
* adds a bench to read from parquet
* adds Python to benchmark reading a parquet from pyarrow
* (`parquet2`, really) opens the possibility to deserialize parquet files in parallel, as it decouples the reading of parquet pages (IO-intensive) from deserialization (CPU-intensive).

Some benchmarks (reading 10^4 and 10^5 with null density ~40%) generated by pyarrow:

parquet+arrow (master):
```
read u64 10000          time:   [217.26 us 217.41 us 217.58 us]
read u64 100000         time:   [1.6632 ms 1.6761 ms 1.6876 ms]
read utf8 10000         time:   [611.50 us 611.92 us 612.34 us]
read utf8 100000        time:   [5.7691 ms 5.7763 ms 5.7836 ms]
```

This PR:
```
read u64 10000          time:   [81.456 us 81.552 us 81.650 us]
read u64 100000         time:   [138.43 us 138.54 us 138.64 us]
read utf8 10000         time:   [89.185 us 89.281 us 89.380 us]
read utf8 100000        time:   [274.32 us 274.49 us 274.68 us]
```

Using a brute `timeit` on pyarrow yields 

```
read u64 100000     time: 1.540 ms
read utf8 100000    time: 3.532 ms
```

This is not 100% fair as `parquet` also reads the arrow schema and pyarrow has some python overhead, but IMO those do not explain the significant difference.

This purposely does not read row groups to `RecordBatch`es, as that operation can be trivially parallelizable across columns and should thus be handled downstream (DataFusion, Polars, etc.), according to their respective execution model (async, custom scheduler, rayon, etc.).

Closes #21 