### PR TITLE
Scalar

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod bitmap;
 pub mod buffer;
 mod endianess;
 pub mod error;
+pub mod scalar;
 pub mod trusted_len;
 pub mod types;
 

--- a/src/scalar/README.md
+++ b/src/scalar/README.md
@@ -10,7 +10,7 @@ There are three reasons:
 * forward-compatibility: a new entry on an `enum` is backward-incompatible
 * do not expose implementation details to users (reduce the surface of the public API)
 
-### `Scalar` should contain nullability information
+### `Scalar` MUST contain nullability information
 
 This is to be aligned with the general notion of arrow's `Array`.
 

--- a/src/scalar/README.md
+++ b/src/scalar/README.md
@@ -1,0 +1,28 @@
+# Scalar API
+
+Design choices:
+
+### `Scalar` is trait object
+
+There are three reasons:
+
+* a scalar should have a small memory footprint, which an enum would not ensure given the different physical types available.
+* forward-compatibility: a new entry on an `enum` is backward-incompatible
+* do not expose implementation details to users (reduce the surface of the public API)
+
+### `Scalar` should contain nullability information
+
+This is to be aligned with the general notion of arrow's `Array`.
+
+This API is a companion to the `Array`, and follows the same design as `Array`.
+Specifically, a `Scalar` is a trait object that can be downcasted to concrete implementations.
+
+Like `Array`, `Scalar` implements
+
+* `data_type`, which is used to perform the correct downcast
+* `is_valid`, to tell whether the scalar is null or not
+
+### There is one implementation per arrows' physical type
+
+* Reduces the number of `match` that users need to write
+* Allows casting of logical types without changing the underlying physical type

