### PR TITLE
Removed clone of arity::unary

### DIFF
--- a/src/compute/arithmetics/basic/add.rs
+++ b/src/compute/arithmetics/basic/add.rs
@@ -164,7 +164,7 @@ where
     T: NativeType + Add<Output = T>,
 {
     let rhs = *rhs;
-    unary(lhs, |a| a + rhs, lhs.data_type())
+    unary(lhs, |a| a + rhs, lhs.data_type().clone())
 }
 
 /// Checked addition of a scalar T to a primitive array of type T. If the
@@ -190,7 +190,7 @@ where
     let rhs = *rhs;
     let op = move |a: T| a.checked_add(&rhs);
 
-    unary_checked(lhs, op, lhs.data_type())
+    unary_checked(lhs, op, lhs.data_type().clone())
 }
 
 /// Saturated addition of a scalar T to a primitive array of type T. If the
@@ -216,7 +216,7 @@ where
     let rhs = *rhs;
     let op = move |a: T| a.saturating_add(&rhs);
 
-    unary(lhs, op, lhs.data_type())
+    unary(lhs, op, lhs.data_type().clone())
 }
 
 /// Overflowing addition of a scalar T to a primitive array of type T. If the
@@ -243,7 +243,7 @@ where
     let rhs = *rhs;
     let op = move |a: T| a.overflowing_add(&rhs);
 
-    unary_with_bitmap(lhs, op, lhs.data_type())
+    unary_with_bitmap(lhs, op, lhs.data_type().clone())
 }
 
 #[cfg(test)]

--- a/src/compute/arithmetics/basic/div.rs
+++ b/src/compute/arithmetics/basic/div.rs
@@ -90,7 +90,7 @@ where
     T: NativeType + Div<Output = T>,
 {
     let rhs = *rhs;
-    unary(lhs, |a| a / rhs, lhs.data_type())
+    unary(lhs, |a| a / rhs, lhs.data_type().clone())
 }
 
 /// Checked division of a primitive array of type T by a scalar T. If the
@@ -115,7 +115,7 @@ where
     let rhs = *rhs;
     let op = move |a: T| a.checked_div(&rhs);
 
-    unary_checked(lhs, op, lhs.data_type())
+    unary_checked(lhs, op, lhs.data_type().clone())
 }
 
 #[cfg(test)]

--- a/src/compute/arithmetics/basic/mul.rs
+++ b/src/compute/arithmetics/basic/mul.rs
@@ -165,7 +165,7 @@ where
     T: NativeType + Mul<Output = T>,
 {
     let rhs = *rhs;
-    unary(lhs, |a| a * rhs, lhs.data_type())
+    unary(lhs, |a| a * rhs, lhs.data_type().clone())
 }
 
 /// Checked multiplication of a scalar T to a primitive array of type T. If the
@@ -191,7 +191,7 @@ where
     let rhs = *rhs;
     let op = move |a: T| a.checked_mul(&rhs);
 
-    unary_checked(lhs, op, lhs.data_type())
+    unary_checked(lhs, op, lhs.data_type().clone())
 }
 
 /// Saturated multiplication of a scalar T to a primitive array of type T. If the
@@ -217,7 +217,7 @@ where
     let rhs = *rhs;
     let op = move |a: T| a.saturating_mul(&rhs);
 
-    unary(lhs, op, lhs.data_type())
+    unary(lhs, op, lhs.data_type().clone())
 }
 
 /// Overflowing multiplication of a scalar T to a primitive array of type T. If
@@ -244,7 +244,7 @@ where
     let rhs = *rhs;
     let op = move |a: T| a.overflowing_mul(&rhs);
 
-    unary_with_bitmap(lhs, op, lhs.data_type())
+    unary_with_bitmap(lhs, op, lhs.data_type().clone())
 }
 
 #[cfg(test)]

--- a/src/compute/arithmetics/basic/pow.rs
+++ b/src/compute/arithmetics/basic/pow.rs
@@ -26,7 +26,7 @@ pub fn powf_scalar<T>(array: &PrimitiveArray<T>, exponent: T) -> PrimitiveArray<
 where
     T: NativeType + Pow<T, Output = T>,
 {
-    unary(array, |x| x.pow(exponent), array.data_type())
+    unary(array, |x| x.pow(exponent), array.data_type().clone())
 }
 
 /// Checked operation of raising an array of primitives to the power of
@@ -51,7 +51,7 @@ where
 {
     let op = move |a: T| checked_pow(a, exponent);
 
-    unary_checked(array, op, array.data_type())
+    unary_checked(array, op, array.data_type().clone())
 }
 
 #[cfg(test)]

