### PR TITLE
Basic arithmetics kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To run the tests including integration with pyarrow's parquet writer, run
 ```bash
 python3 -m venv venv
 venv/bin/pip install pyarrow==3
-venv/bin/python -m parquet_integration/write_parquet.py
+venv/bin/python parquet_integration/write_parquet.py
 ```
 
 ## Features in this crate and not in the original

--- a/src/compute/aggregate/mod.rs
+++ b/src/compute/aggregate/mod.rs
@@ -268,7 +268,7 @@ mod tests {
             .collect::<Primitive<i64>>()
             .to(DataType::Int64);
         // create an array that actually has non-zero values at the invalid indices
-        let c = arithmetics::add(&a, &b).unwrap();
+        let c = arithmetics::basic::add::add(&a, &b).unwrap();
         assert_eq!(Some((1..=100).filter(|i| i % 3 == 0).sum()), sum(&c));
     }
 

--- a/src/compute/arithmetics/basic/add.rs
+++ b/src/compute/arithmetics/basic/add.rs
@@ -2,13 +2,15 @@ use std::ops::Add;
 
 use num::{
     traits::{ops::overflowing::OverflowingAdd, SaturatingAdd},
-    CheckedAdd,
+    CheckedAdd, Zero,
 };
 
 use crate::{
     array::{Array, PrimitiveArray},
     bitmap::Bitmap,
-    compute::arity::{binary, binary_with_bitmap, try_binary, try_unary, unary, unary_with_bitmap},
+    compute::arity::{
+        binary, binary_checked, binary_with_bitmap, unary, unary_checked, unary_with_bitmap,
+    },
     error::{ArrowError, Result},
     types::NativeType,
 };
@@ -42,9 +44,8 @@ where
     binary(lhs, rhs, lhs.data_type().clone(), |a, b| a + b)
 }
 
-/// Checked addition of two primitive arrays. If the result from the sum is
-/// larger than the possible number for this type an
-/// ArrowError::ArithmeticError is returned.
+/// Checked addition of two primitive arrays. If the result from the sum
+/// overflows, the validity for that index is changed to None
 ///
 /// # Examples
 /// ```
@@ -52,15 +53,15 @@ where
 /// use arrow2::array::Primitive;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
-/// let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
-/// checked_add(&a, &b)
-///     .err()
-///     .expect("should have failed due to overflow");
+/// let a = Primitive::from(&vec![Some(100i8), Some(100i8), Some(100i8)]).to(DataType::Int8);
+/// let b = Primitive::from(&vec![Some(0i8), Some(100i8), Some(0i8)]).to(DataType::Int8);
+/// let result = checked_add(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![Some(100i8), None, Some(100i8)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
 /// ```
 pub fn checked_add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
-    T: NativeType + CheckedAdd<Output = T>,
+    T: NativeType + CheckedAdd<Output = T> + Zero,
 {
     if lhs.data_type() != rhs.data_type() {
         return Err(ArrowError::InvalidArgumentError(
@@ -68,20 +69,9 @@ where
         ));
     }
 
-    let op = move |a: T, b: T| {
-        let res = a.checked_add(&b);
+    let op = move |a: T, b: T| a.checked_add(&b);
 
-        match res {
-            Some(val) => Ok(val),
-            None => {
-                return Err(ArrowError::ArithmeticError(
-                    "Saturated result in addition".to_string(),
-                ));
-            }
-        }
-    };
-
-    try_binary(lhs, rhs, lhs.data_type().clone(), op)
+    binary_checked(lhs, rhs, lhs.data_type().clone(), op)
 }
 
 /// Saturating addition of two primitive arrays. If the result from the sum is
@@ -177,8 +167,8 @@ where
 }
 
 /// Checked addition of a scalar T to a primitive array of type T. If the
-/// result from the sum is larger than the possible number for this type an
-/// ArrowError::ArithmeticError is returned.
+/// result from the sum overflows then the validity index for that value is
+/// changed to None
 ///
 /// # Examples
 /// ```
@@ -186,31 +176,20 @@ where
 /// use arrow2::array::Primitive;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
-/// checked_add_scalar(&a, &100i8)
-///     .err()
-///     .expect("should have failed due to overflow");
+/// let a = Primitive::from(&vec![None, Some(100), None, Some(100)]).to(DataType::Int8);
+/// let result = checked_add_scalar(&a, &100i8);
+/// let expected = Primitive::<i8>::from(&vec![None, None, None, None]).to(DataType::Int8);
+/// assert_eq!(result, expected);
 /// ```
 #[inline]
-pub fn checked_add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> Result<PrimitiveArray<T>>
+pub fn checked_add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
-    T: NativeType + CheckedAdd<Output = T>,
+    T: NativeType + CheckedAdd<Output = T> + Zero,
 {
     let rhs = *rhs;
-    let op = move |a: T| {
-        let res = a.checked_add(&rhs);
+    let op = move |a: T| a.checked_add(&rhs);
 
-        match res {
-            Some(val) => Ok(val),
-            None => {
-                return Err(ArrowError::ArithmeticError(
-                    "Saturated result in addition".to_string(),
-                ));
-            }
-        }
-    };
-
-    try_unary(lhs, op, lhs.data_type())
+    unary_checked(lhs, op, lhs.data_type())
 }
 
 /// Saturated addition of a scalar T to a primitive array of type T. If the
@@ -306,11 +285,11 @@ mod tests {
         let expected = Primitive::from(&vec![None, None, None, Some(12)]).to(DataType::Int32);
         assert_eq!(result, expected);
 
-        let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
-        let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
-        checked_add(&a, &b)
-            .err()
-            .expect("should have failed due to overflow");
+        let a = Primitive::from(&vec![Some(100i8), Some(100i8), Some(100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(0i8), Some(100i8), Some(0i8)]).to(DataType::Int8);
+        let result = checked_add(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![Some(100i8), None, Some(100i8)]).to(DataType::Int8);
+        assert_eq!(result, expected);
     }
 
     #[test]
@@ -356,14 +335,14 @@ mod tests {
     #[test]
     fn test_add_scalar_checked() {
         let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
-        let result = checked_add_scalar(&a, &1i32).unwrap();
+        let result = checked_add_scalar(&a, &1i32);
         let expected = Primitive::from(&vec![None, Some(7), None, Some(7)]).to(DataType::Int32);
         assert_eq!(result, expected);
 
-        let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
-        checked_add_scalar(&a, &100i8)
-            .err()
-            .expect("should have failed due to overflow");
+        let a = Primitive::from(&vec![None, Some(100), None, Some(100)]).to(DataType::Int8);
+        let result = checked_add_scalar(&a, &100i8);
+        let expected = Primitive::<i8>::from(&vec![None, None, None, None]).to(DataType::Int8);
+        assert_eq!(result, expected);
     }
 
     #[test]

--- a/src/compute/arithmetics/basic/add.rs
+++ b/src/compute/arithmetics/basic/add.rs
@@ -1,3 +1,4 @@
+//! Definition of basic add operations with primitive arrays
 use std::ops::Add;
 
 use num::{

--- a/src/compute/arithmetics/basic/add.rs
+++ b/src/compute/arithmetics/basic/add.rs
@@ -1,0 +1,56 @@
+use std::ops::Add;
+
+use crate::{
+    array::{Array, PrimitiveArray},
+    compute::arity::{binary, unary},
+    error::{ArrowError, Result},
+    types::NativeType,
+};
+
+#[inline]
+pub fn add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + Add<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    binary(lhs, rhs, lhs.data_type().clone(), |a, b| a + b)
+}
+
+#[inline]
+pub fn add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
+where
+    T: NativeType + Add<Output = T>,
+{
+    let rhs = *rhs;
+    unary(lhs, |a| a + rhs, lhs.data_type())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::Primitive;
+    use crate::datatypes::DataType;
+
+    #[test]
+    fn test_add() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let result = add(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(12)]).to(DataType::Int32);
+        assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_add_mismatched_length() {
+        let a = Primitive::from_slice(vec![5, 6]).to(DataType::Int32);
+        let b = Primitive::from_slice(vec![5]).to(DataType::Int32);
+        add(&a, &b)
+            .err()
+            .expect("should have failed due to different lengths");
+    }
+}

--- a/src/compute/arithmetics/basic/add.rs
+++ b/src/compute/arithmetics/basic/add.rs
@@ -1,12 +1,33 @@
 use std::ops::Add;
 
+use num::{
+    traits::{ops::overflowing::OverflowingAdd, SaturatingAdd},
+    CheckedAdd,
+};
+
 use crate::{
     array::{Array, PrimitiveArray},
-    compute::arity::{binary, unary},
+    bitmap::Bitmap,
+    compute::arity::{binary, binary_with_bitmap, try_binary, try_unary, unary, unary_with_bitmap},
     error::{ArrowError, Result},
     types::NativeType,
 };
 
+/// Adds two primitive arrays with the same type.
+/// Panics if the sum of one pair of values overflows.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::add::add;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+/// let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+/// let result = add(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![None, None, None, Some(12)]).to(DataType::Int32);
+/// assert_eq!(result, expected)
+/// ```
 #[inline]
 pub fn add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
@@ -21,6 +42,131 @@ where
     binary(lhs, rhs, lhs.data_type().clone(), |a, b| a + b)
 }
 
+/// Checked addition of two primitive arrays. If the result from the sum is
+/// larger than the possible number for this type an
+/// ArrowError::ArithmeticError is returned.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::add::checked_add;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// checked_add(&a, &b)
+///     .err()
+///     .expect("should have failed due to overflow");
+/// ```
+pub fn checked_add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + CheckedAdd<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    let op = move |a: T, b: T| {
+        let res = a.checked_add(&b);
+
+        match res {
+            Some(val) => Ok(val),
+            None => {
+                return Err(ArrowError::ArithmeticError(
+                    "Saturated result in addition".to_string(),
+                ));
+            }
+        }
+    };
+
+    try_binary(lhs, rhs, lhs.data_type().clone(), op)
+}
+
+/// Saturating addition of two primitive arrays. If the result from the sum is
+/// larger than the possible number for this type, the result for the operation
+/// will be the saturated value.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::add::saturating_add;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// let result = saturating_add(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![Some(127)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+pub fn saturating_add<T>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveArray<T>,
+) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + SaturatingAdd<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    let op = move |a: T, b: T| a.saturating_add(&b);
+
+    binary(lhs, rhs, lhs.data_type().clone(), op)
+}
+
+/// Overflowing addition of two primitive arrays. If the result from the sum is
+/// larger than the possible number for this type, the result for the operation
+/// will be an array with overflowed values and a  validity array indicating
+/// the overflowing elements from the array.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::add::overflowing_add;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+/// let b = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+/// let (result, overflow) = overflowing_add(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![Some(2i8), Some(-56i8)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+pub fn overflowing_add<T>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveArray<T>,
+) -> Result<(PrimitiveArray<T>, Bitmap)>
+where
+    T: NativeType + OverflowingAdd<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    let op = move |a: T, b: T| a.overflowing_add(&b);
+
+    binary_with_bitmap(lhs, rhs, lhs.data_type().clone(), op)
+}
+
+/// Adds a scalar T to a primitive array of type T.
+/// Panics if the sum of the values overflows.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::add::add_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+/// let result = add_scalar(&a, &1i32);
+/// let expected = Primitive::from(&vec![None, Some(7), None, Some(7)]).to(DataType::Int32);
+/// assert_eq!(result, expected)
+/// ```
 #[inline]
 pub fn add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
@@ -30,11 +176,110 @@ where
     unary(lhs, |a| a + rhs, lhs.data_type())
 }
 
