### PR TITLE
Reduced usage of `unsafe` for TrustedLen iterators

### DIFF
--- a/src/array/binary/iterator.rs
+++ b/src/array/binary/iterator.rs
@@ -1,12 +1,11 @@
 use crate::{
     array::{Array, Offset},
     bits::{zip_validity, ZipValidity},
+    trusted_len::TrustedLen,
 };
 
 use super::BinaryArray;
 
-/// # Safety
-/// This iterator is `TrustedLen`
 pub struct BinaryValueIter<'a, O: Offset> {
     array: &'a BinaryArray<O>,
     index: usize,
@@ -60,3 +59,5 @@ impl<'a, O: Offset> BinaryArray<O> {
         BinaryValueIter::new(self)
     }
 }
+
+unsafe impl<O: Offset> TrustedLen for BinaryValueIter<'_, O> {}

--- a/src/array/utf8/iterator.rs
+++ b/src/array/utf8/iterator.rs
@@ -1,11 +1,12 @@
-use crate::array::{Array, Offset};
 use crate::bits::{zip_validity, ZipValidity};
+use crate::{
+    array::{Array, Offset},
+    trusted_len::TrustedLen,
+};
 
 use super::Utf8Array;
 
 /// Iterator of values of an `Utf8Array`.
-/// # Safety
-/// This iterator is `TrustedLen`
 pub struct Utf8ValuesIter<'a, O: Offset> {
     array: &'a Utf8Array<O>,
     index: usize,
@@ -59,3 +60,5 @@ impl<'a, O: Offset> Utf8Array<O> {
         Utf8ValuesIter::new(self)
     }
 }
+
+unsafe impl<O: Offset> TrustedLen for Utf8ValuesIter<'_, O> {}

--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -24,7 +24,7 @@ where
         .zip(a4_chunks.by_ref())
         .map(|(((a1, a2), a3), a4)| op(a1, a2, a3, a4));
     // Soundness: `BitChunks` is a trusted len iterator
-    let mut buffer = unsafe { MutableBuffer::from_chunk_iter(chunks) };
+    let mut buffer = unsafe { MutableBuffer::from_chunk_iter_unchecked(chunks) };
 
     let remainder_bytes = a1_chunks.remainder_len().saturating_add(7) / 8;
     let rem = op(
@@ -58,7 +58,7 @@ where
         .zip(a3_chunks.by_ref())
         .map(|((a1, a2), a3)| op(a1, a2, a3));
     // Soundness: `BitChunks` is a trusted len iterator
-    let mut buffer = unsafe { MutableBuffer::from_chunk_iter(chunks) };
+    let mut buffer = unsafe { MutableBuffer::from_chunk_iter_unchecked(chunks) };
 
     let remainder_bytes = a1_chunks.remainder_len().saturating_add(7) / 8;
     let rem = op(
@@ -88,7 +88,7 @@ where
         .zip(rhs_chunks.by_ref())
         .map(|(left, right)| op(left, right));
     // Soundness: `BitChunks` is a trusted len iterator
-    let mut buffer = unsafe { MutableBuffer::from_chunk_iter(chunks) };
+    let mut buffer = unsafe { MutableBuffer::from_chunk_iter_unchecked(chunks) };
 
     let remainder_bytes = lhs_chunks.remainder_len().saturating_add(7) / 8;
     let rem = op(lhs_chunks.remainder(), rhs_chunks.remainder());
@@ -108,7 +108,7 @@ where
     let mut lhs_chunks = lhs.chunks();
 
     let chunks = lhs_chunks.by_ref().map(|left| op(left));
-    let mut buffer = unsafe { MutableBuffer::from_chunk_iter(chunks) };
+    let mut buffer = unsafe { MutableBuffer::from_chunk_iter_unchecked(chunks) };
 
     let remainder_bytes = lhs_chunks.remainder_len().saturating_add(7) / 8;
     let rem = op(lhs_chunks.remainder());

--- a/src/bitmap/iterator.rs
+++ b/src/bitmap/iterator.rs
@@ -1,3 +1,5 @@
+use crate::trusted_len::TrustedLen;
+
 use super::Bitmap;
 
 /// An iterator of bits according to the LSB format
@@ -81,6 +83,8 @@ impl<'a> Iterator for BitmapIter<'a> {
         }
     }
 }
