### PR TITLE
Removed unsafe code

### DIFF
--- a/benches/aggregate.rs
+++ b/benches/aggregate.rs
@@ -21,13 +21,13 @@ fn add_benchmark(c: &mut Criterion) {
     let size = 65536;
     let arr_a = create_primitive_array::<f32>(size, DataType::Float32, 0.0);
 
-    c.bench_function("add f32", |b| b.iter(|| bench_op(&arr_a)));
+    c.bench_function("sum f32", |b| b.iter(|| bench_sum(&arr_a)));
 
     c.bench_function("min f32", |b| b.iter(|| bench_min(&arr_a)));
 
     let arr_a = create_primitive_array::<f32>(size, DataType::Float32, 0.5);
 
-    c.bench_function("add nulls f32", |b| b.iter(|| bench_op(&arr_a)));
+    c.bench_function("sum nulls f32", |b| b.iter(|| bench_sum(&arr_a)));
 }
 
 criterion_group!(benches, add_benchmark);

--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -13,16 +13,16 @@ where
     assert_eq!(a1.len(), a2.len());
     assert_eq!(a1.len(), a3.len());
     assert_eq!(a1.len(), a4.len());
-    let a1_chunks = a1.chunks();
-    let a2_chunks = a2.chunks();
-    let a3_chunks = a3.chunks();
-    let a4_chunks = a4.chunks();
+    let mut a1_chunks = a1.chunks();
+    let mut a2_chunks = a2.chunks();
+    let mut a3_chunks = a3.chunks();
+    let mut a4_chunks = a4.chunks();
 
     let chunks = a1_chunks
-        .iter()
-        .zip(a2_chunks.iter())
-        .zip(a3_chunks.iter())
-        .zip(a4_chunks.iter())
+        .by_ref()
+        .zip(a2_chunks.by_ref())
+        .zip(a3_chunks.by_ref())
+        .zip(a4_chunks.by_ref())
         .map(|(((a1, a2), a3), a4)| op(a1, a2, a3, a4));
     // Soundness: `BitChunks` is a trusted len iterator
     let mut buffer = unsafe { MutableBuffer::from_chunk_iter(chunks) };