+/// Checked addition of a scalar T to a primitive array of type T. If the
+/// result from the sum is larger than the possible number for this type an
+/// ArrowError::ArithmeticError is returned.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::add::checked_add_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// checked_add_scalar(&a, &100i8)
+///     .err()
+///     .expect("should have failed due to overflow");
+/// ```
+#[inline]
+pub fn checked_add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + CheckedAdd<Output = T>,
+{
+    let rhs = *rhs;
+    let op = move |a: T| {
+        let res = a.checked_add(&rhs);
+
+        match res {
+            Some(val) => Ok(val),
+            None => {
+                return Err(ArrowError::ArithmeticError(
+                    "Saturated result in addition".to_string(),
+                ));
+            }
+        }
+    };
+
+    try_unary(lhs, op, lhs.data_type())
+}
+
+/// Saturated addition of a scalar T to a primitive array of type T. If the
+/// result from the sum is larger than the possible number for this type, then
+/// the result will be saturated
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::add::saturating_add_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// let result = saturating_add_scalar(&a, &100i8);
+/// let expected = Primitive::from(&vec![Some(127)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+#[inline]
+pub fn saturating_add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
+where
+    T: NativeType + SaturatingAdd<Output = T>,
+{
+    let rhs = *rhs;
+    let op = move |a: T| a.saturating_add(&rhs);
+
+    unary(lhs, op, lhs.data_type())
+}
+
+/// Overflowing addition of a scalar T to a primitive array of type T. If the
+/// result from the sum is larger than the possible number for this type, then
+/// the result will be an array with overflowed values and a validity array
+/// indicating the overflowing elements from the array
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::add::overflowing_add_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+/// let (result, overflow) = overflowing_add_scalar(&a, &100i8);
+/// let expected = Primitive::from(&vec![Some(101i8), Some(-56i8)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+#[inline]
+pub fn overflowing_add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> (PrimitiveArray<T>, Bitmap)
+where
+    T: NativeType + OverflowingAdd<Output = T>,
+{
+    let rhs = *rhs;
+    let op = move |a: T| a.overflowing_add(&rhs);
+
+    unary_with_bitmap(lhs, op, lhs.data_type())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::array::Primitive;
     use crate::datatypes::DataType;
+
+    #[test]
+    fn test_add_mismatched_length() {
+        let a = Primitive::from_slice(vec![5, 6]).to(DataType::Int32);
+        let b = Primitive::from_slice(vec![5]).to(DataType::Int32);
+        add(&a, &b)
+            .err()
+            .expect("should have failed due to different lengths");
+    }
 
     #[test]
     fn test_add() {
@@ -46,11 +291,106 @@ mod tests {
     }
 
     #[test]
-    fn test_add_mismatched_length() {
-        let a = Primitive::from_slice(vec![5, 6]).to(DataType::Int32);
-        let b = Primitive::from_slice(vec![5]).to(DataType::Int32);
-        add(&a, &b)
+    #[should_panic]
+    fn test_add_panic() {
+        let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        let _ = add(&a, &b);
+    }
+
+    #[test]
+    fn test_add_checked() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let result = checked_add(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(12)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        checked_add(&a, &b)
             .err()
-            .expect("should have failed due to different lengths");
+            .expect("should have failed due to overflow");
+    }
+
+    #[test]
+    fn test_add_saturating() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let result = saturating_add(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(12)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        let result = saturating_add(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![Some(127)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_add_overflowing() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let (result, overflow) = overflowing_add(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(12)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b0000);
+
+        let a = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+        let (result, overflow) = overflowing_add(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![Some(2i8), Some(-56i8)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b10);
+    }
+
+    #[test]
+    fn test_add_scalar() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let result = add_scalar(&a, &1i32);
+        let expected = Primitive::from(&vec![None, Some(7), None, Some(7)]).to(DataType::Int32);
+        assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_add_scalar_checked() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let result = checked_add_scalar(&a, &1i32).unwrap();
+        let expected = Primitive::from(&vec![None, Some(7), None, Some(7)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        checked_add_scalar(&a, &100i8)
+            .err()
+            .expect("should have failed due to overflow");
+    }
+
+    #[test]
+    fn test_add_scalar_saturating() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let result = saturating_add_scalar(&a, &1i32);
+        let expected = Primitive::from(&vec![None, Some(7), None, Some(7)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        let result = saturating_add_scalar(&a, &100i8);
+        let expected = Primitive::from(&vec![Some(127)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_add_scalar_overflowing() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let (result, overflow) = overflowing_add_scalar(&a, &1i32);
+        let expected = Primitive::from(&vec![None, Some(7), None, Some(7)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b0000);
+
+        let a = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+        let (result, overflow) = overflowing_add_scalar(&a, &100i8);
+        let expected = Primitive::from(&vec![Some(101i8), Some(-56i8)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b10);
     }
 }

--- a/src/compute/arithmetics/basic/div.rs
+++ b/src/compute/arithmetics/basic/div.rs
@@ -1,0 +1,128 @@
+use std::ops::Div;
+
+use crate::{
+    array::{Array, PrimitiveArray},
+    buffer::Buffer,
+    compute::arity::unary,
+    error::{ArrowError, Result},
+    types::NativeType,
+};
+
+use num::Zero;
+
+use crate::compute::utils::combine_validities;
+
+/// Divide two arrays.
+///
+/// # Errors
+///
+/// This function errors iff:
+/// * the arrays have different lengths
+/// * a division by zero is found
+pub fn div<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType,
+    T: Div<Output = T> + Zero,
+{
+    if lhs.len() != rhs.len() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Cannot perform math operation on arrays of different length".to_string(),
+        ));
+    }
+
+    let validity = combine_validities(lhs.validity(), rhs.validity());
+
+    let values = if let Some(b) = &validity {
+        // there are nulls. Division by zero on them should be ignored
+        let values =
+            b.iter()
+                .zip(lhs.values().iter().zip(rhs.values()))
+                .map(|(is_valid, (lhs, rhs))| {
+                    if is_valid {
+                        if rhs.is_zero() {
+                            Err(ArrowError::InvalidArgumentError(
+                                "There is a zero in the division, causing a division by zero"
+                                    .to_string(),
+                            ))
+                        } else {
+                            Ok(*lhs / *rhs)
+                        }
+                    } else {
+                        Ok(T::default())
+                    }
+                });
+        unsafe { Buffer::try_from_trusted_len_iter(values) }
+    } else {
+        // no value is null
+        let values = lhs.values().iter().zip(rhs.values()).map(|(lhs, rhs)| {
+            if rhs.is_zero() {
+                Err(ArrowError::InvalidArgumentError(
+                    "There is a zero in the division, causing a division by zero".to_string(),
+                ))
+            } else {
+                Ok(*lhs / *rhs)
+            }
+        });
+        unsafe { Buffer::try_from_trusted_len_iter(values) }
+    }?;
+
+    Ok(PrimitiveArray::<T>::from_data(
+        lhs.data_type().clone(),
+        values,
+        validity,
+    ))
+}
+
+/// Divide an array by a constant
+pub fn div_scalar<T>(array: &PrimitiveArray<T>, divisor: &T) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType,
+    T: Div<Output = T> + Zero,
+{
+    if divisor.is_zero() {
+        return Err(ArrowError::InvalidArgumentError(
+            "The divisor cannot be zero".to_string(),
+        ));
+    }
+    let divisor = *divisor;
+    Ok(unary(array, |x| x / divisor, array.data_type()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::Primitive;
+    use crate::datatypes::DataType;
+
+    #[test]
+    fn test_divide() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let result = div(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(1)]).to(DataType::Int32);
+        assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_divide_scalar() {
+        let a = Primitive::from(&vec![None, Some(6)]).to(DataType::Int32);
+        let b = 3i32;
+        let result = div_scalar(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, Some(2)]).to(DataType::Int32);
+        assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_divide_by_zero() {
+        let a = Primitive::from(&vec![Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(0)]).to(DataType::Int32);
+        assert_eq!(div(&a, &b).is_err(), true);
+    }
+
+    #[test]
+    fn test_divide_by_zero_on_null() {
+        let a = Primitive::from(&vec![None]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(0)]).to(DataType::Int32);
+        assert_eq!(div(&a, &b).is_err(), false);
+    }
+}

--- a/src/compute/arithmetics/basic/div.rs
+++ b/src/compute/arithmetics/basic/div.rs
@@ -1,3 +1,4 @@
+//! Definition of basic div operations with primitive arrays
 use std::ops::Div;
 
 use num::{CheckedDiv, Zero};

--- a/src/compute/arithmetics/basic/div.rs
+++ b/src/compute/arithmetics/basic/div.rs
@@ -19,10 +19,10 @@ use crate::{
 /// use arrow2::array::Primitive;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
-/// let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+/// let a = Primitive::from(&vec![Some(10), Some(6)]).to(DataType::Int32);
+/// let b = Primitive::from(&vec![Some(5), Some(6)]).to(DataType::Int32);
 /// let result = div(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![None, None, None, Some(36)]).to(DataType::Int32);
+/// let expected = Primitive::from(&vec![Some(2), Some(1)]).to(DataType::Int32);
 /// assert_eq!(result, expected)
 /// ```
 #[inline]
@@ -49,10 +49,10 @@ where
 /// use arrow2::array::Primitive;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
-/// let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// let a = Primitive::from(&vec![Some(-100i8), Some(10i8)]).to(DataType::Int8);
+/// let b = Primitive::from(&vec![Some(100i8), Some(0i8)]).to(DataType::Int8);
 /// let result = checked_div(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(-128)]).to(DataType::Int8);
+/// let expected = Primitive::from(&vec![Some(-1i8), None]).to(DataType::Int8);
 /// assert_eq!(result, expected);
 /// ```
 pub fn checked_div<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
@@ -81,7 +81,7 @@ where
 ///
 /// let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
 /// let result = div_scalar(&a, &2i32);
-/// let expected = Primitive::from(&vec![None, Some(12), None, Some(12)]).to(DataType::Int32);
+/// let expected = Primitive::from(&vec![None, Some(3), None, Some(3)]).to(DataType::Int32);
 /// assert_eq!(result, expected)
 /// ```
 #[inline]
@@ -98,13 +98,13 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::div::saturating_div_scalar;
+/// use arrow2::compute::arithmetics::basic::div::checked_div_scalar;
 /// use arrow2::array::Primitive;
 /// use arrow2::datatypes::DataType;
 ///
 /// let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
-/// let result = saturating_div_scalar(&a, &100i8);
-/// let expected = Primitive::from(&vec![Some(-128i8)]).to(DataType::Int8);
+/// let result = checked_div_scalar(&a, &100i8);
+/// let expected = Primitive::from(&vec![Some(-1i8)]).to(DataType::Int8);
 /// assert_eq!(result, expected);
 /// ```
 #[inline]

--- a/src/compute/arithmetics/basic/mod.rs
+++ b/src/compute/arithmetics/basic/mod.rs
@@ -1,0 +1,5 @@
+pub mod add;
+pub mod div;
+pub mod mul;
+pub mod pow;
+pub mod sub;

--- a/src/compute/arithmetics/basic/mod.rs
+++ b/src/compute/arithmetics/basic/mod.rs
@@ -1,4 +1,3 @@
-//! Defines the basic arithmetic kernels for primitives `PrimitiveArrays`.
 pub mod add;
 pub mod div;
 pub mod mul;

--- a/src/compute/arithmetics/basic/mod.rs
+++ b/src/compute/arithmetics/basic/mod.rs
@@ -1,3 +1,4 @@
+//! Defines the basic arithmetic kernels for primitives `PrimitiveArrays`.
 pub mod add;
 pub mod div;
 pub mod mul;

--- a/src/compute/arithmetics/basic/mod.rs
+++ b/src/compute/arithmetics/basic/mod.rs
@@ -1,3 +1,4 @@
+//! Defines the arithmetic kernels for `PrimitiveArrays`.
 pub mod add;
 pub mod div;
 pub mod mul;

--- a/src/compute/arithmetics/basic/mul.rs
+++ b/src/compute/arithmetics/basic/mul.rs
@@ -1,0 +1,47 @@
+use std::ops::Mul;
+
+use crate::{
+    array::{Array, PrimitiveArray},
+    compute::arity::{binary, unary},
+    error::{ArrowError, Result},
+    types::NativeType,
+};
+
+#[inline]
+pub fn mul<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + Mul<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    binary(lhs, rhs, lhs.data_type().clone(), |lhs, rhs| lhs * rhs)
+}
+
+#[inline]
+pub fn mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
+where
+    T: NativeType + Mul<Output = T>,
+{
+    let rhs = *rhs;
+    unary(lhs, |lhs| lhs * rhs, lhs.data_type())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::Primitive;
+    use crate::datatypes::DataType;
+
+    #[test]
+    fn test_multiply() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let result = mul(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(36)]).to(DataType::Int32);
+        assert_eq!(result, expected)
+    }
+}

--- a/src/compute/arithmetics/basic/mul.rs
+++ b/src/compute/arithmetics/basic/mul.rs
@@ -1,3 +1,4 @@
+//! Definition of basic mul operations with primitive arrays
 use std::ops::Mul;
 
 use num::{

--- a/src/compute/arithmetics/basic/mul.rs
+++ b/src/compute/arithmetics/basic/mul.rs
@@ -1,12 +1,33 @@
 use std::ops::Mul;
 
+use num::{
+    traits::{ops::overflowing::OverflowingMul, SaturatingMul},
+    CheckedMul,
+};
+
 use crate::{
     array::{Array, PrimitiveArray},
-    compute::arity::{binary, unary},
+    bitmap::Bitmap,
+    compute::arity::{binary, binary_with_bitmap, try_binary, try_unary, unary, unary_with_bitmap},
     error::{ArrowError, Result},
     types::NativeType,
 };
 
+/// Multiplies two primitive arrays with the same type.
+/// Panics if the multiplication of one pair of values overflows.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::mul::mul;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+/// let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+/// let result = mul(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![None, None, None, Some(36)]).to(DataType::Int32);
+/// assert_eq!(result, expected)
+/// ```
 #[inline]
 pub fn mul<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
@@ -18,16 +39,231 @@ where
         ));
     }
 
-    binary(lhs, rhs, lhs.data_type().clone(), |lhs, rhs| lhs * rhs)
+    binary(lhs, rhs, lhs.data_type().clone(), |a, b| a * b)
 }
 
+/// Checked multiplication of two primitive arrays. If the result from the
+/// multiplications overflows for this type an ArrowError::ArithmeticError is
+/// returned.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::mul::checked_mul;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// checked_mul(&a, &b)
+///     .err()
+///     .expect("should have failed due to overflow");
+/// ```
+pub fn checked_mul<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + CheckedMul<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    let op = move |a: T, b: T| {
+        let res = a.checked_mul(&b);
+
+        match res {
+            Some(val) => Ok(val),
+            None => {
+                return Err(ArrowError::ArithmeticError(
+                    "Saturated result in multiplication".to_string(),
+                ));
+            }
+        }
+    };
+
+    try_binary(lhs, rhs, lhs.data_type().clone(), op)
+}
+
+/// Saturating multiplication of two primitive arrays. If the result from the
+/// multiplication overflows, the result for the
+/// operation will be the saturated value.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::mul::saturating_mul;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+/// let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// let result = saturating_mul(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![Some(-128)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+pub fn saturating_mul<T>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveArray<T>,
+) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + SaturatingMul<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    let op = move |a: T, b: T| a.saturating_mul(&b);
+
+    binary(lhs, rhs, lhs.data_type().clone(), op)
+}
+
+/// Overflowing multiplication of two primitive arrays. If the result from the
+/// mul overflows, the result for the operation will be an array with
+/// overflowed values and a validity array indicating the overflowing elements
+/// from the array.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::mul::overflowing_mul;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(1i8), Some(-100i8)]).to(DataType::Int8);
+/// let b = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+/// let (result, overflow) = overflowing_mul(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![Some(1i8), Some(-16i8)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+pub fn overflowing_mul<T>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveArray<T>,
+) -> Result<(PrimitiveArray<T>, Bitmap)>
+where
+    T: NativeType + OverflowingMul<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    let op = move |a: T, b: T| a.overflowing_mul(&b);
+
+    binary_with_bitmap(lhs, rhs, lhs.data_type().clone(), op)
+}
+
+/// Multiply a scalar T to a primitive array of type T.
+/// Panics if the multiplication of the values overflows.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::mul::mul_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+/// let result = mul_scalar(&a, &2i32);
+/// let expected = Primitive::from(&vec![None, Some(12), None, Some(12)]).to(DataType::Int32);
+/// assert_eq!(result, expected)
+/// ```
 #[inline]
 pub fn mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + Mul<Output = T>,
 {
     let rhs = *rhs;
-    unary(lhs, |lhs| lhs * rhs, lhs.data_type())
+    unary(lhs, |a| a * rhs, lhs.data_type())
+}
+
+/// Checked multiplication of a scalar T to a primitive array of type T. If the
+/// result from the multiplication overflows for this
+/// type an ArrowError::ArithmeticError is returned.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::mul::checked_mul_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+/// checked_mul_scalar(&a, &100i8)
+///     .err()
+///     .expect("should have failed due to overflow");
+/// ```
+#[inline]
+pub fn checked_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + CheckedMul<Output = T>,
+{
+    let rhs = *rhs;
+    let op = move |a: T| {
+        let res = a.checked_mul(&rhs);
+
+        match res {
+            Some(val) => Ok(val),
+            None => {
+                return Err(ArrowError::ArithmeticError(
+                    "Saturated result in multiplication".to_string(),
+                ));
+            }
+        }
+    };
+
+    try_unary(lhs, op, lhs.data_type())
+}
+
+/// Saturated multiplication of a scalar T to a primitive array of type T. If the
+/// result from the mul overflows for this type, then
+/// the result will be saturated
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::mul::saturating_mul_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+/// let result = saturating_mul_scalar(&a, &100i8);
+/// let expected = Primitive::from(&vec![Some(-128i8)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+#[inline]
+pub fn saturating_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
+where
+    T: NativeType + SaturatingMul<Output = T>,
+{
+    let rhs = *rhs;
+    let op = move |a: T| a.saturating_mul(&rhs);
+
+    unary(lhs, op, lhs.data_type())
+}
+
+/// Overflowing multiplication of a scalar T to a primitive array of type T. If
+/// the result from the mul overflows for this type,
+/// then the result will be an array with overflowed values and a validity
+/// array indicating the overflowing elements from the array
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::mul::overflowing_mul_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+/// let (result, overflow) = overflowing_mul_scalar(&a, &100i8);
+/// let expected = Primitive::from(&vec![Some(100i8), Some(16i8)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+#[inline]
+pub fn overflowing_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> (PrimitiveArray<T>, Bitmap)
+where
+    T: NativeType + OverflowingMul<Output = T>,
+{
+    let rhs = *rhs;
+    let op = move |a: T| a.overflowing_mul(&rhs);
+
+    unary_with_bitmap(lhs, op, lhs.data_type())
 }
 
 #[cfg(test)]
