### PR TITLE
Adding and subtracting duration to timestamp

### DIFF
--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -214,7 +214,13 @@ pub fn add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<Primit
 where
     T: NativeType + Add<Output = T>,
 {
-    binary(lhs, rhs, |a, b| a + b)
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    binary(lhs, rhs, lhs.data_type().clone(), |a, b| a + b)
 }
 
 #[inline]
@@ -231,7 +237,13 @@ fn subtract<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<Primi
 where
     T: NativeType + Sub<Output = T>,
 {
-    binary(lhs, rhs, |a, b| a - b)
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    binary(lhs, rhs, lhs.data_type().clone(), |a, b| a - b)
 }
 
 #[inline]
@@ -264,7 +276,13 @@ fn multiply<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<Primi
 where
     T: NativeType + Mul<Output = T>,
 {
-    binary(lhs, rhs, |lhs, rhs| lhs * rhs)
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    binary(lhs, rhs, lhs.data_type().clone(), |lhs, rhs| lhs * rhs)
 }
 
 #[inline]

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 //! Defines basic arithmetic kernels for `PrimitiveArrays`.
+pub mod timestamp;
 
 use std::ops::{Add, Div, Mul, Neg, Sub};
 

--- a/src/compute/arithmetics/timestamp.rs
+++ b/src/compute/arithmetics/timestamp.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 /// Calculates the scale factor between two TimeUnits. The function returns the
-/// number that should multiply the TimeUnit "b" to have at the same scale as
+/// scale that should multiply the TimeUnit "b" to have the same time scale as
 /// the TimeUnit "a".
 fn timeunit_scale(a: &TimeUnit, b: &TimeUnit) -> f64 {
     match (a, b) {

--- a/src/compute/arithmetics/timestamp.rs
+++ b/src/compute/arithmetics/timestamp.rs
@@ -1,0 +1,351 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines the arithmetic kernels for Timestamp and Duration.
+//! For the purposes of Arrow Implementations, adding this value to a Timestamp
+//! ("t1") naively (i.e. simply summing the two number) is acceptable even
+//! though in some cases the resulting Timestamp (t2) would not account for
+//! leap-seconds during the elapsed time between "t1" and "t2".  Similarly,
+//! representing the difference between two Unix timestamp is acceptable, but
+//! would yield a value that is possibly a few seconds off from the true elapsed
+//! time.
+
+use crate::{
+    array::{Array, PrimitiveArray},
+    compute::arity::unchecked_binary,
+    datatypes::{DataType, TimeUnit},
+    error::{ArrowError, Result},
+};
+
+/// Calculates the scale factor between two TimeUnits. The function returns the
+/// number that should multiply the TimeUnit "b" to have at the same scale as
+/// the TimeUnit "a".
+fn timeunit_scale(a: &TimeUnit, b: &TimeUnit) -> f64 {
+    match (a, b) {
+        (TimeUnit::Second, TimeUnit::Second) => 1.0,
+        (TimeUnit::Second, TimeUnit::Millisecond) => 0.001,
+        (TimeUnit::Second, TimeUnit::Microsecond) => 0.000_001,
+        (TimeUnit::Second, TimeUnit::Nanosecond) => 0.000_000_001,
+        (TimeUnit::Millisecond, TimeUnit::Second) => 1_000.0,
+        (TimeUnit::Millisecond, TimeUnit::Millisecond) => 1.0,
+        (TimeUnit::Millisecond, TimeUnit::Microsecond) => 0.001,
+        (TimeUnit::Millisecond, TimeUnit::Nanosecond) => 0.000_001,
+        (TimeUnit::Microsecond, TimeUnit::Second) => 1_000_000.0,
+        (TimeUnit::Microsecond, TimeUnit::Millisecond) => 1_000.0,
+        (TimeUnit::Microsecond, TimeUnit::Microsecond) => 1.0,
+        (TimeUnit::Microsecond, TimeUnit::Nanosecond) => 0.001,
+        (TimeUnit::Nanosecond, TimeUnit::Second) => 1_000_000_000.0,
+        (TimeUnit::Nanosecond, TimeUnit::Millisecond) => 1_000_000.0,
+        (TimeUnit::Nanosecond, TimeUnit::Microsecond) => 1_000.0,
+        (TimeUnit::Nanosecond, TimeUnit::Nanosecond) => 1.0,
+    }
+}
+
+/// Adds a duration to a timestamp array. The timeunit enum is used to scale
+/// correctly both arrays; adding seconds with seconds, or milliseconds with
+/// milliseconds.
+pub fn add_duration(
+    timestamp: &PrimitiveArray<i64>,
+    duration: &PrimitiveArray<i64>,
+) -> Result<PrimitiveArray<i64>> {
+    // Matching on both data types from both arrays.
+    // The timestamp and duration have a Timeunit enum in its data type.
+    // This enum is used to describe the addition of the duration.
+    match (timestamp.data_type(), duration.data_type()) {
+        (DataType::Timestamp(timeunit_a, _), DataType::Duration(timeunit_b)) => {
+            // Closure for the binary operation. The closure contains the scale
+            // required to add a duration to the timestamp array.
+            let scale = timeunit_scale(timeunit_a, timeunit_b);
+            let op = move |a, b| a + (b as f64 * scale) as i64;
+
+            unchecked_binary(timestamp, duration, timestamp.data_type().clone(), op)
+        }
+        _ => Err(ArrowError::InvalidArgumentError(
+            "Incorrect data type for the arguments".to_string(),
+        )),
+    }
+}
+
+/// Subtract a duration to a timestamp array. The timeunit enum is used to scale
+/// correctly both arrays; subtracting seconds with seconds, or milliseconds with
+/// milliseconds.
+pub fn subtract_duration(
+    timestamp: &PrimitiveArray<i64>,
+    duration: &PrimitiveArray<i64>,
+) -> Result<PrimitiveArray<i64>> {
+    // Matching on both data types from both arrays.
+    // The timestamp and duration have a Timeunit enum in its data type.
+    // This enum is used to describe the addition of the duration.
+    match (timestamp.data_type(), duration.data_type()) {
+        (DataType::Timestamp(timeunit_a, _), DataType::Duration(timeunit_b)) => {
+            // Closure for the binary operation. The closure contains the scale
+            // required to add a duration to the timestamp array.
+            let scale = timeunit_scale(timeunit_a, timeunit_b);
+            let op = move |a, b| a - (b as f64 * scale) as i64;
+
+            unchecked_binary(timestamp, duration, timestamp.data_type().clone(), op)
+        }
+        _ => Err(ArrowError::InvalidArgumentError(
+            "Incorrect data type for the arguments".to_string(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::Primitive;
+    use crate::datatypes::{DataType, TimeUnit};
+
+    #[test]
+    fn test_adding_timestamp() {
+        let timestamp = Primitive::from(&vec![
+            Some(100000i64),
+            Some(200000i64),
+            None,
+            Some(300000i64),
+        ])
+        .to(DataType::Timestamp(
+            TimeUnit::Second,
+            Some("America/New_York".to_string()),
+        ));
+
+        let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+            .to(DataType::Duration(TimeUnit::Second));
+
+        let result = add_duration(&timestamp, &duration).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(100010i64),
+            Some(200020i64),
+            None,
+            Some(300030i64),
+        ])
+        .to(DataType::Timestamp(
+            TimeUnit::Second,
+            Some("America/New_York".to_string()),
+        ));
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_adding_duration_different_scale() {
+        let timestamp = Primitive::from(&vec![
+            Some(100000i64),
+            Some(200000i64),
+            None,
+            Some(300000i64),
+        ])
+        .to(DataType::Timestamp(
+            TimeUnit::Second,
+            Some("America/New_York".to_string()),
+        ));
+        let expected = Primitive::from(&vec![
+            Some(100010i64),
+            Some(200020i64),
+            None,
+            Some(300030i64),
+        ])
+        .to(DataType::Timestamp(
+            TimeUnit::Second,
+            Some("America/New_York".to_string()),
+        ));
+
+        // Testing duration in milliseconds
+        let duration = Primitive::from(&vec![
+            Some(10_000i64),
+            Some(20_000i64),
+            None,
+            Some(30_000i64),
+        ])
+        .to(DataType::Duration(TimeUnit::Millisecond));
+
+        let result = add_duration(&timestamp, &duration).unwrap();
+        assert_eq!(result, expected);
+
+        // Testing duration in nanoseconds.
+        // The last digits in the nanosecond are not significant enough to
+        // be added to the timestamp which is in seconds and doesn't have a
+        // fractional value
+        let duration = Primitive::from(&vec![
+            Some(10_000_000_999i64),
+            Some(20_000_000_000i64),
+            None,
+            Some(30_000_000_000i64),
+        ])
+        .to(DataType::Duration(TimeUnit::Nanosecond));
+
+        let result = add_duration(&timestamp, &duration).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_adding_timestamp_different_scale() {
+        let timestamp = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
+            DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
+        );
+        let duration = Primitive::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
+            .to(DataType::Duration(TimeUnit::Second));
+
+        let expected =
+            Primitive::from(&vec![Some(1_010i64), Some(2_020i64), None, Some(3_030i64)]).to(
+                DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
+            );
+
+        let result = add_duration(&timestamp, &duration).unwrap();
+        assert_eq!(result, expected);
+
+        let timestamp = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("America/New_York".to_string())),
+        );
+        let duration = Primitive::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
+            .to(DataType::Duration(TimeUnit::Second));
+
+        let expected = Primitive::from(&vec![
+            Some(1_000_000_010i64),
+            Some(2_000_000_020i64),
+            None,
+            Some(3_000_000_030i64),
+        ])
+        .to(DataType::Timestamp(
+            TimeUnit::Nanosecond,
+            Some("America/New_York".to_string()),
+        ));
+
+        let result = add_duration(&timestamp, &duration).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_subtract_timestamp() {
+        let timestamp = Primitive::from(&vec![
+            Some(100000i64),
+            Some(200000i64),
+            None,
+            Some(300000i64),
+        ])
+        .to(DataType::Timestamp(
+            TimeUnit::Second,
+            Some("America/New_York".to_string()),
+        ));
+
+        let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+            .to(DataType::Duration(TimeUnit::Second));
+
+        let result = subtract_duration(&timestamp, &duration).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(99990i64),
+            Some(199980i64),
+            None,
+            Some(299970i64),
+        ])
+        .to(DataType::Timestamp(
+            TimeUnit::Second,
+            Some("America/New_York".to_string()),
+        ));
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_subtracting_duration_different_scale() {
+        let timestamp = Primitive::from(&vec![
+            Some(100000i64),
+            Some(200000i64),
+            None,
+            Some(300000i64),
+        ])
+        .to(DataType::Timestamp(
+            TimeUnit::Second,
+            Some("America/New_York".to_string()),
+        ));
+        let expected = Primitive::from(&vec![
+            Some(99990i64),
+            Some(199980i64),
+            None,
+            Some(299970i64),
+        ])
+        .to(DataType::Timestamp(
+            TimeUnit::Second,
+            Some("America/New_York".to_string()),
+        ));
+
+        // Testing duration in milliseconds
+        let duration = Primitive::from(&vec![
+            Some(10_000i64),
+            Some(20_000i64),
+            None,
+            Some(30_000i64),
+        ])
+        .to(DataType::Duration(TimeUnit::Millisecond));
+
+        let result = subtract_duration(&timestamp, &duration).unwrap();
+        assert_eq!(result, expected);
+
+        // Testing duration in nanoseconds.
+        // The last digits in the nanosecond are not significant enough to
+        // be added to the timestamp which is in seconds and doesn't have a
+        // fractional value
+        let duration = Primitive::from(&vec![
+            Some(10_000_000_999i64),
+            Some(20_000_000_000i64),
+            None,
+            Some(30_000_000_000i64),
+        ])
+        .to(DataType::Duration(TimeUnit::Nanosecond));
+
+        let result = subtract_duration(&timestamp, &duration).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_subtracting_timestamp_different_scale() {
+        let timestamp = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
+            DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
+        );
+        let duration = Primitive::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
+            .to(DataType::Duration(TimeUnit::Second));
+
+        let expected =
+            Primitive::from(&vec![Some(-990i64), Some(-1_980i64), None, Some(-2_970i64)]).to(
+                DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
+            );
+
+        let result = subtract_duration(&timestamp, &duration).unwrap();
+        assert_eq!(result, expected);
+
+        let timestamp = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
+            DataType::Timestamp(TimeUnit::Nanosecond, Some("America/New_York".to_string())),
+        );
+        let duration = Primitive::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
+            .to(DataType::Duration(TimeUnit::Second));
+
+        let expected = Primitive::from(&vec![
+            Some(-999_999_990i64),
+            Some(-1_999_999_980i64),
+            None,
+            Some(-2_999_999_970i64),
+        ])
+        .to(DataType::Timestamp(
+            TimeUnit::Nanosecond,
+            Some("America/New_York".to_string()),
+        ));
+
+        let result = subtract_duration(&timestamp, &duration).unwrap();
+        assert_eq!(result, expected);
+    }
+}

--- a/src/compute/arithmetics/timestamp.rs
+++ b/src/compute/arithmetics/timestamp.rs
@@ -76,7 +76,9 @@ pub fn timestamp_diff(
     // Both timestamps have a Timeunit enum in its data type.
     // This enum is used to adjust the scale between the timestamps.
     match (lhs.data_type(), rhs.data_type()) {
-        (DataType::Timestamp(timeunit_a, _), DataType::Timestamp(timeunit_b, _)) => {
+        // Naive timestamp comparison. It doesn't take into account timezones
+        // from the Timestamp timeunit.
+        (DataType::Timestamp(timeunit_a, None), DataType::Timestamp(timeunit_b, None)) => {
             // Closure for the binary operation. The closure contains the scale
             // required to calculate the difference between the timestamps.
             let scale = timeunit_scale(timeunit_a, timeunit_b);
@@ -342,10 +344,7 @@ mod tests {
             None,
             Some(300_030i64),
         ])
-        .to(DataType::Timestamp(
-            TimeUnit::Second,
-            Some("America/New_York".to_string()),
-        ));
+        .to(DataType::Timestamp(TimeUnit::Second, None));
 
         let timestamp_b = Primitive::from(&vec![
             Some(100_000i64),
@@ -353,10 +352,7 @@ mod tests {
             None,
             Some(300_000i64),
         ])
-        .to(DataType::Timestamp(
-            TimeUnit::Second,
-            Some("America/New_York".to_string()),
-        ));
+        .to(DataType::Timestamp(TimeUnit::Second, None));
 
         let expected = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
             .to(DataType::Duration(TimeUnit::Second));
@@ -373,10 +369,7 @@ mod tests {
             None,
             Some(300_000_000i64),
         ])
-        .to(DataType::Timestamp(
-            TimeUnit::Millisecond,
-            Some("America/New_York".to_string()),
-        ));
+        .to(DataType::Timestamp(TimeUnit::Millisecond, None));
 
         let timestamp_b = Primitive::from(&vec![
             Some(100_010i64),
@@ -384,10 +377,7 @@ mod tests {
             None,
             Some(300_030i64),
         ])
-        .to(DataType::Timestamp(
-            TimeUnit::Second,
-            Some("America/New_York".to_string()),
-        ));
+        .to(DataType::Timestamp(TimeUnit::Second, None));
 
         let expected = Primitive::from(&vec![
             Some(-10_000i64),

--- a/src/compute/arity.rs
+++ b/src/compute/arity.rs
@@ -10,13 +10,15 @@ use crate::{
     datatypes::DataType,
 };
 
-/// Applies an unary and infallible function to a primitive array.
-/// This is the fastest way to perform an operation on a primitive array when
-/// the benefits of a vectorized operation outweights the cost of branching nulls and non-nulls.
+/// Applies an unary and infallible function to a primitive array. This is the
+/// fastest way to perform an operation on a primitive array when the benefits
+/// of a vectorized operation outweights the cost of branching nulls and
+/// non-nulls.
+///
 /// # Implementation
 /// This will apply the function for all values, including those on null slots.
-/// This implies that the operation must be infalible for any value of the corresponding type
-/// or this function may panic.
+/// This implies that the operation must be infalible for any value of the
+/// corresponding type or this function may panic.
 #[inline]
 pub fn unary<I, F, O>(array: &PrimitiveArray<I>, op: F, data_type: &DataType) -> PrimitiveArray<O>
 where
@@ -84,17 +86,13 @@ where
 pub fn try_binary<E, T, F>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<T>,
+    data_type: DataType,
     op: F,
 ) -> Result<PrimitiveArray<T>>
 where
     T: NativeType,
     F: Fn(T, T) -> Result<T>,
 {
-    if lhs.data_type() != rhs.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Arrays must have the same logical type".to_string(),
-        ));
-    }
     if lhs.len() != rhs.len() {
         return Err(ArrowError::InvalidArgumentError(
             "Arrays must have the same length".to_string(),
@@ -115,9 +113,5 @@ where
     //      `values` is an iterator with a known size.
     let values = unsafe { Buffer::try_from_trusted_len_iter(values) }?;
 
-    Ok(PrimitiveArray::<T>::from_data(
-        lhs.data_type().clone(),
-        values,
-        validity,
-    ))
+    Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
 }

--- a/src/compute/arity.rs
+++ b/src/compute/arity.rs
@@ -10,7 +10,7 @@ use crate::{
     datatypes::DataType,
 };
 
-/// Applies an unary and infalible function to a primitive array.
+/// Applies an unary and infallible function to a primitive array.
 /// This is the fastest way to perform an operation on a primitive array when
 /// the benefits of a vectorized operation outweights the cost of branching nulls and non-nulls.
 /// # Implementation
@@ -35,95 +35,20 @@ where
     PrimitiveArray::<O>::from_data(data_type.clone(), values, array.validity().clone())
 }
 
+/// Applies a binary operations to two primitive arrays. This is the fastest
+/// way to perform an operation on two primitive array when the benefits of a
+/// vectorized operation outweighs the cost of branching nulls and non-nulls.
+///
+/// # Implementation
+/// This will apply the function for all values, including those on null slots.
+/// This implies that the operation must be infallible for any value of the
+/// corresponding type.
+/// The types of the arrays are not checked with this operation. The closure
+/// "op" needs to handle the different types in the arrays. The datatype for the
+/// resulting array has to be selected by the implementer of the function as
+/// an argument for the function.
 #[inline]
 pub fn binary<T, F>(
-    lhs: &PrimitiveArray<T>,
-    rhs: &PrimitiveArray<T>,
-    op: F,
-) -> Result<PrimitiveArray<T>>
-where
-    T: NativeType,
-    F: Fn(T, T) -> T,
-{
-    if lhs.data_type() != rhs.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Arays must have the same logical type".to_string(),
-        ));
-    }
-    if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Arrays must have the same length".to_string(),
-        ));
-    }
-
-    let validity = combine_validities(lhs.validity(), rhs.validity());
-
-    let values = lhs
-        .values()
-        .iter()
-        .zip(rhs.values().iter())
-        .map(|(l, r)| op(*l, *r));
-    // JUSTIFICATION
-    //  Benefit
-    //      ~60% speedup
-    //  Soundness
-    //      `values` is an iterator with a known size.
-    let values = unsafe { Buffer::from_trusted_len_iter(values) };
-
-    Ok(PrimitiveArray::<T>::from_data(
-        lhs.data_type().clone(),
-        values,
-        validity,
-    ))
-}
-
-pub fn try_binary<E, T, F>(
-    lhs: &PrimitiveArray<T>,
-    rhs: &PrimitiveArray<T>,
-    op: F,
-) -> Result<PrimitiveArray<T>>
-where
-    T: NativeType,
-    F: Fn(T, T) -> Result<T>,
-{
-    if lhs.data_type() != rhs.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Arays must have the same logical type".to_string(),
-        ));
-    }
-    if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Arrays must have the same length".to_string(),
-        ));
-    }
-
-    let validity = combine_validities(lhs.validity(), rhs.validity());
-
-    let values = lhs
-        .values()
-        .iter()
-        .zip(rhs.values().iter())
-        .map(|(l, r)| op(*l, *r).map_err(ArrowError::from_external_error));
-    // JUSTIFICATION
-    //  Benefit
-    //      ~60% speedup
-    //  Soundness
-    //      `values` is an iterator with a known size.
-    let values = unsafe { Buffer::try_from_trusted_len_iter(values) }?;
-
-    Ok(PrimitiveArray::<T>::from_data(
-        lhs.data_type().clone(),
-        values,
-        validity,
-    ))
-}
-
-// The types of the arrays are not checked with this operation. The closure
-// "op" needs to handle the different types in the arrays. The datatype for the
-// resulting array has to be selected by the implementer of the function as
-// an argument for the function.
-#[inline]
-pub fn unchecked_binary<T, F>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<T>,
     data_type: DataType,