+
+unsafe impl TrustedLen for BitmapIter<'_> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/bits/chunk_iterator/mod.rs
+++ b/src/bits/chunk_iterator/mod.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 mod merge;
 
 pub use crate::types::BitChunk;
-use crate::types::BitChunkIter;
+use crate::{trusted_len::TrustedLen, types::BitChunkIter};
 use merge::merge_reversed;
 
 /// This struct is used to efficiently iterate over bit masks by loading bytes on
@@ -173,6 +173,8 @@ impl<T: BitChunk> ExactSizeIterator for BitChunks<'_, T> {
         self.chunk_iterator.len()
     }
 }
+
+unsafe impl<T: BitChunk> TrustedLen for BitChunks<'_, T> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/bits/zip_validity.rs
+++ b/src/bits/zip_validity.rs
@@ -1,4 +1,4 @@
-use crate::bitmap::Bitmap;
+use crate::{bitmap::Bitmap, trusted_len::TrustedLen};
 
 /// Iterator of Option<T> from an iterator and validity.
 pub struct ZipValidity<'a, T, I: Iterator<Item = T>> {
@@ -83,6 +83,8 @@ impl<'a, T, I: Iterator<Item = T>> Iterator for ZipValidity<'a, T, I> {
 
 /// all arrays have known size.
 impl<'a, T, I: Iterator<Item = T>> std::iter::ExactSizeIterator for ZipValidity<'a, T, I> {}
+
+unsafe impl<T, I: TrustedLen<Item = T>> TrustedLen for ZipValidity<'_, T, I> {}
 
 /// Returns an iterator adapter that returns Option<T> according to an optional validity.
 #[inline]

--- a/src/compute/arity.rs
+++ b/src/compute/arity.rs
@@ -32,12 +32,7 @@ where
     F: Fn(I) -> O,
 {
     let values = array.values().iter().map(|v| op(*v));
-    // JUSTIFICATION
-    //  Benefit
-    //      ~60% speedup
-    //  Soundness
-    //      `values` is an iterator with a known size because arrays are sized.
-    let values = unsafe { Buffer::from_trusted_len_iter(values) };
+    let values = Buffer::from_trusted_len_iter(values);
 
     PrimitiveArray::<O>::from_data(data_type.clone(), values, array.validity().clone())
 }
@@ -55,7 +50,7 @@ where
     F: Fn(I) -> Result<O>,
 {
     let values = array.values().iter().map(|v| op(*v));
-    let values = unsafe { Buffer::try_from_trusted_len_iter(values) }?;
+    let values = Buffer::try_from_trusted_len_iter(values)?;
 
     Ok(PrimitiveArray::<O>::from_data(
         data_type.clone(),
@@ -84,7 +79,7 @@ where
         res
     });
 
-    let values = unsafe { Buffer::from_trusted_len_iter(values) };
+    let values = Buffer::from_trusted_len_iter(values);
 
     (
         PrimitiveArray::<O>::from_data(data_type.clone(), values, array.validity().clone()),
@@ -118,7 +113,7 @@ where
         }
     });
 
-    let values = unsafe { Buffer::from_trusted_len_iter(values) };
+    let values = Buffer::from_trusted_len_iter(values);
 
     // The validity has to be checked against the bitmap created during the
     // creation of the values with the iterator. If an error was found during
@@ -167,12 +162,7 @@ where
         .iter()
         .zip(rhs.values().iter())
         .map(|(l, r)| op(*l, *r));
-    // JUSTIFICATION
-    //  Benefit
-    //      ~60% speedup
-    //  Soundness
-    //      `values` is an iterator with a known size.
-    let values = unsafe { Buffer::from_trusted_len_iter(values) };
+    let values = Buffer::from_trusted_len_iter(values);
 
     Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
 }