--- a/src/scalar/binary.rs
+++ b/src/scalar/binary.rs
@@ -1,0 +1,95 @@
+use crate::{array::*, buffer::Buffer, datatypes::DataType};
+
+use super::Scalar;
+
+#[derive(Debug, Clone)]
+pub struct BinaryScalar<O: Offset> {
+    value: Buffer<u8>,
+    is_valid: bool,
+    phantom: std::marker::PhantomData<O>,
+}
+
+impl<O: Offset> PartialEq for BinaryScalar<O> {
+    fn eq(&self, other: &Self) -> bool {
+        self.is_valid == other.is_valid && ((!self.is_valid) | (self.value == other.value))
+    }
+}
+
+impl<O: Offset> BinaryScalar<O> {
+    #[inline]
+    pub fn new<P: AsRef<[u8]>>(v: Option<P>) -> Self {
+        let is_valid = v.is_some();
+        O::from_usize(v.as_ref().map(|x| x.as_ref().len()).unwrap_or_default()).expect("Too large");
+        let value = Buffer::from(v.as_ref().map(|x| x.as_ref()).unwrap_or(&[]));
+        Self {
+            value,
+            is_valid,
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn value(&self) -> &[u8] {
+        self.value.as_slice()
+    }
+}
+
+impl<O: Offset, P: AsRef<[u8]>> From<Option<P>> for BinaryScalar<O> {
+    #[inline]
+    fn from(v: Option<P>) -> Self {
+        Self::new(v)
+    }
+}
+
+impl<O: Offset> Scalar for BinaryScalar<O> {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
+    #[inline]
+    fn data_type(&self) -> &DataType {
+        if O::is_large() {
+            &DataType::LargeBinary
+        } else {
+            &DataType::Binary
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::eq_op)]
+    #[test]
+    fn equal() {
+        let a = BinaryScalar::<i32>::from(Some("a"));
+        let b = BinaryScalar::<i32>::from(None::<&str>);
+        assert_eq!(a, a);
+        assert_eq!(b, b);
+        assert!(a != b);
+        let b = BinaryScalar::<i32>::from(Some("b"));
+        assert!(a != b);
+        assert_eq!(b, b);
+    }
+
+    #[test]
+    fn basics() {
+        let a = BinaryScalar::<i32>::from(Some("a"));
+
+        assert_eq!(a.value(), b"a");
+        assert_eq!(a.data_type(), &DataType::Binary);
+        assert!(a.is_valid());
+
+        let a = BinaryScalar::<i64>::from(None::<&str>);
+
+        assert_eq!(a.data_type(), &DataType::LargeBinary);
+        assert!(!a.is_valid());
+    }
+}

--- a/src/scalar/boolean.rs
+++ b/src/scalar/boolean.rs
@@ -1,0 +1,82 @@
+use crate::datatypes::DataType;
+
+use super::Scalar;
+
+#[derive(Debug, Clone)]
+pub struct BooleanScalar {
+    value: bool,
+    is_valid: bool,
+}
+
+impl PartialEq for BooleanScalar {
+    fn eq(&self, other: &Self) -> bool {
+        self.is_valid == other.is_valid && ((!self.is_valid) | (self.value == other.value))
+    }
+}
+
+impl BooleanScalar {
+    #[inline]
+    pub fn new(v: Option<bool>) -> Self {
+        let is_valid = v.is_some();
+        Self {
+            value: v.unwrap_or_default(),
+            is_valid,
+        }
+    }
+
+    #[inline]
+    pub fn value(&self) -> bool {
+        self.value
+    }
+}
+
+impl Scalar for BooleanScalar {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
+    #[inline]
+    fn data_type(&self) -> &DataType {
+        &DataType::Boolean
+    }
+}
+
+impl From<Option<bool>> for BooleanScalar {
+    #[inline]
+    fn from(v: Option<bool>) -> Self {
+        Self::new(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::eq_op)]
+    #[test]
+    fn equal() {
+        let a = BooleanScalar::from(Some(true));
+        let b = BooleanScalar::from(None);
+        assert_eq!(a, a);
+        assert_eq!(b, b);
+        assert!(a != b);
+        let b = BooleanScalar::from(Some(false));
+        assert!(a != b);
+        assert_eq!(b, b);
+    }
+
+    #[test]
+    fn basics() {
+        let a = BooleanScalar::new(Some(true));
+
+        assert!(a.value());
+        assert_eq!(a.data_type(), &DataType::Boolean);
+        assert!(a.is_valid());
+    }
+}

--- a/src/scalar/equal.rs
+++ b/src/scalar/equal.rs
@@ -1,0 +1,115 @@
+use super::*;
+
+impl PartialEq for dyn Scalar {
+    fn eq(&self, other: &Self) -> bool {
+        equal(self, other)
+    }
+}
+
+macro_rules! dyn_eq {
+    ($ty:ty, $lhs:expr, $rhs:expr) => {{
+        let lhs = $lhs
+            .as_any()
+            .downcast_ref::<PrimitiveScalar<$ty>>()
+            .unwrap();
+        let rhs = $rhs
+            .as_any()
+            .downcast_ref::<PrimitiveScalar<$ty>>()
+            .unwrap();
+        lhs == rhs
+    }};
+}
+
+fn equal(lhs: &dyn Scalar, rhs: &dyn Scalar) -> bool {
+    if lhs.data_type() != rhs.data_type() {
+        return false;
+    }
+
+    match lhs.data_type() {
+        DataType::Null => {
+            let lhs = lhs.as_any().downcast_ref::<NullScalar>().unwrap();
+            let rhs = rhs.as_any().downcast_ref::<NullScalar>().unwrap();
+            lhs == rhs
+        }
+        DataType::Boolean => {
+            let lhs = lhs.as_any().downcast_ref::<BooleanScalar>().unwrap();
+            let rhs = rhs.as_any().downcast_ref::<BooleanScalar>().unwrap();
+            lhs == rhs
+        }
+        DataType::UInt8 => {
+            dyn_eq!(u8, lhs, rhs)
+        }
+        DataType::UInt16 => {
+            dyn_eq!(u16, lhs, rhs)
+        }
+        DataType::UInt32 => {
+            dyn_eq!(u32, lhs, rhs)
+        }
+        DataType::UInt64 => {
+            dyn_eq!(u64, lhs, rhs)
+        }
+        DataType::Int8 => {
+            dyn_eq!(i8, lhs, rhs)
+        }
+        DataType::Int16 => {
+            dyn_eq!(i16, lhs, rhs)
+        }
+        DataType::Int32
+        | DataType::Date32
+        | DataType::Time32(_)
+        | DataType::Interval(IntervalUnit::YearMonth) => {
+            dyn_eq!(i32, lhs, rhs)
+        }
+        DataType::Int64
+        | DataType::Date64
+        | DataType::Time64(_)
+        | DataType::Timestamp(_, _)
+        | DataType::Duration(_) => {
+            dyn_eq!(i64, lhs, rhs)
+        }
+        DataType::Decimal(_, _) => {
+            dyn_eq!(i128, lhs, rhs)
+        }
+        DataType::Interval(IntervalUnit::DayTime) => {
+            dyn_eq!(days_ms, lhs, rhs)
+        }
+        DataType::Float16 => unreachable!(),
+        DataType::Float32 => {
+            dyn_eq!(f32, lhs, rhs)
+        }
+        DataType::Float64 => {
+            dyn_eq!(f64, lhs, rhs)
+        }
+        DataType::Utf8 => {
+            let lhs = lhs.as_any().downcast_ref::<Utf8Scalar<i32>>().unwrap();
+            let rhs = rhs.as_any().downcast_ref::<Utf8Scalar<i32>>().unwrap();
+            lhs == rhs
+        }
+        DataType::LargeUtf8 => {
+            let lhs = lhs.as_any().downcast_ref::<Utf8Scalar<i64>>().unwrap();
+            let rhs = rhs.as_any().downcast_ref::<Utf8Scalar<i64>>().unwrap();
+            lhs == rhs
+        }
+        DataType::Binary => {
+            let lhs = lhs.as_any().downcast_ref::<BinaryScalar<i32>>().unwrap();
+            let rhs = rhs.as_any().downcast_ref::<BinaryScalar<i32>>().unwrap();
+            lhs == rhs
+        }
+        DataType::LargeBinary => {
+            let lhs = lhs.as_any().downcast_ref::<BinaryScalar<i64>>().unwrap();
+            let rhs = rhs.as_any().downcast_ref::<BinaryScalar<i64>>().unwrap();
+            lhs == rhs
+        }
+        DataType::List(_) => {
+            let lhs = lhs.as_any().downcast_ref::<ListScalar<i32>>().unwrap();
+            let rhs = rhs.as_any().downcast_ref::<ListScalar<i32>>().unwrap();
+            lhs == rhs
+        }
+        DataType::LargeList(_) => {
+            let lhs = lhs.as_any().downcast_ref::<ListScalar<i64>>().unwrap();
+            let rhs = rhs.as_any().downcast_ref::<ListScalar<i64>>().unwrap();
+            lhs == rhs
+        }
+        _ => unimplemented!(),
+    }
+}

--- a/src/scalar/list.rs
+++ b/src/scalar/list.rs
@@ -1,0 +1,66 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use crate::{array::*, datatypes::DataType};
+
+use super::Scalar;
+
+/// The scalar equivalent of [`ListArray`]. Like [`ListArray`], this struct holds a dynamically-typed
+/// [`Array`]. The only difference is that this has only one element.
+#[derive(Debug, Clone)]
+pub struct ListScalar<O: Offset> {
+    values: Arc<dyn Array>,
+    is_valid: bool,
+    phantom: std::marker::PhantomData<O>,
+    data_type: DataType,
+}
+
+impl<O: Offset> PartialEq for ListScalar<O> {
+    fn eq(&self, other: &Self) -> bool {
+        (self.data_type == other.data_type)
+            && (self.is_valid == other.is_valid)
+            && ((!self.is_valid) | (self.values.as_ref() == other.values.as_ref()))
+    }
+}
+
+impl<O: Offset> ListScalar<O> {
+    /// # Panics
+    /// iff
+    /// * the `data_type` is not `List` or `LargeList` (depending on this scalar's offset `O`)
+    /// * the child of the `data_type` is not equal to the `values`
+    #[inline]
+    pub fn new(data_type: DataType, values: Option<Arc<dyn Array>>) -> Self {
+        let inner_data_type = ListArray::<O>::get_child_type(&data_type);
+        let (is_valid, values) = match values {
+            Some(values) => {
+                assert_eq!(inner_data_type, values.data_type());
+                (true, values)
+            }
+            None => (false, new_empty_array(inner_data_type.clone()).into()),
+        };
+        Self {
+            values,
+            is_valid,
+            phantom: std::marker::PhantomData,
+            data_type,
+        }
+    }
+
+    pub fn values(&self) -> &Arc<dyn Array> {
+        &self.values
+    }
+}
+
+impl<O: Offset> Scalar for ListScalar<O> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+}

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -1,0 +1,245 @@
+use std::any::Any;
+
+use crate::{array::*, bitmap::Bitmap, buffer::Buffer, datatypes::DataType, types::NativeType};
+
+pub trait Scalar: std::fmt::Debug {
+    fn as_any(&self) -> &dyn Any;
+
+    fn is_valid(&self) -> bool;
+
+    fn data_type(&self) -> &DataType;
+
+    fn to_boxed_array(&self, length: usize) -> Box<dyn Array>;
+}
+
+#[derive(Debug, Clone)]
+pub struct PrimitiveScalar<T: NativeType> {
+    // Not Option<T> because this offers a stabler pointer offset on the struct
+    value: T,
+    is_valid: bool,
+    data_type: DataType,
+}
+
+impl<T: NativeType> PrimitiveScalar<T> {
+    #[inline]
+    pub fn new(data_type: DataType, v: Option<T>) -> Self {
+        let is_valid = v.is_some();
+        Self {
+            value: v.unwrap_or_default(),
+            is_valid,
+            data_type,
+        }
+    }
+
+    #[inline]
+    pub fn value(&self) -> T {
+        self.value
+    }
+}
+
+impl<T: NativeType> Scalar for PrimitiveScalar<T> {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
+    #[inline]
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn to_boxed_array(&self, length: usize) -> Box<dyn Array> {
+        if self.is_valid {
+            let values = Buffer::from_trusted_len_iter(std::iter::repeat(self.value).take(length));
+            Box::new(PrimitiveArray::from_data(
+                self.data_type.clone(),
+                values,
+                None,
+            ))
+        } else {
+            Box::new(PrimitiveArray::<T>::new_null(
+                self.data_type.clone(),
+                length,
+            ))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BooleanScalar {
+    value: bool,
+    is_valid: bool,
+}
+
+impl BooleanScalar {
+    #[inline]
+    pub fn new(v: Option<bool>) -> Self {
+        let is_valid = v.is_some();
+        Self {
+            value: v.unwrap_or_default(),
+            is_valid,
+        }
+    }
+
+    #[inline]
+    pub fn value(&self) -> bool {
+        self.value
+    }
+}
+
+impl Scalar for BooleanScalar {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
+    #[inline]
+    fn data_type(&self) -> &DataType {
+        &DataType::Boolean
+    }
+
+    fn to_boxed_array(&self, length: usize) -> Box<dyn Array> {
+        if self.is_valid {
+            let values = Bitmap::from_trusted_len_iter(std::iter::repeat(self.value).take(length));
+            Box::new(BooleanArray::from_data(values, None))
+        } else {
+            Box::new(BooleanArray::new_null(length))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Utf8Scalar<O: Offset> {
+    value: Buffer<u8>,
+    is_valid: bool,
+    phantom: std::marker::PhantomData<O>,
+}
+
+impl<O: Offset> Utf8Scalar<O> {
+    #[inline]
+    pub fn new(v: Option<&str>) -> Self {
+        let is_valid = v.is_some();
+        O::from_usize(v.map(|x| x.len()).unwrap_or_default()).expect("Too large");
+        let value = Buffer::from(v.map(|x| x.as_bytes()).unwrap_or(&[]));
+        Self {
+            value,
+            is_valid,
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn value(&self) -> &str {
+        unsafe { std::str::from_utf8_unchecked(self.value.as_slice()) }
+    }
+}
+
+impl<O: Offset> Scalar for Utf8Scalar<O> {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
+    #[inline]
+    fn data_type(&self) -> &DataType {
+        if O::is_large() {
+            &DataType::LargeUtf8
+        } else {
+            &DataType::Utf8
+        }
+    }
+
+    fn to_boxed_array(&self, length: usize) -> Box<dyn Array> {
+        if self.is_valid {
+            let item_length = O::from_usize(self.value.len()).unwrap(); // verified at `new`
+            let offsets = (0..=length).map(|i| O::from_usize(i).unwrap() * item_length);
+            let offsets = unsafe { Buffer::from_trusted_len_iter_unchecked(offsets) };
+            let values = std::iter::repeat(self.value.as_slice())
+                .take(length)
+                .flatten()
+                .copied()
+                .collect();
+            Box::new(Utf8Array::<O>::from_data(offsets, values, None))
+        } else {
+            Box::new(Utf8Array::<O>::new_null(length))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BinaryScalar<O: Offset> {
+    value: Buffer<u8>,
+    is_valid: bool,
+    phantom: std::marker::PhantomData<O>,
+}
+
+impl<O: Offset> BinaryScalar<O> {
+    #[inline]
+    pub fn new(v: Option<&str>) -> Self {
+        let is_valid = v.is_some();
+        O::from_usize(v.map(|x| x.len()).unwrap_or_default()).expect("Too large");
+        let value = Buffer::from(v.map(|x| x.as_bytes()).unwrap_or(&[]));
+        Self {
+            value,
+            is_valid,
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn value(&self) -> &[u8] {
+        self.value.as_slice()
+    }
+}
+
+impl<O: Offset> Scalar for BinaryScalar<O> {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
+    #[inline]
+    fn data_type(&self) -> &DataType {
+        if O::is_large() {
+            &DataType::LargeBinary
+        } else {
+            &DataType::Binary
+        }
+    }
+
+    fn to_boxed_array(&self, length: usize) -> Box<dyn Array> {
+        if self.is_valid {
+            let item_length = O::from_usize(self.value.len()).unwrap(); // verified at `new`
+            let offsets = (0..=length).map(|i| O::from_usize(i).unwrap() * item_length);
+            let offsets = unsafe { Buffer::from_trusted_len_iter_unchecked(offsets) };
+            let values = std::iter::repeat(self.value.as_slice())
+                .take(length)
+                .flatten()
+                .copied()
+                .collect();
+            Box::new(BinaryArray::<O>::from_data(offsets, values, None))
+        } else {
+            Box::new(BinaryArray::<O>::new_null(length))
+        }
+    }
+}

--- a/src/scalar/null.rs
+++ b/src/scalar/null.rs
@@ -1,0 +1,36 @@
+use crate::datatypes::DataType;
+
+use super::Scalar;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NullScalar {}
+
+impl NullScalar {
+    #[inline]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for NullScalar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Scalar for NullScalar {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    fn data_type(&self) -> &DataType {
+        &DataType::Null
+    }
+}

--- a/src/scalar/primitive.rs
+++ b/src/scalar/primitive.rs
@@ -1,0 +1,113 @@
+use crate::{
+    datatypes::DataType,
+    types::{NativeType, NaturalDataType},
+};
+
+use super::Scalar;
+
+#[derive(Debug, Clone)]
+pub struct PrimitiveScalar<T: NativeType> {
+    // Not Option<T> because this offers a stabler pointer offset on the struct
+    value: T,
+    is_valid: bool,
+    data_type: DataType,
+}
+
+impl<T: NativeType> PartialEq for PrimitiveScalar<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.data_type == other.data_type
+            && self.is_valid == other.is_valid
+            && ((!self.is_valid) | (self.value == other.value))
+    }
+}
+
+impl<T: NativeType> PrimitiveScalar<T> {
+    #[inline]
+    pub fn new(data_type: DataType, v: Option<T>) -> Self {
+        let is_valid = v.is_some();
+        Self {
+            value: v.unwrap_or_default(),
+            is_valid,
+            data_type,
+        }
+    }
+
+    #[inline]
+    pub fn value(&self) -> T {
+        self.value
+    }
+
+    /// Returns a new `PrimitiveScalar` with the same value but different [`DataType`]
+    /// # Panic
+    /// This function panics if the `data_type` is not valid for self's physical type `T`.
+    pub fn to(self, data_type: DataType) -> Self {
+        let v = if self.is_valid {
+            Some(self.value)
+        } else {
+            None
+        };
+        Self::new(data_type, v)
+    }
+}
+
+impl<T: NativeType + NaturalDataType> From<Option<T>> for PrimitiveScalar<T> {
+    #[inline]
+    fn from(v: Option<T>) -> Self {
+        Self::new(T::DATA_TYPE, v)
+    }
+}
+
+impl<T: NativeType> Scalar for PrimitiveScalar<T> {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
+    #[inline]
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::eq_op)]
+    #[test]
+    fn equal() {
+        let a = PrimitiveScalar::from(Some(2i32));
+        let b = PrimitiveScalar::<i32>::from(None);
+        assert_eq!(a, a);
+        assert_eq!(b, b);
+        assert!(a != b);
+        let b = PrimitiveScalar::<i32>::from(Some(1i32));
+        assert!(a != b);
+        assert_eq!(b, b);
+    }
+
+    #[test]
+    fn basics() {
+        let a = PrimitiveScalar::from(Some(2i32));
+
+        assert_eq!(a.value(), 2i32);
+        assert_eq!(a.data_type(), &DataType::Int32);
+        assert!(a.is_valid());
+
+        let a = a.to(DataType::Date32);
+        assert_eq!(a.data_type(), &DataType::Date32);
+
+        let a = PrimitiveScalar::<i32>::from(None);
+
+        assert_eq!(a.data_type(), &DataType::Int32);
+        assert!(!a.is_valid());
+
+        let a = a.to(DataType::Date32);
+        assert_eq!(a.data_type(), &DataType::Date32);
+    }
+}

--- a/src/scalar/struct_.rs
+++ b/src/scalar/struct_.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+use crate::datatypes::DataType;
+
+use super::Scalar;
+
+#[derive(Debug, Clone)]
+pub struct StructScalar {
+    values: Vec<Arc<dyn Scalar>>,
+    is_valid: bool,
+    data_type: DataType,
+}
+
+impl PartialEq for StructScalar {
+    fn eq(&self, other: &Self) -> bool {
+        (self.data_type == other.data_type)
+            && (self.is_valid == other.is_valid)
+            && ((!self.is_valid) | (self.values == other.values))
+    }
+}
+
+impl StructScalar {
+    #[inline]
+    pub fn new(data_type: DataType, values: Option<Vec<Arc<dyn Scalar>>>) -> Self {
+        let is_valid = values.is_some();
+        Self {
+            values: values.unwrap_or_default(),
+            is_valid,
+            data_type,
+        }
+    }
+
+    #[inline]
+    pub fn values(&self) -> &[Arc<dyn Scalar>] {
+        &self.values
+    }
+}
+
+impl Scalar for StructScalar {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
+    #[inline]
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+}

--- a/src/scalar/utf8.rs
+++ b/src/scalar/utf8.rs
@@ -1,0 +1,95 @@
+use crate::{array::*, buffer::Buffer, datatypes::DataType};
+
+use super::Scalar;
+
+#[derive(Debug, Clone)]
+pub struct Utf8Scalar<O: Offset> {
+    value: Buffer<u8>,
+    is_valid: bool,
+    phantom: std::marker::PhantomData<O>,
+}
+
+impl<O: Offset> PartialEq for Utf8Scalar<O> {
+    fn eq(&self, other: &Self) -> bool {
+        self.is_valid == other.is_valid && ((!self.is_valid) | (self.value == other.value))
+    }
+}
+
+impl<O: Offset> Utf8Scalar<O> {
+    #[inline]
+    pub fn new<P: AsRef<str>>(v: Option<P>) -> Self {
+        let is_valid = v.is_some();
+        O::from_usize(v.as_ref().map(|x| x.as_ref().len()).unwrap_or_default()).expect("Too large");
+        let value = Buffer::from(v.as_ref().map(|x| x.as_ref().as_bytes()).unwrap_or(&[]));
+        Self {
+            value,
+            is_valid,
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn value(&self) -> &str {
+        unsafe { std::str::from_utf8_unchecked(self.value.as_slice()) }
+    }
+}
+
+impl<O: Offset, P: AsRef<str>> From<Option<P>> for Utf8Scalar<O> {
+    #[inline]
+    fn from(v: Option<P>) -> Self {
+        Self::new(v)
+    }
+}
+
+impl<O: Offset> Scalar for Utf8Scalar<O> {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        self.is_valid
+    }
+
+    #[inline]
+    fn data_type(&self) -> &DataType {
+        if O::is_large() {
+            &DataType::LargeUtf8
+        } else {
+            &DataType::Utf8
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(clippy::eq_op)]
+    #[test]
+    fn equal() {
+        let a = Utf8Scalar::<i32>::from(Some("a"));
+        let b = Utf8Scalar::<i32>::from(None::<&str>);
+        assert_eq!(a, a);
+        assert_eq!(b, b);
+        assert!(a != b);
+        let b = Utf8Scalar::<i32>::from(Some("b"));
+        assert!(a != b);
+        assert_eq!(b, b);
+    }
+
+    #[test]
+    fn basics() {
+        let a = Utf8Scalar::<i32>::from(Some("a"));
+
+        assert_eq!(a.value(), "a");
+        assert_eq!(a.data_type(), &DataType::Utf8);
+        assert!(a.is_valid());
+
+        let a = Utf8Scalar::<i64>::from(None::<&str>);
+
+        assert_eq!(a.data_type(), &DataType::LargeUtf8);
+        assert!(!a.is_valid());
+    }
+}


### PR DESCRIPTION
This PR is an experiment to enable support for scalar values, the dimension 0 version of an `Array`. See README with the design choices.

It does not enforce any in-memory specification, but their struct alignments are semantically equivalent to arrays.

The rational for this scalar is that it allows some of our compute operators to be written as generic functions. The two most relevant use-cases:

1. aggregates, `Fn(Array) -> Scalar`
2. arithmetic with scalars, `Fn(Array, Scalar) -> Array`

This PR demonstrates the usefulness on the aggregates.