### PR TITLE
Adding/subtracting duration to Timestamp, Time and Date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ venv
 lcov.info
 Cargo.lock
 fixtures
+settings.json

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 //! Defines basic arithmetic kernels for `PrimitiveArrays`.
-pub mod timestamp;
+pub mod time;
 
 use std::ops::{Add, Div, Mul, Neg, Sub};
 

--- a/src/compute/arithmetics/time.rs
+++ b/src/compute/arithmetics/time.rs
@@ -1,68 +1,155 @@
-//! Defines the arithmetic kernels for Timestamp and Duration.
+//! Defines the arithmetic kernels for adding a Duration to a Timestamp,
+//! Time32, Time64, Date32 and Date64.
+//!
 //! For the purposes of Arrow Implementations, adding this value to a Timestamp
 //! ("t1") naively (i.e. simply summing the two number) is acceptable even
 //! though in some cases the resulting Timestamp (t2) would not account for
 //! leap-seconds during the elapsed time between "t1" and "t2".  Similarly,
 //! representing the difference between two Unix timestamp is acceptable, but
-//! would yield a value that is possibly a few seconds off from the true elapsed
-//! time.
+//! would yield a value that is possibly a few seconds off from the true
+//! elapsed time.
+
+use num::cast::AsPrimitive;
 
 use crate::{
     array::{Array, PrimitiveArray},
     compute::arity::binary,
-    datatypes::DataType,
+    datatypes::{DataType, TimeUnit},
     error::{ArrowError, Result},
-    temporal_conversions::timeunit_scale,
+    temporal_conversions::{timeunit_scale, SECONDS_IN_DAY},
+    types::NativeType,
 };
 