@@ -37,11 +273,124 @@ mod tests {
     use crate::datatypes::DataType;
 
     #[test]
-    fn test_multiply() {
+    fn test_mul_mismatched_length() {
+        let a = Primitive::from_slice(vec![5, 6]).to(DataType::Int32);
+        let b = Primitive::from_slice(vec![5]).to(DataType::Int32);
+        mul(&a, &b)
+            .err()
+            .expect("should have failed due to different lengths");
+    }
+
+    #[test]
+    fn test_mul() {
         let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
         let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
         let result = mul(&a, &b).unwrap();
         let expected = Primitive::from(&vec![None, None, None, Some(36)]).to(DataType::Int32);
         assert_eq!(result, expected)
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_mul_panic() {
+        let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        let _ = mul(&a, &b);
+    }
+
+    #[test]
+    fn test_mul_checked() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let result = checked_mul(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(36)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        checked_mul(&a, &b)
+            .err()
+            .expect("should have failed due to overflow");
+    }
+
+    #[test]
+    fn test_mul_saturating() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let result = saturating_mul(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(36)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        let result = saturating_mul(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![Some(-128)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_mul_overflowing() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let (result, overflow) = overflowing_mul(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(36)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b0000);
+
+        let a = Primitive::from(&vec![Some(1i8), Some(-100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+        let (result, overflow) = overflowing_mul(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![Some(1i8), Some(-16i8)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b10);
+    }
+
+    #[test]
+    fn test_mul_scalar() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let result = mul_scalar(&a, &1i32);
+        let expected = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_mul_scalar_checked() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let result = checked_mul_scalar(&a, &1i32).unwrap();
+        let expected = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+        checked_mul_scalar(&a, &100i8)
+            .err()
+            .expect("should have failed due to overflow");
+    }
+
+    #[test]
+    fn test_mul_scalar_saturating() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let result = saturating_mul_scalar(&a, &1i32);
+        let expected = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+        let result = saturating_mul_scalar(&a, &100i8);
+        let expected = Primitive::from(&vec![Some(-128)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_mul_scalar_overflowing() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let (result, overflow) = overflowing_mul_scalar(&a, &1i32);
+        let expected = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b0000);
+
+        let a = Primitive::from(&vec![Some(1i8), Some(-100i8)]).to(DataType::Int8);
+        let (result, overflow) = overflowing_mul_scalar(&a, &100i8);
+        let expected = Primitive::from(&vec![Some(100i8), Some(-16i8)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b10);
     }
 }

--- a/src/compute/arithmetics/basic/pow.rs
+++ b/src/compute/arithmetics/basic/pow.rs
@@ -1,17 +1,57 @@
-use num::traits::Pow;
+//! Definition of basic pow operations with primitive arrays
+use num::{checked_pow, traits::Pow, CheckedMul, One, Zero};
 
 use crate::{
     array::{Array, PrimitiveArray},
-    compute::arity::unary,
+    compute::arity::{unary, unary_checked},
     types::NativeType,
 };
 
+/// Raises an array of primitives to the power of exponent. Panics if one of
+/// the values values overflows.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::pow::powf_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(2f32), None]).to(DataType::Float32);
+/// let actual = powf_scalar(&a, 2.0);
+/// let expected = Primitive::from(&vec![Some(4f32), None]).to(DataType::Float32);
+/// assert_eq!(expected, actual);
+/// ```
 #[inline]
 pub fn powf_scalar<T>(array: &PrimitiveArray<T>, exponent: T) -> PrimitiveArray<T>
 where
     T: NativeType + Pow<T, Output = T>,
 {
     unary(array, |x| x.pow(exponent), array.data_type())
+}
+
+/// Checked operation of raising an array of primitives to the power of
+/// exponent. If the result from the multiplications overflows, the validity
+/// for that index is changed returned.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::pow::checked_powf_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(1i8), None, Some(7i8)]).to(DataType::Int8);
+/// let actual = checked_powf_scalar(&a, 8usize);
+/// let expected = Primitive::from(&vec![Some(1i8), None, None]).to(DataType::Int8);
+/// assert_eq!(expected, actual);
+/// ```
+#[inline]
+pub fn checked_powf_scalar<T>(array: &PrimitiveArray<T>, exponent: usize) -> PrimitiveArray<T>
+where
+    T: NativeType + Zero + One + CheckedMul,
+{
+    let op = move |a: T| checked_pow(a, exponent);
+
+    unary_checked(array, op, array.data_type())
 }
 
 #[cfg(test)]
@@ -25,6 +65,14 @@ mod tests {
         let a = Primitive::from(&vec![Some(2f32), None]).to(DataType::Float32);
         let actual = powf_scalar(&a, 2.0);
         let expected = Primitive::from(&vec![Some(4f32), None]).to(DataType::Float32);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_raise_power_scalar_checked() {
+        let a = Primitive::from(&vec![Some(1i8), None, Some(7i8)]).to(DataType::Int8);
+        let actual = checked_powf_scalar(&a, 8usize);
+        let expected = Primitive::from(&vec![Some(1i8), None, None]).to(DataType::Int8);
         assert_eq!(expected, actual);
     }
 }

--- a/src/compute/arithmetics/basic/pow.rs
+++ b/src/compute/arithmetics/basic/pow.rs
@@ -1,0 +1,30 @@
+use num::traits::Pow;
+
+use crate::{
+    array::{Array, PrimitiveArray},
+    compute::arity::unary,
+    types::NativeType,
+};
+
+#[inline]
+pub fn powf_scalar<T>(array: &PrimitiveArray<T>, exponent: T) -> PrimitiveArray<T>
+where
+    T: NativeType + Pow<T, Output = T>,
+{
+    unary(array, |x| x.pow(exponent), array.data_type())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::Primitive;
+    use crate::datatypes::DataType;
+
+    #[test]
+    fn test_raise_power_scalar() {
+        let a = Primitive::from(&vec![Some(2f32), None]).to(DataType::Float32);
+        let actual = powf_scalar(&a, 2.0);
+        let expected = Primitive::from(&vec![Some(4f32), None]).to(DataType::Float32);
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/compute/arithmetics/basic/sub.rs
+++ b/src/compute/arithmetics/basic/sub.rs
@@ -1,0 +1,55 @@
+use std::ops::{Neg, Sub};
+
+use crate::{
+    array::{Array, PrimitiveArray},
+    compute::arity::{binary, unary},
+    error::{ArrowError, Result},
+    types::NativeType,
+};
+
+#[inline]
+pub fn sub<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + Sub<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    binary(lhs, rhs, lhs.data_type().clone(), |a, b| a - b)
+}
+
+#[inline]
+pub fn sub_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
+where
+    T: NativeType + Sub<Output = T>,
+{
+    let rhs = *rhs;
+    unary(lhs, |a| a - rhs, lhs.data_type())
+}
+
+#[inline]
+pub fn negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
+where
+    T: NativeType + Neg<Output = T>,
+{
+    unary(array, |a| -a, array.data_type())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::Primitive;
+    use crate::datatypes::DataType;
+
+    #[test]
+    fn test_subtract() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let result = sub(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(0)]).to(DataType::Int32);
+        assert_eq!(result, expected)
+    }
+}

--- a/src/compute/arithmetics/basic/sub.rs
+++ b/src/compute/arithmetics/basic/sub.rs
@@ -1,12 +1,54 @@
 use std::ops::{Neg, Sub};
 
+use num::{
+    traits::{ops::overflowing::OverflowingSub, SaturatingSub},
+    CheckedSub,
+};
+
 use crate::{
     array::{Array, PrimitiveArray},
-    compute::arity::{binary, unary},
+    bitmap::Bitmap,
+    compute::arity::{binary, binary_with_bitmap, try_binary, try_unary, unary, unary_with_bitmap},
     error::{ArrowError, Result},
     types::NativeType,
 };
 
+/// Negates values from array.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::sub::negate;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![None, Some(6), None, Some(7)]).to(DataType::Int32);
+/// let result = negate(&a);
+/// let expected = Primitive::from(&vec![None, Some(-6), None, Some(-7)]).to(DataType::Int32);
+/// assert_eq!(result, expected)
+/// ```
+#[inline]
+pub fn negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
+where
+    T: NativeType + Neg<Output = T>,
+{
+    unary(array, |a| -a, array.data_type())
+}
+
+/// Subtracts two primitive arrays with the same type.
+/// Panics if the subtraction of one pair of values overflows.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::sub::sub;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+/// let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+/// let result = sub(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![None, None, None, Some(0)]).to(DataType::Int32);
+/// assert_eq!(result, expected)
+/// ```
 #[inline]
 pub fn sub<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
@@ -21,6 +63,131 @@ where
     binary(lhs, rhs, lhs.data_type().clone(), |a, b| a - b)
 }
 
+/// Checked subtraction of two primitive arrays. If the result from the
+/// subtraction is smaller than the possible number for this type an
+/// ArrowError::ArithmeticError is returned.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::sub::checked_sub;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+/// let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// checked_sub(&a, &b)
+///     .err()
+///     .expect("should have failed due to overflow");
+/// ```
+pub fn checked_sub<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + CheckedSub<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    let op = move |a: T, b: T| {
+        let res = a.checked_sub(&b);
+
+        match res {
+            Some(val) => Ok(val),
+            None => {
+                return Err(ArrowError::ArithmeticError(
+                    "Saturated result in subtraction".to_string(),
+                ));
+            }
+        }
+    };
+
+    try_binary(lhs, rhs, lhs.data_type().clone(), op)
+}
+
+/// Saturating subtraction of two primitive arrays. If the result from the sub
+/// is smaller than the possible number for this type, the result for the
+/// operation will be the saturated value.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::sub::saturating_sub;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+/// let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// let result = saturating_sub(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![Some(-128)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+pub fn saturating_sub<T>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveArray<T>,
+) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + SaturatingSub<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    let op = move |a: T, b: T| a.saturating_sub(&b);
+
+    binary(lhs, rhs, lhs.data_type().clone(), op)
+}
+
+/// Overflowing subtraction of two primitive arrays. If the result from the sub
+/// is smaller than the possible number for this type, the result for the
+/// operation will be an array with overflowed values and a validity array
+/// indicating the overflowing elements from the array.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::sub::overflowing_sub;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(1i8), Some(-100i8)]).to(DataType::Int8);
+/// let b = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+/// let (result, overflow) = overflowing_sub(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![Some(0i8), Some(56i8)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+pub fn overflowing_sub<T>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveArray<T>,
+) -> Result<(PrimitiveArray<T>, Bitmap)>
+where
+    T: NativeType + OverflowingSub<Output = T>,
+{
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Arrays must have the same logical type".to_string(),
+        ));
+    }
+
+    let op = move |a: T, b: T| a.overflowing_sub(&b);
+
+    binary_with_bitmap(lhs, rhs, lhs.data_type().clone(), op)
+}
+
+/// Subtract a scalar T to a primitive array of type T.
+/// Panics if the subtraction of the values overflows.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::sub::sub_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+/// let result = sub_scalar(&a, &1i32);
+/// let expected = Primitive::from(&vec![None, Some(5), None, Some(5)]).to(DataType::Int32);
+/// assert_eq!(result, expected)
+/// ```
 #[inline]
 pub fn sub_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