@@ -204,7 +194,7 @@ where
         .zip(rhs.values().iter())
         .map(|(l, r)| op(*l, *r));
 
-    let values = unsafe { Buffer::try_from_trusted_len_iter(values) }?;
+    let values = Buffer::try_from_trusted_len_iter(values)?;
 
     Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
 }
@@ -238,7 +228,7 @@ where
         res
     });
 
-    let values = unsafe { Buffer::from_trusted_len_iter(values) };
+    let values = Buffer::from_trusted_len_iter(values);
 
     Ok((
         PrimitiveArray::<T>::from_data(data_type, values, validity),
@@ -283,7 +273,7 @@ where
             }
         });
 
-    let values = unsafe { Buffer::from_trusted_len_iter(values) };
+    let values = Buffer::from_trusted_len_iter(values);
 
     let bitmap: Bitmap = mut_bitmap.into();
     let validity = combine_validities(lhs.validity(), rhs.validity());

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -278,8 +278,8 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
             // cast primitive to list's primitive
             let values = cast(array, to.data_type())?.into();
             // create offsets, where if array.len() = 2, we have [0,1,2]
-            let offsets: Buffer<i32> =
-                unsafe { Buffer::from_trusted_len_iter(0..=array.len() as i32) };
+            let offsets =
+                unsafe { Buffer::from_trusted_len_iter_unchecked(0..=array.len() as i32) };
 
             let data_type = ListArray::<i32>::default_datatype(to.data_type().clone());
             let list_array = ListArray::<i32>::from_data(data_type, offsets, values, None);

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -33,7 +33,7 @@ pub fn hash_boolean(array: &BooleanArray) -> PrimitiveArray<u64> {
         x.hash(&mut hasher);
         hasher.finish()
     });
-    let values = unsafe { Buffer::from_trusted_len_iter(iter) };
+    let values = Buffer::from_trusted_len_iter(iter);
     PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().clone())
 }
 
@@ -44,7 +44,7 @@ pub fn hash_utf8<O: Offset>(array: &Utf8Array<O>) -> PrimitiveArray<u64> {
         x.hash(&mut hasher);
         hasher.finish()
     });
-    let values = unsafe { Buffer::from_trusted_len_iter(iter) };
+    let values = Buffer::from_trusted_len_iter(iter);
     PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().clone())
 }
 
@@ -55,7 +55,7 @@ pub fn hash_binary<O: Offset>(array: &BinaryArray<O>) -> PrimitiveArray<u64> {
         x.hash(&mut hasher);
         hasher.finish()
     });
-    let values = unsafe { Buffer::from_trusted_len_iter(iter) };
+    let values = Buffer::from_trusted_len_iter(iter);
     PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().clone())
 }
 

--- a/src/compute/length.rs
+++ b/src/compute/length.rs
@@ -34,10 +34,7 @@ where
         .windows(2)
         .map(|offset| op(offset[1] - offset[0]));
 