--- a/src/compute/arithmetics/basic/sub.rs
+++ b/src/compute/arithmetics/basic/sub.rs
@@ -164,7 +164,7 @@ where
     T: NativeType + Sub<Output = T>,
 {
     let rhs = *rhs;
-    unary(lhs, |a| a - rhs, lhs.data_type())
+    unary(lhs, |a| a - rhs, lhs.data_type().clone())
 }
 
 /// Checked subtraction of a scalar T to a primitive array of type T. If the
@@ -190,7 +190,7 @@ where
     let rhs = *rhs;
     let op = move |a: T| a.checked_sub(&rhs);
 
-    unary_checked(lhs, op, lhs.data_type())
+    unary_checked(lhs, op, lhs.data_type().clone())
 }
 
 /// Saturated subtraction of a scalar T to a primitive array of type T. If the
@@ -216,7 +216,7 @@ where
     let rhs = *rhs;
     let op = move |a: T| a.saturating_sub(&rhs);
 
-    unary(lhs, op, lhs.data_type())
+    unary(lhs, op, lhs.data_type().clone())
 }
 
 /// Overflowing subtraction of a scalar T to a primitive array of type T. If
@@ -243,7 +243,7 @@ where
     let rhs = *rhs;
     let op = move |a: T| a.overflowing_sub(&rhs);
 
-    unary_with_bitmap(lhs, op, lhs.data_type())
+    unary_with_bitmap(lhs, op, lhs.data_type().clone())
 }
 
 #[cfg(test)]

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -200,5 +200,5 @@ pub fn negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + Neg<Output = T>,
 {
-    unary(array, |a| -a, array.data_type())
+    unary(array, |a| -a, array.data_type().clone())
 }

--- a/src/compute/arity.rs
+++ b/src/compute/arity.rs
@@ -25,7 +25,7 @@ use crate::{
 /// This implies that the operation must be infallible for any value of the
 /// corresponding type or this function may panic.
 #[inline]
-pub fn unary<I, F, O>(array: &PrimitiveArray<I>, op: F, data_type: &DataType) -> PrimitiveArray<O>
+pub fn unary<I, F, O>(array: &PrimitiveArray<I>, op: F, data_type: DataType) -> PrimitiveArray<O>
 where
     I: NativeType,
     O: NativeType,
@@ -34,7 +34,7 @@ where
     let values = array.values().iter().map(|v| op(*v));
     let values = Buffer::from_trusted_len_iter(values);
 
-    PrimitiveArray::<O>::from_data(data_type.clone(), values, array.validity().clone())
+    PrimitiveArray::<O>::from_data(data_type, values, array.validity().clone())
 }
 
 /// Version of unary that checks for errors in the closure used to create the
@@ -42,7 +42,7 @@ where
 pub fn try_unary<I, F, O>(
     array: &PrimitiveArray<I>,
     op: F,
-    data_type: &DataType,
+    data_type: DataType,
 ) -> Result<PrimitiveArray<O>>
 where
     I: NativeType,
@@ -53,7 +53,7 @@ where
     let values = Buffer::try_from_trusted_len_iter(values)?;
 
     Ok(PrimitiveArray::<O>::from_data(
-        data_type.clone(),
+        data_type,
         values,
         array.validity().clone(),
     ))
@@ -64,7 +64,7 @@ where
 pub fn unary_with_bitmap<I, F, O>(
     array: &PrimitiveArray<I>,
     op: F,
-    data_type: &DataType,
+    data_type: DataType,
 ) -> (PrimitiveArray<O>, Bitmap)
 where
     I: NativeType,
@@ -82,7 +82,7 @@ where
     let values = Buffer::from_trusted_len_iter(values);
 
     (
-        PrimitiveArray::<O>::from_data(data_type.clone(), values, array.validity().clone()),
+        PrimitiveArray::<O>::from_data(data_type, values, array.validity().clone()),
         mut_bitmap.into(),
     )
 }
@@ -93,7 +93,7 @@ where
 pub fn unary_checked<I, F, O>(
     array: &PrimitiveArray<I>,
     op: F,
-    data_type: &DataType,
+    data_type: DataType,
 ) -> PrimitiveArray<O>
 where
     I: NativeType,
@@ -122,7 +122,7 @@ where
     let bitmap: Bitmap = mut_bitmap.into();
     let validity = combine_validities(&array.validity(), &Some(bitmap));
 
-    PrimitiveArray::<O>::from_data(data_type.clone(), values, validity)
+    PrimitiveArray::<O>::from_data(data_type, values, validity)
 }
 
 /// Applies a binary operations to two primitive arrays. This is the fastest

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -538,7 +538,8 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
                 .downcast_ref::<PrimitiveArray<i32>>()
                 .unwrap();
 
-            let values = unary::<_, _, i64>(array, |x| x as i64 * MILLISECONDS_IN_DAY, to_type);
+            let values =
+                unary::<_, _, i64>(array, |x| x as i64 * MILLISECONDS_IN_DAY, to_type.clone());
 
             Ok(Box::new(values))
         }