@@ -154,4 +79,45 @@ where
     let values = unsafe { Buffer::from_trusted_len_iter(values) };
 
     Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
+}
+
+pub fn try_binary<E, T, F>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveArray<T>,
+    op: F,
+) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType,
+    F: Fn(T, T) -> Result<T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+    if lhs.len() != rhs.len() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same length".to_string(),
+        ));
+    }
+
+    let validity = combine_validities(lhs.validity(), rhs.validity());
+
+    let values = lhs
+        .values()
+        .iter()
+        .zip(rhs.values().iter())
+        .map(|(l, r)| op(*l, *r).map_err(ArrowError::from_external_error));
+    // JUSTIFICATION
+    //  Benefit
+    //      ~60% speedup
+    //  Soundness
+    //      `values` is an iterator with a known size.
+    let values = unsafe { Buffer::try_from_trusted_len_iter(values) }?;
+
+    Ok(PrimitiveArray::<T>::from_data(
+        lhs.data_type().clone(),
+        values,
+        validity,
+    ))
 }

--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -1,5 +1,6 @@
 //! Conversion methods for dates and times.
 
+use crate::datatypes::TimeUnit;
 use chrono::{NaiveDateTime, NaiveTime};
 
 /// Number of seconds in a day
@@ -111,4 +112,28 @@ pub fn timestamp_ns_to_datetime(v: i64) -> NaiveDateTime {
         // discard extracted seconds
         (v % NANOSECONDS) as u32,
     )
