### PR TITLE
Fix a couple broken links in the guide

### DIFF
--- a/guide/src/README.md
+++ b/guide/src/README.md
@@ -5,8 +5,8 @@ interoperability with the arrow format.
 
 The typical use-case for this library is to perform CPU and memory-intensive analytics in a format that supports heterogeneous data structures, null values, and IPC and FFI interfaces across languages.
 
-Arrow2 is divided into two main parts: a [low-end API](./low_end.md) to efficiently
-operate with contiguous memory regions, and a [high-end API](./high_end.md) to operate with
+Arrow2 is divided into two main parts: a [low-level API](./low_level.md) to efficiently
+operate with contiguous memory regions, and a [high-level API](./high_level.md) to operate with
 arrow arrays, logical types, schemas, etc.
 
 This repo started as an experiment forked from the Apache arrow project to offer a transmute-free

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -2,8 +2,8 @@
 
 - [Arrow2](./README.md)
 - [The arrow format](./arrow.md)
-- [Low level API](./low_level.md)
-- [High level API](./high_level.md)
+- [Low-level API](./low_level.md)
+- [High-level API](./high_level.md)
 - [Foreign interfaces](./ffi.md)
 - [IO](./io/README.md)
     - [Read CSV](./io/csv_reader.md)

--- a/guide/src/high_level.md
+++ b/guide/src/high_level.md
@@ -1,6 +1,6 @@
-# High end API
+# High-level API
 
-The simplest way to think about an arrow `Array` is that it represents 
+The simplest way to think about an arrow `Array` is that it represents
 `Vec<Option<T>>` and has a logical type associated with it.
 
 Probably the most simple array in this crate is `PrimitiveArray<T>`. It can be constructed
@@ -226,7 +226,7 @@ bitwise operations, it is often more performant to operate on chunks of bits ins
 
 ## Vectorized operations
 
-One of the main advantages of the arrow format and its memory layout is that 
+One of the main advantages of the arrow format and its memory layout is that
 it often enables SIMD. For example, an unary operation `op` on a `PrimitiveArray` is likely auto-vectorized on the following code:
 
 ```rust

--- a/guide/src/low_level.md
+++ b/guide/src/low_level.md
@@ -1,4 +1,4 @@
-# Low end API
+# Low-level API
 
 The starting point of this crate is the idea that data must be stored in memory in a specific arrangement to be interoperable with Arrow's ecosystem. With this in mind, this crate does not use `Vec` but instead has its own containers to store data, including sharing and consuming it via FFI.
 
@@ -47,7 +47,7 @@ assert_eq!(x.as_slice(), &[0.0, 1.0, 2.0]);
 
 In this context, `MutableBuffer` is the closest API to rust's `Vec`.
 
-The following demonstrates how to efficiently 
+The following demonstrates how to efficiently
 perform an operation from an iterator of [TrustedLen](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html):
 
 ```rust


### PR DESCRIPTION
Fixes two broken links that I noticed, and since the intention seems to be to use `low-level / high-level API` instead of `low-end / high-end API` (which IMO is correct), I also updated a few section headers, in a separate commit.