### PR TITLE
Made schema of RecordBatch `Arc` and moved endianess from schema

### DIFF
--- a/src/datatypes/schema.rs
+++ b/src/datatypes/schema.rs
@@ -31,7 +31,6 @@ pub struct Schema {
     /// A map of key-value pairs containing additional meta data.
     //#[serde(skip_serializing_if = "HashMap::is_empty")]
     pub(crate) metadata: HashMap<String, String>,
-    pub(crate) is_little_endian: bool,
 }
 
 impl Schema {
@@ -40,7 +39,6 @@ impl Schema {
         Self {
             fields: vec![],
             metadata: HashMap::new(),
-            is_little_endian: true,
         }
     }
 
@@ -56,7 +54,7 @@ impl Schema {
     /// let schema = Schema::new(vec![field_a, field_b]);
     /// ```
     pub fn new(fields: Vec<Field>) -> Self {
-        Self::new_from(fields, HashMap::new(), true)
+        Self::new_from(fields, HashMap::new())
     }
 
     /// Creates a new `Schema` from a sequence of `Field` values
@@ -73,23 +71,11 @@ impl Schema {
     /// let mut metadata: HashMap<String, String> = HashMap::new();
     /// metadata.insert("row_count".to_string(), "100".to_string());
     ///
-    /// let schema = Schema::new_from(vec![field_a, field_b], metadata, true);
+    /// let schema = Schema::new_from(vec![field_a, field_b], metadata);
     /// ```
     #[inline]
-    pub const fn new_from(
-        fields: Vec<Field>,
-        metadata: HashMap<String, String>,
-        is_little_endian: bool,
-    ) -> Self {
-        Self {
-            fields,
-            metadata,
-            is_little_endian,
-        }
-    }
-
-    pub const fn is_little_endian(&self) -> bool {
-        self.is_little_endian
+    pub const fn new_from(fields: Vec<Field>, metadata: HashMap<String, String>) -> Self {
+        Self { fields, metadata }
     }
 
     /// Merge schema into self if it is compatible. Struct fields will be merged recursively.
@@ -124,11 +110,7 @@ impl Schema {
         schemas
             .into_iter()
             .try_fold(Self::empty(), |mut merged, schema| {
-                let Schema {
-                    metadata,
-                    fields,
-                    is_little_endian: _,
-                } = schema;
+                let Schema { metadata, fields } = schema;
                 for (key, value) in metadata.into_iter() {
                     // merge metadata
                     if let Some(old_val) = merged.metadata.get(&key) {

--- a/src/endianess.rs
+++ b/src/endianess.rs
@@ -1,0 +1,11 @@
+#[cfg(target_endian = "little")]
+#[inline]
+pub fn is_native_little_endian() -> bool {
+    true
+}
+
+#[cfg(target_endian = "big")]
+#[inline]
+pub fn is_native_little_endian() -> bool {
+    false
+}

--- a/src/io/csv/reader.rs
+++ b/src/io/csv/reader.rs
@@ -35,7 +35,7 @@ pub fn read_batch<R: Read, P: GenericParser<ArrowError>>(
     parser: &P,
     skip: usize,
     len: usize,
-    schema: Schema,
+    schema: Arc<Schema>,
     projection: Option<&[usize]>,
 ) -> Result<RecordBatch> {
     // skip first `start` rows.
@@ -132,7 +132,7 @@ fn parse<P: GenericParser<ArrowError>>(
 
     let projected_fields: Vec<Field> = projection.iter().map(|i| fields[*i].clone()).collect();
 
-    let projected_schema = Schema::new(projected_fields);
+    let projected_schema = Arc::new(Schema::new(projected_fields));
 
     RecordBatch::try_new(projected_schema, columns)
 }
@@ -186,7 +186,7 @@ mod tests {
         let mut reader = ReaderBuilder::new().from_path("test/data/uk_cities_with_headers.csv")?;
         let parser = DefaultParser::default();
 
-        let schema = infer_schema(&mut reader, None, true, &infer)?;
+        let schema = Arc::new(infer_schema(&mut reader, None, true, &infer)?);
 
         let batch = read_batch(&mut reader, &parser, 0, 100, schema.clone(), None)?;
 

--- a/src/io/csv/reader.rs
+++ b/src/io/csv/reader.rs
@@ -20,11 +20,7 @@ pub fn projected_schema(schema: &Schema, projection: Option<&[usize]>) -> Schema
             let fields = schema.fields();
             let projected_fields: Vec<Field> =
                 projection.iter().map(|i| fields[*i].clone()).collect();
-            Schema::new_from(
-                projected_fields,
-                schema.metadata().clone(),
-                schema.is_little_endian(),
-            )
+            Schema::new_from(projected_fields, schema.metadata().clone())
         }
         None => schema.clone(),
     }

--- a/src/io/csv/write/mod.rs
+++ b/src/io/csv/write/mod.rs
@@ -108,7 +108,7 @@ mod tests {
             .to(DataType::Time32(TimeUnit::Second));
 
         RecordBatch::try_new(
-            schema,
+            Arc::new(schema),
             vec![
                 Arc::new(c1),
                 Arc::new(c2),

--- a/src/io/ipc/common.rs
+++ b/src/io/ipc/common.rs
@@ -45,8 +45,7 @@ pub(crate) mod tests {
         let arrow_json: ArrowJson = serde_json::from_str(&s).unwrap();
 
         let schema = serde_json::to_value(arrow_json.schema).unwrap();
-        let mut schema = Schema::try_from(&schema).unwrap();
-        schema.is_little_endian = version.contains("littleendian");
+        let schema = Schema::try_from(&schema).unwrap();
 
         // read dictionaries
         let mut dictionaries = HashMap::new();

--- a/src/io/ipc/common.rs
+++ b/src/io/ipc/common.rs
@@ -79,7 +79,10 @@ pub(crate) mod tests {
 
         let schema = reader.schema();
 
-        (schema.clone(), reader.collect::<Result<_>>().unwrap())
+        (
+            schema.as_ref().clone(),
+            reader.collect::<Result<_>>().unwrap(),
+        )
     }
 
     pub fn read_arrow_stream(version: &str, file_name: &str) -> (Schema, Vec<RecordBatch>) {
@@ -94,6 +97,9 @@ pub(crate) mod tests {
 
         let schema = reader.schema();
 
-        (schema.clone(), reader.collect::<Result<_>>().unwrap())
+        (
+            schema.as_ref().clone(),
+            reader.collect::<Result<_>>().unwrap(),
+        )
     }
 }

--- a/src/io/ipc/read/common.rs
+++ b/src/io/ipc/read/common.rs
@@ -32,7 +32,7 @@ type ArrayRef = Arc<dyn Array>;
 /// Creates a record batch from binary data using the `ipc::RecordBatch` indexes and the `Schema`
 pub fn read_record_batch<R: Read + Seek>(
     batch: gen::Message::RecordBatch,
-    schema: Schema,
+    schema: Arc<Schema>,
     dictionaries: &[Option<ArrayRef>],
     reader: &mut R,
     block_offset: u64,
@@ -98,11 +98,11 @@ pub fn read_dictionary<R: Read + Seek>(
     let dictionary_values: ArrayRef = match first_field.data_type() {
         DataType::Dictionary(_, ref value_type) => {
             // Make a fake schema for the dictionary batch.
-            let schema = Schema {
+            let schema = Arc::new(Schema {
                 fields: vec![Field::new("", value_type.as_ref().clone(), false)],
                 metadata: HashMap::new(),
                 is_little_endian: schema.is_little_endian,
-            };
+            });
             // Read a single column
             let record_batch = read_record_batch(
                 batch.data().unwrap(),

--- a/src/io/ipc/read/deserialize.rs
+++ b/src/io/ipc/read/deserialize.rs
@@ -28,6 +28,7 @@ use std::{
 
 use crate::buffer::Buffer;
 use crate::datatypes::{DataType, IntervalUnit};
+use crate::endianess::is_native_little_endian;
 use crate::error::Result as ArrowResult;
 use crate::{
     array::*,
@@ -39,18 +40,6 @@ use crate::{
 use super::super::gen;
 
 type Node<'a> = (&'a gen::Message::FieldNode, &'a Option<Arc<dyn Array>>);
-
-#[cfg(target_endian = "little")]
-#[inline]
-fn is_native_little_endian() -> bool {
-    true
-}
-
-#[cfg(target_endian = "big")]
-#[inline]
-fn is_native_little_endian() {
-    false
-}
 
 fn read_buffer<T: NativeType, R: Read + Seek>(
     buf: &mut VecDeque<&gen::Schema::Buffer>,

--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -60,6 +60,8 @@ pub struct FileReader<R: Read + Seek> {
 
     /// Metadata version
     metadata_version: gen::Schema::MetadataVersion,
+
+    is_little_endian: bool,
 }
 
 impl<R: Read + Seek> FileReader<R> {
@@ -105,7 +107,8 @@ impl<R: Read + Seek> FileReader<R> {
         let total_blocks = blocks.len();
 
         let ipc_schema = footer.schema().unwrap();
-        let schema = Arc::new(convert::fb_to_schema(ipc_schema));
+        let (schema, is_little_endian) = convert::fb_to_schema(ipc_schema);
+        let schema = Arc::new(schema);
 
         // Create an array of optional dictionary value arrays, one per field.
         let mut dictionaries_by_field = vec![None; schema.fields().len()];
@@ -136,6 +139,7 @@ impl<R: Read + Seek> FileReader<R> {
                     read_dictionary(
                         batch,
                         &schema,
+                        is_little_endian,
                         &mut dictionaries_by_field,
                         &mut reader,
                         block_offset,
@@ -153,6 +157,7 @@ impl<R: Read + Seek> FileReader<R> {
         Ok(Self {
             reader,
             schema,
+            is_little_endian,
             blocks: blocks.to_vec(),
             current_block: 0,
             total_blocks,
@@ -226,6 +231,7 @@ impl<R: Read + Seek> FileReader<R> {
                 read_record_batch(
                     batch,
                     self.schema().clone(),
+                    self.is_little_endian,
                     &self.dictionaries_by_field,
                     &mut self.reader,
                     block.offset() as u64 + block.metaDataLength() as u64,

--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -40,7 +40,7 @@ pub struct FileReader<R: Read + Seek> {
     reader: BufReader<R>,
 
     /// The schema that is read from the file header
-    schema: Schema,
+    schema: Arc<Schema>,
 
     /// The blocks in the file
     ///
@@ -105,7 +105,7 @@ impl<R: Read + Seek> FileReader<R> {
         let total_blocks = blocks.len();
 
         let ipc_schema = footer.schema().unwrap();
-        let schema = convert::fb_to_schema(ipc_schema);
+        let schema = Arc::new(convert::fb_to_schema(ipc_schema));
 
         // Create an array of optional dictionary value arrays, one per field.
         let mut dictionaries_by_field = vec![None; schema.fields().len()];
@@ -167,7 +167,7 @@ impl<R: Read + Seek> FileReader<R> {
     }
 
     /// Return the schema of the file
-    pub fn schema(&self) -> &Schema {
+    pub fn schema(&self) -> &Arc<Schema> {
         &self.schema
     }
 
@@ -281,7 +281,7 @@ mod tests {
         // read expected JSON output
         let (schema, batches) = read_gzip_json(version, file_name);
 
-        assert_eq!(&schema, reader.schema());
+        assert_eq!(&schema, reader.schema().as_ref());
 
         batches
             .iter()

--- a/src/io/ipc/write/common.rs
+++ b/src/io/ipc/write/common.rs
@@ -29,6 +29,7 @@ use super::{write, write_dictionary};
 use flatbuffers::FlatBufferBuilder;
 
 use crate::array::Array;
+use crate::endianess::is_native_little_endian;
 use crate::error::{ArrowError, Result};
 use crate::record_batch::RecordBatch;
 use crate::{array::DictionaryArray, datatypes::*};
@@ -155,7 +156,7 @@ impl IpcDataGenerator {
                         dict_id,
                         column.as_ref(),
                         write_options,
-                        batch.schema().is_little_endian,
+                        is_native_little_endian(),
                     ));
                 }
             }
@@ -186,7 +187,7 @@ impl IpcDataGenerator {
                 &mut arrow_data,
                 &mut nodes,
                 &mut offset,
-                batch.schema().is_little_endian,
+                is_native_little_endian(),
             )
         }
 

--- a/src/io/ipc/write/stream.rs
+++ b/src/io/ipc/write/stream.rs
@@ -143,7 +143,7 @@ mod tests {
         // read expected JSON output
         let (expected_schema, expected_batches) = read_gzip_json(version, file_name);
 
-        assert_eq!(schema, expected_schema);
+        assert_eq!(schema.as_ref(), &expected_schema);
 
         let batches = reader.collect::<Result<Vec<_>>>().unwrap();
 

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -198,7 +198,7 @@ mod tests {
         // read expected JSON output
         let (expected_schema, expected_batches) = read_gzip_json(version, file_name);
 
-        assert_eq!(schema, expected_schema);
+        assert_eq!(schema.as_ref(), &expected_schema);
 
         let batches = reader.collect::<Result<Vec<_>>>().unwrap();
 

--- a/src/io/json/schema.rs
+++ b/src/io/json/schema.rs
@@ -586,11 +586,7 @@ impl TryFrom<&Value> for Schema {
                     HashMap::default()
                 };
 
-                Ok(Self {
-                    fields,
-                    metadata,
-                    is_little_endian: true,
-                })
+                Ok(Self { fields, metadata })
             }
             _ => Err(ArrowError::Schema(
                 "Invalid json value type for schema".to_string(),

--- a/src/io/json/write/mod.rs
+++ b/src/io/json/write/mod.rs
@@ -43,7 +43,7 @@ mod tests {
             Primitive::<i32>::from([Some(1), Some(2), Some(3), None, Some(5)]).to(DataType::Int32);
         let b = Utf8Array::<i32>::from(&vec![Some("a"), Some("b"), Some("c"), Some("d"), None]);
 
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(a), Arc::new(b)]).unwrap();
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)]).unwrap();
 
         let mut buf = Vec::new();
         {
@@ -93,7 +93,8 @@ mod tests {
 
         let c2 = Utf8Array::<i32>::from(&vec![Some("a"), Some("b"), Some("c")]);
 
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(c1), Arc::new(c2)]).unwrap();
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(c1), Arc::new(c2)]).unwrap();
 
         let mut buf = Vec::new();
         {
@@ -130,7 +131,7 @@ mod tests {
 
         let b = Primitive::from_slice(&vec![1, 2, 3, 4, 5]).to(DataType::Int32);
 
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(a), Arc::new(b)]).unwrap();
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)]).unwrap();
 
         let mut buf = Vec::new();
         {
@@ -170,7 +171,8 @@ mod tests {
 
         let c2 = Utf8Array::<i32>::from(&vec![Some("foo"), Some("bar"), None]);
 
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(c1), Arc::new(c2)]).unwrap();
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(c1), Arc::new(c2)]).unwrap();
 
         let mut buf = Vec::new();
         {
@@ -233,7 +235,8 @@ mod tests {
 
         let c2 = Primitive::<i32>::from_slice(&[1, 2, 3]).to(DataType::Int32);
 
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(c1), Arc::new(c2)]).unwrap();
+        let batch =
+            RecordBatch::try_new(Arc::new(schema), vec![Arc::new(c1), Arc::new(c2)]).unwrap();
 
         let mut buf = Vec::new();
         {

--- a/src/io/json/write/serialize.rs
+++ b/src/io/json/write/serialize.rs
@@ -343,7 +343,7 @@ fn set_column_for_json_rows(
 /// use arrow2::io::json;
 /// use arrow2::record_batch::RecordBatch;
 ///
-/// let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+/// let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
 /// let a = Primitive::from_slice(&[1i32, 2, 3]).to(DataType::Int32);
 /// let batch = RecordBatch::try_new(schema, vec![Arc::new(a)]).unwrap();
 ///

--- a/src/io/json/write/writer.rs
+++ b/src/io/json/write/writer.rs
@@ -39,7 +39,7 @@ use super::serialize::write_record_batches;
 /// use arrow2::io::json;
 /// use arrow2::record_batch::RecordBatch;
 ///
-/// let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+/// let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
 /// let a = Primitive::from_slice(&[1i32, 2, 3]).to(DataType::Int32);
 /// let batch = RecordBatch::try_new(schema, vec![Arc::new(a)]).unwrap();
 ///

--- a/src/io/json_integration/read.rs
+++ b/src/io/json_integration/read.rs
@@ -340,5 +340,5 @@ pub fn to_record_batch(
         .map(|(field, json_col)| to_array(field, &json_col, json_dictionaries))
         .collect::<Result<Vec<_>>>()?;
 
-    RecordBatch::try_new(schema.clone(), columns)
+    RecordBatch::try_new(Arc::new(schema.clone()), columns)
 }

--- a/src/io/parquet/read/schema/convert.rs
+++ b/src/io/parquet/read/schema/convert.rs
@@ -52,7 +52,7 @@ pub fn parquet_to_arrow_schema(
         .map(|t| to_field(t))
         .filter_map(|x| x.transpose())
         .collect::<Result<Vec<_>>>()
-        .map(|fields| Schema::new_from(fields, metadata, true))
+        .map(|fields| Schema::new_from(fields, metadata))
 }
 
 fn from_int32(

--- a/src/io/parquet/read/schema/metadata.rs
+++ b/src/io/parquet/read/schema/metadata.rs
@@ -35,6 +35,7 @@ fn get_arrow_schema_from_metadata(encoded_meta: &str) -> Result<Schema> {
                 Ok(message) => message
                     .header_as_schema()
                     .map(ipc::fb_to_schema)
+                    .map(|x| x.0)
                     .ok_or_else(|| ArrowError::Ipc("the message is not Arrow Schema".to_string())),
                 Err(err) => {
                     // The flatbuffers implementation returns an error on verification error.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod alloc;
 pub mod array;
 pub mod bitmap;
 pub mod buffer;
+mod endianess;
 pub mod error;
 pub mod trusted_len;
 pub mod types;

--- a/src/record_batch.rs
+++ b/src/record_batch.rs
@@ -40,7 +40,7 @@ type ArrayRef = Arc<dyn Array>;
 /// [JSON reader](crate::json::Reader).
 #[derive(Clone, Debug, PartialEq)]
 pub struct RecordBatch {
-    schema: Schema,
+    schema: Arc<Schema>,
     columns: Vec<ArrayRef>,
 }
 
@@ -75,7 +75,7 @@ impl RecordBatch {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn try_new(schema: Schema, columns: Vec<ArrayRef>) -> Result<Self> {
+    pub fn try_new(schema: Arc<Schema>, columns: Vec<ArrayRef>) -> Result<Self> {
         let options = RecordBatchOptions::default();
         Self::validate_new_batch(&schema, columns.as_slice(), &options)?;
         Ok(RecordBatch { schema, columns })
@@ -86,7 +86,7 @@ impl RecordBatch {
     ///
     /// See [`RecordBatch::try_new`] for the expected conditions.
     pub fn try_new_with_options(
-        schema: Schema,
+        schema: Arc<Schema>,
         columns: Vec<ArrayRef>,
         options: &RecordBatchOptions,
     ) -> Result<Self> {
@@ -95,7 +95,7 @@ impl RecordBatch {
     }
 
     /// Creates a new empty [`RecordBatch`].
-    pub fn new_empty(schema: Schema) -> Self {
+    pub fn new_empty(schema: Arc<Schema>) -> Self {
         let columns = schema
             .fields()
             .iter()
@@ -168,7 +168,7 @@ impl RecordBatch {
     }
 
     /// Returns the [`Schema`](crate::datatypes::Schema) of the record batch.
-    pub fn schema(&self) -> &Schema {
+    pub fn schema(&self) -> &Arc<Schema> {
         &self.schema
     }
 
@@ -262,7 +262,7 @@ impl From<&StructArray> for RecordBatch {
     /// This currently does not flatten and nested struct types
     fn from(struct_array: &StructArray) -> Self {
         if let DataType::Struct(fields) = struct_array.data_type() {
-            let schema = Schema::new(fields.clone());
+            let schema = Arc::new(Schema::new(fields.clone()));
             let columns = struct_array.values().to_vec();
             RecordBatch { schema, columns }
         } else {

--- a/src/record_batch.rs
+++ b/src/record_batch.rs
@@ -64,9 +64,9 @@ impl RecordBatch {
     /// # use arrow2::record_batch::RecordBatch;
     /// # fn main() -> arrow2::error::Result<()> {
     /// let id_array = Primitive::from_slice(&[1i32, 2, 3, 4, 5]).to(DataType::Int32);
-    /// let schema = Schema::new(vec![
+    /// let schema = Arc::new(Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false)
-    /// ]);
+    /// ]));
     ///
     /// let batch = RecordBatch::try_new(
     ///     schema,
@@ -183,9 +183,9 @@ impl RecordBatch {
     /// # use arrow2::record_batch::RecordBatch;
     /// # fn main() -> arrow2::error::Result<()> {
     /// let id_array = Primitive::from_slice(&[1i32, 2, 3, 4, 5]).to(DataType::Int32);
-    /// let schema = Schema::new(vec![
+    /// let schema = Arc::new(Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false)
-    /// ]);
+    /// ]));
     ///
     /// let batch = RecordBatch::try_new(schema, vec![Arc::new(id_array)])?;
     ///
@@ -212,9 +212,9 @@ impl RecordBatch {
     /// # use arrow2::record_batch::RecordBatch;
     /// # fn main() -> arrow2::error::Result<()> {
     /// let id_array = Primitive::from_slice(&[1i32, 2, 3, 4, 5]).to(DataType::Int32);
-    /// let schema = Schema::new(vec![
+    /// let schema = Arc::new(Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false)
-    /// ]);
+    /// ]));
     ///
     /// let batch = RecordBatch::try_new(schema, vec![Arc::new(id_array)])?;
     ///


### PR DESCRIPTION
This was an old experiment that I am now reverting. This also removes endianess from the schema, as it is only relevant in the context of IPC where a file or stream may have been written in big endian.