### PR TITLE
Improved min/max of primitives through auto-vectorization (4x)

### DIFF
--- a/benches/aggregate.rs
+++ b/benches/aggregate.rs
@@ -4,13 +4,17 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use arrow2::array::*;
 use arrow2::util::bench_util::*;
-use arrow2::{compute::aggregate::sum, datatypes::DataType, types::NativeType};
+use arrow2::{compute::aggregate::*, datatypes::DataType, types::NativeType};
 
-fn bench_op<T>(arr_a: &PrimitiveArray<T>)
+fn bench_sum<T>(arr_a: &PrimitiveArray<T>)
 where
     T: NativeType + std::iter::Sum + AddAssign,
 {
     sum(criterion::black_box(arr_a)).unwrap();
+}
+
+fn bench_min(arr_a: &PrimitiveArray<f32>) {
+    min_f32(criterion::black_box(arr_a)).unwrap();
 }
 
 fn add_benchmark(c: &mut Criterion) {
@@ -18,6 +22,8 @@ fn add_benchmark(c: &mut Criterion) {
     let arr_a = create_primitive_array::<f32>(size, DataType::Float32, 0.0);
 
     c.bench_function("add f32", |b| b.iter(|| bench_op(&arr_a)));
+
+    c.bench_function("min f32", |b| b.iter(|| bench_min(&arr_a)));
 
     let arr_a = create_primitive_array::<f32>(size, DataType::Float32, 0.5);
 

--- a/src/compute/aggregate/mod.rs
+++ b/src/compute/aggregate/mod.rs
@@ -105,7 +105,56 @@ pub fn min_string<O: Offset>(array: &Utf8Array<O>) -> Option<&str> {
     min_max_string(array, |a, b| a > b)
 }
 
+#[inline]
+fn reduce_slice<T, F>(initial: T, values: &[T], cmp: F) -> T
+where
+    T: NativeType,
+    F: Fn(&T, &T) -> std::cmp::Ordering,
+{
+    values.iter().fold(initial, |max, item| {
+        if cmp(&max, item) == std::cmp::Ordering::Greater {
+            *item
+        } else {
+            max
+        }
+    })
+}
+
+fn nonnull_min_max_primitive<T, F>(values: &[T], cmp: F) -> T
+where
+    T: NativeType,
+    F: Fn(&T, &T) -> std::cmp::Ordering,
+{
+    if values.len() < T::LANES {
+        return reduce_slice(values[0], &values[1..], cmp);
+    };
+    let mut chunks = values.chunks_exact(T::LANES);
+    let remainder = chunks.remainder();
+
+    let initial = T::from_slice(chunks.next().unwrap());
+
+    let chunk_reduced = chunks.fold(initial, |mut acc, chunk| {
+        let chunk = T::from_slice(chunk);
+        for i in 0..T::LANES {
+            if cmp(&acc[i], &chunk[i]) == std::cmp::Ordering::Greater {
+                acc[i] = chunk[i];
+            }
+        }
+        acc
+    });
+
+    let mut reduced = chunk_reduced[0];
+    for i in 1..T::LANES {
+        if cmp(&reduced, &chunk_reduced[i]) == std::cmp::Ordering::Greater {
+            reduced = chunk_reduced[i];
+        }
+    }
+
+    reduce_slice(reduced, remainder, cmp)
+}
+
 /// Helper function to perform min/max lambda function on values from a numeric array.
+#[inline]
 fn min_max_helper<T, F>(array: &PrimitiveArray<T>, cmp: F) -> Option<T>
 where
     T: NativeType,
@@ -117,31 +166,22 @@ where
     if null_count == array.len() {
         return None;
     }
-
-    let m = array.values();
-    let mut n;
+    let values = array.values();
 
     if let Some(validity) = array.validity() {
-        n = T::default();
+        let mut n = T::default();
         let mut has_value = false;
-        for (i, item) in m.iter().enumerate() {
+        for (i, item) in values.iter().enumerate() {
             let is_valid = unsafe { validity.get_bit_unchecked(i) };
             if is_valid && (!has_value || cmp(&n, item) == std::cmp::Ordering::Greater) {
                 has_value = true;
                 n = *item
             }
         }
+        Some(n)
     } else {
-        // optimized path for arrays without null values
-        n = m[1..].iter().fold(m[0], |max, item| {
-            if cmp(&max, item) == std::cmp::Ordering::Greater {
-                *item
-            } else {
-                max
-            }
-        });
+        Some(nonnull_min_max_primitive(values, cmp))
     }
-    Some(n)
 }
 
 /// Returns the minimum value in the boolean array.

--- a/src/compute/aggregate/mod.rs
+++ b/src/compute/aggregate/mod.rs
@@ -21,7 +21,7 @@ use std::{iter::Sum, ops::AddAssign};
 
 use crate::types::{BitChunkIter, NativeType};
 use crate::{
-    array::{ord::total_cmp, Array, BooleanArray, Offset, PrimitiveArray, Utf8Array},
+    array::{ord::*, Array, BooleanArray, Offset, PrimitiveArray, Utf8Array},
     bitmap::Bitmap,
 };
 
@@ -63,7 +63,6 @@ fn min_max_string<O: Offset, F: Fn(&str, &str) -> bool>(
 
 /// Returns the minimum value in the array, according to the natural order.
 /// For floating point arrays any NaN values are considered to be greater than any other non-null value
-#[inline]
 pub fn min<T>(array: &PrimitiveArray<T>) -> Option<T>
 where
     T: NativeType + Ord,
@@ -71,9 +70,24 @@ where
     min_max_helper(array, total_cmp)
 }
 
+pub fn max_f32(array: &PrimitiveArray<f32>) -> Option<f32> {
+    min_max_helper(array, |x, y| total_cmp_f32(x, y).reverse())
+}
+
+pub fn max_f64(array: &PrimitiveArray<f64>) -> Option<f64> {
+    min_max_helper(array, |x, y| total_cmp_f64(x, y).reverse())
+}
+
+pub fn min_f32(array: &PrimitiveArray<f32>) -> Option<f32> {
+    min_max_helper(array, |x, y| total_cmp_f32(x, y))
+}
+
+pub fn min_f64(array: &PrimitiveArray<f64>) -> Option<f64> {
+    min_max_helper(array, |x, y| total_cmp_f64(x, y))
+}
+
 /// Returns the maximum value in the array, according to the natural order.
 /// For floating point arrays any NaN values are considered to be greater than any other non-null value
-#[inline]
 pub fn max<T>(array: &PrimitiveArray<T>) -> Option<T>
 where
     T: NativeType + Ord,


### PR DESCRIPTION
Same spirit as #42 , for the `min / max` kernels for primitive arrays.

before:
```
min f32                 time:   [87.223 us 87.401 us 87.583 us]
```

after:
```
min f32                 time:   [26.125 us 26.193 us 26.253 us]
```

arrow simd:
```
min 512                 time:   [39.083 us 39.156 us 39.220 us]
```