-    // JUSTIFICATION
-    //  Soundness
-    //      `values` is an iterator with a known size.
-    let values = unsafe { Buffer::from_trusted_len_iter(values) };
+    let values = Buffer::from_trusted_len_iter(values);
 
     let data_type = if O::is_large() {
         DataType::Int64

--- a/src/compute/sort/lex_sort.rs
+++ b/src/compute/sort/lex_sort.rs
@@ -157,7 +157,7 @@ pub fn lexsort_to_indices(columns: &[SortColumn]) -> Result<PrimitiveArray<i32>>
     value_indices.sort_by(lex_comparator);
 
     let values = value_indices.into_iter().map(|i| i as i32);
-    let values = unsafe { Buffer::<i32>::from_trusted_len_iter(values) };
+    let values = Buffer::<i32>::from_trusted_len_iter(values);
     Ok(PrimitiveArray::<i32>::from_data(
         DataType::Int32,
         values,

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -355,10 +355,10 @@ where
 
     let values = if options.nulls_first {
         let values = nulls.into_iter().chain(valids);
-        unsafe { Buffer::<i32>::from_trusted_len_iter(values) }
+        Buffer::<i32>::from_trusted_len_iter(values)
     } else {
         let values = valids.chain(nulls.into_iter());
-        unsafe { Buffer::<i32>::from_trusted_len_iter(values) }
+        Buffer::<i32>::from_trusted_len_iter(values)
     };
 
     PrimitiveArray::<i32>::from_data(DataType::Int32, values, None)
@@ -404,12 +404,11 @@ where
     let values = valids.iter().map(|tuple| tuple.0);
 
     let values = if options.nulls_first {
-        let mut buffer =
-            unsafe { MutableBuffer::<i32>::from_trusted_len_iter(null_indices.into_iter()) };
+        let mut buffer = MutableBuffer::<i32>::from_trusted_len_iter(null_indices.into_iter());
         values.for_each(|x| buffer.push(x));
         buffer.into()
     } else {
-        let mut buffer = unsafe { MutableBuffer::<i32>::from_trusted_len_iter(values) };
+        let mut buffer = MutableBuffer::<i32>::from_trusted_len_iter(values);
         null_indices.iter().for_each(|x| buffer.push(*x));
         buffer.into()
     };

--- a/src/compute/sort/primitive/indices.rs
+++ b/src/compute/sort/primitive/indices.rs
@@ -119,7 +119,8 @@ where
 
         PrimitiveArray::<i32>::from_data(DataType::Int32, indices.into(), None)
     } else {
-        let mut indices = unsafe { MutableBuffer::from_trusted_len_iter(0..values.len() as i32) };
+        let mut indices =
+            unsafe { MutableBuffer::from_trusted_len_iter_unchecked(0..values.len() as i32) };
 
         // Soundness:
         // indices are by construction `< values.len()`

--- a/src/compute/take/generic_binary.rs
+++ b/src/compute/take/generic_binary.rs
@@ -64,8 +64,7 @@ pub fn take_no_validity<O: Offset, I: Offset>(
         Result::Ok(length)
     });
     let offsets = std::iter::once(Ok(O::default())).chain(offsets);
-    // Soundness: `TrustedLen`.
-    let offsets = unsafe { Buffer::try_from_trusted_len_iter(offsets)? };
+    let offsets = Buffer::try_from_trusted_len_iter(offsets)?;
 
     Ok((offsets, buffer.into(), None))
 }
@@ -97,8 +96,7 @@ pub fn take_values_validity<O: Offset, I: Offset, A: GenericBinaryArray<O>>(
         Result::Ok(length)
     });
     let offsets = std::iter::once(Ok(O::default())).chain(offsets);
-    // Soundness: `TrustedLen`.
-    let offsets = unsafe { Buffer::try_from_trusted_len_iter(offsets) }?;
+    let offsets = Buffer::try_from_trusted_len_iter(offsets)?;
     let starts: Buffer<O> = starts.into();
 
     let buffer = take_values(length, starts.as_slice(), offsets.as_slice(), values_values)?;
@@ -128,7 +126,7 @@ pub fn take_indices_validity<O: Offset, I: Offset>(
         Result::Ok(length)
     });
     let offsets = std::iter::once(Ok(O::default())).chain(offsets);
-    let offsets = unsafe { Buffer::try_from_trusted_len_iter(offsets) }?;
+    let offsets = Buffer::try_from_trusted_len_iter(offsets)?;
     let starts: Buffer<O> = starts.into();
 
     let buffer = take_values(length, starts.as_slice(), offsets.as_slice(), values)?;
@@ -170,7 +168,7 @@ pub fn take_values_indices_validity<O: Offset, I: Offset, A: GenericBinaryArray<
         Result::Ok(length)
     });
     let offsets = std::iter::once(Ok(O::default())).chain(offsets);
-    let offsets = unsafe { Buffer::try_from_trusted_len_iter(offsets) }?;
+    let offsets = Buffer::try_from_trusted_len_iter(offsets)?;
     let starts: Buffer<O> = starts.into();
 
     let buffer = take_values(length, starts.as_slice(), offsets.as_slice(), values_values)?;