@@ -548,7 +549,8 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
                 .downcast_ref::<PrimitiveArray<i64>>()
                 .unwrap();
 
-            let values = unary::<_, _, i32>(array, |x| (x / MILLISECONDS_IN_DAY) as i32, to_type);
+            let values =
+                unary::<_, _, i32>(array, |x| (x / MILLISECONDS_IN_DAY) as i32, to_type.clone());
 
             Ok(Box::new(values))
         }
@@ -558,7 +560,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
                 .downcast_ref::<PrimitiveArray<i32>>()
                 .unwrap();
 
-            let values = unary::<_, _, i32>(array, |x| x * MILLISECONDS as i32, to_type);
+            let values = unary::<_, _, i32>(array, |x| x * MILLISECONDS as i32, to_type.clone());
 
             Ok(Box::new(values))
         }
@@ -568,7 +570,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
                 .downcast_ref::<PrimitiveArray<i32>>()
                 .unwrap();
 
-            let values = unary::<_, _, i32>(array, |x| x / (MILLISECONDS as i32), to_type);
+            let values = unary::<_, _, i32>(array, |x| x / (MILLISECONDS as i32), to_type.clone());
 
             Ok(Box::new(values))
         }
@@ -581,7 +583,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
             let from_size = time_unit_multiple(&from_unit);
             let to_size = time_unit_multiple(&to_unit);
             let divisor = to_size / from_size;
-            let values = unary::<_, _, i64>(&array, |x| (x as i64 * divisor), to_type);
+            let values = unary::<_, _, i64>(&array, |x| (x as i64 * divisor), to_type.clone());
             Ok(Box::new(values))
         }
         (Time64(TimeUnit::Microsecond), Time64(TimeUnit::Nanosecond)) => {
@@ -590,7 +592,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
                 .downcast_ref::<PrimitiveArray<i64>>()
                 .unwrap();
 
-            let values = unary::<_, _, i64>(array, |x| x * MILLISECONDS, to_type);
+            let values = unary::<_, _, i64>(array, |x| x * MILLISECONDS, to_type.clone());
             Ok(Box::new(values))
         }
         (Time64(TimeUnit::Nanosecond), Time64(TimeUnit::Microsecond)) => {
@@ -599,7 +601,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
                 .downcast_ref::<PrimitiveArray<i64>>()
                 .unwrap();
 
-            let values = unary::<_, _, i64>(array, |x| x / MILLISECONDS, to_type);
+            let values = unary::<_, _, i64>(array, |x| x / MILLISECONDS, to_type.clone());
             Ok(Box::new(values))
         }
         (Time64(from_unit), Time32(to_unit)) => {
@@ -611,7 +613,8 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
             let from_size = time_unit_multiple(&from_unit);
             let to_size = time_unit_multiple(&to_unit);
             let divisor = from_size / to_size;
-            let values = unary::<_, _, i32>(&array, |x| (x as i64 / divisor) as i32, to_type);
+            let values =
+                unary::<_, _, i32>(&array, |x| (x as i64 / divisor) as i32, to_type.clone());
             Ok(Box::new(values))
         }
         (Timestamp(_, _), Int64) => cast_array_data::<i64>(array, &to_type),
@@ -626,9 +629,9 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
             let to_size = time_unit_multiple(&to_unit);
             // we either divide or multiply, depending on size of each unit
             let array = if from_size >= to_size {
-                unary::<_, _, i64>(&array, |x| (x / (from_size / to_size)), to_type)
+                unary::<_, _, i64>(&array, |x| (x / (from_size / to_size)), to_type.clone())
             } else {
-                unary::<_, _, i64>(&array, |x| (x * (to_size / from_size)), to_type)
+                unary::<_, _, i64>(&array, |x| (x * (to_size / from_size)), to_type.clone())
             };
             Ok(Box::new(array))
         }
@@ -639,7 +642,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
                 .unwrap();
 
             let from_size = time_unit_multiple(&from_unit) * SECONDS_IN_DAY;
-            let array = unary::<_, _, i32>(&array, |x| (x / from_size) as i32, to_type);
+            let array = unary::<_, _, i32>(&array, |x| (x / from_size) as i32, to_type.clone());
 
             Ok(Box::new(array))
         }