-/// Adds a duration to a timestamp array. The timeunit enum is used to scale
-/// correctly both arrays; adding seconds with seconds, or milliseconds with
-/// milliseconds.
-pub fn add_duration(
-    timestamp: &PrimitiveArray<i64>,
-    duration: &PrimitiveArray<i64>,
-) -> Result<PrimitiveArray<i64>> {
-    // Matching on both data types from both arrays.
-    // The timestamp and duration have a Timeunit enum in its data type.
-    // This enum is used to describe the addition of the duration.
-    match (timestamp.data_type(), duration.data_type()) {
-        (DataType::Timestamp(timeunit_a, _), DataType::Duration(timeunit_b)) => {
-            // Closure for the binary operation. The closure contains the scale
-            // required to add a duration to the timestamp array.
-            let scale = timeunit_scale(timeunit_a, timeunit_b);
-            let op = move |a, b| a + (b as f64 * scale) as i64;
+/// Scaling trait used to define scaled operations for certain numbers. The
+/// Scaled trait is sealed using the Sealed Trait Pattern. This pattern
+/// guarantees that the Sealed trait is not implement outside this crate.
+pub trait Scaled<D>: private::Sealed {
+    fn scaled_add(&self, duration: D, scale: f64) -> Self;
+    fn scaled_subtract(&self, duration: D, scale: f64) -> Self;
+}
 
-            binary(timestamp, duration, timestamp.data_type().clone(), op)
-        }
-        _ => Err(ArrowError::InvalidArgumentError(
-            "Incorrect data type for the arguments".to_string(),
-        )),
+impl<D> Scaled<D> for i32
+where
+    D: AsPrimitive<f64>,
+{
+    fn scaled_add(&self, duration: D, scale: f64) -> Self {
+        let d: f64 = duration.as_();
+        let scaled: i32 = (d * scale).as_();
+
+        self + scaled
+    }
+
+    fn scaled_subtract(&self, duration: D, scale: f64) -> Self {
+        let d: f64 = duration.as_();
+        let scaled: i32 = (d * scale).as_();
+
+        self - scaled
     }
 }
 
-/// Subtract a duration to a timestamp array. The timeunit enum is used to scale
-/// correctly both arrays; subtracting seconds with seconds, or milliseconds with
-/// milliseconds.
-pub fn subtract_duration(
-    timestamp: &PrimitiveArray<i64>,
-    duration: &PrimitiveArray<i64>,
-) -> Result<PrimitiveArray<i64>> {
-    // Matching on both data types from both arrays.
-    // The timestamp and duration have a Timeunit enum in its data type.
-    // This enum is used to describe the addition of the duration.
-    match (timestamp.data_type(), duration.data_type()) {
-        (DataType::Timestamp(timeunit_a, _), DataType::Duration(timeunit_b)) => {
-            // Closure for the binary operation. The closure contains the scale
-            // required to add a duration to the timestamp array.
-            let scale = timeunit_scale(timeunit_a, timeunit_b);
-            let op = move |a, b| a - (b as f64 * scale) as i64;
+impl<D> Scaled<D> for i64
+where
+    D: AsPrimitive<f64>,
+{
+    fn scaled_add(&self, duration: D, scale: f64) -> Self {
+        let d: f64 = duration.as_();
+        let scaled: i64 = (d * scale).as_();
 
-            binary(timestamp, duration, timestamp.data_type().clone(), op)
-        }
-        _ => Err(ArrowError::InvalidArgumentError(
-            "Incorrect data type for the arguments".to_string(),
-        )),
+        self + scaled
     }
+
+    fn scaled_subtract(&self, duration: D, scale: f64) -> Self {
+        let d: f64 = duration.as_();
+        let scaled: i64 = (d * scale).as_();
+
+        self - scaled
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for i32 {}
+    impl Sealed for i64 {}
+}
+
+/// Creates the scale required to add or subtract a Duration to a time array
+/// (Timestamp, Time, or Date). The resulting scale always multiplies the rhs
+/// number (Duration) so it can be added to the lhs number (time array).
+fn create_scale(lhs: &DataType, rhs: &DataType) -> Result<f64> {
+    // Matching on both data types from both numbers to calculate the correct
+    // scale for the operation. The timestamp, Time and duration have a
+    // Timeunit enum in its data type. This enum is used to describe the
+    // addition of the duration. The Date32 and Date64 have different rules for
+    // the scaling.
+    let scale = match (lhs, rhs) {
+        (DataType::Timestamp(timeunit_a, _), DataType::Duration(timeunit_b))
+        | (DataType::Time32(timeunit_a), DataType::Duration(timeunit_b))
+        | (DataType::Time64(timeunit_a), DataType::Duration(timeunit_b)) => {
+            // The scale is based on the TimeUnit that each of the numbers have.
+            timeunit_scale(timeunit_a, timeunit_b)
+        }
+        (DataType::Date32, DataType::Duration(timeunit)) => {
+            // Date32 represents the time elapsed time since UNIX epoch
+            // (1970-01-01) in days (32 bits). The duration value has to be
+            // scaled to days to be able to add the value to the Date.
+            timeunit_scale(&TimeUnit::Second, timeunit) / SECONDS_IN_DAY as f64
+        }
+        (DataType::Date64, DataType::Duration(timeunit)) => {
+            // Date64 represents the time elapsed time since UNIX epoch
+            // (1970-01-01) in milliseconds (64 bits). The duration value has
+            // to be scaled to milliseconds to be able to add the value to the
+            // Date.
+            timeunit_scale(&TimeUnit::Millisecond, timeunit)
+        }
+        _ => {
+            return Err(ArrowError::InvalidArgumentError(
+                "Incorrect data type for the arguments".to_string(),
+            ));
+        }
+    };
+
+    Ok(scale)
+}
+
+/// Adds a duration to a time array (Timestamp, Time and Date). The timeunit
+/// enum is used to scale correctly both arrays; adding seconds with seconds,
+/// or milliseconds with milliseconds.
+pub fn add_duration<T, D>(
+    time: &PrimitiveArray<T>,
+    duration: &PrimitiveArray<D>,
+) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + Scaled<D>,
+    D: NativeType + AsPrimitive<f64>,
+{
+    let scale = create_scale(time.data_type(), duration.data_type())?;
+
+    // Closure for the binary operation. The closure contains the scale
+    // required to add a duration to the timestamp array.
+    let op = move |a: T, b: D| a.scaled_add(b, scale);
+
+    binary(time, duration, time.data_type().clone(), op)
+}
+
+/// Subtract a duration to a time array (Timestamp, Time and Date). The timeunit
+/// enum is used to scale correctly both arrays; adding seconds with seconds,
+/// or milliseconds with milliseconds.
+pub fn subtract_duration<T, D>(
+    time: &PrimitiveArray<T>,
+    duration: &PrimitiveArray<D>,
+) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + Scaled<D>,
+    D: NativeType + AsPrimitive<f64>,
+{
+    let scale = create_scale(time.data_type(), duration.data_type())?;
+
+    // Closure for the binary operation. The closure contains the scale
+    // required to add a duration to the timestamp array.
+    let op = move |a: T, b: D| a.scaled_subtract(b, scale);
+
+    binary(time, duration, time.data_type().clone(), op)
 }
 
 /// Calculates the difference between two timestamps returning an array of type
@@ -388,6 +475,180 @@ mod tests {
         .to(DataType::Duration(TimeUnit::Millisecond));
 
         let result = timestamp_diff(&timestamp_a, &&timestamp_b).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_adding_to_time() {
+        let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+            .to(DataType::Duration(TimeUnit::Second));
+
+        // Testing Time32
+        let time_32 = Primitive::from(&vec![
+            Some(100000i32),
+            Some(200000i32),
+            None,
+            Some(300000i32),
+        ])
+        .to(DataType::Time32(TimeUnit::Second));
+
+        let result = add_duration(&time_32, &duration).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(100010i32),
+            Some(200020i32),
+            None,
+            Some(300030i32),
+        ])
+        .to(DataType::Time32(TimeUnit::Second));
+
+        assert_eq!(result, expected);
+
+        // Testing Time64
+        let time_64 = Primitive::from(&vec![
+            Some(100000i64),
+            Some(200000i64),
+            None,
+            Some(300000i64),
+        ])
+        .to(DataType::Time64(TimeUnit::Second));
+
+        let result = add_duration(&time_64, &duration).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(100010i64),
+            Some(200020i64),
+            None,
+            Some(300030i64),
+        ])
+        .to(DataType::Time64(TimeUnit::Second));
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_subtract_to_time() {
+        let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+            .to(DataType::Duration(TimeUnit::Second));
+
+        // Testing Time32
+        let time_32 = Primitive::from(&vec![
+            Some(100000i32),
+            Some(200000i32),
+            None,
+            Some(300000i32),
+        ])
+        .to(DataType::Time32(TimeUnit::Second));
+
+        let result = subtract_duration(&time_32, &duration).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(99990i32),
+            Some(199980i32),
+            None,
+            Some(299970i32),
+        ])
+        .to(DataType::Time32(TimeUnit::Second));
+
+        assert_eq!(result, expected);
+
+        // Testing Time64
+        let time_64 = Primitive::from(&vec![
+            Some(100000i64),
+            Some(200000i64),
+            None,
+            Some(300000i64),
+        ])
+        .to(DataType::Time64(TimeUnit::Second));
+
+        let result = subtract_duration(&time_64, &duration).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(99990i64),
+            Some(199980i64),
+            None,
+            Some(299970i64),
+        ])
+        .to(DataType::Time64(TimeUnit::Second));
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_date32() {
+        let duration = Primitive::from(&vec![
+            Some(86_400),     // 1 day
+            Some(864_000i64), // 10 days
+            None,
+            Some(8_640_000i64), // 100 days
+        ])
+        .to(DataType::Duration(TimeUnit::Second));
+
+        let date_32 = Primitive::from(&vec![
+            Some(100_000i32),
+            Some(100_000i32),
+            None,
+            Some(100_000i32),
+        ])
+        .to(DataType::Date32);
+
+        let result = add_duration(&date_32, &duration).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(100_001i32),
+            Some(100_010i32),
+            None,
+            Some(100_100i32),
+        ])
+        .to(DataType::Date32);
+
+        assert_eq!(result, expected);
+
+        let result = subtract_duration(&date_32, &duration).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(99_999i32),
+            Some(99_990i32),
+            None,
+            Some(99_900i32),
+        ])
+        .to(DataType::Date32);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_date64() {
+        let duration = Primitive::from(&vec![
+            Some(10i64),  // 10 milliseconds
+            Some(100i64), // 100 milliseconds
+            None,
+            Some(1_000i64), // 1000 milliseconds
+        ])
+        .to(DataType::Duration(TimeUnit::Millisecond));
+
+        let date_64 = Primitive::from(&vec![
+            Some(100_000i64),
+            Some(100_000i64),
+            None,
+            Some(100_000i64),
+        ])
+        .to(DataType::Date64);
+
+        let result = add_duration(&date_64, &duration).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(100_010i64),
+            Some(100_100i64),
+            None,
+            Some(101_000i64),
+        ])
+        .to(DataType::Date64);
+
+        assert_eq!(result, expected);
+
+        let result = subtract_duration(&date_64, &duration).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(99_990i64),
+            Some(99_900i64),
+            None,
+            Some(99_000i64),
+        ])
+        .to(DataType::Date64);
+
         assert_eq!(result, expected);
     }
 }