+}
+
+/// Calculates the scale factor between two TimeUnits. The function returns the
+/// scale that should multiply the TimeUnit "b" to have the same time scale as
+/// the TimeUnit "a".
+pub fn timeunit_scale(a: &TimeUnit, b: &TimeUnit) -> f64 {
+    match (a, b) {
+        (TimeUnit::Second, TimeUnit::Second) => 1.0,
+        (TimeUnit::Second, TimeUnit::Millisecond) => 0.001,
+        (TimeUnit::Second, TimeUnit::Microsecond) => 0.000_001,
+        (TimeUnit::Second, TimeUnit::Nanosecond) => 0.000_000_001,
+        (TimeUnit::Millisecond, TimeUnit::Second) => 1_000.0,
+        (TimeUnit::Millisecond, TimeUnit::Millisecond) => 1.0,
+        (TimeUnit::Millisecond, TimeUnit::Microsecond) => 0.001,
+        (TimeUnit::Millisecond, TimeUnit::Nanosecond) => 0.000_001,
+        (TimeUnit::Microsecond, TimeUnit::Second) => 1_000_000.0,
+        (TimeUnit::Microsecond, TimeUnit::Millisecond) => 1_000.0,
+        (TimeUnit::Microsecond, TimeUnit::Microsecond) => 1.0,
+        (TimeUnit::Microsecond, TimeUnit::Nanosecond) => 0.001,
+        (TimeUnit::Nanosecond, TimeUnit::Second) => 1_000_000_000.0,
+        (TimeUnit::Nanosecond, TimeUnit::Millisecond) => 1_000_000.0,
+        (TimeUnit::Nanosecond, TimeUnit::Microsecond) => 1_000.0,
+        (TimeUnit::Nanosecond, TimeUnit::Nanosecond) => 1.0,
+    }
 }


### PR DESCRIPTION
This PR defines functions to add and subtract a duration to a timestamp. The duration is always scaled up/down to have the same time scale as the timestamp.

Closes #26