### PR TITLE
Added writing primitives to parquet (ints, floats, bool, utf8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ itertools = { version = "^0.10", optional = true }
 
 [dependencies.parquet2]
 git = "https://github.com/jorgecarleitao/parquet2"
-rev = "e6b81efb228ac1137e290c58e2ca531b4d13ff46"
+rev = "1ec0838e5dae7e5fe1ae70bd479179446a8e3270"
 default-features = false
 features = ["snappy", "gzip", "lz4", "zstd", "brotli"]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,3 +109,7 @@ harness = false
 [[bench]]
 name = "read_parquet"
 harness = false
+
+[[bench]]
+name = "write_parquet"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ itertools = { version = "^0.10", optional = true }
 
 [dependencies.parquet2]
 git = "https://github.com/jorgecarleitao/parquet2"
-rev = "58975badad09819dd5bdb09c7441ab3239bb14c1"
+rev = "e6b81efb228ac1137e290c58e2ca531b4d13ff46"
 default-features = false
 features = ["snappy", "gzip", "lz4", "zstd", "brotli"]
 optional = true

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ venv/bin/python -m parquet_integration/write_parquet.py
 ## Features in this crate and not in the original
 
 * Uses Rust's compiler whenever possible to prove that memory reads are sound
+* Reading parquet is 10-20x faster (single core) and deserialization is parallelizable
+* Writing parquet is 3-10x faster (single core) and serialization is parallelizable
 * MIRI checks on non-IO components (MIRI and file systems are a bit funny atm)
+* parquet IO has no `unsafe`
 * IPC supports big endian
 * More predictable JSON reader
 * Generalized parsing of CSV based on logical data types
@@ -52,16 +55,14 @@ venv/bin/python -m parquet_integration/write_parquet.py
 
 ## Features in the original not availabe in this crate
 
-* Parquet write
-* some compute kernels
-* SIMD (no plans to support: favor auto-vectorization instead)
+* Parquet read of nested types, arrow schema from the metadata, etc.
+* Parquet write V2, nested types, arrow schema to the metadata, etc.
 
 ## Roadmap
 
-1. parquet IO
-2. bring documentation up to speed
-3. compute kernels
-4. auto-vectorization of bitmap operations
+1. parquet read of nested types, arrow schema from the metadata, etc.
+2. parquet nested types, arrow schema to the metadata, etc.
+3. bring documentation up to speed
 
 ## How to develop
 

--- a/benches/read_parquet.rs
+++ b/benches/read_parquet.rs
@@ -9,8 +9,10 @@ use parquet2::read::{get_page_iterator, read_metadata};
 fn read_decompressed_pages(size: usize, column: usize) -> Result<()> {
     // reads decompressed pages (i.e. CPU)
     let dir = env!("CARGO_MANIFEST_DIR");
-    let path =
-        PathBuf::from(dir).join(format!("fixtures/pyarrow3/v1/basic_nulls_{}.parquet", size));
+    let path = PathBuf::from(dir).join(format!(
+        "fixtures/pyarrow3/v1/basic_nullable_{}.parquet",
+        size
+    ));
     let mut file = File::open(path).unwrap();
 
     let metadata = read_metadata(&mut file)?;

--- a/benches/write_parquet.rs
+++ b/benches/write_parquet.rs
@@ -6,7 +6,7 @@ use arrow2::array::*;
 use arrow2::datatypes::DataType;
 use arrow2::error::Result;
 use arrow2::io::parquet::write::array_to_page;
-use arrow2::util::bench_util::{create_boolean_array, create_primitive_array};
+use arrow2::util::bench_util::{create_boolean_array, create_primitive_array, create_string_array};
 
 use parquet2::{
     compression::CompressionCodec, metadata::SchemaDescriptor, schema::io_message::from_message,
@@ -18,18 +18,18 @@ fn write(array: &dyn Array) -> Result<()> {
         array_to_page(array),
     )))));
 