@@ -30,12 +197,94 @@ where
     unary(lhs, |a| a - rhs, lhs.data_type())
 }
 
+/// Checked subtraction of a scalar T to a primitive array of type T. If the
+/// result from the subtraction is smaller than the possible number for this
+/// type an ArrowError::ArithmeticError is returned.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::sub::checked_sub_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+/// checked_sub_scalar(&a, &100i8)
+///     .err()
+///     .expect("should have failed due to overflow");
+/// ```
 #[inline]
-pub fn negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
+pub fn checked_sub_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> Result<PrimitiveArray<T>>
 where
-    T: NativeType + Neg<Output = T>,
+    T: NativeType + CheckedSub<Output = T>,
 {
-    unary(array, |a| -a, array.data_type())
+    let rhs = *rhs;
+    let op = move |a: T| {
+        let res = a.checked_sub(&rhs);
+
+        match res {
+            Some(val) => Ok(val),
+            None => {
+                return Err(ArrowError::ArithmeticError(
+                    "Saturated result in subtraction".to_string(),
+                ));
+            }
+        }
+    };
+
+    try_unary(lhs, op, lhs.data_type())
+}
+
+/// Saturated subtraction of a scalar T to a primitive array of type T. If the
+/// result from the sub is smaller than the possible number for this type, then
+/// the result will be saturated
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::sub::saturating_sub_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+/// let result = saturating_sub_scalar(&a, &100i8);
+/// let expected = Primitive::from(&vec![Some(-128i8)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+#[inline]
+pub fn saturating_sub_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
+where
+    T: NativeType + SaturatingSub<Output = T>,
+{
+    let rhs = *rhs;
+    let op = move |a: T| a.saturating_sub(&rhs);
+
+    unary(lhs, op, lhs.data_type())
+}
+
+/// Overflowing subtraction of a scalar T to a primitive array of type T. If
+/// the result from the sub is smaller than the possible number for this type,
+/// then the result will be an array with overflowed values and a validity
+/// array indicating the overflowing elements from the array
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::basic::sub::overflowing_sub_scalar;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(1i8), Some(-100i8)]).to(DataType::Int8);
+/// let (result, overflow) = overflowing_sub_scalar(&a, &100i8);
+/// let expected = Primitive::from(&vec![Some(-99i8), Some(56i8)]).to(DataType::Int8);
+/// assert_eq!(result, expected);
+/// ```
+#[inline]
+pub fn overflowing_sub_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> (PrimitiveArray<T>, Bitmap)
+where
+    T: NativeType + OverflowingSub<Output = T>,
+{
+    let rhs = *rhs;
+    let op = move |a: T| a.overflowing_sub(&rhs);
+
+    unary_with_bitmap(lhs, op, lhs.data_type())
 }
 
 #[cfg(test)]