--- a/src/compute/take/primitive.rs
+++ b/src/compute/take/primitive.rs
@@ -33,8 +33,7 @@ fn take_no_validity<T: NativeType, I: Offset>(
     let values = indices
         .iter()
         .map(|index| Result::Ok(values[maybe_usize::<I>(*index)?]));
-    // Soundness: `slice.map` is `TrustedLen`.
-    let buffer = unsafe { MutableBuffer::try_from_trusted_len_iter(values)? };
+    let buffer = MutableBuffer::try_from_trusted_len_iter(values)?;
 
     Ok((buffer.into(), None))
 }
@@ -59,8 +58,7 @@ fn take_values_validity<T: NativeType, I: Offset>(
         }
         Result::Ok(values_values[index])
     });
-    // Soundness: `slice.map` is `TrustedLen`.
-    let buffer = unsafe { MutableBuffer::try_from_trusted_len_iter(values)? };
+    let buffer = MutableBuffer::try_from_trusted_len_iter(values)?;
 
     Ok((buffer.into(), null.into()))
 }
@@ -85,8 +83,7 @@ fn take_indices_validity<T: NativeType, I: Offset>(
         })
     });
 
-    // Soundness: `slice.map` is `TrustedLen`.
-    let buffer = unsafe { MutableBuffer::try_from_trusted_len_iter(values)? };
+    let buffer = MutableBuffer::try_from_trusted_len_iter(values)?;
 
     Ok((buffer.into(), indices.validity().clone()))
 }
@@ -112,8 +109,7 @@ fn take_values_indices_validity<T: NativeType, I: Offset>(
             Ok(T::default())
         }
     });
-    // Soundness: `slice.map` is `TrustedLen`.
-    let buffer = unsafe { MutableBuffer::try_from_trusted_len_iter(values)? };
+    let buffer = MutableBuffer::try_from_trusted_len_iter(values)?;
     Ok((buffer.into(), bitmap.into()))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod array;
 pub mod bitmap;
 pub mod buffer;
 pub mod error;
+pub mod trusted_len;
 pub mod types;
 
 pub mod compute;

--- a/src/trusted_len.rs
+++ b/src/trusted_len.rs
@@ -1,0 +1,37 @@
+use std::slice::Iter;
+
+/// A trait denoting Rusts' unstable [TrustedLen](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
+/// This is re-defined here and implemented for some iterators until `std::iter::TrustedLen`
+/// is stabilized.
+pub unsafe trait TrustedLen: Iterator {}
+
+unsafe impl<T> TrustedLen for Iter<'_, T> {}
+
+unsafe impl<B, I: TrustedLen, T: FnMut(I::Item) -> B> TrustedLen for std::iter::Map<I, T> {}
+
+unsafe impl<'a, I, T: 'a> TrustedLen for std::iter::Copied<I>
+where
+    I: TrustedLen<Item = &'a T>,
+    T: Copy,
+{
+}
+
+unsafe impl<A, B> TrustedLen for std::iter::Zip<A, B>
+where
+    A: TrustedLen,
+    B: TrustedLen,
+{
+}
+
+unsafe impl<T> TrustedLen for std::slice::Windows<'_, T> {}
+
+unsafe impl<A, B> TrustedLen for std::iter::Chain<A, B>
+where
+    A: TrustedLen,
+    B: TrustedLen<Item = A::Item>,
+{
+}
+
+unsafe impl<T> TrustedLen for std::iter::Once<T> {}
+
+unsafe impl<T> TrustedLen for std::vec::IntoIter<T> {}


### PR DESCRIPTION
This PR adds a new trait, `TrustedLen`, and implements it for iterators in the crate and in `std` that fulfill the contract, so that the code that uses `from_trusted_len_iter` does not have to use `unsafe`.

This reduces usage of `unsafe` to end users, limiting it to implementing an `unsafe` trait, which is closer to where it should be (in general, the implementation of the iterator dictates whether it is `TrustedLen`)