-    // prepare schema
-    let a = match array.data_type() {
-        DataType::Int32 => "INT32",
-        DataType::Int64 => "INT64",
-        DataType::Float32 => "FLOAT",
-        DataType::Float64 => "DOUBLE",
-        DataType::Boolean => "BOOLEAN",
+    let (physical, converted) = match array.data_type() {
+        DataType::Int32 => ("INT32", ""),
+        DataType::Int64 => ("INT64", ""),
+        DataType::Float32 => ("FLOAT", ""),
+        DataType::Float64 => ("DOUBLE", ""),
+        DataType::Boolean => ("BOOLEAN", ""),
+        DataType::Utf8 => ("BYTE_ARRAY", "(UTF8)"),
         _ => todo!(),
     };
     let schema = SchemaDescriptor::new(from_message(&format!(
-        "message schema {{ OPTIONAL {} col; }}",
-        a
+        "message schema {{ OPTIONAL {} col {}; }}",
+        physical, converted
     ))?);
 
     let mut writer = Cursor::new(vec![]);
@@ -53,6 +53,12 @@ fn add_benchmark(c: &mut Criterion) {
     (0..=10).step_by(2).for_each(|i| {
         let array = &create_boolean_array(1024 * 2usize.pow(i), 0.1, 0.5);
         let a = format!("write bool 2^{}", 10 + i);
+        c.bench_function(&a, |b| b.iter(|| write(array).unwrap()));
+    });
+
+    (0..=10).step_by(2).for_each(|i| {
+        let array = &create_string_array::<i32>(1024 * 2usize.pow(i), 0.1);
+        let a = format!("write utf8 2^{}", 10 + i);
         c.bench_function(&a, |b| b.iter(|| write(array).unwrap()));
     });
 }

--- a/benches/write_parquet.rs
+++ b/benches/write_parquet.rs
@@ -1,0 +1,57 @@
+use std::io::Cursor;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use arrow2::array::*;
+use arrow2::datatypes::DataType;
+use arrow2::error::Result;
+use arrow2::io::parquet::write::array_to_page;
+use arrow2::util::bench_util::create_primitive_array;
+
+use parquet2::{
+    compression::CompressionCodec, metadata::SchemaDescriptor, schema::io_message::from_message,
+    write::write_file,
+};
+
+fn write(array: &dyn Array) -> Result<()> {
+    let row_groups = std::iter::once(Result::Ok(std::iter::once(Ok(std::iter::once(
+        array_to_page(array),
+    )))));
+
+    // prepare schema
+    let a = match array.data_type() {
+        DataType::Int32 => "INT32",
+        DataType::Int64 => "INT64",
+        DataType::Float32 => "FLOAT",
+        DataType::Float64 => "DOUBLE",
+        _ => todo!(),
+    };
+    let schema = SchemaDescriptor::new(from_message(&format!(
+        "message schema {{ OPTIONAL {} col; }}",
+        a
+    ))?);
+
+    let mut writer = Cursor::new(vec![]);
+    write_file(
+        &mut writer,
+        &schema,
+        CompressionCodec::Uncompressed,
+        row_groups,
+    )
+    .unwrap();
+    Ok(())
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    // parity with `parquet` crates' bench
+    let array = &create_primitive_array::<i64>(1024, DataType::Int64, 0.1);
+    c.bench_function("write i64 2^10", |b| b.iter(|| write(array).unwrap()));
+
+    let array = &create_primitive_array::<i64>(1024 * 4, DataType::Int64, 0.1);
+    c.bench_function("write i64 2^12", |b| b.iter(|| write(array).unwrap()));
+    let array = &create_primitive_array::<i64>(1024 * 4 * 4, DataType::Int64, 0.1);
+    c.bench_function("write i64 2^14", |b| b.iter(|| write(array).unwrap()));
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/parquet_integration/bench_pyarrow.py
+++ b/parquet_integration/bench_pyarrow.py
@@ -3,7 +3,7 @@ import timeit
 import pyarrow.parquet
 
 def f(column):
-    pyarrow.parquet.read_table("fixtures/pyarrow3/basic_nulls_100000.parquet", columns=[column])
+    pyarrow.parquet.read_table("fixtures/pyarrow3/basic_nullable_100000.parquet", columns=[column])
 
 seconds = timeit.Timer(lambda: f("int64")).timeit(number=512) / 512
 microseconds = seconds * 1000 * 1000

--- a/parquet_integration/bench_write.py
+++ b/parquet_integration/bench_write.py
@@ -1,0 +1,75 @@
+"""
+Benchmark of writing a pyarrow table of size N to parquet.
+"""
+import io
+import os
+import timeit
+
+import numpy
+import pyarrow.parquet
+
+
+def case_basic_nullable(size = 1):
+    int64 = [0, 1, None, 3, None, 5, 6, 7, None, 9]
+    float64 = [0.0, 1.0, None, 3.0, None, 5.0, 6.0, 7.0, None, 9.0]
+    string = ["Hello", None, "aa", "", None, "abc", None, None, "def", "aaa"]
+    boolean = [True, None, False, False, None, True, None, None, True, True]
+
+    fields = [
+        pa.field('int64', pa.int64()),
+        pa.field('float64', pa.float64()),
+        pa.field('string', pa.utf8()),
+        pa.field('bool', pa.bool_()),
+        pa.field('date', pa.timestamp('ms')),
+        pa.field('uint32', pa.uint32()),
+    ]
+    schema = pa.schema(fields)
+
+    return {
+        "int64": int64 * size,
+        "float64": float64 * size,
+        "string": string * size,
+        "bool": boolean * size,
+        "date": int64 * size,
+        "uint32": int64 * size,
+    }, schema, f"basic_nullable_{size*10}.parquet"
+
+def bench(log2_size: int, datatype: str):
+
+    if datatype == 'int64':
+        data = [0, 1, None, 3, 4, 5, 6, 7] * 128   # 1024 entries
+        field = pyarrow.field('int64', pyarrow.int64())
+    elif datatype == 'utf8':
+        # 4 each because our own benches also use 4
+        data = ["aaaa", "aaab", None, "aaac", "aaad", "aaae", "aaaf", "aaag"] * 128   # 1024 entries
+        field = pyarrow.field('utf8', pyarrow.utf8())
+    elif datatype == 'bool':
+        data = [True, False, None, True, False, True, True, True] * 128   # 1024 entries
+        field = pyarrow.field('bool', pyarrow.bool_())
+
+    data = data * 2**log2_size
+
+    t = pyarrow.table([data], schema=pyarrow.schema([field]))
+
+    def f():
+        page_version = 1
+        pyarrow.parquet.write_table(t,
+            io.BytesIO(),
+            use_dictionary=False,
+            compression=None,
+            write_statistics=False,
+            data_page_size=2**40,  # i.e. a large number to ensure a single page
+            data_page_version="1.0")
+
+    seconds = timeit.Timer(f).timeit(number=512) / 512
+    microseconds = seconds * 1000 * 1000
+    print(f"write {datatype} 2^{10 + log2_size}     time: {microseconds:.2f} us")
+
+for i in range(0, 12, 2):
+    bench(i, "int64")
+
+for i in range(0, 12, 2):
+    bench(i, "utf8")
+
+for i in range(0, 12, 2):
+    bench(i, "bool")

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -14,7 +14,7 @@ mod tests {
     use crate::array::*;
     use crate::datatypes::*;
 
-    pub fn pyarrow_integration(column: usize) -> Box<dyn Array> {
+    pub fn pyarrow_nullable(column: usize) -> Box<dyn Array> {
         let i64_values = &[
             Some(0),
             Some(1),
@@ -80,6 +80,27 @@ mod tests {
                     .collect::<Vec<_>>();
                 Box::new(Primitive::<u32>::from(values).to(DataType::UInt32))
             }
+            _ => unreachable!(),
+        }
+    }
+
+    // these values match the values in `integration`
+    pub fn pyarrow_required(column: usize) -> Box<dyn Array> {
+        let i64_values = &[
+            Some(0),
+            Some(1),
+            Some(2),
+            Some(3),
+            Some(4),
+            Some(5),
+            Some(6),
+            Some(7),
+            Some(8),
+            Some(9),
+        ];
+
+        match column {
+            0 => Box::new(Primitive::<i64>::from(i64_values).to(DataType::Int64)),
             _ => unreachable!(),
         }
     }

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -1,9 +1,86 @@
 use crate::error::ArrowError;
 
 pub mod read;
+pub mod write;
 
 impl From<parquet2::error::ParquetError> for ArrowError {
     fn from(error: parquet2::error::ParquetError) -> Self {
         ArrowError::External("".to_string(), Box::new(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::array::*;
+    use crate::datatypes::*;
+
+    pub fn pyarrow_integration(column: usize) -> Box<dyn Array> {
+        let i64_values = &[
+            Some(0),
+            Some(1),
+            None,
+            Some(3),
+            None,
+            Some(5),
+            Some(6),
+            Some(7),
+            None,
+            Some(9),
+        ];
+
+        match column {
+            0 => Box::new(Primitive::<i64>::from(i64_values).to(DataType::Int64)),
+            1 => Box::new(
+                Primitive::<f64>::from(&[
+                    Some(0.0),
+                    Some(1.0),
+                    None,
+                    Some(3.0),
+                    None,
+                    Some(5.0),
+                    Some(6.0),
+                    Some(7.0),
+                    None,
+                    Some(9.0),
+                ])
+                .to(DataType::Float64),
+            ),
+            2 => Box::new(Utf8Array::<i32>::from(&vec![
+                Some("Hello".to_string()),
+                None,
+                Some("aa".to_string()),
+                Some("".to_string()),
+                None,
+                Some("abc".to_string()),
+                None,
+                None,
+                Some("def".to_string()),
+                Some("aaa".to_string()),
+            ])),
+            3 => Box::new(BooleanArray::from(&[
+                Some(true),
+                None,
+                Some(false),
+                Some(false),
+                None,
+                Some(true),
+                None,
+                None,
+                Some(true),
+                Some(true),
+            ])),
+            4 => Box::new(
+                Primitive::<i64>::from(i64_values)
+                    .to(DataType::Timestamp(TimeUnit::Millisecond, None)),
+            ),
+            5 => {
+                let values = i64_values
+                    .iter()
+                    .map(|x| x.map(|x| x as u32))
+                    .collect::<Vec<_>>();
+                Box::new(Primitive::<u32>::from(values).to(DataType::UInt32))
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/src/io/parquet/read/boolean.rs
+++ b/src/io/parquet/read/boolean.rs
@@ -34,11 +34,11 @@ fn read_bitmap(
     values.reserve(length);
     for run in validity_iterator {
         match run {
-            hybrid_rle::HybridEncoded::Bitpacked(packed) => {
+            hybrid_rle::HybridEncoded::Bitpacked(packed_validity) => {
                 // the pack may contain more items than needed.
                 let remaining = length - values.len();
-                let len = std::cmp::min(packed.len() * 8, remaining);
-                for is_valid in BitmapIter::new(packed, 0, len) {
+                let len = std::cmp::min(packed_validity.len() * 8, remaining);
+                for is_valid in BitmapIter::new(packed_validity, 0, len) {
                     validity.push(is_valid);
                     let value = if is_valid {
                         values_iterator.next().unwrap()

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -110,13 +110,9 @@ pub fn page_iter_to_array<I: Iterator<Item = std::result::Result<CompressedPage,
             (PhysicalType::Boolean, None, None) => {
                 Ok(Box::new(boolean::iter_to_array(iter, descriptor)?))
             }
-            (
-                PhysicalType::ByteArray,
-                Some(PrimitiveConvertedType::Utf8),
-                Some(LogicalType::STRING(_)),
-            ) => Ok(Box::new(utf8::iter_to_array::<i32, _, _>(
-                iter, descriptor,
-            )?)),
+            (PhysicalType::ByteArray, Some(PrimitiveConvertedType::Utf8), _) => Ok(Box::new(
+                utf8::iter_to_array::<i32, _, _>(iter, descriptor)?,
+            )),
             (p, c, l) => Err(ArrowError::NotYetImplemented(format!(
                 "The conversion of ({:?}, {:?}, {:?}) to arrow still not implemented",
                 p, c, l

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -134,77 +134,8 @@ mod tests {
 
     use crate::array::*;
 
+    use super::super::tests::pyarrow_integration;
     use super::*;
-
-    fn pyarrow_integration(column: usize) -> Box<dyn Array> {
-        let i64_values = &[
-            Some(0),
-            Some(1),
-            None,
-            Some(3),
-            None,
-            Some(5),
-            Some(6),
-            Some(7),
-            None,
-            Some(9),
-        ];
-
-        match column {
-            0 => Box::new(Primitive::<i64>::from(i64_values).to(DataType::Int64)),
-            1 => Box::new(
-                Primitive::<f64>::from(&[
-                    Some(0.0),
-                    Some(1.0),
-                    None,
-                    Some(3.0),
-                    None,
-                    Some(5.0),
-                    Some(6.0),
-                    Some(7.0),
-                    None,
-                    Some(9.0),
-                ])
-                .to(DataType::Float64),
-            ),
-            2 => Box::new(Utf8Array::<i32>::from(&vec![
-                Some("Hello".to_string()),
-                None,
-                Some("aa".to_string()),
-                Some("".to_string()),
-                None,
-                Some("abc".to_string()),
-                None,
-                None,
-                Some("def".to_string()),
-                Some("aaa".to_string()),
-            ])),
-            3 => Box::new(BooleanArray::from(&[
-                Some(true),
-                None,
-                Some(false),
-                Some(false),
-                None,
-                Some(true),
-                None,
-                None,
-                Some(true),
-                Some(true),
-            ])),
-            4 => Box::new(
-                Primitive::<i64>::from(i64_values)
-                    .to(DataType::Timestamp(TimeUnit::Millisecond, None)),
-            ),
-            5 => {
-                let values = i64_values
-                    .iter()
-                    .map(|x| x.map(|x| x as u32))
-                    .collect::<Vec<_>>();
-                Box::new(Primitive::<u32>::from(values).to(DataType::UInt32))
-            }
-            _ => unreachable!(),
-        }
-    }
 
     fn get_column(path: &str, row_group: usize, column: usize) -> Result<Box<dyn Array>> {
         let mut file = File::open(path).unwrap();

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -130,7 +130,7 @@ mod tests {
 
     use crate::array::*;
 
-    use super::super::tests::pyarrow_integration;
+    use super::super::tests::*;
     use super::*;
 
     fn get_column(path: &str, row_group: usize, column: usize) -> Result<Box<dyn Array>> {
@@ -144,16 +144,28 @@ mod tests {
         page_iter_to_array(iter, &descriptor)
     }
 
-    #[test]
-    fn pyarrow_integration_v1_int64() -> Result<()> {
+    fn test_pyarrow_integration(column: usize, version: usize, required: bool) -> Result<()> {
         if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
             return Ok(());
         }
-        let column = 0;
-        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
-        let array = get_column(path, 0, column)?;
+        let path = if required {
+            format!(
+                "fixtures/pyarrow3/v{}/basic_{}_10.parquet",
+                version, "required"
+            )
+        } else {
+            format!(
+                "fixtures/pyarrow3/v{}/basic_{}_10.parquet",
+                version, "nullable"
+            )
+        };
+        let array = get_column(&path, 0, column)?;
 
-        let expected = pyarrow_integration(column);
+        let expected = if required {
+            pyarrow_required(column)
+        } else {
+            pyarrow_nullable(column)
+        };
 
         assert_eq!(expected.as_ref(), array.as_ref());
 
@@ -161,131 +173,48 @@ mod tests {
     }
 
     #[test]
-    fn pyarrow_integration_v1_float64() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
-            return Ok(());
-        }
-        let column = 1;
-        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
-        let array = get_column(path, 0, column)?;
-
-        let expected = pyarrow_integration(column);
-
-        assert_eq!(expected.as_ref(), array.as_ref());
-
-        Ok(())
+    fn v1_int64_nullable() -> Result<()> {
+        test_pyarrow_integration(0, 1, false)
     }
 
     #[test]
-    fn pyarrow_integration_v1_utf8() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
-            return Ok(());
-        }
-        let column = 2;
-        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
-        let array = get_column(path, 0, column)?;
-
-        let expected = pyarrow_integration(column);
-
-        assert_eq!(expected.as_ref(), array.as_ref());
-
-        Ok(())
+    fn v1_float64_nullable() -> Result<()> {
+        test_pyarrow_integration(1, 1, false)
     }
 
     #[test]
-    fn pyarrow_integration_v1_boolean() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
-            return Ok(());
-        }
-        let column = 3;
-        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
-        let array = get_column(path, 0, column)?;
-
-        let expected = pyarrow_integration(column);
-
-        assert_eq!(expected.as_ref(), array.as_ref());
-
-        Ok(())
+    fn v1_utf8_nullable() -> Result<()> {
+        test_pyarrow_integration(2, 1, false)
     }
 
     #[test]
-    fn pyarrow_integration_v1_timestamp() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
-            return Ok(());
-        }
-        let column = 4;
-        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
-        let array = get_column(path, 0, column)?;
+    fn v1_boolean_nullable() -> Result<()> {
+        test_pyarrow_integration(3, 1, false)
+    }
 
-        let expected = pyarrow_integration(column);
-
-        assert_eq!(expected.as_ref(), array.as_ref());
-
-        Ok(())
+    #[test]
+    fn v1_timestamp_nullable() -> Result<()> {
+        test_pyarrow_integration(4, 1, false)
     }
 
     #[test]
     #[ignore] // pyarrow issue; see https://issues.apache.org/jira/browse/ARROW-12201
-    fn pyarrow_integration_v1_u32() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
-            return Ok(());
-        }
-        let column = 5;
-        let path = "fixtures/pyarrow3/v1/basic_nulls_10.parquet";
-        let array = get_column(path, 0, column)?;
-
-        let expected = pyarrow_integration(column);
-
-        assert_eq!(expected.as_ref(), array.as_ref());
-
-        Ok(())
+    fn v1_u32_nullable() -> Result<()> {
+        test_pyarrow_integration(5, 1, false)
     }
 
     #[test]
-    fn pyarrow_integration_v2_int64() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
-            return Ok(());
-        }
-        let column = 0;
-        let path = "fixtures/pyarrow3/v2/basic_nulls_10.parquet";
-        let array = get_column(path, 0, column)?;
-
-        let expected = pyarrow_integration(column);
-
-        assert_eq!(expected.as_ref(), array.as_ref());
-
-        Ok(())
+    fn v2_int64_nullable() -> Result<()> {
+        test_pyarrow_integration(0, 2, false)
     }
 
     #[test]
-    fn pyarrow_integration_v2_utf8() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
-            return Ok(());
-        }
-        let column = 2;
-        let path = "fixtures/pyarrow3/v2/basic_nulls_10.parquet";
-        let array = get_column(path, 0, column)?;
-
-        let expected = pyarrow_integration(column);
-
-        assert_eq!(expected.as_ref(), array.as_ref());
-
-        Ok(())
+    fn v2_utf8_nullable() -> Result<()> {
+        test_pyarrow_integration(2, 2, false)
     }
 
     #[test]
-    fn pyarrow_integration_v2_boolean() -> Result<()> {
-        if std::env::var("ARROW2_IGNORE_PARQUET").is_ok() {
-            return Ok(());
-        }
-        let column = 3;
-        let path = "fixtures/pyarrow3/v2/basic_nulls_10.parquet";
-        let array = get_column(path, 0, column)?;
-
-        let expected = pyarrow_integration(column);
-
-        assert_eq!(expected.as_ref(), array.as_ref());
-
-        Ok(())
+    fn v2_boolean_nullable() -> Result<()> {
+        test_pyarrow_integration(3, 2, false)
     }
 }

--- a/src/io/parquet/read/primitive.rs
+++ b/src/io/parquet/read/primitive.rs
@@ -23,7 +23,6 @@ fn read_dict_buffer<T: NativeType + ArrowNativeType>(
     indices_buffer: &[u8],
     length: u32,
     dict: &PrimitivePageDict<T>,
-    _has_validity: bool,
     values: &mut MutableBuffer<T>,
     validity: &mut MutableBitmap,
 ) {
@@ -75,11 +74,10 @@ fn read_dict_buffer<T: NativeType + ArrowNativeType>(
     }
 }
 
-fn read_buffer<T: NativeType + ArrowNativeType>(
+fn read_nullable<T: NativeType + ArrowNativeType>(
     validity_buffer: &[u8],
     values_buffer: &[u8],
     length: u32,
-    _has_validity: bool,
     values: &mut MutableBuffer<T>,
     validity: &mut MutableBitmap,
 ) {
@@ -123,6 +121,23 @@ fn read_buffer<T: NativeType + ArrowNativeType>(
     }
 }
 
+fn read_required<T: NativeType + ArrowNativeType>(
+    values_buffer: &[u8],
+    length: u32,
+    values: &mut MutableBuffer<T>,
+) {
+    // todo: for little endian machines this can be replaced by `extend_from_slice`
+    // via transmute.
+    let length = length as usize;
+    let size = std::mem::size_of::<T>();
+
+    let chunks = values_buffer[..length * size].chunks_exact(size);
+
+    let iter = chunks.map(|chunk| types::decode::<T>(chunk));
+
+    values.extend(iter);
+}
+
 pub fn iter_to_array<T, I, E>(
     mut iter: I,
     descriptor: &ColumnDescriptor,
@@ -154,32 +169,32 @@ fn extend_from_page<T: NativeType + ArrowNativeType>(
 ) -> Result<()> {
     let page = decompress_page(page)?;
     assert_eq!(descriptor.max_rep_level(), 0);
-    assert_eq!(descriptor.max_def_level(), 1);
     let has_validity = descriptor.max_def_level() == 1;
     match page {
         Page::V1(page) => {
             assert_eq!(page.header.definition_level_encoding, Encoding::Rle);
             let (validity_buffer, values_buffer) = utils::split_buffer_v1(&page.buffer);
 
-            match (&page.header.encoding, &page.dictionary_page) {
-                (Encoding::PlainDictionary, Some(dict)) => read_dict_buffer::<T>(
+            match (&page.header.encoding, &page.dictionary_page, has_validity) {
+                (Encoding::PlainDictionary, Some(dict), true) => read_dict_buffer::<T>(
                     validity_buffer,
                     values_buffer,
                     page.header.num_values as u32,
                     dict.as_any().downcast_ref().unwrap(),
-                    has_validity,
                     values,
                     validity,
                 ),
-                (Encoding::Plain, None) => read_buffer::<T>(
+                (Encoding::Plain, None, true) => read_nullable::<T>(
                     validity_buffer,
                     values_buffer,
                     page.header.num_values as u32,
-                    has_validity,
                     values,
                     validity,
                 ),
-                (encoding, None) => {
+                (Encoding::Plain, None, false) => {
+                    read_required::<T>(values_buffer, page.header.num_values as u32, values)
+                }
+                (encoding, None, _) => {
                     return Err(ArrowError::NotYetImplemented(format!(
                         "Encoding {:?} not yet implemented",
                         encoding
@@ -192,25 +207,26 @@ fn extend_from_page<T: NativeType + ArrowNativeType>(
             let def_level_buffer_length = page.header.definition_levels_byte_length as usize;
             let (validity_buffer, values_buffer) =
                 utils::split_buffer_v2(&page.buffer, def_level_buffer_length);
-            match (&page.header.encoding, &page.dictionary_page) {
-                (Encoding::PlainDictionary, Some(dict)) => read_dict_buffer::<T>(
+            match (&page.header.encoding, &page.dictionary_page, has_validity) {
+                (Encoding::PlainDictionary, Some(dict), true) => read_dict_buffer::<T>(
                     validity_buffer,
                     values_buffer,
                     page.header.num_values as u32,
                     dict.as_any().downcast_ref().unwrap(),
-                    has_validity,
                     values,
                     validity,
                 ),
-                (Encoding::Plain, None) => read_buffer::<T>(
+                (Encoding::Plain, None, true) => read_nullable::<T>(
                     validity_buffer,
                     values_buffer,
                     page.header.num_values as u32,
-                    has_validity,
                     values,
                     validity,
                 ),
-                (encoding, None) => {
+                (Encoding::Plain, None, false) => {
+                    read_required::<T>(values_buffer, page.header.num_values as u32, values)
+                }
+                (encoding, None, _) => {
                     return Err(ArrowError::NotYetImplemented(format!(
                         "Encoding {:?} not yet implemented",
                         encoding

--- a/src/io/parquet/read/primitive.rs
+++ b/src/io/parquet/read/primitive.rs
@@ -85,8 +85,7 @@ fn read_buffer<T: NativeType + ArrowNativeType>(
 ) {
     let length = length as usize;
 
-    let mut chunks = values_buffer[..length as usize * std::mem::size_of::<T>()]
-        .chunks_exact(std::mem::size_of::<T>());
+    let mut chunks = values_buffer.chunks_exact(std::mem::size_of::<T>());
 
     let validity_iterator = hybrid_rle::Decoder::new(&validity_buffer, 1);
 

--- a/src/io/parquet/read/primitive.rs
+++ b/src/io/parquet/read/primitive.rs
@@ -2,7 +2,7 @@ use parquet2::{
     encoding::{hybrid_rle, Encoding},
     metadata::ColumnDescriptor,
     read::{decompress_page, CompressedPage, Page, PrimitivePageDict},
-    serialization::levels,
+    serialization::read::levels,
     types,
     types::NativeType,
 };

--- a/src/io/parquet/read/utf8.rs
+++ b/src/io/parquet/read/utf8.rs
@@ -2,7 +2,7 @@ use parquet2::{
     encoding::{hybrid_rle, Encoding},
     metadata::ColumnDescriptor,
     read::{decompress_page, BinaryPageDict, CompressedPage, Page},
-    serialization::levels,
+    serialization::read::levels,
 };
 
 use crate::{

--- a/src/io/parquet/read/utf8.rs
+++ b/src/io/parquet/read/utf8.rs
@@ -95,7 +95,6 @@ fn read_buffer<O: Offset>(
     let mut last_offset = *offsets.as_slice_mut().last().unwrap();
 
     // values_buffer: first 4 bytes are len, remaining is values
-    println!("{:?}", values_buffer);
     let mut values_iterator = utils::BinaryIter::new(values_buffer);
 
     let validity_iterator = hybrid_rle::Decoder::new(&validity_buffer, 1);
@@ -172,7 +171,6 @@ fn extend_from_page<O: Offset>(
     let has_validity = descriptor.max_def_level() == 1;
     match page {
         Page::V1(page) => {
-            println!("{:?}", page);
             assert_eq!(page.header.definition_level_encoding, Encoding::Rle);
             // split in two buffers: def_levels and data
             let (validity_buffer, values_buffer) = utils::split_buffer_v1(&page.buffer);

--- a/src/io/parquet/read/utils.rs
+++ b/src/io/parquet/read/utils.rs
@@ -20,8 +20,8 @@ impl<'a> Iterator for BinaryIter<'a> {
         }
         let length = get_length(self.values) as usize;
         self.values = &self.values[4..];
-        let result = &self.values[4..length as usize];
-        self.values = &self.values[4 + length..];
+        let result = &self.values[..length];
+        self.values = &self.values[length..];
         Some(result)
     }
 }

--- a/src/io/parquet/write/boolean.rs
+++ b/src/io/parquet/write/boolean.rs
@@ -1,0 +1,80 @@
+use parquet2::{
+    compression::create_codec,
+    encoding::{
+        hybrid_rle::{bitpacked_encode, encode},
+        Encoding,
+    },
+    read::{CompressedPage, PageV1},
+    schema::{CompressionCodec, DataPageHeader},
+};
+
+use crate::array::*;
+use crate::error::Result;
+
+pub fn array_to_page_v1(
+    array: &BooleanArray,
+    compression: CompressionCodec,
+) -> Result<CompressedPage> {
+    let validity = array.validity();
+
+    // parquet: first 4 bytes represent the length in bytes
+    let mut buffer = std::io::Cursor::new(vec![0; 4]);
+    buffer.set_position(4);
+
+    // encode def levels
+    if let Some(validity) = validity {
+        encode(&mut buffer, validity.iter())?;
+    }
+
+    let mut buffer = buffer.into_inner();
+    let length = buffer.len() - 4;
+    // todo: pay this small debt (loop?)
+    let length = length.to_le_bytes();
+    buffer[0] = length[0];
+    buffer[1] = length[1];
+    buffer[2] = length[2];
+    buffer[3] = length[3];
+
+    let iterator = array.iter().filter_map(|x| x).take(
+        validity
+            .as_ref()
+            .map(|x| x.len() - x.null_count())
+            .unwrap_or_else(|| array.len()),
+    );
+
+    // encode values using bitpacking
+    let len = buffer.len();
+    let mut buffer = std::io::Cursor::new(buffer);
+    buffer.set_position(len as u64);
+    bitpacked_encode(&mut buffer, iterator)?;
+    let buffer = buffer.into_inner();
+
+    let uncompressed_page_size = buffer.len();
+
+    let codec = create_codec(&compression)?;
+    let buffer = if let Some(mut codec) = codec {
+        // todo: remove this allocation by extending `buffer` directly.
+        // needs refactoring `compress`'s API.
+        let mut tmp = vec![];
+        codec.compress(&buffer, &mut tmp)?;
+        tmp
+    } else {
+        buffer
+    };
+
+    let header = DataPageHeader {
+        num_values: array.len() as i32,
+        encoding: Encoding::Plain,
+        definition_level_encoding: Encoding::Rle,
+        repetition_level_encoding: Encoding::Rle,
+        statistics: None,
+    };
+
+    Ok(CompressedPage::V1(PageV1 {
+        buffer,
+        header,
+        compression,
+        uncompressed_page_size,
+        dictionary_page: None,
+    }))
+}

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -53,7 +53,7 @@ mod tests {
     use crate::error::Result;
     use crate::io::parquet::read::page_iter_to_array;
 
-    use super::super::tests::pyarrow_integration;
+    use super::super::tests::*;
 
     fn read_column<R: Read + Seek>(
         reader: &mut R,
@@ -68,8 +68,8 @@ mod tests {
         page_iter_to_array(iter, &descriptor)
     }
 
-    fn round_trip(column: usize) -> Result<()> {
-        let array = pyarrow_integration(column);
+    fn round_trip_optional(column: usize) -> Result<()> {
+        let array = pyarrow_nullable(column);
 
         let row_groups = std::iter::once(Result::Ok(std::iter::once(Ok(std::iter::once(
             array_to_page(array.as_ref()),
@@ -106,17 +106,17 @@ mod tests {
     }
 
     #[test]
-    fn test_int32() -> Result<()> {
-        round_trip(0)
+    fn test_int32_optional() -> Result<()> {
+        round_trip_optional(0)
     }
 
     #[test]
-    fn test_utf8() -> Result<()> {
-        round_trip(2)
+    fn test_utf8_optional() -> Result<()> {
+        round_trip_optional(2)
     }
 
     #[test]
-    fn test_bool() -> Result<()> {
-        round_trip(3)
+    fn test_bool_optional() -> Result<()> {
+        round_trip_optional(3)
     }
 }

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -1,3 +1,4 @@
+mod boolean;
 mod primitive;
 
 use parquet2::{compression::CompressionCodec, read::CompressedPage};
@@ -10,6 +11,9 @@ pub fn array_to_page(array: &dyn Array) -> Result<CompressedPage> {
     // using plain encoding format
     let compression = CompressionCodec::Uncompressed;
     match array.data_type() {
+        DataType::Boolean => {
+            boolean::array_to_page_v1(array.as_any().downcast_ref().unwrap(), compression)
+        }
         DataType::Int32 => {
             primitive::array_to_page_v1::<i32>(array.as_any().downcast_ref().unwrap(), compression)
         }
@@ -70,6 +74,7 @@ mod tests {
             DataType::Int64 => "INT64",
             DataType::Float32 => "FLOAT",
             DataType::Float64 => "DOUBLE",
+            DataType::Boolean => "BOOLEAN",
             _ => todo!(),
         };
         let schema = SchemaDescriptor::new(from_message(&format!(
@@ -95,5 +100,10 @@ mod tests {
     #[test]
     fn test_int32() -> Result<()> {
         round_trip(0)
+    }
+
+    #[test]
+    fn test_bool() -> Result<()> {
+        round_trip(3)
     }
 }

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -1,0 +1,99 @@
+mod primitive;
+
+use parquet2::{compression::CompressionCodec, read::CompressedPage};
+
+use crate::array::*;
+use crate::datatypes::DataType;
+use crate::error::Result;
+
+pub fn array_to_page(array: &dyn Array) -> Result<CompressedPage> {
+    // using plain encoding format
+    let compression = CompressionCodec::Uncompressed;
+    match array.data_type() {
+        DataType::Int32 => {
+            primitive::array_to_page_v1::<i32>(array.as_any().downcast_ref().unwrap(), compression)
+        }
+        DataType::Int64 => {
+            primitive::array_to_page_v1::<i64>(array.as_any().downcast_ref().unwrap(), compression)
+        }
+        DataType::Float32 => {
+            primitive::array_to_page_v1::<f32>(array.as_any().downcast_ref().unwrap(), compression)
+        }
+        DataType::Float64 => {
+            primitive::array_to_page_v1::<f64>(array.as_any().downcast_ref().unwrap(), compression)
+        }
+        _ => todo!(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Read, Seek};
+
+    use super::*;
+
+    use parquet2::{
+        metadata::SchemaDescriptor,
+        read::{get_page_iterator, read_metadata},
+        schema::io_message::from_message,
+        write::write_file,
+    };
+
+    use crate::error::Result;
+    use crate::io::parquet::read::page_iter_to_array;
+
+    use super::super::tests::pyarrow_integration;
+
+    fn read_column<R: Read + Seek>(
+        reader: &mut R,
+        row_group: usize,
+        column: usize,
+    ) -> Result<Box<dyn Array>> {
+        let metadata = read_metadata(reader)?;
+        let iter = get_page_iterator(&metadata, row_group, column, reader)?;
+
+        let descriptor = iter.descriptor().clone();
+
+        page_iter_to_array(iter, &descriptor)
+    }
+
+    fn round_trip(column: usize) -> Result<()> {
+        let array = pyarrow_integration(column);
+
+        let row_groups = std::iter::once(Result::Ok(std::iter::once(Ok(std::iter::once(
+            array_to_page(array.as_ref()),
+        )))));
+
+        // prepare schema
+        let a = match array.data_type() {
+            DataType::Int32 => "INT32",
+            DataType::Int64 => "INT64",
+            DataType::Float32 => "FLOAT",
+            DataType::Float64 => "DOUBLE",
+            _ => todo!(),
+        };
+        let schema = SchemaDescriptor::new(from_message(&format!(
+            "message schema {{ OPTIONAL {} col; }}",
+            a
+        ))?);
+
+        let mut writer = Cursor::new(vec![]);
+        write_file(
+            &mut writer,
+            &schema,
+            CompressionCodec::Uncompressed,
+            row_groups,
+        )?;
+
+        let data = writer.into_inner();
+
+        let result = read_column(&mut Cursor::new(data), 0, 0)?;
+        assert_eq!(array.as_ref(), result.as_ref());
+        Ok(())
+    }
+
+    #[test]
+    fn test_int32() -> Result<()> {
+        round_trip(0)
+    }
+}

--- a/src/io/parquet/write/primitive.rs
+++ b/src/io/parquet/write/primitive.rs
@@ -1,0 +1,73 @@
+use parquet2::{
+    compression::create_codec,
+    encoding::{hybrid_rle::encode, Encoding},
+    read::{CompressedPage, PageV1},
+    schema::{CompressionCodec, DataPageHeader},
+    types,
+    types::NativeType,
+};
+
+use crate::{
+    array::{Array, PrimitiveArray},
+    error::Result,
+    types::NativeType as ArrowNativeType,
+};
+
+pub fn array_to_page_v1<T: NativeType + ArrowNativeType>(
+    array: &PrimitiveArray<T>,
+    compression: CompressionCodec,
+) -> Result<CompressedPage> {
+    let validity = array.validity();
+
+    // parquet: first 4 bytes represent the length in bytes
+    let mut buffer = std::io::Cursor::new(vec![0; 4]);
+    buffer.set_position(4);
+
+    // encode def levels
+    if let Some(validity) = validity {
+        encode(&mut buffer, validity.iter())?;
+    }
+    let mut buffer = buffer.into_inner();
+    let length = buffer.len() - 4;
+    // todo: pay this small debt (loop?)
+    let length = length.to_le_bytes();
+    buffer[0] = length[0];
+    buffer[1] = length[1];
+    buffer[2] = length[2];
+    buffer[3] = length[3];
+
+    // append the non-null values
+    array.iter().for_each(|x| {
+        if let Some(x) = x {
+            buffer.extend_from_slice(types::NativeType::to_le_bytes(x).as_ref())
+        }
+    });
+    let uncompressed_page_size = buffer.len();
+
+    let codec = create_codec(&compression)?;
+    let buffer = if let Some(mut codec) = codec {
+        // todo: remove this allocation by extending `buffer` directly.
+        // needs refactoring `compress`'s API.
+        let mut tmp = vec![];
+        codec.compress(&buffer, &mut tmp)?;
+        tmp
+    } else {
+        buffer
+    };
+
+    let header = DataPageHeader {
+        num_values: array.len() as i32,
+        encoding: Encoding::Plain,
+        definition_level_encoding: Encoding::Rle,
+        repetition_level_encoding: Encoding::Rle,
+        statistics: None,
+    };
+
+    Ok(CompressedPage::V1(PageV1 {
+        buffer,
+        header,
+        compression,
+        uncompressed_page_size,
+        dictionary_page: None,
+    }))
+}

--- a/src/io/parquet/write/utf8.rs
+++ b/src/io/parquet/write/utf8.rs
@@ -43,7 +43,6 @@ pub fn array_to_page_v1<O: Offset>(
         }
     });
     let uncompressed_page_size = buffer.len();
-    println!("{:?}", buffer);
 
     let codec = create_codec(&compression)?;
     let buffer = if let Some(mut codec) = codec {

--- a/src/io/parquet/write/utf8.rs
+++ b/src/io/parquet/write/utf8.rs
@@ -1,0 +1,74 @@
+use parquet2::{
+    compression::create_codec,
+    encoding::{hybrid_rle::encode, Encoding},
+    read::{CompressedPage, PageV1},
+    schema::{CompressionCodec, DataPageHeader},
+};
+
+use crate::{
+    array::{Array, Offset, Utf8Array},
+    error::Result,
+};
+
+pub fn array_to_page_v1<O: Offset>(
+    array: &Utf8Array<O>,
+    compression: CompressionCodec,
+) -> Result<CompressedPage> {
+    let validity = array.validity();
+
+    // parquet: first 4 bytes represent the length in bytes
+    let mut buffer = std::io::Cursor::new(vec![0; 4]);
+    buffer.set_position(4);
+
+    // encode def levels
+    if let Some(validity) = validity {
+        encode(&mut buffer, validity.iter())?;
+    }
+    let mut buffer = buffer.into_inner();
+    let length = buffer.len() - 4;
+    // todo: pay this small debt (loop?)
+    let length = length.to_le_bytes();
+    buffer[0] = length[0];
+    buffer[1] = length[1];
+    buffer[2] = length[2];
+    buffer[3] = length[3];
+
+    // append the non-null values
+    array.iter().for_each(|x| {
+        if let Some(x) = x {
+            // BYTE_ARRAY: first 4 bytes denote length in littleendian.
+            let len = (x.len() as u32).to_le_bytes();
+            buffer.extend_from_slice(&len);
+            buffer.extend_from_slice(x.as_bytes());
+        }
+    });
+    let uncompressed_page_size = buffer.len();
+    println!("{:?}", buffer);
+
+    let codec = create_codec(&compression)?;
+    let buffer = if let Some(mut codec) = codec {
+        // todo: remove this allocation by extending `buffer` directly.
+        // needs refactoring `compress`'s API.
+        let mut tmp = vec![];
+        codec.compress(&buffer, &mut tmp)?;
+        tmp
+    } else {
+        buffer
+    };
+
+    let header = DataPageHeader {
+        num_values: array.len() as i32,
+        encoding: Encoding::Plain,
+        definition_level_encoding: Encoding::Rle,
+        repetition_level_encoding: Encoding::Rle,
+        statistics: None,
+    };
+
+    Ok(CompressedPage::V1(PageV1 {
+        buffer,
+        header,
+        compression,
+        uncompressed_page_size,
+        dictionary_page: None,
+    }))
+}


### PR DESCRIPTION
This PR adds support to encode some primitive arrays, boolean, and utf8, into parquet with version 1 pages and PLAIN encoding. It is the first step to close the last missing feature of this crate, write to parquet.

Like reading, this does not introduce `unsafe`.

This yields speedups vs `parquet==3.0.0` (details below) (on my VM, writing to an in memory cursor) of about 3-10x, depending on the type.

Sheet with the numbers running on my VM available here: https://docs.google.com/spreadsheets/d/12Sj1kjhadT-l0KXirexQDOocsLg-M4Ao1jnqXstCpx0/edit?usp=sharing

Closes #35 