@@ -45,11 +294,124 @@ mod tests {
     use crate::datatypes::DataType;
 
     #[test]
-    fn test_subtract() {
+    fn test_sub_mismatched_length() {
+        let a = Primitive::from_slice(vec![5, 6]).to(DataType::Int32);
+        let b = Primitive::from_slice(vec![5]).to(DataType::Int32);
+        sub(&a, &b)
+            .err()
+            .expect("should have failed due to different lengths");
+    }
+
+    #[test]
+    fn test_sub() {
         let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
         let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
         let result = sub(&a, &b).unwrap();
         let expected = Primitive::from(&vec![None, None, None, Some(0)]).to(DataType::Int32);
         assert_eq!(result, expected)
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sub_panic() {
+        let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        let _ = sub(&a, &b);
+    }
+
+    #[test]
+    fn test_sub_checked() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let result = checked_sub(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(0)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        checked_sub(&a, &b)
+            .err()
+            .expect("should have failed due to overflow");
+    }
+
+    #[test]
+    fn test_sub_saturating() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let result = saturating_sub(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(0)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+        let result = saturating_sub(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![Some(-128)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_sub_overflowing() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+        let (result, overflow) = overflowing_sub(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![None, None, None, Some(0)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b0000);
+
+        let a = Primitive::from(&vec![Some(1i8), Some(-100i8)]).to(DataType::Int8);
+        let b = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+        let (result, overflow) = overflowing_sub(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![Some(0i8), Some(56i8)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b10);
+    }
+
+    #[test]
+    fn test_sub_scalar() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let result = sub_scalar(&a, &1i32);
+        let expected = Primitive::from(&vec![None, Some(5), None, Some(5)]).to(DataType::Int32);
+        assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_sub_scalar_checked() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let result = checked_sub_scalar(&a, &1i32).unwrap();
+        let expected = Primitive::from(&vec![None, Some(5), None, Some(5)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+        checked_sub_scalar(&a, &100i8)
+            .err()
+            .expect("should have failed due to overflow");
+    }
+
+    #[test]
+    fn test_sub_scalar_saturating() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let result = saturating_sub_scalar(&a, &1i32);
+        let expected = Primitive::from(&vec![None, Some(5), None, Some(5)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+
+        let a = Primitive::from(&vec![Some(-100i8)]).to(DataType::Int8);
+        let result = saturating_sub_scalar(&a, &100i8);
+        let expected = Primitive::from(&vec![Some(-128)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_sub_scalar_overflowing() {
+        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+        let (result, overflow) = overflowing_sub_scalar(&a, &1i32);
+        let expected = Primitive::from(&vec![None, Some(5), None, Some(5)]).to(DataType::Int32);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b0000);
+
+        let a = Primitive::from(&vec![Some(1i8), Some(-100i8)]).to(DataType::Int8);
+        let (result, overflow) = overflowing_sub_scalar(&a, &100i8);
+        let expected = Primitive::from(&vec![Some(-99i8), Some(56i8)]).to(DataType::Int8);
+        assert_eq!(result, expected);
+        assert_eq!(overflow.as_slice()[0], 0b10);
     }
 }

--- a/src/compute/arithmetics/basic/sub.rs
+++ b/src/compute/arithmetics/basic/sub.rs
@@ -1,3 +1,4 @@
+//! Definition of basic sub operations with primitive arrays
 use std::ops::{Neg, Sub};
 
 use num::{

--- a/src/compute/arithmetics/decimal/div.rs
+++ b/src/compute/arithmetics/decimal/div.rs
@@ -21,6 +21,10 @@
 use crate::{
     array::{Array, PrimitiveArray},
     buffer::Buffer,
+    compute::{
+        arity::{binary, binary_checked},
+        utils::combine_validities,
+    },
 };
 use crate::{
     datatypes::DataType,
@@ -28,14 +32,27 @@ use crate::{
 };
 
 use super::{adjusted_precision_scale, max_value, number_digits};
-use crate::compute::arity::{binary, try_binary};
-use crate::compute::utils::combine_validities;
 
 /// Divide two decimal primitive arrays with the same precision and scale. If
 /// the precision and scale is different, then an InvalidArgumentError is
 /// returned. This function panics if the dividend is divided by 0 or None.
 /// This function also panics if the division produces a number larger
 /// than the possible number for the array precision.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::decimal::div::div;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(1_00i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
+/// let b = Primitive::from(&vec![Some(1_00i128), Some(2_00i128), Some(2_00i128)]).to(DataType::Decimal(5, 2));
+///
+/// let result = div(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![Some(1_00i128), Some(2_00i128), Some(3_00i128)]).to(DataType::Decimal(5, 2));
+///
+/// assert_eq!(result, expected);
+/// ```
 pub fn div(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<PrimitiveArray<i128>> {
     // Matching on both data types from both arrays
     // This match will be true only when precision and scale from both
@@ -91,7 +108,22 @@ pub fn div(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<Pri
 /// InvalidArgumentError is returned. If the result from the division is
 /// larger than the possible number with the selected precision then the
 /// resulted number in the arrow array is the maximum number for the selected
-/// precision.
+/// precision. The function panics if divided by zero.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::decimal::div::saturating_div;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(999_99i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
+/// let b = Primitive::from(&vec![Some(000_01i128), Some(2_00i128), Some(2_00i128)]).to(DataType::Decimal(5, 2));
+///
+/// let result = saturating_div(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![Some(999_99i128), Some(2_00i128), Some(3_00i128)]).to(DataType::Decimal(5, 2));
+///
+/// assert_eq!(result, expected);
+/// ```
 pub fn saturating_div(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
@@ -142,9 +174,23 @@ pub fn saturating_div(
 
 /// Checked division of two decimal primitive arrays with the same precision
 /// and scale. If the precision and scale is different, then an
-/// InvalidArgumentError is returned. If the result from the division is larger
-/// than the possible number with the selected precision then the function
-/// returns an ArrowError::ArithmeticError.
+/// InvalidArgumentError is returned. If the divisor is zero, then the
+/// validity for that index is changed to None
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::decimal::div::checked_div;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(1_00i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
+/// let b = Primitive::from(&vec![Some(000_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
+///
+/// let result = checked_div(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![None, None, Some(3_00i128)]).to(DataType::Decimal(5, 2));
+///
+/// assert_eq!(result, expected);
+/// ```
 pub fn checked_div(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
@@ -159,24 +205,16 @@ pub fn checked_div(
                 let op = move |a: i128, b: i128| {
                     let numeral: i128 = a * 10i128.pow(*lhs_s as u32);
 
-                    match numeral.checked_mul(b) {
+                    match numeral.checked_div(b) {
                         Some(res) => match res {
-                            res if res.abs() > max_value(*lhs_p) => {
-                                return Err(ArrowError::ArithmeticError(
-                                    "Saturated result in multiplication".to_string(),
-                                ));
-                            }
-                            _ => Ok(res),
+                            res if res.abs() > max_value(*lhs_p) => None,
+                            _ => Some(res),
                         },
-                        None => {
-                            return Err(ArrowError::ArithmeticError(
-                                "Found division by zero".to_string(),
-                            ));
-                        }
+                        None => None,
                     }
                 };
 
-                try_binary(lhs, rhs, lhs.data_type().clone(), op)
+                binary_checked(lhs, rhs, lhs.data_type().clone(), op)
             } else {
                 return Err(ArrowError::InvalidArgumentError(
                     "Arrays must have the same precision and scale".to_string(),
@@ -195,7 +233,28 @@ pub fn checked_div(
 /// and scale. If the precision and scale is different, then the smallest scale
 /// and precision is adjusted to the largest precision and scale. If during the
 /// division one of the results is larger than the max possible value, the
-/// result precision is changed to the precision of the max value
+/// result precision is changed to the precision of the max value. The function
+/// panics when divided by zero.
+///
+/// ```nocode
+///  1000.00   -> 7, 2
+///    10.0000 -> 6, 4
+/// -----------------
+///   100.0000 -> 9, 4
+/// ```
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::decimal::div::adaptive_div;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::DataType;
+///
+/// let a = Primitive::from(&vec![Some(1000_00i128)]).to(DataType::Decimal(7, 2));
+/// let b = Primitive::from(&vec![Some(10_0000i128)]).to(DataType::Decimal(6, 4));
+/// let result = adaptive_div(&a, &b).unwrap();
+/// let expected = Primitive::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(9, 4));
+///
+/// assert_eq!(result, expected);
+/// ```
 pub fn adaptive_div(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
@@ -432,17 +491,16 @@ mod tests {
 
     #[test]
     fn test_divide_checked_overflow() {
-        let a = Primitive::from(&vec![Some(99999i128)]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![Some(00001i128)]).to(DataType::Decimal(5, 2));
-        let result = checked_div(&a, &b);
+        let a = Primitive::from(&vec![Some(1_00i128), Some(4_00i128), Some(6_00i128)])
+            .to(DataType::Decimal(5, 2));
+        let b = Primitive::from(&vec![Some(000_00i128), None, Some(2_00i128)])
+            .to(DataType::Decimal(5, 2));
 
-        match result {
-            Err(err) => match err {
-                ArrowError::ArithmeticError(_) => assert!(true),
-                _ => panic!("Should return ArrowError::ArithmeticError should be detected"),
-            },
-            _ => panic!("Should return ArrowError::ArithmeticError should be detected"),
-        }
+        let result = checked_div(&a, &b).unwrap();
+        let expected =
+            Primitive::from(&vec![None, None, Some(3_00i128)]).to(DataType::Decimal(5, 2));
+
+        assert_eq!(result, expected);
     }
 
     #[test]

--- a/src/compute/arithmetics/decimal/mod.rs
+++ b/src/compute/arithmetics/decimal/mod.rs
@@ -1,20 +1,3 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 //! Defines the arithmetic kernels for Decimal `PrimitiveArrays`.
 //! The Decimal type specifies the precision and scale parameters. These
 //! affect the arithmetic operations and need to be considered while

--- a/src/compute/arithmetics/decimal/mod.rs
+++ b/src/compute/arithmetics/decimal/mod.rs
@@ -21,9 +21,9 @@
 //! doing operations with Decimal numbers.
 
 pub mod add;
-pub mod divide;
-pub mod multiply;
-pub mod subtract;
+pub mod div;
+pub mod mul;
+pub mod sub;
 
 /// Maximum value that can exist with a selected precision
 #[inline]

--- a/src/compute/arithmetics/decimal/mod.rs
+++ b/src/compute/arithmetics/decimal/mod.rs
@@ -1,7 +1,7 @@
-//! Defines the arithmetic kernels for Decimal `PrimitiveArrays`.
-//! The Decimal type specifies the precision and scale parameters. These
-//! affect the arithmetic operations and need to be considered while
-//! doing operations with Decimal numbers.
+//! Defines the arithmetic kernels for Decimal `PrimitiveArrays`. The
+//! [`Decimal`](crate::datatypes::DataType::Decimal) type specifies the
+//! precision and scale parameters. These affect the arithmetic operations and
+//! need to be considered while doing operations with Decimal numbers.
 
 pub mod add;
 pub mod div;

--- a/src/compute/arithmetics/decimal/mul.rs
+++ b/src/compute/arithmetics/decimal/mul.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines the division arithmetic kernels for Decimal
+//! Defines the multiplication arithmetic kernels for Decimal
 //! `PrimitiveArrays`.
 
 use crate::{
@@ -31,15 +31,11 @@ use super::{adjusted_precision_scale, max_value, number_digits};
 use crate::compute::arity::{binary, try_binary};
 use crate::compute::utils::combine_validities;
 
-/// Divide two decimal primitive arrays with the same precision and scale. If
+/// Multiply two decimal primitive arrays with the same precision and scale. If
 /// the precision and scale is different, then an InvalidArgumentError is
-/// returned. This function panics if the dividend is divided by 0 or None.
-/// This function also panics if the division produces a number larger
-/// than the possible number for the array precision.
-pub fn divide(
-    lhs: &PrimitiveArray<i128>,
-    rhs: &PrimitiveArray<i128>,
-) -> Result<PrimitiveArray<i128>> {
+/// returned. This function panics if the multiplied numbers result in a number
+/// larger than the possible number for the selected precision.
+pub fn mul(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<PrimitiveArray<i128>> {
     // Matching on both data types from both arrays
     // This match will be true only when precision and scale from both
     // arrays are the same, otherwise it will return and ArrowError
@@ -50,19 +46,20 @@ pub fn divide(
                 // the sum of the values is larger than the max value possible
                 // for the decimal precision
                 let op = move |a: i128, b: i128| {
-                    // The division is done using the numbers without scale.
-                    // The dividend is scaled up to maintain precision after the
-                    // division
+                    // The multiplication between i128 can overflow if they are
+                    // very large numbers. For that reason a checked
+                    // multiplication is used.
+                    let res: i128 = a.checked_mul(b).expect("Mayor overflow for multiplication");
 
-                    //   222.222 -->  222222000
-                    //   123.456 -->     123456
-                    // --------       ---------
-                    //     1.800 <--       1800
-                    let numeral: i128 = a * 10i128.pow(*lhs_s as u32);
+                    // The multiplication is done using the numbers without scale.
+                    // The resulting scale of the value has to be corrected by
+                    // dividing by (10^scale)
 
-                    // The division can overflow if the dividend is divided
-                    // by zero.
-                    let res: i128 = numeral.checked_div(b).expect("Found division by zero");
+                    //   111.111 -->      111111
+                    //   222.222 -->      222222
+                    // --------          -------
+                    // 24691.308 <-- 24691308642
+                    let res = res / 10i128.pow(*lhs_s as u32);
 
                     if res.abs() > max_value(*lhs_p) {
                         panic!(
@@ -89,13 +86,13 @@ pub fn divide(
     }
 }
 
-/// Saturated division of two decimal primitive arrays with the same
+/// Saturated multiplication of two decimal primitive arrays with the same
 /// precision and scale. If the precision and scale is different, then an
-/// InvalidArgumentError is returned. If the result from the division is
+/// InvalidArgumentError is returned. If the result from the multiplication is
 /// larger than the possible number with the selected precision then the
 /// resulted number in the arrow array is the maximum number for the selected
 /// precision.
-pub fn saturating_divide(
+pub fn saturating_mul(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
 ) -> Result<PrimitiveArray<i128>> {
@@ -106,26 +103,23 @@ pub fn saturating_divide(
         (DataType::Decimal(lhs_p, lhs_s), DataType::Decimal(rhs_p, rhs_s)) => {
             if lhs_p == rhs_p && lhs_s == rhs_s {
                 // Closure for the binary operation.
-                let op = move |a: i128, b: i128| {
-                    let numeral: i128 = a * 10i128.pow(*lhs_s as u32);
+                let op = move |a: i128, b: i128| match a.checked_mul(b) {
+                    Some(res) => {
+                        let res = res / 10i128.pow(*lhs_s as u32);
+                        let max = max_value(*lhs_p);
 
-                    match numeral.checked_div(b) {
-                        Some(res) => {
-                            let max = max_value(*lhs_p);
-
-                            match res {
-                                res if res.abs() > max => {
-                                    if res > 0 {
-                                        max
-                                    } else {
-                                        -1 * max
-                                    }
+                        match res {
+                            res if res.abs() > max => {
+                                if res > 0 {
+                                    max
+                                } else {
+                                    -1 * max
                                 }
-                                _ => res,
                             }
+                            _ => res,
                         }
-                        None => 0,
                     }
+                    None => max_value(*lhs_p),
                 };
 
                 binary(lhs, rhs, lhs.data_type().clone(), op)
@@ -143,12 +137,12 @@ pub fn saturating_divide(
     }
 }
 
-/// Checked division of two decimal primitive arrays with the same precision
-/// and scale. If the precision and scale is different, then an
-/// InvalidArgumentError is returned. If the result from the division is larger
-/// than the possible number with the selected precision then the function
-/// returns an ArrowError::ArithmeticError.
-pub fn checked_divide(
+/// Checked multiplication of two decimal primitive arrays with the same
+/// precision and scale. If the precision and scale is different, then an
+/// InvalidArgumentError is returned. If the result from the multiplication is
+/// larger than the possible number with the selected precision then the
+/// function returns an ArrowError::ArithmeticError.
+pub fn checked_mul(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
 ) -> Result<PrimitiveArray<i128>> {
@@ -159,23 +153,23 @@ pub fn checked_divide(
         (DataType::Decimal(lhs_p, lhs_s), DataType::Decimal(rhs_p, rhs_s)) => {
             if lhs_p == rhs_p && lhs_s == rhs_s {
                 // Closure for the binary operation.
-                let op = move |a: i128, b: i128| {
-                    let numeral: i128 = a * 10i128.pow(*lhs_s as u32);
+                let op = move |a: i128, b: i128| match a.checked_mul(b) {
+                    Some(res) => {
+                        let res = res / 10i128.pow(*lhs_s as u32);
 
-                    match numeral.checked_mul(b) {
-                        Some(res) => match res {
+                        match res {
                             res if res.abs() > max_value(*lhs_p) => {
                                 return Err(ArrowError::ArithmeticError(
                                     "Saturated result in multiplication".to_string(),
                                 ));
                             }
                             _ => Ok(res),
-                        },
-                        None => {
-                            return Err(ArrowError::ArithmeticError(
-                                "Found division by zero".to_string(),
-                            ));
                         }
+                    }
+                    None => {
+                        return Err(ArrowError::ArithmeticError(
+                            "Saturated result in multiplication".to_string(),
+                        ));
                     }
                 };
 
@@ -194,12 +188,13 @@ pub fn checked_divide(
     }
 }
 
-/// Adaptive division of two decimal primitive arrays with different precision
-/// and scale. If the precision and scale is different, then the smallest scale
-/// and precision is adjusted to the largest precision and scale. If during the
-/// division one of the results is larger than the max possible value, the
-/// result precision is changed to the precision of the max value
-pub fn adaptive_divide(
+/// Adaptive multiplication of two decimal primitive arrays with different
+/// precision and scale. If the precision and scale is different, then the
+/// smallest scale and precision is adjusted to the largest precision and
+/// scale. If during the multiplication one of the results is larger than the
+/// max possible value, the result precision is changed to the precision of the
+/// max value
+pub fn adaptive_mul(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
 ) -> Result<PrimitiveArray<i128>> {
@@ -219,26 +214,25 @@ pub fn adaptive_divide(
 
         let mut result = Vec::new();
         for (l, r) in lhs.values().iter().zip(rhs.values().iter()) {
-            let numeral: i128 = l * 10i128.pow(res_s as u32);
-
             // Based on the array's scales one of the arguments in the sum has to be shifted
             // to the left to match the final scale
             let res = if lhs_s > rhs_s {
-                numeral
-                    .checked_div(r * 10i128.pow(diff as u32))
-                    .expect("Found division by zero")
+                l.checked_mul(r * 10i128.pow(diff as u32))
+                    .expect("Mayor overflow for multiplication")
             } else {
-                (numeral * 10i128.pow(diff as u32))
-                    .checked_div(*r)
-                    .expect("Found division by zero")
+                (l * 10i128.pow(diff as u32))
+                    .checked_mul(*r)
+                    .expect("Mayor overflow for multiplication")
             };
+
+            let res = res / 10i128.pow(res_s as u32);
 
             // The precision of the resulting array will change if one of the
             // multiplications during the iteration produces a value bigger
             // than the possible value for the initial precision
 
             //  10.0000 -> 6, 4
-            //  00.1000 -> 6, 4
+            //  10.0000 -> 6, 4
             // -----------------
             // 100.0000 -> 7, 4
             if res.abs() > max_value(res_p) {
@@ -270,50 +264,50 @@ mod tests {
     use crate::datatypes::DataType;
 
     #[test]
-    fn test_divide_normal() {
-        //   222.222 -->  222222000
-        //   123.456 -->     123456
-        // --------       ---------
-        //     1.800 <--       1800
+    fn test_multiply_normal() {
+        //   111.11 -->     11111
+        //   222.22 -->     22222
+        // --------       -------
+        // 24690.86 <-- 246908642
         let a = Primitive::from(&vec![
-            Some(222_222i128),
-            Some(10_000i128),
-            Some(20_000i128),
+            Some(111_11i128),
+            Some(10_00i128),
+            Some(20_00i128),
             None,
-            Some(30_000i128),
-            Some(123_456i128),
+            Some(30_00i128),
+            Some(123_45i128),
         ])
-        .to(DataType::Decimal(7, 3));
+        .to(DataType::Decimal(7, 2));
 
         let b = Primitive::from(&vec![
-            Some(123_456i128),
-            Some(2_000i128),
-            Some(3_000i128),
-            Some(4_000i128),
-            Some(4_000i128),
-            Some(654_321i128),
-        ])
-        .to(DataType::Decimal(7, 3));
-
-        let result = divide(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
-            Some(1_800i128),
-            Some(5_000i128),
-            Some(6_666i128),
+            Some(222_22i128),
+            Some(2_00i128),
+            Some(3_00i128),
             None,
-            Some(7_500i128),
-            Some(0_188i128),
+            Some(4_00i128),
+            Some(543_21i128),
         ])
-        .to(DataType::Decimal(7, 3));
+        .to(DataType::Decimal(7, 2));
+
+        let result = mul(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(24690_86i128),
+            Some(20_00i128),
+            Some(60_00i128),
+            None,
+            Some(120_00i128),
+            Some(67059_27i128),
+        ])
+        .to(DataType::Decimal(7, 2));
 
         assert_eq!(result, expected);
     }
 
     #[test]
-    fn test_divide_decimal_wrong_precision() {
+    fn test_multiply_decimal_wrong_precision() {
         let a = Primitive::from(&vec![None]).to(DataType::Decimal(5, 2));
         let b = Primitive::from(&vec![None]).to(DataType::Decimal(6, 2));
-        let result = divide(&a, &b);
+        let result = mul(&a, &b);
 
         if result.is_ok() {
             panic!("Should panic for different precision");
@@ -322,52 +316,51 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "Overflow in multiplication presented for precision 5")]
-    fn test_divide_panic() {
+    fn test_multiply_panic() {
         let a = Primitive::from(&vec![Some(99999i128)]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![Some(000_01i128)]).to(DataType::Decimal(5, 2));
-        let _ = divide(&a, &b);
+        let b = Primitive::from(&vec![Some(100_00i128)]).to(DataType::Decimal(5, 2));
+        let _ = mul(&a, &b);
     }
 
     #[test]
-    fn test_divide_saturating() {
+    fn test_multiply_saturating() {
         let a = Primitive::from(&vec![
-            Some(222_222i128),
-            Some(10_000i128),
-            Some(20_000i128),
+            Some(111_11i128),
+            Some(10_00i128),
+            Some(20_00i128),
             None,
-            Some(30_000i128),
-            Some(123_456i128),
+            Some(30_00i128),
+            Some(123_45i128),
         ])
-        .to(DataType::Decimal(7, 3));
+        .to(DataType::Decimal(7, 2));
 
         let b = Primitive::from(&vec![
-            Some(123_456i128),
-            Some(2_000i128),
-            Some(3_000i128),
-            Some(4_000i128),
-            Some(4_000i128),
-            Some(654_321i128),
-        ])
-        .to(DataType::Decimal(7, 3));
-
-        let result = saturating_divide(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
-            Some(1_800i128),
-            Some(5_000i128),
-            Some(6_666i128),
+            Some(222_22i128),
+            Some(2_00i128),
+            Some(3_00i128),
             None,
-            Some(7_500i128),
-            Some(0_188i128),
+            Some(4_00i128),
+            Some(543_21i128),
         ])
-        .to(DataType::Decimal(7, 3));
+        .to(DataType::Decimal(7, 2));
+
+        let result = saturating_mul(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(24690_86i128),
+            Some(20_00i128),
+            Some(60_00i128),
+            None,
+            Some(120_00i128),
+            Some(67059_27i128),
+        ])
+        .to(DataType::Decimal(7, 2));
 
         assert_eq!(result, expected);
     }
 
     #[test]
-    fn test_divide_saturating_overflow() {
+    fn test_multiply_saturating_overflow() {
         let a = Primitive::from(&vec![
-            Some(99999i128),
             Some(99999i128),
             Some(99999i128),
             Some(99999i128),
@@ -375,22 +368,20 @@ mod tests {
         ])
         .to(DataType::Decimal(5, 2));
         let b = Primitive::from(&vec![
-            Some(-00001i128),
-            Some(00001i128),
-            Some(00010i128),
-            Some(-00020i128),
-            Some(00000i128),
+            Some(-00100i128),
+            Some(01000i128),
+            Some(10000i128),
+            Some(-99999i128),
         ])
         .to(DataType::Decimal(5, 2));
 
-        let result = saturating_divide(&a, &b).unwrap();
+        let result = saturating_mul(&a, &b).unwrap();
 
         let expected = Primitive::from(&vec![
             Some(-99999i128),
             Some(99999i128),
             Some(99999i128),
             Some(-99999i128),
-            Some(00000i128),
         ])
         .to(DataType::Decimal(5, 2));
 
@@ -398,46 +389,46 @@ mod tests {
     }
 
     #[test]
-    fn test_divide_checked() {
+    fn test_multiply_checked() {
         let a = Primitive::from(&vec![
-            Some(222_222i128),
-            Some(10_000i128),
-            Some(20_000i128),
+            Some(111_11i128),
+            Some(10_00i128),
+            Some(20_00i128),
             None,
-            Some(30_000i128),
-            Some(123_456i128),
+            Some(30_00i128),
+            Some(123_45i128),
         ])
-        .to(DataType::Decimal(7, 3));
+        .to(DataType::Decimal(7, 2));
 
         let b = Primitive::from(&vec![
-            Some(123_456i128),
-            Some(2_000i128),
-            Some(3_000i128),
-            Some(4_000i128),
-            Some(4_000i128),
-            Some(654_321i128),
-        ])
-        .to(DataType::Decimal(7, 3));
-
-        let result = divide(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
-            Some(1_800i128),
-            Some(5_000i128),
-            Some(6_666i128),
+            Some(222_22i128),
+            Some(2_00i128),
+            Some(3_00i128),
             None,
-            Some(7_500i128),
-            Some(0_188i128),
+            Some(4_00i128),
+            Some(543_21i128),
         ])
-        .to(DataType::Decimal(7, 3));
+        .to(DataType::Decimal(7, 2));
+
+        let result = checked_mul(&a, &b).unwrap();
+        let expected = Primitive::from(&vec![
+            Some(24690_86i128),
+            Some(20_00i128),
+            Some(60_00i128),
+            None,
+            Some(120_00i128),
+            Some(67059_27i128),
+        ])
+        .to(DataType::Decimal(7, 2));
 
         assert_eq!(result, expected);
     }
 
     #[test]
-    fn test_divide_checked_overflow() {
+    fn test_multiply_checked_overflow() {
         let a = Primitive::from(&vec![Some(99999i128)]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![Some(00001i128)]).to(DataType::Decimal(5, 2));
-        let result = checked_divide(&a, &b);
+        let b = Primitive::from(&vec![Some(10000i128)]).to(DataType::Decimal(5, 2));
+        let result = checked_mul(&a, &b);
 
         match result {
             Err(err) => match err {
@@ -449,16 +440,16 @@ mod tests {
     }
 
     #[test]
-    fn test_divide_adaptive() {
+    fn test_multiply_adaptive() {
         //  1000.00   -> 7, 2
         //    10.0000 -> 6, 4
         // -----------------
-        //   100.0000 -> 9, 4
+        // 10000.0000 -> 9, 4
         let a = Primitive::from(&vec![Some(1000_00i128)]).to(DataType::Decimal(7, 2));
         let b = Primitive::from(&vec![Some(10_0000i128)]).to(DataType::Decimal(6, 4));
-        let result = adaptive_divide(&a, &b).unwrap();
+        let result = adaptive_mul(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(9, 4));
+        let expected = Primitive::from(&vec![Some(10000_0000i128)]).to(DataType::Decimal(9, 4));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(9, 4));
@@ -466,27 +457,27 @@ mod tests {
         //   11111.0    -> 6, 1
         //      10.002  -> 5, 3
         // -----------------
-        //    1110.877  -> 8, 3
+        //  111132.222  -> 9, 3
         let a = Primitive::from(&vec![Some(11111_0i128)]).to(DataType::Decimal(6, 1));
         let b = Primitive::from(&vec![Some(10_002i128)]).to(DataType::Decimal(5, 3));
-        let result = adaptive_divide(&a, &b).unwrap();
+        let result = adaptive_mul(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(1110_877i128)]).to(DataType::Decimal(8, 3));
+        let expected = Primitive::from(&vec![Some(111132_222i128)]).to(DataType::Decimal(9, 3));
 
         assert_eq!(result, expected);
-        assert_eq!(result.data_type(), &DataType::Decimal(8, 3));
+        assert_eq!(result.data_type(), &DataType::Decimal(9, 3));
 
         //     12345.67   ->  7, 2
         //     12345.678  ->  8, 3
         // -----------------
-        //         0.999  ->  8, 3
+        // 152415666.514  -> 11, 3
         let a = Primitive::from(&vec![Some(12345_67i128)]).to(DataType::Decimal(7, 2));
         let b = Primitive::from(&vec![Some(12345_678i128)]).to(DataType::Decimal(8, 3));
-        let result = adaptive_divide(&a, &b).unwrap();
+        let result = adaptive_mul(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(0_999i128)]).to(DataType::Decimal(8, 3));
+        let expected = Primitive::from(&vec![Some(152415666_514i128)]).to(DataType::Decimal(12, 3));
 
         assert_eq!(result, expected);
-        assert_eq!(result.data_type(), &DataType::Decimal(8, 3));
+        assert_eq!(result.data_type(), &DataType::Decimal(12, 3));
     }
 }

--- a/src/compute/arithmetics/decimal/sub.rs
+++ b/src/compute/arithmetics/decimal/sub.rs
@@ -34,10 +34,7 @@ use crate::compute::utils::combine_validities;
 /// the precision and scale is different, then an InvalidArgumentError is
 /// returned. This function panics if the subtracted numbers result in a number
 /// smaller than the possible number for the selected precision.
-pub fn subtract(
-    lhs: &PrimitiveArray<i128>,
-    rhs: &PrimitiveArray<i128>,
-) -> Result<PrimitiveArray<i128>> {
+pub fn sub(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<PrimitiveArray<i128>> {
     // Matching on both data types from both arrays This match will be true
     // only when precision and scale from both arrays are the same, otherwise
     // it will return and ArrowError
@@ -77,7 +74,7 @@ pub fn subtract(
 /// InvalidArgumentError is returned. If the result from the sum is smaller
 /// than the possible number with the selected precision then the resulted
 /// number in the arrow array is the minimum number for the selected precision.
-pub fn saturating_subtract(
+pub fn saturating_sub(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
 ) -> Result<PrimitiveArray<i128>> {
@@ -124,7 +121,7 @@ pub fn saturating_subtract(
 /// InvalidArgumentError is returned. If the result from the subtraction is
 /// smaller than the possible number with the selected precision then the
 /// function returns an ArrowError::ArithmeticError.
-pub fn checked_subtract(
+pub fn checked_sub(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
 ) -> Result<PrimitiveArray<i128>> {
@@ -168,7 +165,7 @@ pub fn checked_subtract(
 /// and precision is adjusted to the largest precision and scale. If during the
 /// addition one of the results is smaller than the min possible value, the
 /// result precision is changed to the precision of the min value
-pub fn adaptive_subtract(
+pub fn adaptive_sub(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
 ) -> Result<PrimitiveArray<i128>> {
@@ -250,7 +247,7 @@ mod tests {
         ])
         .to(DataType::Decimal(5, 2));
 
-        let result = subtract(&a, &b).unwrap();
+        let result = sub(&a, &b).unwrap();
         let expected = Primitive::from(&vec![
             Some(-11111i128),
             Some(11100i128),
@@ -266,7 +263,7 @@ mod tests {
     fn test_subtract_decimal_wrong_precision() {
         let a = Primitive::from(&vec![None]).to(DataType::Decimal(5, 2));
         let b = Primitive::from(&vec![None]).to(DataType::Decimal(6, 2));
-        let result = subtract(&a, &b);
+        let result = sub(&a, &b);
 
         if result.is_ok() {
             panic!("Should panic for different precision");
@@ -278,7 +275,7 @@ mod tests {
     fn test_subtract_panic() {
         let a = Primitive::from(&vec![Some(-99999i128)]).to(DataType::Decimal(5, 2));
         let b = Primitive::from(&vec![Some(1i128)]).to(DataType::Decimal(5, 2));
-        let _ = subtract(&a, &b);
+        let _ = sub(&a, &b);
     }
 
     #[test]
@@ -299,7 +296,7 @@ mod tests {
         ])
         .to(DataType::Decimal(5, 2));
 
-        let result = saturating_subtract(&a, &b).unwrap();
+        let result = saturating_sub(&a, &b).unwrap();
         let expected = Primitive::from(&vec![
             Some(-11111i128),
             Some(11100i128),
@@ -328,7 +325,7 @@ mod tests {
         ])
         .to(DataType::Decimal(5, 2));
 
-        let result = saturating_subtract(&a, &b).unwrap();
+        let result = saturating_sub(&a, &b).unwrap();
 
         let expected = Primitive::from(&vec![
             Some(-99999i128),
@@ -359,7 +356,7 @@ mod tests {
         ])
         .to(DataType::Decimal(5, 2));
 
-        let result = checked_subtract(&a, &b).unwrap();
+        let result = checked_sub(&a, &b).unwrap();
         let expected = Primitive::from(&vec![
             Some(-11111i128),
             Some(11100i128),
@@ -375,7 +372,7 @@ mod tests {
     fn test_subtract_checked_overflow() {
         let a = Primitive::from(&vec![Some(-99999i128)]).to(DataType::Decimal(5, 2));
         let b = Primitive::from(&vec![Some(1i128)]).to(DataType::Decimal(5, 2));
-        let result = checked_subtract(&a, &b);
+        let result = checked_sub(&a, &b);
 
         match result {
             Err(err) => match err {
@@ -394,7 +391,7 @@ mod tests {
         // -11099.9989 -> 9, 4
         let a = Primitive::from(&vec![Some(11_1111i128)]).to(DataType::Decimal(6, 4));
         let b = Primitive::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
-        let result = adaptive_subtract(&a, &b).unwrap();
+        let result = adaptive_sub(&a, &b).unwrap();
 
         let expected = Primitive::from(&vec![Some(-11099_9989i128)]).to(DataType::Decimal(9, 4));
 
@@ -407,7 +404,7 @@ mod tests {
         // 11110.8889 -> 9, 4
         let a = Primitive::from(&vec![Some(11111_0i128)]).to(DataType::Decimal(6, 1));
         let b = Primitive::from(&vec![Some(1111i128)]).to(DataType::Decimal(5, 4));
-        let result = adaptive_subtract(&a, &b).unwrap();
+        let result = adaptive_sub(&a, &b).unwrap();
 
         let expected = Primitive::from(&vec![Some(11110_8889i128)]).to(DataType::Decimal(9, 4));
 
@@ -420,7 +417,7 @@ mod tests {
         // -00000.001  -> 8, 3
         let a = Primitive::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
         let b = Primitive::from(&vec![Some(11111_111i128)]).to(DataType::Decimal(8, 3));
-        let result = adaptive_subtract(&a, &b).unwrap();
+        let result = adaptive_sub(&a, &b).unwrap();
 
         let expected = Primitive::from(&vec![Some(-00000_001i128)]).to(DataType::Decimal(8, 3));
 
@@ -433,7 +430,7 @@ mod tests {
         // 100.0000 -> 7, 4
         let a = Primitive::from(&vec![Some(99_9999i128)]).to(DataType::Decimal(6, 4));
         let b = Primitive::from(&vec![Some(-00_0001i128)]).to(DataType::Decimal(6, 4));
-        let result = adaptive_subtract(&a, &b).unwrap();
+        let result = adaptive_sub(&a, &b).unwrap();
 
         let expected = Primitive::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(7, 4));
 

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -15,7 +15,45 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines basic arithmetic kernels for `PrimitiveArrays`.
+//! Defines basic arithmetic kernels for [`PrimitiveArray`]s.
+//!
+//! # Description
+//!
+//! The Arithmetics module is composed by basic arithmetics operations that can
+//! be performed on Primitive Arrays. These operations can be the building for
+//! any implementation using Arrow.
+//!
+//! Whenever possible, each of the operations in these modules has variations
+//! of the basic operation that offers different guarantees. These options are:
+//!
+//! * plain: The plain type (add, sub, mul, and div) don't offer any protection
+//!   when performing the operations. This means that if overflow is found,
+//!   then the operations will panic.
+//!
+//! * checked: A checked operation will change the validity Bitmap for the
+//!   offending operation. For example, if one of the operations overflows, the
+//!   validity will be changed to None, indicating a Null value.
+//!
+//! * saturating: If overflowing is presented in one operation, the resulting
+//!   value for that index will be saturated to the MAX or MIN value possible
+//!   for that type. For [`Decimal`](crate::datatypes::DataType::Decimal)
+//!   arrays, the saturated value is calculated considering the precision and
+//!   scale of the array.
+//!
+//! * overflowing: When an operation overflows, the resulting will be the
+//!   overflowed value for the operation. The result from the array operation
+//!   includes a Binary bitmap indicating which values overflowed.
+//!
+//! * adaptive: For [`Decimal`](crate::datatypes::DataType::Decimal) arrays,
+//!   the adaptive variation adjusts the precision and scale to avoid
+//!   saturation or overflowing.
+//!
+//! # New kernels
+//!
+//! When adding a new operation to this module, it is strongly suggested to
+//! follow the design description presented in the [`compute`](crate::compute)
+//! module and the function descriptions presented in this document.
+
 pub mod basic;
 pub mod decimal;
 pub mod time;

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -137,6 +137,6 @@ where
         Operator::Add => Ok(basic::add::add_scalar(lhs, rhs)),
         Operator::Subtract => Ok(basic::sub::sub_scalar(lhs, rhs)),
         Operator::Multiply => Ok(basic::mul::mul_scalar(lhs, rhs)),
-        Operator::Divide => basic::div::div_scalar(lhs, rhs),
+        Operator::Divide => Ok(basic::div::div_scalar(lhs, rhs)),
     }
 }

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -51,8 +51,9 @@
 //! # New kernels
 //!
 //! When adding a new operation to this module, it is strongly suggested to
-//! follow the design description presented in the [`compute`](crate::compute)
-//! module and the function descriptions presented in this document.
+//! follow the design description presented in the README.md file located in
+//! the [`compute`](crate::compute) module and the function descriptions
+//! presented in this document.
 
 pub mod basic;
 pub mod decimal;

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -16,21 +16,18 @@
 // under the License.
 
 //! Defines basic arithmetic kernels for `PrimitiveArrays`.
+pub mod basic;
 pub mod decimal;
 pub mod time;
 
-use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::ops::{Add, Div, Mul, Sub};
 
-use num::{traits::Pow, Zero};
+use num::Zero;
 
 use crate::array::*;
-use crate::buffer::Buffer;
 use crate::datatypes::DataType;
 use crate::error::{ArrowError, Result};
 use crate::types::NativeType;
-
-use super::arity::{binary, unary};
-use super::utils::combine_validities;
 
 // Macro to evaluate match branch in arithmetic function.
 // The macro is used to downcast both arrays to a primitive_array_type. If there
@@ -86,9 +83,9 @@ pub fn arithmetic(lhs: &dyn Array, op: Operator, rhs: &dyn Array) -> Result<Box<
 
             let res = match op {
                 Operator::Add => decimal::add::add(lhs, rhs),
-                Operator::Subtract => decimal::subtract::subtract(lhs, rhs),
-                Operator::Multiply => decimal::multiply::multiply(lhs, rhs),
-                Operator::Divide => decimal::divide::divide(lhs, rhs),
+                Operator::Subtract => decimal::sub::sub(lhs, rhs),
+                Operator::Multiply => decimal::mul::mul(lhs, rhs),
+                Operator::Divide => decimal::div::div(lhs, rhs),
             };
 
             res.map(Box::new).map(|x| x as Box<dyn Array>)
@@ -119,10 +116,10 @@ where
     T: NativeType + Div<Output = T> + Zero + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
 {
     match op {
-        Operator::Add => add(lhs, rhs),
-        Operator::Subtract => subtract(lhs, rhs),
-        Operator::Multiply => multiply(lhs, rhs),
-        Operator::Divide => divide(lhs, rhs),
+        Operator::Add => basic::add::add(lhs, rhs),
+        Operator::Subtract => basic::sub::sub(lhs, rhs),
+        Operator::Multiply => basic::mul::mul(lhs, rhs),
+        Operator::Divide => basic::div::div(lhs, rhs),
     }
 }
 
@@ -137,252 +134,9 @@ where
     T: NativeType + Div<Output = T> + Zero + Add<Output = T> + Sub<Output = T> + Mul<Output = T>,
 {
     match op {
-        Operator::Add => Ok(add_scalar(lhs, rhs)),
-        Operator::Subtract => Ok(subtract_scalar(lhs, rhs)),
-        Operator::Multiply => Ok(multiply_scalar(lhs, rhs)),
-        Operator::Divide => divide_scalar(lhs, rhs),
-    }
-}
-
-/// Divide two arrays.
-///
-/// # Errors
-///
-/// This function errors iff:
-/// * the arrays have different lengths
-/// * a division by zero is found
-fn divide<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
-where
-    T: NativeType,
-    T: Div<Output = T> + Zero,
-{
-    if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Cannot perform math operation on arrays of different length".to_string(),
-        ));
-    }
-
-    let validity = combine_validities(lhs.validity(), rhs.validity());
-
-    let values = if let Some(b) = &validity {
-        // there are nulls. Division by zero on them should be ignored
-        let values =
-            b.iter()
-                .zip(lhs.values().iter().zip(rhs.values()))
-                .map(|(is_valid, (lhs, rhs))| {
-                    if is_valid {
-                        if rhs.is_zero() {
-                            Err(ArrowError::InvalidArgumentError(
-                                "There is a zero in the division, causing a division by zero"
-                                    .to_string(),
-                            ))
-                        } else {
-                            Ok(*lhs / *rhs)
-                        }
-                    } else {
-                        Ok(T::default())
-                    }
-                });
-        unsafe { Buffer::try_from_trusted_len_iter(values) }
-    } else {
-        // no value is null
-        let values = lhs.values().iter().zip(rhs.values()).map(|(lhs, rhs)| {
-            if rhs.is_zero() {
-                Err(ArrowError::InvalidArgumentError(
-                    "There is a zero in the division, causing a division by zero".to_string(),
-                ))
-            } else {
-                Ok(*lhs / *rhs)
-            }
-        });
-        unsafe { Buffer::try_from_trusted_len_iter(values) }
-    }?;
-
-    Ok(PrimitiveArray::<T>::from_data(
-        lhs.data_type().clone(),
-        values,
-        validity,
-    ))
-}
-
-/// Divide an array by a constant
-pub fn divide_scalar<T>(array: &PrimitiveArray<T>, divisor: &T) -> Result<PrimitiveArray<T>>
-where
-    T: NativeType,
-    T: Div<Output = T> + Zero,
-{
-    if divisor.is_zero() {
-        return Err(ArrowError::InvalidArgumentError(
-            "The divisor cannot be zero".to_string(),
-        ));
-    }
-    let divisor = *divisor;
-    Ok(unary(array, |x| x / divisor, array.data_type()))
-}
-
-#[inline]
-pub fn add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
-where
-    T: NativeType + Add<Output = T>,
-{
-    if lhs.data_type() != rhs.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Arrays must have the same logical type".to_string(),
-        ));
-    }
-
-    binary(lhs, rhs, lhs.data_type().clone(), |a, b| a + b)
-}
-
-#[inline]
-fn add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
-where
-    T: NativeType + Add<Output = T>,
-{
-    let rhs = *rhs;
-    unary(lhs, |a| a + rhs, lhs.data_type())
-}
-
-#[inline]
-fn subtract<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
-where
-    T: NativeType + Sub<Output = T>,
-{
-    if lhs.data_type() != rhs.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Arrays must have the same logical type".to_string(),
-        ));
-    }
-
-    binary(lhs, rhs, lhs.data_type().clone(), |a, b| a - b)
-}
-
-#[inline]
-fn subtract_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
-where
-    T: NativeType + Sub<Output = T>,
-{
-    let rhs = *rhs;
-    unary(lhs, |a| a - rhs, lhs.data_type())
-}
-
-#[inline]
-pub fn negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
-where
-    T: NativeType + Neg<Output = T>,
-{
-    unary(array, |a| -a, array.data_type())
-}
-
-#[inline]
-pub fn powf_scalar<T>(array: &PrimitiveArray<T>, exponent: T) -> PrimitiveArray<T>
-where
-    T: NativeType + Pow<T, Output = T>,
-{
-    unary(array, |x| x.pow(exponent), array.data_type())
-}
-
-#[inline]
-fn multiply<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
-where
-    T: NativeType + Mul<Output = T>,
-{
-    if lhs.data_type() != rhs.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Arrays must have the same logical type".to_string(),
-        ));
-    }
-
-    binary(lhs, rhs, lhs.data_type().clone(), |lhs, rhs| lhs * rhs)
-}
-
-#[inline]
-pub fn multiply_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
-where
-    T: NativeType + Mul<Output = T>,
-{
-    let rhs = *rhs;
-    unary(lhs, |lhs| lhs * rhs, lhs.data_type())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::datatypes::DataType;
-
-    #[test]
-    fn test_add() {
-        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
-        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
-        let result = add(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![None, None, None, Some(12)]).to(DataType::Int32);
-        assert_eq!(result, expected)
-    }
-
-    #[test]
-    fn test_add_mismatched_length() {
-        let a = Primitive::from_slice(vec![5, 6]).to(DataType::Int32);
-        let b = Primitive::from_slice(vec![5]).to(DataType::Int32);
-        add(&a, &b)
-            .err()
-            .expect("should have failed due to different lengths");
-    }
-
-    #[test]
-    fn test_subtract() {
-        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
-        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
-        let result = subtract(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![None, None, None, Some(0)]).to(DataType::Int32);
-        assert_eq!(result, expected)
-    }
-
-    #[test]
-    fn test_multiply() {
-        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
-        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
-        let result = multiply(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![None, None, None, Some(36)]).to(DataType::Int32);
-        assert_eq!(result, expected)
-    }
-
-    #[test]
-    fn test_divide() {
-        let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
-        let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
-        let result = divide(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![None, None, None, Some(1)]).to(DataType::Int32);
-        assert_eq!(result, expected)
-    }
-
-    #[test]
-    fn test_divide_scalar() {
-        let a = Primitive::from(&vec![None, Some(6)]).to(DataType::Int32);
-        let b = 3i32;
-        let result = divide_scalar(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![None, Some(2)]).to(DataType::Int32);
-        assert_eq!(result, expected)
-    }
-
-    #[test]
-    fn test_divide_by_zero() {
-        let a = Primitive::from(&vec![Some(6)]).to(DataType::Int32);
-        let b = Primitive::from(&vec![Some(0)]).to(DataType::Int32);
-        assert_eq!(divide(&a, &b).is_err(), true);
-    }
-
-    #[test]
-    fn test_divide_by_zero_on_null() {
-        let a = Primitive::from(&vec![None]).to(DataType::Int32);
-        let b = Primitive::from(&vec![Some(0)]).to(DataType::Int32);
-        assert_eq!(divide(&a, &b).is_err(), false);
-    }
-
-    #[test]
-    fn test_raise_power_scalar() {
-        let a = Primitive::from(&vec![Some(2f32), None]).to(DataType::Float32);
-        let actual = powf_scalar(&a, 2.0);
-        let expected = Primitive::from(&vec![Some(4f32), None]).to(DataType::Float32);
-        assert_eq!(expected, actual);
+        Operator::Add => Ok(basic::add::add_scalar(lhs, rhs)),
+        Operator::Subtract => Ok(basic::sub::sub_scalar(lhs, rhs)),
+        Operator::Multiply => Ok(basic::mul::mul_scalar(lhs, rhs)),
+        Operator::Divide => basic::div::div_scalar(lhs, rhs),
     }
 }

--- a/src/compute/arithmetics/time.rs
+++ b/src/compute/arithmetics/time.rs
@@ -64,6 +64,41 @@ fn create_scale(lhs: &DataType, rhs: &DataType) -> Result<f64> {
 /// Adds a duration to a time array (Timestamp, Time and Date). The timeunit
 /// enum is used to scale correctly both arrays; adding seconds with seconds,
 /// or milliseconds with milliseconds.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::time::add_duration;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::{DataType, TimeUnit};
+///
+/// let timestamp = Primitive::from(&vec![
+///     Some(100000i64),
+///     Some(200000i64),
+///     None,
+///     Some(300000i64),
+/// ])
+/// .to(DataType::Timestamp(
+///     TimeUnit::Second,
+///     Some("America/New_York".to_string()),
+/// ));
+///
+/// let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+///     .to(DataType::Duration(TimeUnit::Second));
+///
+/// let result = add_duration(&timestamp, &duration).unwrap();
+/// let expected = Primitive::from(&vec![
+///     Some(100010i64),
+///     Some(200020i64),
+///     None,
+///     Some(300030i64),
+/// ])
+/// .to(DataType::Timestamp(
+///     TimeUnit::Second,
+///     Some("America/New_York".to_string()),
+/// ));
+///
+/// assert_eq!(result, expected);
+/// ```
 pub fn add_duration<T, D>(
     time: &PrimitiveArray<T>,
     duration: &PrimitiveArray<D>,
@@ -85,6 +120,42 @@ where
 /// Subtract a duration to a time array (Timestamp, Time and Date). The timeunit
 /// enum is used to scale correctly both arrays; adding seconds with seconds,
 /// or milliseconds with milliseconds.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::time::subtract_duration;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::{DataType, TimeUnit};
+///
+/// let timestamp = Primitive::from(&vec![
+///     Some(100000i64),
+///     Some(200000i64),
+///     None,
+///     Some(300000i64),
+/// ])
+/// .to(DataType::Timestamp(
+///     TimeUnit::Second,
+///     Some("America/New_York".to_string()),
+/// ));
+///
+/// let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+///     .to(DataType::Duration(TimeUnit::Second));
+///
+/// let result = subtract_duration(&timestamp, &duration).unwrap();
+/// let expected = Primitive::from(&vec![
+///     Some(99990i64),
+///     Some(199980i64),
+///     None,
+///     Some(299970i64),
+/// ])
+/// .to(DataType::Timestamp(
+///     TimeUnit::Second,
+///     Some("America/New_York".to_string()),
+/// ));
+///
+/// assert_eq!(result, expected);
+///
+/// ```
 pub fn subtract_duration<T, D>(
     time: &PrimitiveArray<T>,
     duration: &PrimitiveArray<D>,
@@ -106,6 +177,34 @@ where
 /// Calculates the difference between two timestamps returning an array of type
 /// Duration. The timeunit enum is used to scale correctly both arrays;
 /// subtracting seconds with seconds, or milliseconds with milliseconds.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::time::timestamp_diff;
+/// use arrow2::array::Primitive;
+/// use arrow2::datatypes::{DataType, TimeUnit};
+/// let timestamp_a = Primitive::from(&vec![
+///     Some(100_010i64),
+///     Some(200_020i64),
+///     None,
+///     Some(300_030i64),
+/// ])
+/// .to(DataType::Timestamp(TimeUnit::Second, None));
+///
+/// let timestamp_b = Primitive::from(&vec![
+///     Some(100_000i64),
+///     Some(200_000i64),
+///     None,
+///     Some(300_000i64),
+/// ])
+/// .to(DataType::Timestamp(TimeUnit::Second, None));
+///
+/// let expected = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+///     .to(DataType::Duration(TimeUnit::Second));
+///
+/// let result = timestamp_diff(&timestamp_a, &&timestamp_b).unwrap();
+/// assert_eq!(result, expected);
+/// ```
 pub fn timestamp_diff(
     lhs: &PrimitiveArray<i64>,
     rhs: &PrimitiveArray<i64>,

--- a/src/compute/arity.rs
+++ b/src/compute/arity.rs
@@ -51,11 +51,6 @@ where
     F: Fn(I) -> Result<O>,
 {
     let values = array.values().iter().map(|v| op(*v));
-    // JUSTIFICATION
-    //  Benefit
-    //      ~60% speedup
-    //  Soundness
-    //      `values` is an iterator with a known size because arrays are sized.
     let values = unsafe { Buffer::try_from_trusted_len_iter(values) }?;
 
     Ok(PrimitiveArray::<O>::from_data(
@@ -163,11 +158,6 @@ where
         .zip(rhs.values().iter())
         .map(|(l, r)| op(*l, *r));
 
-    // JUSTIFICATION
-    //  Benefit
-    //      ~60% speedup
-    //  Soundness
-    //      `values` is an iterator with a known size.
     let values = unsafe { Buffer::try_from_trusted_len_iter(values) }?;
 
     Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -15,6 +15,55 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Kernel operations for arrow arrays
+
+//! # Compute module
+//!
+//! The compute module is composed by independent operations common in
+//! analytics
+//!
+//! ## Design principles
+//!
+//! Below are the design principles followed to define the compute kernels:
+//!
+//! * APIs MUST return an error when either:
+//!     * The arguments are incorrect
+//!     * The execution results in a predictable error (e.g. divide by zero)
+//!
+//! * APIs MAY error when an operation overflows (e.g. `i32 + i32`)
+//!
+//! * kernels MUST NOT have side-effects
+//!
+//! * kernels MUST NOT take ownership of any of its arguments (i.e. everything
+//!   must be a reference).
+//!
+//! * APIs SHOULD error when an operation on variable sized containers can
+//!   overflow the maximum size of `usize`.
+//!
+//! * Kernels SHOULD use the arrays' logical type to decide whether kernels can
+//!   be applied on an array. For example, `Date32 + Date32` is meaningless and
+//!   SHOULD NOT be implemented.
+//!
+//! * Kernels SHOULD be implemented via `clone`, `slice` or the `iterator` API
+//!   provided by `Buffer`, `Bitmap`, `MutableBuffer` or `MutableBitmap`.
+//!
+//! * Kernels MUST NOT use any API to read bits other than the ones provided by
+//!   `Bitmap`.
+//!
+//! * Implementations SHOULD aim for auto-vectorization, which is usually
+//!   accomplished via `from_trusted_len_iter`.
+//!
+//! * Implementations MUST feature-gate any implementation that requires
+//!   external dependencies
+//!
+//! * When a kernel accepts dynamically-typed arrays, it MUST expect them as
+//!   `&dyn Array`.
+//!
+//! * When an API returns `&dyn Array`, it MUST return `Box<dyn Array>`. The
+//!   rational is that a `Box` is mutable, while an `Arc` is not. As such,
+//!   `Box` offers the most flexible API to consumers and the compiler. Users
+//!   can cast a `Box` into `Arc` via `.into()`.
+
 pub mod aggregate;
 pub mod arithmetics;
 pub mod arity;

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -15,54 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Kernel operations for arrow arrays
-
-//! # Compute module
-//!
-//! The compute module is composed by independent operations common in
-//! analytics
-//!
-//! ## Design principles
-//!
-//! Below are the design principles followed to define the compute kernels:
-//!
-//! * APIs MUST return an error when either:
-//!     * The arguments are incorrect
-//!     * The execution results in a predictable error (e.g. divide by zero)
-//!
-//! * APIs MAY error when an operation overflows (e.g. `i32 + i32`)
-//!
-//! * kernels MUST NOT have side-effects
-//!
-//! * kernels MUST NOT take ownership of any of its arguments (i.e. everything
-//!   must be a reference).
-//!
-//! * APIs SHOULD error when an operation on variable sized containers can
-//!   overflow the maximum size of `usize`.
-//!
-//! * Kernels SHOULD use the arrays' logical type to decide whether kernels can
-//!   be applied on an array. For example, `Date32 + Date32` is meaningless and
-//!   SHOULD NOT be implemented.
-//!
-//! * Kernels SHOULD be implemented via `clone`, `slice` or the `iterator` API
-//!   provided by `Buffer`, `Bitmap`, `MutableBuffer` or `MutableBitmap`.
-//!
-//! * Kernels MUST NOT use any API to read bits other than the ones provided by
-//!   `Bitmap`.
-//!
-//! * Implementations SHOULD aim for auto-vectorization, which is usually
-//!   accomplished via `from_trusted_len_iter`.
-//!
-//! * Implementations MUST feature-gate any implementation that requires
-//!   external dependencies
-//!
-//! * When a kernel accepts dynamically-typed arrays, it MUST expect them as
-//!   `&dyn Array`.
-//!
-//! * When an API returns `&dyn Array`, it MUST return `Box<dyn Array>`. The
-//!   rational is that a `Box` is mutable, while an `Arc` is not. As such,
-//!   `Box` offers the most flexible API to consumers and the compiler. Users
-//!   can cast a `Box` into `Arc` via `.into()`.
+//! Kernel operations for arrow arrays. The compute module is composed by
+//! independent operations common in analytics
 
 pub mod aggregate;
 pub mod arithmetics;


### PR DESCRIPTION
This PR defines functions for basic arithmetics on PrimitiveArrays. It includes Saturating, Overflowing and Checked functions for the add, sub, mul and div operations. It also includes documentation and examples on these operations. 

Extra documentation was added to the compute and arithmetics modules. These comments adds description for the design principles followed when designing the arithmetics kernels. 

Documentation examples were added to the time and decimal modules to be consistent with the basic module