@@ -51,14 +51,14 @@ where
 {
     assert_eq!(a1.len(), a2.len());
     assert_eq!(a1.len(), a3.len());
-    let a1_chunks = a1.chunks();
-    let a2_chunks = a2.chunks();
-    let a3_chunks = a3.chunks();
+    let mut a1_chunks = a1.chunks();
+    let mut a2_chunks = a2.chunks();
+    let mut a3_chunks = a3.chunks();
 
     let chunks = a1_chunks
-        .iter()
-        .zip(a2_chunks.iter())
-        .zip(a3_chunks.iter())
+        .by_ref()
+        .zip(a2_chunks.by_ref())
+        .zip(a3_chunks.by_ref())
         .map(|((a1, a2), a3)| op(a1, a2, a3));
     // Soundness: `BitChunks` is a trusted len iterator
     let mut buffer = unsafe { MutableBuffer::from_chunk_iter(chunks) };
@@ -85,12 +85,12 @@ where
     F: Fn(u64, u64) -> u64,
 {
     assert_eq!(lhs.len(), rhs.len());
-    let lhs_chunks = lhs.chunks();
-    let rhs_chunks = rhs.chunks();
+    let mut lhs_chunks = lhs.chunks();
+    let mut rhs_chunks = rhs.chunks();
 
     let chunks = lhs_chunks
-        .iter()
-        .zip(rhs_chunks.iter())
+        .by_ref()
+        .zip(rhs_chunks.by_ref())
         .map(|(left, right)| op(left, right));
     // Soundness: `BitChunks` is a trusted len iterator
     let mut buffer = unsafe { MutableBuffer::from_chunk_iter(chunks) };
@@ -112,9 +112,9 @@ pub fn unary<F>(lhs: &Bitmap, op: F) -> Bitmap
 where
     F: Fn(u64) -> u64,
 {
-    let lhs_chunks = lhs.chunks();
+    let mut lhs_chunks = lhs.chunks();
 
-    let chunks = lhs_chunks.iter().map(|left| op(left));
+    let chunks = lhs_chunks.by_ref().map(|left| op(left));
     let mut buffer = unsafe { MutableBuffer::from_chunk_iter(chunks) };
 
     let remainder_bytes = lhs_chunks.remainder_len().saturating_add(7) / 8;
@@ -140,12 +140,12 @@ fn eq(lhs: &Bitmap, rhs: &Bitmap) -> bool {
         return false;
     }
 
-    let lhs_chunks = lhs.chunks::<u64>();
-    let rhs_chunks = rhs.chunks::<u64>();
+    let mut lhs_chunks = lhs.chunks::<u64>();
+    let mut rhs_chunks = rhs.chunks::<u64>();
 
     let equal_chunks = lhs_chunks
-        .iter()
-        .zip(rhs_chunks.iter())
+        .by_ref()
+        .zip(rhs_chunks.by_ref())
         .all(|(left, right)| left == right);
 
     if !equal_chunks {

--- a/src/bits/chunk_iterator/mod.rs
+++ b/src/bits/chunk_iterator/mod.rs
@@ -1,124 +1,111 @@
+use std::convert::TryInto;
+
 mod merge;
 
 pub use crate::types::BitChunk;
 use merge::merge_reversed;
 
+/// This struct is used to efficiently iterate over bit masks by loading bytes on
+/// the stack with alignments of `uX`. This allows efficient iteration over bitmaps.
 #[derive(Debug)]
-pub struct BitChunks<'a, T> {
-    buffer: &'a [u8],
+pub struct BitChunks<'a, T: BitChunk> {
+    chunk_iterator: std::slice::ChunksExact<'a, u8>,
+    current: T,
+    remainder_bytes: &'a [u8],
+    remaining: usize,
     /// offset inside a byte
     bit_offset: u32,
-    remainder_bytes_len: usize,
     len: usize,
     phantom: std::marker::PhantomData<T>,
 }
 
+/// writes `bytes` into `dst`.
 #[inline]
-fn remainder_bytes(offset: usize, len: usize, bits_in_chunk: usize) -> usize {
-    (((offset + len) % bits_in_chunk) + 7) / 8
-}
-
-/// writes `bytes` into `dst` assuming that they correspond to an arrow bitmap
-/// # Safety
-/// `dst` must be writable for `bytes.len()` bytes.
-#[inline]
-unsafe fn copy_with_merge(mut dst: *mut u8, bytes: &[u8], bit_offset: u32) {
-    bytes.windows(2).for_each(|w| {
-        let val = merge_reversed(w[0], w[1], bit_offset);
-        dst.write(val);
-        dst = dst.offset(1);
-    });
+fn copy_with_merge<T: BitChunk>(dst: &mut T::Bytes, bytes: &[u8], bit_offset: u32) {
     let mut last = bytes[bytes.len() - 1];
     last >>= bit_offset;
-    dst.write(last);
+    dst[0] = last;
+    bytes.windows(2).enumerate().for_each(|(i, w)| {
+        let val = merge_reversed(w[0], w[1], bit_offset);
+        dst[i] = val;
+    });
 }
 
 impl<'a, T: BitChunk> BitChunks<'a, T> {
-    #[inline]
-    fn bits_in_chunk() -> usize {
-        std::mem::size_of::<T>() * 8
-    }
-
     pub fn new(buffer: &'a [u8], offset: usize, len: usize) -> Self {
         assert!(offset + len <= buffer.len() * 8);
 
-        let bits_in_chunk = Self::bits_in_chunk();
         let skip_offset = offset / 8;
         let bit_offset = offset % 8;
-        let remainder_bytes_len = remainder_bytes(bit_offset, len, bits_in_chunk);
-        debug_assert!(bit_offset < 8);
+        let size_of = std::mem::size_of::<T>();
+
+        let bytes_len = (len + bit_offset + 7) / 8;
+        let (mut chunks, remainder_bytes) = if size_of != 1 {
+            // case where a chunk has more than one byte
+            let chunks = (&buffer[skip_offset..skip_offset + bytes_len]).chunks_exact(size_of);
+            let remainder_bytes = chunks.remainder();
+            (chunks, remainder_bytes)
+        } else {
+            // case where a chunk is exactly one byte
+            let bytes = (len + bit_offset) / 8;
+            let chunks = &buffer[skip_offset..skip_offset + bytes];
+            let chunks = chunks.chunks_exact(size_of);
+            (chunks, &buffer[buffer.len() - 1..bytes_len])
+        };
+
+        let remaining = chunks.size_hint().0;
+
+        let current = chunks
+            .next()
+            .map(|x| match x.try_into() {
+                Ok(a) => T::from_ne_bytes(a),
+                Err(_) => unreachable!(),
+            })
+            .unwrap_or_else(T::zero);
 
         Self {
-            buffer: &buffer[skip_offset..],
+            chunk_iterator: chunks,
             len,
-            remainder_bytes_len,
+            current,
+            remaining,
+            remainder_bytes,
             bit_offset: bit_offset as u32,
             phantom: std::marker::PhantomData,
         }
     }
 
     #[inline]
+    fn load_next(&mut self) {
+        self.current = match self.chunk_iterator.next().unwrap().try_into() {
+            Ok(a) => T::from_ne_bytes(a),
+            Err(_) => unreachable!(),
+        };
+    }
+
+    #[inline]
     pub fn remainder(&self) -> T {
         // remaining bytes may not fit in `size_of::<T>()`. We complement
         // them to fit by allocating T and writing to it byte by byte
-        let mut remainder = T::zero();
+        let mut remainder = T::zero().to_ne_bytes();
 
-        match (self.remainder_bytes_len == 0, self.bit_offset == 0) {
+        let remainder = match (self.remainder_bytes.is_empty(), self.bit_offset == 0) {
             (true, _) => remainder,
             (false, true) => {
-                // remaining bytes but not bit offset: bytes bit-aligned
-                // and thus we only need to write them to `remainder`.
-                let chunked_bytes_len = std::mem::size_of::<T>() * self.chunk_len();
-
                 // all remaining bytes
-                let remainder_bytes =
-                    &self.buffer[chunked_bytes_len..chunked_bytes_len + self.remainder_bytes_len];
-
-                let mut dst = &mut remainder as *mut T as *mut u8;
-                remainder_bytes.iter().for_each(|val| unsafe {
-                    dst.write(*val);
-                    dst = dst.offset(1);
-                });
+                self.remainder_bytes
+                    .iter()
+                    .enumerate()
+                    .for_each(|(i, val)| remainder[i] = *val);
 
                 remainder
             }
             (false, false) => {
-                // there is a min-alignment; we need to write to `remainder`
-                // with valid bit-alignment, via `copy_with_merge`
-                let dst = &mut remainder as *mut T as *mut u8;
-
-                // build T by combining the remaining bytes at the end.
-                // when: len == 514 and T = u64 (=512 bits)
-                // chunked_bytes_len = 8 * (514/8) / 8 = 64;
-                let chunked_bytes_len =
-                    std::mem::size_of::<T>() * (self.len / Self::bits_in_chunk());
-
                 // all remaining bytes
-                let remainder_bytes =
-                    &self.buffer[chunked_bytes_len..chunked_bytes_len + self.remainder_bytes_len];
-
-                unsafe { copy_with_merge(dst, remainder_bytes, self.bit_offset) };
+                copy_with_merge::<T>(&mut remainder, self.remainder_bytes, self.bit_offset);
                 remainder
             }
-        }
-        .to_le()
-    }
-
-    #[inline]
-    pub fn chunk_len(&self) -> usize {
-        self.len / Self::bits_in_chunk()
-    }
-
-    /// Returns an iterator over chunks of 64 bits represented as an u64
-    #[inline]
-    pub fn iter(&self) -> BitChunkIterator<'a, T> {
-        BitChunkIterator::<'a, T> {
-            buffer: self.buffer,
-            offset: self.bit_offset,
-            chunk_len: self.chunk_len(),
-            chunk_index: 0,
-            phantom: self.phantom,
-        }
+        };
+        T::from_ne_bytes(remainder)
     }
 
     // in bits
@@ -128,81 +115,56 @@ impl<'a, T: BitChunk> BitChunks<'a, T> {
     }
 }
 
-impl<'a, T: BitChunk> IntoIterator for BitChunks<'a, T> {
-    type Item = T;
-    type IntoIter = BitChunkIterator<'a, T>;
-
-    #[inline]
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-#[derive(Debug)]
-pub struct BitChunkIterator<'a, T> {
-    buffer: &'a [u8],
-    chunk_len: usize,
-    offset: u32,
-    chunk_index: usize,
-    phantom: std::marker::PhantomData<T>,
-}
-
-impl<T: BitChunk> Iterator for BitChunkIterator<'_, T> {
+impl<T: BitChunk> Iterator for BitChunks<'_, T> {
     type Item = T;
 
     #[inline]
     fn next(&mut self) -> Option<T> {
-        if self.chunk_index >= self.chunk_len {
+        if self.remaining == 0 {
             return None;
         }
 
-        // cast to *const u64 should be fine since we are using read_unaligned below
-        #[allow(clippy::cast_ptr_alignment)]
-        let chunk_data = self.buffer.as_ptr() as *const T;
-
-        // bit-packed buffers are stored starting with the least-significant byte first
-        // so when reading as u64 on a big-endian machine, the bytes need to be swapped
-        let combined = if self.offset == 0 {
-            unsafe { std::ptr::read_unaligned(chunk_data.add(self.chunk_index)) }
-        } else if self.chunk_index + 1 < self.chunk_len {
-            // on the middle we can use the whole next chunk
-            let current =
-                unsafe { std::ptr::read_unaligned(chunk_data.add(self.chunk_index)) }.to_le();
-            let chunk_data = self.buffer.as_ptr() as *const T;
-            let next = unsafe { std::ptr::read_unaligned(chunk_data.add(self.chunk_index + 1)) };
-
-            merge_reversed(current, next, self.offset)
+        let current = self.current;
+        let combined = if self.bit_offset == 0 {
+            // fast case where there is no offset. In this case, there is bit-alignment
+            // at byte boundary and thus the bytes correspond exactly.
+            if self.remaining >= 2 {
+                self.load_next();
+            }
+            current
         } else {
-            // on the last chunk the "next" chunk may not be complete and thus we must create it from remaining bytes.
-            let mut remainder = T::zero();
-            let dst = &mut remainder as *mut T as *mut u8;
-
-            let size_of = std::mem::size_of::<T>();
-            let remainder_bytes =
-                &self.buffer[self.chunk_index * size_of..(self.chunk_index + 1) * size_of];
-
-            unsafe { copy_with_merge(dst, remainder_bytes, self.offset) };
-            remainder
+            let next = if self.remaining >= 2 {
+                // case where `next` is complete and thus we can take it all
+                self.load_next();
+                self.current
+            } else {
+                // case where the `next` is incomplete and thus we can only take part of it
+                let mut next = T::zero().to_ne_bytes();
+                self.remainder_bytes
+                    .iter()
+                    .enumerate()
+                    .for_each(|(i, byte)| next[i] = *byte);
+                T::from_ne_bytes(next)
+            };
+            merge_reversed(current, next, self.bit_offset)
         };
 
-        self.chunk_index += 1;
-
-        Some(combined.to_le())
+        self.remaining -= 1;
+        Some(combined)
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (
-            self.chunk_len - self.chunk_index,
-            Some(self.chunk_len - self.chunk_index),
-        )
+        // it contains always one more than the chunk_iterator, which is the last
+        // one where the remainder is merged into current.
+        (self.remaining, Some(self.remaining))
     }
 }
 
-impl<T: BitChunk> ExactSizeIterator for BitChunkIterator<'_, T> {
+impl<T: BitChunk> ExactSizeIterator for BitChunks<'_, T> {
     #[inline]
     fn len(&self) -> usize {
-        self.chunk_len - self.chunk_index
+        self.chunk_iterator.len()
     }
 }
 
@@ -211,10 +173,111 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_bla() {
-        assert_eq!(remainder_bytes(2, 2, 64), 1);
-        assert_eq!(remainder_bytes(2, 3, 64), 1);
-        assert_eq!(remainder_bytes(2, 6, 64), 1);
-        assert_eq!(remainder_bytes(2, 8, 64), 2);
+    fn basics() {
+        let mut iter = BitChunks::<u16>::new(&[0b00000001u8, 0b00000010u8], 0, 16);
+        assert_eq!(iter.next().unwrap(), 0b0000_0010_0000_0001u16);
+        assert_eq!(iter.remainder(), 0);
+    }
+
+    #[test]
+    fn remainder() {
+        let a = BitChunks::<u16>::new(&[0b00000001u8, 0b00000010u8, 0b00000100u8], 0, 18);
+        assert_eq!(a.remainder(), 0b00000100u16);
+    }
+
+    #[test]
+    fn remainder_saturating() {
+        let a = BitChunks::<u16>::new(&[0b00000001u8, 0b00000010u8, 0b00000010u8], 0, 18);
+        assert_eq!(a.remainder(), 0b0000_0000_0000_0010u16);
+    }
+
+    #[test]
+    fn basics_offset() {
+        let mut iter = BitChunks::<u16>::new(&[0b00000001u8, 0b00000011u8, 0b00000001u8], 1, 16);
+        let r = iter.next().unwrap();
+        assert_eq!(r, 0b1000_0001_1000_0000u16);
+        assert_eq!(iter.remainder(), 0);
+    }
+
+    #[test]
+    fn basics_offset_remainder() {
+        let a = BitChunks::<u16>::new(&[0b00000001u8, 0b00000011u8, 0b00000001u8], 1, 15);
+        assert_eq!(a.remainder(), 0);
+    }
+
+    #[test]
+    fn offset_remainder_saturating() {
+        let a = BitChunks::<u16>::new(&[0b00000001u8, 0b00000011u8, 0b00000011u8], 1, 17);
+        assert_eq!(a.remainder(), 0b0000_0000_0000_0001u16);
+    }
+
+    #[test]
+    fn offset_remainder_saturating2() {
+        let a = BitChunks::<u64>::new(&[0b01001001u8, 0b00000001], 1, 8);
+        assert_eq!(a.remainder(), 0b1010_0100u64);
+    }
+
+    #[test]
+    fn offset_remainder_saturating3() {
+        let input: &[u8] = &[0b01000000, 0b01000001];
+        let a = BitChunks::<u64>::new(input, 8, 2);
+        assert_eq!(a.remainder(), 0b0100_0001u64);
+    }
+
+    #[test]
+    fn basics_multiple() {
+        let mut iter = BitChunks::<u16>::new(
+            &[0b00000001u8, 0b00000010u8, 0b00000100u8, 0b00001000u8],
+            0,
+            4 * 8,
+        );
+        assert_eq!(iter.next().unwrap(), 0b0000_0010_0000_0001u16);
+        assert_eq!(iter.next().unwrap(), 0b0000_1000_0000_0100u16);
+        assert_eq!(iter.remainder(), 0);
+    }
+
+    #[test]
+    fn basics_multiple_offset() {
+        let mut iter = BitChunks::<u16>::new(
+            &[
+                0b00000001u8,
+                0b00000010u8,
+                0b00000100u8,
+                0b00001000u8,
+                0b00000001u8,
+            ],
+            1,
+            4 * 8,
+        );
+        assert_eq!(iter.next().unwrap(), 0b0000_0001_0000_0000u16);
+        assert_eq!(iter.next().unwrap(), 0b1000_0100_0000_0010u16);
+        assert_eq!(iter.remainder(), 0);
+    }
+
+    #[test]
+    fn remainder_large() {
+        let input: &[u8] = &[
+            0b00100100, 0b01001001, 0b10010010, 0b00100100, 0b01001001, 0b10010010, 0b00100100,
+            0b01001001, 0b10010010, 0b00100100, 0b01001001, 0b10010010, 0b00000100,
+        ];
+        let mut iter = BitChunks::<u8>::new(input, 0, 100);
+        assert_eq!(iter.remainder_len(), 100 - 96);
+
+        for j in 0..12 {
+            let mut a = BitChunkIter::new(iter.next().unwrap());
+            for i in 0..8 {
+                assert_eq!(a.next().unwrap(), (j * 8 + i + 1) % 3 == 0);
+            }
+        }
+        assert_eq!(None, iter.next());
+
+        use crate::types::BitChunkIter;
+        let expected_remainder = 0b00000100u8;
+        assert_eq!(iter.remainder(), expected_remainder);
+
+        let mut a = BitChunkIter::new(expected_remainder);
+        for i in 0..4 {
+            assert_eq!(a.next().unwrap(), (i + 1) % 3 == 0);
+        }
     }
 }

--- a/src/bits/chunk_iterator/mod.rs
+++ b/src/bits/chunk_iterator/mod.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 mod merge;
 
 pub use crate::types::BitChunk;
+use crate::types::BitChunkIter;
 use merge::merge_reversed;
 
 /// This struct is used to efficiently iterate over bit masks by loading bytes on
@@ -112,6 +113,11 @@ impl<'a, T: BitChunk> BitChunks<'a, T> {
     #[inline]
     pub fn remainder_len(&self) -> usize {
         self.len - (std::mem::size_of::<T>() * ((self.len / 8) / std::mem::size_of::<T>()) * 8)
+    }
+
+    #[inline]
+    pub fn remainder_iter(&self) -> BitChunkIter<T> {
+        BitChunkIter::new(self.remainder(), self.remainder_len())
     }
 }
 
@@ -264,7 +270,7 @@ mod tests {
         assert_eq!(iter.remainder_len(), 100 - 96);
 
         for j in 0..12 {
-            let mut a = BitChunkIter::new(iter.next().unwrap());
+            let mut a = BitChunkIter::new(iter.next().unwrap(), 8);
             for i in 0..8 {
                 assert_eq!(a.next().unwrap(), (j * 8 + i + 1) % 3 == 0);
             }
@@ -275,7 +281,7 @@ mod tests {
         let expected_remainder = 0b00000100u8;
         assert_eq!(iter.remainder(), expected_remainder);
 
-        let mut a = BitChunkIter::new(expected_remainder);
+        let mut a = BitChunkIter::new(expected_remainder, 8);
         for i in 0..4 {
             assert_eq!(a.next().unwrap(), (i + 1) % 3 == 0);
         }

--- a/src/bits/mod.rs
+++ b/src/bits/mod.rs
@@ -43,9 +43,9 @@ pub fn bytes_for(bits: usize) -> usize {
 #[inline]
 pub fn null_count(slice: &[u8], offset: usize, len: usize) -> usize {
     // u64 results in optimal performance (verified via benches)
-    let chunks = chunk_iterator::BitChunks::<u64>::new(slice, offset, len);
+    let mut chunks = chunk_iterator::BitChunks::<u64>::new(slice, offset, len);
 
-    let mut count: usize = chunks.iter().map(|c| c.count_ones() as usize).sum();
+    let mut count: usize = chunks.by_ref().map(|c| c.count_ones() as usize).sum();
 
     if chunks.remainder_len() > 0 {
         // mask least significant bits up to len, as they are otherwise not required
@@ -57,7 +57,7 @@ pub fn null_count(slice: &[u8], offset: usize, len: usize) -> usize {
     len - count
 }
 
-pub use chunk_iterator::{BitChunk, BitChunkIterator, BitChunks};
+pub use chunk_iterator::{BitChunk, BitChunks};
 
 #[cfg(test)]
 mod tests {

--- a/src/types/bit_chunk.rs
+++ b/src/types/bit_chunk.rs
@@ -22,20 +22,33 @@ pub unsafe trait BitChunk:
     + BitAndAssign
     + BitOr<Output = Self>
 {
+    type Bytes: std::ops::Index<usize, Output = u8>
+        + std::ops::IndexMut<usize, Output = u8>
+        + for<'a> std::convert::TryFrom<&'a [u8]>
+        + std::fmt::Debug;
+
     fn one() -> Self;
     fn zero() -> Self;
-    fn to_le(self) -> Self;
+    fn to_ne_bytes(self) -> Self::Bytes;
+    fn from_ne_bytes(v: Self::Bytes) -> Self;
 }
 
 unsafe impl BitChunk for u8 {
+    type Bytes = [u8; 1];
+
     #[inline(always)]
     fn zero() -> Self {
         0
     }
 
     #[inline(always)]
-    fn to_le(self) -> Self {
-        self.to_le()
+    fn to_ne_bytes(self) -> Self::Bytes {
+        self.to_ne_bytes()
+    }
+
+    #[inline(always)]
+    fn from_ne_bytes(v: Self::Bytes) -> Self {
+        Self::from_ne_bytes(v)
     }
 
     #[inline(always)]
@@ -45,14 +58,21 @@ unsafe impl BitChunk for u8 {
 }
 
 unsafe impl BitChunk for u16 {
+    type Bytes = [u8; 2];
+
     #[inline(always)]
     fn zero() -> Self {
         0
     }
 
     #[inline(always)]
-    fn to_le(self) -> Self {
-        self.to_le()
+    fn to_ne_bytes(self) -> Self::Bytes {
+        self.to_ne_bytes()
+    }
+
+    #[inline(always)]
+    fn from_ne_bytes(v: Self::Bytes) -> Self {
+        Self::from_ne_bytes(v)
     }
 
     #[inline(always)]
@@ -62,14 +82,21 @@ unsafe impl BitChunk for u16 {
 }
 
 unsafe impl BitChunk for u32 {
+    type Bytes = [u8; 4];
+
     #[inline(always)]
     fn zero() -> Self {
         0
     }
 
     #[inline(always)]
-    fn to_le(self) -> Self {
-        self.to_le()
+    fn from_ne_bytes(v: Self::Bytes) -> Self {
+        Self::from_ne_bytes(v)
+    }
+
+    #[inline(always)]
+    fn to_ne_bytes(self) -> Self::Bytes {
+        self.to_ne_bytes()
     }
 
     #[inline(always)]
@@ -79,14 +106,21 @@ unsafe impl BitChunk for u32 {
 }
 
 unsafe impl BitChunk for u64 {
+    type Bytes = [u8; 8];
+
     #[inline(always)]
     fn zero() -> Self {
         0
     }
 
     #[inline(always)]
-    fn to_le(self) -> Self {
-        self.to_le()
+    fn to_ne_bytes(self) -> Self::Bytes {
+        self.to_ne_bytes()
+    }
+
+    #[inline(always)]
+    fn from_ne_bytes(v: Self::Bytes) -> Self {
+        Self::from_ne_bytes(v)
     }
 
     #[inline(always)]


### PR DESCRIPTION
This PR refactors `BitChunk` and `BitChunkIterator` APIs, removing all `unsafe` on them.

Also added a battery of tests since they were lacking.

No change in performance.

Also made the iterator endianess-independent, which brings the crate closer to support big endianess.