--- a/src/compute/arity.rs
+++ b/src/compute/arity.rs
@@ -12,12 +12,12 @@ use crate::{
 
 /// Applies an unary and infallible function to a primitive array. This is the
 /// fastest way to perform an operation on a primitive array when the benefits
-/// of a vectorized operation outweights the cost of branching nulls and
+/// of a vectorized operation outweighs the cost of branching nulls and
 /// non-nulls.
 ///
 /// # Implementation
 /// This will apply the function for all values, including those on null slots.
-/// This implies that the operation must be infalible for any value of the
+/// This implies that the operation must be infallible for any value of the
 /// corresponding type or this function may panic.
 #[inline]
 pub fn unary<I, F, O>(array: &PrimitiveArray<I>, op: F, data_type: &DataType) -> PrimitiveArray<O>
@@ -50,15 +50,16 @@ where
 /// resulting array has to be selected by the implementer of the function as
 /// an argument for the function.
 #[inline]
-pub fn binary<T, F>(
+pub fn binary<T, D, F>(
     lhs: &PrimitiveArray<T>,
-    rhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveArray<D>,
     data_type: DataType,
     op: F,
 ) -> Result<PrimitiveArray<T>>
 where
     T: NativeType,
-    F: Fn(T, T) -> T,
+    D: NativeType,
+    F: Fn(T, D) -> T,
 {
     if lhs.len() != rhs.len() {
         return Err(ArrowError::InvalidArgumentError(
@@ -83,15 +84,16 @@ where
     Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
 }
 
-pub fn try_binary<E, T, F>(
+pub fn try_binary<E, T, D, F>(
     lhs: &PrimitiveArray<T>,
-    rhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveArray<D>,
     data_type: DataType,
     op: F,
 ) -> Result<PrimitiveArray<T>>
 where
     T: NativeType,
-    F: Fn(T, T) -> Result<T>,
+    D: NativeType,
+    F: Fn(T, D) -> Result<T>,
 {
     if lhs.len() != rhs.len() {
         return Err(ArrowError::InvalidArgumentError(


### PR DESCRIPTION
This PR adds functions to add and subtract a Duration to a Timestamp, Time32, Time64, Date32 and Date64. It uses a trait Scaled to allow addition/subtraction between `i32` and `i64`.

The `timestamp.rs` file was changed to `time.rs` since it encompasses all the types of time arrays it can work with. 

Closes #25 
Closes #24 