@@ -658,14 +661,20 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
 
             match to_size.cmp(&from_size) {
                 std::cmp::Ordering::Less => {
-                    let array =
-                        unary::<_, _, i64>(&array, |x| (x / (from_size / to_size)), to_type);
+                    let array = unary::<_, _, i64>(
+                        &array,
+                        |x| (x / (from_size / to_size)),
+                        to_type.clone(),
+                    );
                     Ok(Box::new(array))
                 }
                 std::cmp::Ordering::Equal => cast_array_data::<i64>(array, &to_type),
                 std::cmp::Ordering::Greater => {
-                    let array =
-                        unary::<_, _, i64>(&array, |x| (x * (to_size / from_size)), to_type);
+                    let array = unary::<_, _, i64>(
+                        &array,
+                        |x| (x * (to_size / from_size)),
+                        to_type.clone(),
+                    );
                     Ok(Box::new(array))
                 }
             }

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -22,7 +22,7 @@ pub fn hash_primitive<T: NativeType + Hash>(array: &PrimitiveArray<T>) -> Primit
             x.hash(&mut hasher);
             hasher.finish()
         },
-        &DataType::UInt64,
+        DataType::UInt64,
     )
 }
 

--- a/src/compute/temporal.rs
+++ b/src/compute/temporal.rs
@@ -35,11 +35,7 @@ pub fn hour(array: &dyn Array) -> Result<PrimitiveArray<u32>> {
                 .as_any()
                 .downcast_ref::<PrimitiveArray<i32>>()
                 .unwrap();
-            Ok(unary(
-                array,
-                |x| time32s_to_time(x).hour(),
-                &final_data_type,
-            ))
+            Ok(unary(array, |x| time32s_to_time(x).hour(), final_data_type))
         }
         DataType::Time32(TimeUnit::Microsecond) => {
             let array = array
@@ -49,7 +45,7 @@ pub fn hour(array: &dyn Array) -> Result<PrimitiveArray<u32>> {
             Ok(unary(
                 array,
                 |x| time32ms_to_time(x).hour(),
-                &final_data_type,
+                final_data_type,
             ))
         }
         DataType::Time64(TimeUnit::Microsecond) => {
@@ -60,7 +56,7 @@ pub fn hour(array: &dyn Array) -> Result<PrimitiveArray<u32>> {
             Ok(unary(
                 array,
                 |x| time64us_to_time(x).hour(),
-                &final_data_type,
+                final_data_type,
             ))
         }
         DataType::Time64(TimeUnit::Nanosecond) => {
@@ -71,7 +67,7 @@ pub fn hour(array: &dyn Array) -> Result<PrimitiveArray<u32>> {
             Ok(unary(
                 array,
                 |x| time64ns_to_time(x).hour(),
-                &final_data_type,
+                final_data_type,
             ))
         }
         DataType::Date32 => {
@@ -82,7 +78,7 @@ pub fn hour(array: &dyn Array) -> Result<PrimitiveArray<u32>> {
             Ok(unary(
                 array,
                 |x| date32_to_datetime(x).hour(),
-                &final_data_type,
+                final_data_type,
             ))
         }
         DataType::Date64 => {
@@ -93,7 +89,7 @@ pub fn hour(array: &dyn Array) -> Result<PrimitiveArray<u32>> {
             Ok(unary(
                 array,
                 |x| date64_to_datetime(x).hour(),
-                &final_data_type,
+                final_data_type,
             ))
         }
         DataType::Timestamp(time_unit, None) => {
@@ -107,7 +103,7 @@ pub fn hour(array: &dyn Array) -> Result<PrimitiveArray<u32>> {
                 TimeUnit::Microsecond => |x| timestamp_us_to_datetime(x).hour(),
                 TimeUnit::Nanosecond => |x| timestamp_ns_to_datetime(x).hour(),
             };
-            Ok(unary(array, op, &final_data_type))
+            Ok(unary(array, op, final_data_type))
         }
         dt => Err(ArrowError::NotYetImplemented(format!(
             "\"hour\" does not support type {:?}",
@@ -128,7 +124,7 @@ pub fn year(array: &dyn Array) -> Result<PrimitiveArray<i32>> {
             Ok(unary(
                 array,
                 |x| date32_to_datetime(x).year(),
-                &final_data_type,
+                final_data_type,
             ))
         }
         DataType::Date64 => {
@@ -139,7 +135,7 @@ pub fn year(array: &dyn Array) -> Result<PrimitiveArray<i32>> {
             Ok(unary(
                 array,
                 |x| date64_to_datetime(x).year(),
-                &final_data_type,
+                final_data_type,
             ))
         }
         DataType::Timestamp(time_unit, None) => {
@@ -153,7 +149,7 @@ pub fn year(array: &dyn Array) -> Result<PrimitiveArray<i32>> {
                 TimeUnit::Microsecond => |x| timestamp_us_to_datetime(x).year(),
                 TimeUnit::Nanosecond => |x| timestamp_ns_to_datetime(x).year(),
             };
-            Ok(unary(array, op, &final_data_type))
+            Ok(unary(array, op, final_data_type))
         }
         dt => Err(ArrowError::NotYetImplemented(format!(
             "\"year\" does not support type {:?}",


### PR DESCRIPTION
It is not needed; consumers can clone if they do not want to pass ownership