### PR TITLE
Use multiversion to speed up nonnull_sum/null_sum for cpus with AVX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ itertools = { version = "^0.10", optional = true }
 
 base64 = { version = "0.13.0", optional = true }
 
+multiversion = "0.6.1"
+
 [dependencies.parquet2]
 git = "https://github.com/jorgecarleitao/parquet2"
 rev = "fb65dcaf7d02c7e0bcf8ec0aa85d3fe0cb0630c6"

--- a/src/compute/aggregate/mod.rs
+++ b/src/compute/aggregate/mod.rs
@@ -221,11 +221,9 @@ fn null_sum<T: NativeType + AddAssign + Sum>(values: &[T], bitmap: &Bitmap) -> T
         .zip(iter)
         .fold(T::new_simd(), |mut acc, (chunk, validity_chunk)| {
             let chunk = T::from_slice(chunk);
-            let mut iter = BitChunkIter::new(validity_chunk);
-            for i in 0..T::LANES {
-                if iter.next().unwrap() {
-                    acc[i] += chunk[i];
-                }
+            let iter = BitChunkIter::new(validity_chunk);
+            for (i, b) in (0..T::LANES).zip(iter) {
+                acc[i] += if b { chunk[i] } else { T::default() };
             }
             acc
         });

--- a/src/compute/aggregate/mod.rs
+++ b/src/compute/aggregate/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     array::{ord::total_cmp, Array, BooleanArray, Offset, PrimitiveArray, Utf8Array},
     bitmap::Bitmap,
 };
+use multiversion::multiversion;
 
 /// Helper macro to perform min/max of strings
 fn min_max_string<O: Offset, F: Fn(&str, &str) -> bool>(
@@ -180,6 +181,8 @@ pub fn max_boolean(array: &BooleanArray) -> Option<bool> {
         .or(Some(false))
 }
 
+#[multiversion]
+#[clone(target = "x86_64+avx")]
 fn nonnull_sum<T: NativeType + AddAssign + Sum>(values: &[T]) -> T {
     let chunks = values.chunks_exact(T::LANES);
     let remainder = chunks.remainder();
@@ -202,6 +205,8 @@ fn nonnull_sum<T: NativeType + AddAssign + Sum>(values: &[T]) -> T {
 
 /// # Panics
 /// iff `values.len() != bitmap.len()` or the operation overflows.
+#[multiversion]
+#[clone(target = "x86_64+avx")]
 fn null_sum<T: NativeType + AddAssign + Sum>(values: &[T], bitmap: &Bitmap) -> T {
     let chunks = values.chunks_exact(T::LANES);
     let remainder = chunks.remainder();


### PR DESCRIPTION
* Use multiversion
* Make inner loop easier to vectorize

```
Benchmarking add f32: Collecting 100 samples in estimated 5.0181 s (146k iterati                                                                                add f32                 time:   [33.429 us 33.478 us 33.533 us]
                        change: [-36.514% -36.290% -36.071%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

Benchmarking add nulls f32: Collecting 100 samples in estimated 5.0523 s (217k i                                                                                add nulls f32           time:   [22.802 us 22.814 us 22.829 us]
                        change: [-85.562% -85.523% -85.484%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
  ```