### PR TITLE
Fixed FFI and added support for nested types

### DIFF
--- a/.github/workflows/integration-ffi.yml
+++ b/.github/workflows/integration-ffi.yml
@@ -1,0 +1,45 @@
+name: FFI integration
+
+on: [push, pull_request]
+
+jobs:
+  # test FFI against the C-Data interface exposed by pyarrow
+  pyarrow-integration-test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+          rustup component add rustfmt clippy
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/.cargo
+          key: cargo-maturin-cache-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/target
+          # this key is not equal because maturin uses different compilation flags.
+          key: ${{ runner.os }}-amd64-target-maturin-cache
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip setuptools wheel
+      - name: Run tests
+        run: |
+          export CARGO_HOME="/home/runner/.cargo"
+          export CARGO_TARGET_DIR="/home/runner/target"
+
+          cd arrow-pyarrow-integration-testing
+
+          python -m venv venv
+          source venv/bin/activate
+
+          pip install maturin==0.10.2 toml==0.10.1 pyarrow==4.0.0
+          maturin develop
+          python -m unittest discover tests

--- a/arrow-pyarrow-integration-testing/.cargo/config
+++ b/arrow-pyarrow-integration-testing/.cargo/config
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[target.x86_64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]

--- a/arrow-pyarrow-integration-testing/.gitignore
+++ b/arrow-pyarrow-integration-testing/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+venv

--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "arrow-pyarrow-integration-testing"
+description = ""
+version = "4.0.0-SNAPSHOT"
+homepage = "https://github.com/apache/arrow-rs"
+repository = "https://github.com/apache/arrow-rs"
+authors = ["Apache Arrow <dev@arrow.apache.org>"]
+license = "Apache-2.0"
+keywords = [ "arrow" ]
+edition = "2018"
+
+[lib]
+name = "arrow_pyarrow_integration_testing"
+crate-type = ["cdylib"]
+
+[dependencies]
+arrow2 = { path = "../", default-features = false, features = [] }
+pyo3 = { version = "0.12.1", features = ["extension-module"] }
+
+[package.metadata.maturin]
+requires-dist = ["pyarrow>=1"]

--- a/arrow-pyarrow-integration-testing/README.md
+++ b/arrow-pyarrow-integration-testing/README.md
@@ -1,0 +1,57 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Arrow c integration
+
+This is a Rust crate that tests compatibility between Rust's Arrow implementation and PyArrow.
+
+Note that this crate uses two languages and an external ABI:
+* `Rust`
+* `Python`
+* C ABI privately exposed by `Pyarrow`.
+
+## Basic idea
+
+Pyarrow exposes a C ABI to convert arrow arrays from and to its C implementation, see [here](https://arrow.apache.org/docs/format/CDataInterface.html).
+
+This package uses the equivalent struct in Rust (`arrow::array::ArrowArray`), and verifies that
+we can use pyarrow's interface to move pointers from and to Rust.
+
+## Relevant literature
+
+* [Arrow's CDataInterface](https://arrow.apache.org/docs/format/CDataInterface.html)
+* [Rust's FFI](https://doc.rust-lang.org/nomicon/ffi.html)
+* [Pyarrow private binds](https://github.com/apache/arrow/blob/ae1d24efcc3f1ac2a876d8d9f544a34eb04ae874/python/pyarrow/array.pxi#L1226)
+* [PyO3](https://docs.rs/pyo3/0.12.1/pyo3/index.html)
+
+## How to develop
+
+```bash
+# prepare development environment (used to build wheel / install in development)
+python -m venv venv
+venv/bin/pip install maturin==0.8.2 toml==0.10.1 pyarrow==1.0.0
+```
+
+Whenever rust code changes (your changes or via git pull):
+
+```bash
+source venv/bin/activate
+maturin develop
+python -m unittest discover tests
+```

--- a/arrow-pyarrow-integration-testing/pyproject.toml
+++ b/arrow-pyarrow-integration-testing/pyproject.toml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[build-system]
+requires = ["maturin"]
+build-backend = "maturin"

--- a/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/arrow-pyarrow-integration-testing/src/lib.rs
@@ -1,0 +1,220 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! This library demonstrates a minimal usage of Rust's C data interface to pass
+//! arrays from and to Python.
+
+use std::error;
+use std::fmt;
+use std::sync::Arc;
+
+use pyo3::exceptions::PyOSError;
+use pyo3::wrap_pyfunction;
+use pyo3::{libc::uintptr_t, prelude::*};
+
+use arrow2::array::{Array, Int64Array};
+use arrow2::ffi;
+use arrow2::{array::Primitive, compute};
+use arrow2::{datatypes::DataType, error::ArrowError};
+
+type ArrayRef = Arc<dyn Array>;
+
+/// an error that bridges ArrowError with a Python error
+#[derive(Debug)]
+enum PyO3ArrowError {
+    ArrowError(ArrowError),
+}
+
+impl fmt::Display for PyO3ArrowError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            PyO3ArrowError::ArrowError(ref e) => e.fmt(f),
+        }
+    }
+}
+
+impl error::Error for PyO3ArrowError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            // The cause is the underlying implementation error type. Is implicitly
+            // cast to the trait object `&error::Error`. This works because the
+            // underlying type already implements the `Error` trait.
+            PyO3ArrowError::ArrowError(ref e) => Some(e),
+        }
+    }
+}
+
+impl From<ArrowError> for PyO3ArrowError {
+    fn from(err: ArrowError) -> PyO3ArrowError {
+        PyO3ArrowError::ArrowError(err)
+    }
+}
+
+impl From<PyO3ArrowError> for PyErr {
+    fn from(err: PyO3ArrowError) -> PyErr {
+        PyOSError::new_err(err.to_string())
+    }
+}
+
+fn to_rust(ob: PyObject, py: Python) -> PyResult<ArrayRef> {
+    // prepare a pointer to receive the Array struct
+    let array = Arc::new(ffi::ArrowArray::create_empty());
+    let (array_ptr, schema_ptr) = array.references();
+
+    // make the conversion through PyArrow's private API
+    // this changes the pointer's memory and is thus unsafe. In particular, `_export_to_c` can go out of bounds
+    ob.call_method1(
+        py,
+        "_export_to_c",
+        (array_ptr as uintptr_t, schema_ptr as uintptr_t),
+    )?;
+
+    Ok(ffi::try_from(array).map_err(PyO3ArrowError::from)?.into())
+}
+
+fn to_py(array: ArrayRef, py: Python) -> PyResult<PyObject> {
+    let array_ptr = ffi::ArrowArray::export_to_c(array).map_err(PyO3ArrowError::from)?;
+
+    let (array_ptr, schema_ptr) = array_ptr.references();
+
+    let pa = py.import("pyarrow")?;
+
+    let array = pa.getattr("Array")?.call_method1(
+        "_import_from_c",
+        (array_ptr as uintptr_t, schema_ptr as uintptr_t),
+    )?;
+
+    Ok(array.to_object(py))
+}
+
+/// Returns `array + array` of an int64 array.
+#[pyfunction]
+fn double(array: PyObject, py: Python) -> PyResult<PyObject> {
+    // import
+    let array = to_rust(array, py)?;
+
+    // perform some operation
+    let array = array.as_any().downcast_ref::<Int64Array>().ok_or_else(|| {
+        PyO3ArrowError::ArrowError(ArrowError::Ffi("Expects an int64".to_string()))
+    })?;
+    let array =
+        compute::arithmetics::basic::add::add(&array, &array).map_err(PyO3ArrowError::from)?;
+    let array = Arc::new(array);
+
+    // export
+    to_py(array, py)
+}
+
+/// calls a lambda function that receives and returns an array
+/// whose result must be the array multiplied by two
+#[pyfunction]
+fn double_py(lambda: PyObject, py: Python) -> PyResult<bool> {
+    // create
+    let array = Arc::new(Primitive::<i64>::from(vec![Some(1), None, Some(3)]).to(DataType::Int64));
+    let expected =
+        Arc::new(Primitive::<i64>::from(vec![Some(2), None, Some(6)]).to(DataType::Int64))
+            as ArrayRef;
+
+    // to py
+    let array = to_py(array, py)?;
+
+    let array = lambda.call1(py, (array,))?;
+
+    let array = to_rust(array, py)?;
+
+    Ok(array == expected)
+}
+
+/// Returns the substring
+#[pyfunction]
+fn substring(array: PyObject, start: i64, py: Python) -> PyResult<PyObject> {
+    // import
+    let array = to_rust(array, py)?;
+
+    // substring
+    let array = compute::substring::substring(array.as_ref(), start, &None)
+        .map_err(PyO3ArrowError::from)?
+        .into();
+
+    // export
+    to_py(array, py)
+}
+
+/// Returns the concatenate
+#[pyfunction]
+fn concatenate(array: PyObject, py: Python) -> PyResult<PyObject> {
+    // import
+    let array = to_rust(array, py)?;
+
+    // concat
+    let array = compute::concat::concatenate(&[array.as_ref(), array.as_ref()])
+        .map_err(PyO3ArrowError::from)?
+        .into();
+
+    // export
+    to_py(array, py)
+}
+
+/// Converts to rust and back to python
+#[pyfunction]
+fn round_trip(array: PyObject, py: Python) -> PyResult<PyObject> {
+    // import
+    let array = to_rust(array, py)?;
+
+    // export
+    to_py(array, py)
+}
+
+/// Converts to rust and back to python
+#[pyfunction]
+fn import_primitive(array: PyObject, py: Python) -> PyResult<bool> {
+    let array = to_rust(array, py)?;
+    let expected =
+        Arc::new(Primitive::<i64>::from(vec![Some(2), None, Some(6)]).to(DataType::Int64))
+            as ArrayRef;
+
+    Ok(array == expected)
+}
+
+/// Converts to rust and back to python
+#[pyfunction]
+fn export_primitive(py: Python) -> PyResult<PyObject> {
+    let array = Arc::new(Primitive::<i64>::from(vec![Some(2), None, Some(6)]).to(DataType::Int64))
+        as ArrayRef;
+
+    let array = to_py(array, py)?;
+
+    Ok(array)
+}
+
+#[pyfunction]
+fn total_allocated_bytes() -> PyResult<isize> {
+    Ok(arrow2::total_allocated_bytes())
+}
+
+#[pymodule]
+fn arrow_pyarrow_integration_testing(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_wrapped(wrap_pyfunction!(total_allocated_bytes))?;
+    m.add_wrapped(wrap_pyfunction!(export_primitive))?;
+    m.add_wrapped(wrap_pyfunction!(import_primitive))?;
+    m.add_wrapped(wrap_pyfunction!(double))?;
+    m.add_wrapped(wrap_pyfunction!(double_py))?;
+    m.add_wrapped(wrap_pyfunction!(substring))?;
+    m.add_wrapped(wrap_pyfunction!(concatenate))?;
+    m.add_wrapped(wrap_pyfunction!(round_trip))?;
+    Ok(())
+}

--- a/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/arrow-pyarrow-integration-testing/src/lib.rs
@@ -72,7 +72,7 @@ impl From<PyO3ArrowError> for PyErr {
 
 fn to_rust(ob: PyObject, py: Python) -> PyResult<ArrayRef> {
     // prepare a pointer to receive the Array struct
-    let array = Arc::new(ffi::ArrowArray::create_empty());
+    let array = Arc::new(ffi::create_empty());
     let (array_ptr, schema_ptr) = array.references();
 
     // make the conversion through PyArrow's private API
@@ -87,7 +87,7 @@ fn to_rust(ob: PyObject, py: Python) -> PyResult<ArrayRef> {
 }
 
 fn to_py(array: ArrayRef, py: Python) -> PyResult<PyObject> {
-    let array_ptr = ffi::ArrowArray::export_to_c(array).map_err(PyO3ArrowError::from)?;
+    let array_ptr = ffi::export_to_c(array).map_err(PyO3ArrowError::from)?;
 
     let (array_ptr, schema_ptr) = array_ptr.references();
 

--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import pyarrow
+import arrow_pyarrow_integration_testing
+
+
+class TestCase(unittest.TestCase):
+    def setUp(self):
+        self.old_allocated_rust = arrow_pyarrow_integration_testing.total_allocated_bytes()
+        self.old_allocated_cpp = pyarrow.total_allocated_bytes()
+
+    def tearDown(self):
+        # No leak of Rust
+        self.assertEqual(self.old_allocated_rust, arrow_pyarrow_integration_testing.total_allocated_bytes())
+
+        # No leak of C++ memory
+        self.assertEqual(self.old_allocated_cpp, pyarrow.total_allocated_bytes())
+
+    def test_primitive_python(self):
+        """
+        Python -> Rust -> Python
+        """
+        a = pyarrow.array([1, 2, 3])
+        b = arrow_pyarrow_integration_testing.double(a)
+        self.assertEqual(b, pyarrow.array([2, 4, 6]))
+
+    def test_primitive_rust(self):
+        """
+        Rust -> Python -> Rust
+        """
+        def double(array):
+            array = array.to_pylist()
+            return pyarrow.array([x * 2 if x is not None else None for x in array])
+
+        is_correct = arrow_pyarrow_integration_testing.double_py(double)
+        self.assertTrue(is_correct)
+
+    def test_import_primitive(self):
+        """
+        Python -> Rust
+        """
+        old_allocated = pyarrow.total_allocated_bytes()
+
+        a = pyarrow.array([2, None, 6])
+
+        is_correct = arrow_pyarrow_integration_testing.import_primitive(a)
+        self.assertTrue(is_correct)
+        # No leak of C++ memory
+        del a
+        self.assertEqual(old_allocated, pyarrow.total_allocated_bytes())
+
+    def test_export_primitive(self):
+        """
+        Python -> Rust
+        """
+        old_allocated = pyarrow.total_allocated_bytes()
+
+        expected = pyarrow.array([2, None, 6])
+
+        result = arrow_pyarrow_integration_testing.export_primitive()
+        self.assertEqual(expected, result)
+        # No leak of C++ memory
+        del expected
+        self.assertEqual(old_allocated, pyarrow.total_allocated_bytes())
+
+    def test_string_roundtrip(self):
+        """
+        Python -> Rust -> Python
+        """
+        a = pyarrow.array(["a", None, "ccc"])
+        b = arrow_pyarrow_integration_testing.round_trip(a)
+        c = pyarrow.array(["a", None, "ccc"])
+        self.assertEqual(b, c)
+
+    def test_string_python(self):
+        """
+        Python -> Rust -> Python
+        """
+        a = pyarrow.array(["a", None, "ccc"])
+        b = arrow_pyarrow_integration_testing.substring(a, 1)
+        self.assertEqual(b, pyarrow.array(["", None, "cc"]))
+
+    def test_time32_python(self):
+        """
+        Python -> Rust -> Python
+        """
+        a = pyarrow.array([None, 1, 2], pyarrow.time32('s'))
+        b = arrow_pyarrow_integration_testing.concatenate(a)
+        expected = pyarrow.array([None, 1, 2] + [None, 1, 2], pyarrow.time32('s'))
+        self.assertEqual(b, expected)
+
+    def test_list_array(self):
+        """
+        Python -> Rust -> Python
+        """
+        for _ in range(2):
+            a = pyarrow.array([[], None, [1, 2], [4, 5, 6]], pyarrow.list_(pyarrow.int64()))
+            b = arrow_pyarrow_integration_testing.round_trip(a)
+
+            b.validate(full=True)
+            assert a.to_pylist() == b.to_pylist()
+            assert a.type == b.type
+
+    def test_struct_array(self):
+        """
+        Python -> Rust -> Python
+        """
+        fields = [
+            ('f1', pyarrow.int32()),
+            ('f2', pyarrow.string()),
+        ]
+        a = pyarrow.array([
+            {"f1": 1, "f2": "a"},
+            None,
+            {"f1": 3, "f2": None},
+            {"f1": None, "f2": "d"},
+            {"f1": None, "f2": None},
+        ], pyarrow.struct(fields))
+        b = arrow_pyarrow_integration_testing.round_trip(a)
+
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type

--- a/src/alloc/mod.rs
+++ b/src/alloc/mod.rs
@@ -34,6 +34,11 @@ use alignment::ALIGNMENT;
 // If this number is not zero after all objects have been `drop`, there is a memory leak
 pub static mut ALLOCATIONS: AtomicIsize = AtomicIsize::new(0);
 
+/// Returns the total number of bytes allocated to buffers by the allocator.
+pub fn total_allocated_bytes() -> isize {
+    unsafe { ALLOCATIONS.load(std::sync::atomic::Ordering::SeqCst) }
+}
+
 #[inline]
 unsafe fn dangling<T: NativeType>() -> NonNull<T> {
     NonNull::new_unchecked(ALIGNMENT as *mut T)

--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -1,7 +1,7 @@
 use crate::{
     array::{FromFfi, Offset, ToFfi},
     datatypes::DataType,
-    ffi::ArrowArray,
+    ffi,
 };
 
 use crate::error::Result;
@@ -9,9 +9,9 @@ use crate::error::Result;
 use super::BinaryArray;
 
 unsafe impl<O: Offset> ToFfi for BinaryArray<O> {
-    fn buffers(&self) -> [Option<std::ptr::NonNull<u8>>; 3] {
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
         unsafe {
-            [
+            vec![
                 self.validity.as_ref().map(|x| x.as_ptr()),
                 Some(std::ptr::NonNull::new_unchecked(
                     self.offsets.as_ptr() as *mut u8
@@ -29,8 +29,9 @@ unsafe impl<O: Offset> ToFfi for BinaryArray<O> {
     }
 }
 
-unsafe impl<O: Offset> FromFfi for BinaryArray<O> {
-    fn try_from_ffi(data_type: DataType, array: ArrowArray) -> Result<Self> {
+unsafe impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryArray<O> {
+    fn try_from_ffi(array: A) -> Result<Self> {
+        let data_type = array.data_type()?;
         let expected = if O::is_large() {
             DataType::LargeBinary
         } else {
@@ -38,11 +39,11 @@ unsafe impl<O: Offset> FromFfi for BinaryArray<O> {
         };
         assert_eq!(data_type, expected);
 
-        let length = array.len();
-        let offset = array.offset();
-        let mut validity = array.validity();
-        let mut offsets = unsafe { array.buffer::<O>(0)? };
-        let values = unsafe { array.buffer::<u8>(1)? };
+        let length = array.array().len();
+        let offset = array.array().offset();
+        let mut validity = unsafe { array.validity() };
+        let mut offsets = unsafe { array.buffer::<O>(0) }?;
+        let values = unsafe { array.buffer::<u8>(1) }?;
 
         if offset > 0 {
             offsets = offsets.slice(offset, length);

--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -41,7 +41,7 @@ unsafe impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryArray<O> {
 
         let length = array.array().len();
         let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() };
+        let mut validity = unsafe { array.validity() }?;
         let mut offsets = unsafe { array.buffer::<O>(0) }?;
         let values = unsafe { array.buffer::<u8>(1) }?;
 

--- a/src/array/boolean/ffi.rs
+++ b/src/array/boolean/ffi.rs
@@ -24,8 +24,8 @@ unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for BooleanArray {
     fn try_from_ffi(array: A) -> Result<Self> {
         let length = array.array().len();
         let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() };
-        let mut values = unsafe { array.bitmap(0)? };
+        let mut validity = unsafe { array.validity() }?;
+        let mut values = unsafe { array.bitmap(0) }?;
 
         if offset > 0 {
             values = values.slice(offset, length);

--- a/src/array/boolean/ffi.rs
+++ b/src/array/boolean/ffi.rs
@@ -1,7 +1,6 @@
 use crate::{
     array::{FromFfi, ToFfi},
-    datatypes::DataType,
-    ffi::ArrowArray,
+    ffi,
 };
 
 use crate::error::Result;
@@ -9,11 +8,10 @@ use crate::error::Result;
 use super::BooleanArray;
 
 unsafe impl ToFfi for BooleanArray {
-    fn buffers(&self) -> [Option<std::ptr::NonNull<u8>>; 3] {
-        [
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
+        vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
             Some(self.values.as_ptr()),
-            None,
         ]
     }
 
@@ -22,11 +20,11 @@ unsafe impl ToFfi for BooleanArray {
     }
 }
 
-unsafe impl FromFfi for BooleanArray {
-    fn try_from_ffi(_: DataType, array: ArrowArray) -> Result<Self> {
-        let length = array.len();
-        let offset = array.offset();
-        let mut validity = array.validity();
+unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for BooleanArray {
+    fn try_from_ffi(array: A) -> Result<Self> {
+        let length = array.array().len();
+        let offset = array.array().offset();
+        let mut validity = unsafe { array.validity() };
         let mut values = unsafe { array.bitmap(0)? };
 
         if offset > 0 {

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -140,12 +140,8 @@ where
 }
 
 unsafe impl<K: DictionaryKey> ToFfi for DictionaryArray<K> {
-    fn buffers(&self) -> [Option<std::ptr::NonNull<u8>>; 3] {
-        [
-            self.keys.validity().as_ref().map(|x| x.as_ptr()),
-            None,
-            None,
-        ]
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
+        vec![self.keys.validity().as_ref().map(|x| x.as_ptr())]
     }
 
     #[inline]

--- a/src/array/ffi.rs
+++ b/src/array/ffi.rs
@@ -1,15 +1,21 @@
-use crate::{datatypes::DataType, ffi::ArrowArray};
+use std::sync::Arc;
+
+use crate::{array::Array, ffi};
 
 use crate::error::Result;
 
 /// Trait describing how a struct presents itself when converting itself to the C data interface (FFI).
 pub unsafe trait ToFfi {
-    fn buffers(&self) -> [Option<std::ptr::NonNull<u8>>; 3];
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>>;
 
     fn offset(&self) -> usize;
+
+    fn children(&self) -> Vec<Arc<dyn Array>> {
+        vec![]
+    }
 }
 
 /// Trait describing how a creates itself from the C data interface (FFI).
-pub unsafe trait FromFfi: Sized {
-    fn try_from_ffi(data_type: DataType, array: ArrowArray) -> Result<Self>;
+pub unsafe trait FromFfi<T: ffi::ArrowArrayRef>: Sized {
+    fn try_from_ffi(array: T) -> Result<Self>;
 }

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -127,14 +127,13 @@ impl std::fmt::Display for FixedSizeBinaryArray {
 }
 
 unsafe impl ToFfi for FixedSizeBinaryArray {
-    fn buffers(&self) -> [Option<std::ptr::NonNull<u8>>; 3] {
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
         unsafe {
-            [
+            vec![
                 self.validity.as_ref().map(|x| x.as_ptr()),
                 Some(std::ptr::NonNull::new_unchecked(
                     self.values.as_ptr() as *mut u8
                 )),
-                None,
             ]
         }
     }

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -121,8 +121,8 @@ impl std::fmt::Display for FixedSizeListArray {
 }
 
 unsafe impl ToFfi for FixedSizeListArray {
-    fn buffers(&self) -> [Option<std::ptr::NonNull<u8>>; 3] {
-        [self.validity.as_ref().map(|x| x.as_ptr()), None, None]
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
+        vec![self.validity.as_ref().map(|x| x.as_ptr())]
     }
 
     fn offset(&self) -> usize {

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -31,9 +31,9 @@ unsafe impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for ListArray<O> {
         let data_type = array.data_type()?;
         let length = array.array().len();
         let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() };
-        let mut offsets = unsafe { array.buffer::<O>(0)? };
-        let child = ffi::child(array, 0)?;
+        let mut validity = unsafe { array.validity() }?;
+        let mut offsets = unsafe { array.buffer::<O>(0) }?;
+        let child = array.child(0)?;
         let values = ffi::try_from(child)?.into();
 
         if offset > 0 {

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -1,21 +1,17 @@
-use crate::{
-    array::{FromFfi, Offset, ToFfi},
-    error::Result,
-    ffi,
-};
+use std::sync::Arc;
 
-use super::Utf8Array;
+use crate::{array::FromFfi, error::Result, ffi};
 
-unsafe impl<O: Offset> ToFfi for Utf8Array<O> {
+use super::super::{ffi::ToFfi, specification::Offset, Array};
+use super::ListArray;
+
+unsafe impl<O: Offset> ToFfi for ListArray<O> {
     fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
         unsafe {
             vec![
                 self.validity.as_ref().map(|x| x.as_ptr()),
                 Some(std::ptr::NonNull::new_unchecked(
                     self.offsets.as_ptr() as *mut u8
-                )),
-                Some(std::ptr::NonNull::new_unchecked(
-                    self.values.as_ptr() as *mut u8
                 )),
             ]
         }
@@ -24,20 +20,26 @@ unsafe impl<O: Offset> ToFfi for Utf8Array<O> {
     fn offset(&self) -> usize {
         self.offset
     }
+
+    fn children(&self) -> Vec<Arc<dyn Array>> {
+        vec![self.values.clone()]
+    }
 }
 
-unsafe impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for Utf8Array<O> {
+unsafe impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for ListArray<O> {
     fn try_from_ffi(array: A) -> Result<Self> {
+        let data_type = array.data_type()?;
         let length = array.array().len();
         let offset = array.array().offset();
         let mut validity = unsafe { array.validity() };
-        let mut offsets = unsafe { array.buffer::<O>(0) }?;
-        let values = unsafe { array.buffer::<u8>(1)? };
+        let mut offsets = unsafe { array.buffer::<O>(0)? };
+        let child = ffi::child(array, 0)?;
+        let values = ffi::try_from(child)?.into();
 
         if offset > 0 {
             offsets = offsets.slice(offset, length);
             validity = validity.map(|x| x.slice(offset, length))
         }
-        Ok(Self::from_data(offsets, values, validity))
+        Ok(Self::from_data(data_type, offsets, values, validity))
     }
 }

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -7,9 +7,7 @@ use crate::{
 };
 
 use super::{
-    display_fmt,
-    ffi::ToFfi,
-    new_empty_array,
+    display_fmt, new_empty_array,
     specification::{check_offsets, Offset},
     Array,
 };
@@ -184,24 +182,7 @@ impl<O: Offset> std::fmt::Display for ListArray<O> {
     }
 }
 
-unsafe impl<O: Offset> ToFfi for ListArray<O> {
-    fn buffers(&self) -> [Option<std::ptr::NonNull<u8>>; 3] {
-        unsafe {
-            [
-                self.validity.as_ref().map(|x| x.as_ptr()),
-                Some(std::ptr::NonNull::new_unchecked(
-                    self.offsets.as_ptr() as *mut u8
-                )),
-                None,
-            ]
-        }
-    }
-
-    fn offset(&self) -> usize {
-        self.offset
-    }
-}
-
+mod ffi;
 mod from;
 pub(crate) mod iterator;
 

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -68,8 +68,8 @@ impl std::fmt::Display for NullArray {
 }
 
 unsafe impl ToFfi for NullArray {
-    fn buffers(&self) -> [Option<std::ptr::NonNull<u8>>; 3] {
-        [None, None, None]
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
+        vec![]
     }
 
     #[inline]

--- a/src/array/primitive/ffi.rs
+++ b/src/array/primitive/ffi.rs
@@ -1,7 +1,6 @@
 use crate::{
     array::{FromFfi, ToFfi},
-    datatypes::DataType,
-    ffi::ArrowArray,
+    ffi,
     types::NativeType,
 };
 
@@ -10,14 +9,13 @@ use crate::error::Result;
 use super::PrimitiveArray;
 
 unsafe impl<T: NativeType> ToFfi for PrimitiveArray<T> {
-    fn buffers(&self) -> [Option<std::ptr::NonNull<u8>>; 3] {
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
         unsafe {
-            [
+            vec![
                 self.validity.as_ref().map(|x| x.as_ptr()),
                 Some(std::ptr::NonNull::new_unchecked(
                     self.values.as_ptr() as *mut u8
                 )),
-                None,
             ]
         }
     }
@@ -28,12 +26,13 @@ unsafe impl<T: NativeType> ToFfi for PrimitiveArray<T> {
     }
 }
 
-unsafe impl<T: NativeType> FromFfi for PrimitiveArray<T> {
-    fn try_from_ffi(data_type: DataType, array: ArrowArray) -> Result<Self> {
-        let length = array.len();
-        let offset = array.offset();
-        let mut validity = array.validity();
-        let mut values = unsafe { array.buffer::<T>(0)? };
+unsafe impl<T: NativeType, A: ffi::ArrowArrayRef> FromFfi<A> for PrimitiveArray<T> {
+    fn try_from_ffi(array: A) -> Result<Self> {
+        let data_type = array.data_type()?;
+        let length = array.array().len();
+        let offset = array.array().offset();
+        let mut validity = unsafe { array.validity() };
+        let mut values = unsafe { array.buffer::<T>(0) }?;
 
         if offset > 0 {
             values = values.slice(offset, length);

--- a/src/array/primitive/ffi.rs
+++ b/src/array/primitive/ffi.rs
@@ -31,7 +31,7 @@ unsafe impl<T: NativeType, A: ffi::ArrowArrayRef> FromFfi<A> for PrimitiveArray<
         let data_type = array.data_type()?;
         let length = array.array().len();
         let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() };
+        let mut validity = unsafe { array.validity() }?;
         let mut values = unsafe { array.buffer::<T>(0) }?;
 
         if offset > 0 {

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -3,9 +3,11 @@ use std::sync::Arc;
 use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, Field},
+    error::Result,
+    ffi,
 };
 
-use super::{ffi::ToFfi, new_empty_array, new_null_array, Array};
+use super::{ffi::ToFfi, new_empty_array, new_null_array, Array, FromFfi};
 
 #[derive(Debug, Clone)]
 pub struct StructArray {
@@ -121,12 +123,38 @@ impl std::fmt::Display for StructArray {
 }
 
 unsafe impl ToFfi for StructArray {
-    fn buffers(&self) -> [Option<std::ptr::NonNull<u8>>; 3] {
-        [self.validity.as_ref().map(|x| x.as_ptr()), None, None]
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
+        vec![self.validity.as_ref().map(|x| x.as_ptr())]
     }
 
     fn offset(&self) -> usize {
         // we do not support offsets in structs. Instead, if an FFI we slice the incoming arrays
         0
+    }
+
+    fn children(&self) -> Vec<Arc<dyn Array>> {
+        self.values.clone()
+    }
+}
+
+unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for StructArray {
+    fn try_from_ffi(array: A) -> Result<Self> {
+        let data_type = array.data_type()?;
+        let fields = Self::get_fields(&data_type).to_vec();
+
+        let length = array.array().len();
+        let offset = array.array().offset();
+        let mut validity = unsafe { array.validity() };
+        let values = (0..fields.len())
+            .map(|index| {
+                let child = array.child(index)?;
+                Ok(ffi::try_from(child)?.into())
+            })
+            .collect::<Result<Vec<Arc<dyn Array>>>>()?;
+
+        if offset > 0 {
+            validity = validity.map(|x| x.slice(offset, length))
+        }
+        Ok(Self::from_data(fields, values, validity))
     }
 }

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -144,7 +144,7 @@ unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for StructArray {
 
         let length = array.array().len();
         let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() };
+        let mut validity = unsafe { array.validity() }?;
         let values = (0..fields.len())
             .map(|index| {
                 let child = array.child(index)?;

--- a/src/array/utf8/ffi.rs
+++ b/src/array/utf8/ffi.rs
@@ -30,7 +30,7 @@ unsafe impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for Utf8Array<O> {
     fn try_from_ffi(array: A) -> Result<Self> {
         let length = array.array().len();
         let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() };
+        let mut validity = unsafe { array.validity() }?;
         let mut offsets = unsafe { array.buffer::<O>(0) }?;
         let values = unsafe { array.buffer::<u8>(1)? };
 

--- a/src/buffer/bytes.rs
+++ b/src/buffer/bytes.rs
@@ -14,7 +14,7 @@ pub enum Deallocation {
     /// Native deallocation, using Rust deallocator with Arrow-specific memory aligment
     Native(usize),
     // Foreign interface, via a callback
-    Foreign(Arc<ffi::Ffi_ArrowArray>),
+    Foreign(Arc<ffi::ArrowArray>),
 }
 
 impl Debug for Deallocation {

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -17,93 +17,89 @@
 
 //! Contains functionality to load an ArrayData from the C Data Interface
 
-use std::{convert::TryFrom, sync::Arc};
-
-use super::ffi::ArrowArray;
+use super::ffi::ArrowArrayRef;
 use crate::array::{BooleanArray, FromFfi};
 use crate::error::{ArrowError, Result};
 use crate::types::days_ms;
 use crate::{
-    array::{Array, BinaryArray, PrimitiveArray, Utf8Array},
+    array::{Array, BinaryArray, ListArray, PrimitiveArray, StructArray, Utf8Array},
     datatypes::{DataType, IntervalUnit},
 };
 
-impl TryFrom<ArrowArray> for Box<dyn Array> {
-    type Error = ArrowError;
+pub fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
+    let data_type = array.data_type()?;
+    let array: Box<dyn Array> = match data_type {
+        DataType::Boolean => Box::new(BooleanArray::try_from_ffi(array)?),
+        DataType::Int8 => Box::new(PrimitiveArray::<i8>::try_from_ffi(array)?),
+        DataType::Int16 => Box::new(PrimitiveArray::<i16>::try_from_ffi(array)?),
+        DataType::Int32
+        | DataType::Date32
+        | DataType::Time32(_)
+        | DataType::Interval(IntervalUnit::YearMonth) => {
+            Box::new(PrimitiveArray::<i32>::try_from_ffi(array)?)
+        }
+        DataType::Interval(IntervalUnit::DayTime) => {
+            Box::new(PrimitiveArray::<days_ms>::try_from_ffi(array)?)
+        }
+        DataType::Int64
+        | DataType::Date64
+        | DataType::Time64(_)
+        | DataType::Timestamp(_, _)
+        | DataType::Duration(_) => Box::new(PrimitiveArray::<i64>::try_from_ffi(array)?),
+        DataType::Decimal(_, _) => Box::new(PrimitiveArray::<i128>::try_from_ffi(array)?),
+        DataType::UInt8 => Box::new(PrimitiveArray::<u8>::try_from_ffi(array)?),
+        DataType::UInt16 => Box::new(PrimitiveArray::<u16>::try_from_ffi(array)?),
+        DataType::UInt32 => Box::new(PrimitiveArray::<u32>::try_from_ffi(array)?),
+        DataType::UInt64 => Box::new(PrimitiveArray::<u64>::try_from_ffi(array)?),
+        DataType::Float16 => unreachable!(),
+        DataType::Float32 => Box::new(PrimitiveArray::<f32>::try_from_ffi(array)?),
+        DataType::Float64 => Box::new(PrimitiveArray::<f64>::try_from_ffi(array)?),
+        DataType::Utf8 => Box::new(Utf8Array::<i32>::try_from_ffi(array)?),
+        DataType::LargeUtf8 => Box::new(Utf8Array::<i64>::try_from_ffi(array)?),
+        DataType::Binary => Box::new(BinaryArray::<i32>::try_from_ffi(array)?),
+        DataType::LargeBinary => Box::new(BinaryArray::<i64>::try_from_ffi(array)?),
+        DataType::List(_) => Box::new(ListArray::<i32>::try_from_ffi(array)?),
+        DataType::LargeList(_) => Box::new(ListArray::<i64>::try_from_ffi(array)?),
+        DataType::Struct(_) => Box::new(StructArray::try_from_ffi(array)?),
+        data_type => {
+            return Err(ArrowError::NotYetImplemented(format!(
+                "Reading DataType \"{}\" is not yet supported.",
+                data_type
+            )))
+        }
+    };
 
-    fn try_from(array: ArrowArray) -> Result<Self> {
-        let data_type = array.data_type()?;
-
-        let array: Box<dyn Array> = match data_type {
-            DataType::Boolean => Box::new(BooleanArray::try_from_ffi(data_type, array)?),
-            DataType::Int8 => Box::new(PrimitiveArray::<i8>::try_from_ffi(data_type, array)?),
-            DataType::Int16 => Box::new(PrimitiveArray::<i16>::try_from_ffi(data_type, array)?),
-            DataType::Int32
-            | DataType::Date32
-            | DataType::Time32(_)
-            | DataType::Interval(IntervalUnit::YearMonth) => {
-                Box::new(PrimitiveArray::<i32>::try_from_ffi(data_type, array)?)
-            }
-            DataType::Interval(IntervalUnit::DayTime) => {
-                Box::new(PrimitiveArray::<days_ms>::try_from_ffi(data_type, array)?)
-            }
-            DataType::Int64
-            | DataType::Date64
-            | DataType::Time64(_)
-            | DataType::Timestamp(_, _)
-            | DataType::Duration(_) => {
-                Box::new(PrimitiveArray::<i64>::try_from_ffi(data_type, array)?)
-            }
-            DataType::Decimal(_, _) => {
-                Box::new(PrimitiveArray::<i128>::try_from_ffi(data_type, array)?)
-            }
-            DataType::UInt8 => Box::new(PrimitiveArray::<u8>::try_from_ffi(data_type, array)?),
-            DataType::UInt16 => Box::new(PrimitiveArray::<u16>::try_from_ffi(data_type, array)?),
-            DataType::UInt32 => Box::new(PrimitiveArray::<u32>::try_from_ffi(data_type, array)?),
-            DataType::UInt64 => Box::new(PrimitiveArray::<u64>::try_from_ffi(data_type, array)?),
-            DataType::Float16 => unreachable!(),
-            DataType::Float32 => Box::new(PrimitiveArray::<f32>::try_from_ffi(data_type, array)?),
-            DataType::Float64 => Box::new(PrimitiveArray::<f64>::try_from_ffi(data_type, array)?),
-            DataType::Utf8 => Box::new(Utf8Array::<i32>::try_from_ffi(data_type, array)?),
-            DataType::LargeUtf8 => Box::new(Utf8Array::<i64>::try_from_ffi(data_type, array)?),
-            DataType::Binary => Box::new(BinaryArray::<i32>::try_from_ffi(data_type, array)?),
-            DataType::LargeBinary => Box::new(BinaryArray::<i64>::try_from_ffi(data_type, array)?),
-            _ => unimplemented!(),
-        };
-
-        Ok(array)
-    }
-}
-
-impl TryFrom<Arc<dyn Array>> for ArrowArray {
-    type Error = ArrowError;
-
-    fn try_from(array: Arc<dyn Array>) -> Result<Self> {
-        ArrowArray::try_new(array)
-    }
+    Ok(array)
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::array::{Array, BinaryArray, Primitive, Utf8Array};
+    use super::*;
+    use crate::array::*;
     use crate::{datatypes::DataType, error::Result, ffi::ArrowArray};
-    use std::{convert::TryFrom, sync::Arc};
+    use std::sync::Arc;
+
+    fn test_release(expected: impl Array + 'static) -> Result<()> {
+        // create a `ArrowArray` from the data.
+        let b: Arc<dyn Array> = Arc::new(expected);
+
+        // export the array as 2 pointers.
+        let _ = ArrowArray::export_to_c(b)?;
+
+        Ok(())
+    }
 
     fn test_round_trip(expected: impl Array + Clone + 'static) -> Result<()> {
-        // create a `ArrowArray` from the data.
         let b: Arc<dyn Array> = Arc::new(expected.clone());
-        let d1 = ArrowArray::try_from(b)?;
-
-        // here we export the array as 2 pointers. We would have no control over ownership if it was not for
-        // the release mechanism.
-        let (array, schema) = ArrowArray::into_raw(d1);
-
-        // simulate an external consumer by being the consumer
-        let d1 = unsafe { ArrowArray::try_from_raw(array, schema) }?;
-
-        let result = Box::<dyn Array>::try_from(d1)?;
-
         let expected = Box::new(expected) as Box<dyn Array>;
+
+        // create a `ArrowArray` from the data.
+        let array = Arc::new(ArrowArray::export_to_c(b)?);
+
+        let (_, _) = array.references();
+
+        let result = try_from(array)?;
+
         assert_eq!(&result, &expected);
         Ok(())
     }
@@ -111,7 +107,7 @@ mod tests {
     #[test]
     fn test_u32() -> Result<()> {
         let data = Primitive::<i32>::from(vec![Some(2), None, Some(1), None]).to(DataType::Int32);
-        test_round_trip(data)
+        test_release(data)
     }
 
     #[test]
@@ -149,6 +145,22 @@ mod tests {
     fn test_large_binary() -> Result<()> {
         let data =
             BinaryArray::<i64>::from(&vec![Some(b"a".as_ref()), None, Some(b"bb".as_ref()), None]);
+        test_round_trip(data)
+    }
+
+    #[test]
+    fn test_list() -> Result<()> {
+        let data = vec![
+            Some(vec![Some(1i32), Some(2), Some(3)]),
+            None,
+            Some(vec![Some(4), None, Some(6)]),
+        ];
+
+        let data: ListArray<i32> = data
+            .into_iter()
+            .collect::<ListPrimitive<i32, Primitive<i32>, i32>>()
+            .to(ListArray::<i32>::default_datatype(DataType::Int32));
+        //test_release(data)
         test_round_trip(data)
     }
 }

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -26,6 +26,11 @@ use crate::{
     datatypes::{DataType, IntervalUnit},
 };
 
+/// Reads a valid `ffi` interface into a `Box<dyn Array>`
+/// # Errors
+/// If and only if:
+/// * the data type is not supported
+/// * the interface is not valid (e.g. a null pointer)
 pub fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
     let data_type = array.data_type()?;
     let array: Box<dyn Array> = match data_type {
@@ -76,7 +81,7 @@ pub fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
 mod tests {
     use super::*;
     use crate::array::*;
-    use crate::{datatypes::DataType, error::Result, ffi::ArrowArray};
+    use crate::{datatypes::DataType, error::Result, ffi};
     use std::sync::Arc;
 
     fn test_release(expected: impl Array + 'static) -> Result<()> {
@@ -84,7 +89,7 @@ mod tests {
         let b: Arc<dyn Array> = Arc::new(expected);
 
         // export the array as 2 pointers.
-        let _ = ArrowArray::export_to_c(b)?;
+        let _ = ffi::export_to_c(b)?;
 
         Ok(())
     }
@@ -94,7 +99,7 @@ mod tests {
         let expected = Box::new(expected) as Box<dyn Array>;
 
         // create a `ArrowArray` from the data.
-        let array = Arc::new(ArrowArray::export_to_c(b)?);
+        let array = Arc::new(ffi::export_to_c(b)?);
 
         let (_, _) = array.references();
 

--- a/src/ffi/ffi.rs
+++ b/src/ffi/ffi.rs
@@ -50,10 +50,16 @@ use crate::{
         bytes::{Bytes, Deallocation},
         Buffer,
     },
-    datatypes::{DataType, TimeUnit},
+    datatypes::{DataType, Field, TimeUnit},
     error::{ArrowError, Result},
     types::NativeType,
 };
+
+#[allow(dead_code)]
+struct SchemaPrivateData {
+    field: Field,
+    children_ptr: Box<[*mut Ffi_ArrowSchema]>,
+}
 
 /// ABI-compatible struct for `ArrowSchema` from C Data Interface
 /// See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>
@@ -73,30 +79,66 @@ pub struct Ffi_ArrowSchema {
 }
 
 // callback used to drop [Ffi_ArrowSchema] when it is exported.
-unsafe extern "C" fn release_schema(schema: *mut Ffi_ArrowSchema) {
+unsafe extern "C" fn c_release_schema(schema: *mut Ffi_ArrowSchema) {
+    if schema.is_null() {
+        return;
+    }
     let schema = &mut *schema;
 
     // take ownership back to release it.
     CString::from_raw(schema.format as *mut std::os::raw::c_char);
+    CString::from_raw(schema.name as *mut std::os::raw::c_char);
+    let private = Box::from_raw(schema.private_data as *mut SchemaPrivateData);
+    for child in private.children_ptr.iter() {
+        let _ = Box::from_raw(*child);
+    }
 
     schema.release = None;
 }
 
 impl Ffi_ArrowSchema {
-    /// create a new [Ffi_ArrowSchema] from a format.
-    fn new(format: &str) -> Ffi_ArrowSchema {
+    /// create a new [`Ffi_ArrowSchema`]. This fails if the fields' [`DataType`] is not supported.
+    fn try_new(field: Field) -> Result<Ffi_ArrowSchema> {
+        let format = to_format(field.data_type())?;
+        let name = field.name().clone();
+
+        // allocate (and hold) the children
+        let children_vec = match field.data_type() {
+            DataType::List(field) => {
+                vec![Box::new(Ffi_ArrowSchema::try_new(field.as_ref().clone())?)]
+            }
+            DataType::LargeList(field) => {
+                vec![Box::new(Ffi_ArrowSchema::try_new(field.as_ref().clone())?)]
+            }
+            DataType::Struct(fields) => fields
+                .iter()
+                .map(|field| Ok(Box::new(Ffi_ArrowSchema::try_new(field.clone())?)))
+                .collect::<Result<Vec<_>>>()?,
+            _ => vec![],
+        };
+        // note: this cannot be done along with the above because the above is fallible and this op leaks.
+        let mut children_ptr = children_vec
+            .into_iter()
+            .map(Box::into_raw)
+            .collect::<Box<_>>();
+        let n_children = children_ptr.len() as i64;
+        let children = children_ptr.as_mut_ptr();
+
         // <https://arrow.apache.org/docs/format/CDataInterface.html#c.ArrowSchema>
-        Ffi_ArrowSchema {
+        Ok(Ffi_ArrowSchema {
             format: CString::new(format).unwrap().into_raw(),
-            name: std::ptr::null_mut(),
+            name: CString::new(name).unwrap().into_raw(),
             metadata: std::ptr::null_mut(),
-            flags: 0,
-            n_children: 0,
-            children: ptr::null_mut(),
+            flags: field.is_nullable() as i64 * 2,
+            n_children,
+            children,
             dictionary: std::ptr::null_mut(),
-            release: Some(release_schema),
-            private_data: std::ptr::null_mut(),
-        }
+            release: Some(c_release_schema),
+            private_data: Box::into_raw(Box::new(SchemaPrivateData {
+                field,
+                children_ptr,
+            })) as *mut ::std::os::raw::c_void,
+        })
     }
 
     /// create an empty [Ffi_ArrowSchema]
@@ -116,9 +158,28 @@ impl Ffi_ArrowSchema {
 
     /// returns the format of this schema.
     pub fn format(&self) -> &str {
+        assert!(!self.format.is_null());
+        // safe because the lifetime of `self.format` equals `self`
         unsafe { CStr::from_ptr(self.format) }
             .to_str()
             .expect("The external API has a non-utf8 as format")
+    }
+
+    /// returns the name of this schema.
+    pub fn name(&self) -> &str {
+        assert!(!self.name.is_null());
+        // safe because the lifetime of `self.name` equals `self`
+        unsafe { CStr::from_ptr(self.name) }.to_str().unwrap()
+    }
+
+    pub fn child(&self, index: usize) -> &Self {
+        assert!(index < self.n_children as usize);
+        assert!(!self.name.is_null());
+        unsafe { self.children.add(index).as_ref().unwrap().as_ref().unwrap() }
+    }
+
+    pub fn nullable(&self) -> bool {
+        (self.flags / 2) & 1 == 1
     }
 }
 
@@ -131,10 +192,9 @@ impl Drop for Ffi_ArrowSchema {
     }
 }
 
-/// maps a DataType `format` to a [DataType](arrow::datatypes::DataType).
 /// See https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings
-fn to_datatype(format: &str) -> Result<DataType> {
-    Ok(match format {
+fn to_field(schema: &Ffi_ArrowSchema) -> Result<Field> {
+    let data_type = match schema.format() {
         "n" => DataType::Null,
         "b" => DataType::Boolean,
         "c" => DataType::Int8,
@@ -158,17 +218,33 @@ fn to_datatype(format: &str) -> Result<DataType> {
         "ttm" => DataType::Time32(TimeUnit::Millisecond),
         "ttu" => DataType::Time64(TimeUnit::Microsecond),
         "ttn" => DataType::Time64(TimeUnit::Nanosecond),
-        _ => {
-            return Err(ArrowError::Ffi(
-                "The datatype \"{}\" is still not supported in Rust implementation".to_string(),
-            ))
+        "+l" => {
+            let child = schema.child(0);
+            DataType::List(Box::new(to_field(child)?))
         }
-    })
+        "+L" => {
+            let child = schema.child(0);
+            DataType::LargeList(Box::new(to_field(child)?))
+        }
+        "+s" => {
+            let children = (0..schema.n_children as usize)
+                .map(|x| to_field(schema.child(x)))
+                .collect::<Result<Vec<_>>>()?;
+            DataType::Struct(children)
+        }
+        other => {
+            return Err(ArrowError::Ffi(format!(
+                "The datatype \"{}\" is still not supported in Rust implementation",
+                other
+            )))
+        }
+    };
+    Ok(Field::new(schema.name(), data_type, schema.nullable()))
 }
 
 /// the inverse of [to_datatype]
-fn from_datatype(datatype: &DataType) -> Result<String> {
-    Ok(match datatype {
+fn to_format(data_type: &DataType) -> Result<String> {
+    Ok(match data_type {
         DataType::Null => "n",
         DataType::Boolean => "b",
         DataType::Int8 => "c",
@@ -192,6 +268,9 @@ fn from_datatype(datatype: &DataType) -> Result<String> {
         DataType::Time32(TimeUnit::Millisecond) => "ttm",
         DataType::Time64(TimeUnit::Microsecond) => "ttu",
         DataType::Time64(TimeUnit::Nanosecond) => "ttn",
+        DataType::List(_) => "+l",
+        DataType::LargeList(_) => "+L",
+        DataType::Struct(_) => "+s",
         z => {
             return Err(ArrowError::Ffi(format!(
                 "The datatype \"{:?}\" is still not supported in Rust implementation",
@@ -206,7 +285,7 @@ fn from_datatype(datatype: &DataType) -> Result<String> {
 /// See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>
 /// This was created by bindgen
 #[repr(C)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Ffi_ArrowArray {
     pub(crate) length: i64,
     pub(crate) null_count: i64,
@@ -225,14 +304,27 @@ pub struct Ffi_ArrowArray {
     private_data: *mut ::std::os::raw::c_void,
 }
 
+impl Drop for Ffi_ArrowArray {
+    fn drop(&mut self) {
+        match self.release {
+            None => (),
+            Some(release) => unsafe { release(self) },
+        };
+    }
+}
+
 // callback used to drop [Ffi_ArrowArray] when it is exported
-unsafe extern "C" fn release_array(array: *mut Ffi_ArrowArray) {
+unsafe extern "C" fn c_release_array(array: *mut Ffi_ArrowArray) {
     if array.is_null() {
         return;
     }
     let array = &mut *array;
+
     // take ownership of `private_data`, therefore dropping it
-    Box::from_raw(array.private_data as *mut PrivateData);
+    let private = Box::from_raw(array.private_data as *mut PrivateData);
+    for child in private.children_ptr.iter() {
+        let _ = Box::from_raw(*child);
+    }
 
     array.release = None;
 }
@@ -241,6 +333,7 @@ unsafe extern "C" fn release_array(array: *mut Ffi_ArrowArray) {
 struct PrivateData {
     array: Arc<dyn Array>,
     buffers_ptr: Box<[*const std::os::raw::c_void]>,
+    children_ptr: Box<[*mut Ffi_ArrowArray]>,
 }
 
 impl Ffi_ArrowArray {
@@ -249,8 +342,8 @@ impl Ffi_ArrowArray {
     /// This method releases `buffers`. Consumers of this struct *must* call `release` before
     /// releasing this struct, or contents in `buffers` leak.
     fn new(array: Arc<dyn Array>) -> Self {
-        let buffers_ptr = array
-            .buffers()
+        let buffers = array.buffers();
+        let mut buffers_ptr = buffers
             .iter()
             .map(|maybe_buffer| match maybe_buffer {
                 // note that `raw_data` takes into account the buffer's offset
@@ -258,20 +351,32 @@ impl Ffi_ArrowArray {
                 None => std::ptr::null(),
             })
             .collect::<Box<[_]>>();
-        let pointer = buffers_ptr.as_ptr() as *mut *const std::ffi::c_void;
+        let n_buffers = buffers.len() as i64;
+        let buffers = buffers_ptr.as_mut_ptr();
+
+        let mut children_ptr = array
+            .children()
+            .into_iter()
+            .map(|child| Box::into_raw(Box::new(Ffi_ArrowArray::new(child))))
+            .collect::<Box<_>>();
+        let n_children = children_ptr.len() as i64;
+        let children = children_ptr.as_mut_ptr();
 
         Self {
             length: array.len() as i64,
             null_count: array.null_count() as i64,
             offset: 0i64,
-            n_buffers: 3, // todo: fix me
-            n_children: 0,
-            buffers: pointer,
-            children: std::ptr::null_mut(),
+            n_buffers,
+            n_children,
+            buffers,
+            children,
             dictionary: std::ptr::null_mut(),
-            release: Some(release_array),
-            private_data: Box::into_raw(Box::new(PrivateData { array, buffers_ptr }))
-                as *mut ::std::os::raw::c_void,
+            release: Some(c_release_array),
+            private_data: Box::into_raw(Box::new(PrivateData {
+                array,
+                buffers_ptr,
+                children_ptr,
+            })) as *mut ::std::os::raw::c_void,
         }
     }
 
@@ -290,29 +395,47 @@ impl Ffi_ArrowArray {
             private_data: std::ptr::null_mut(),
         }
     }
+
+    /// the length of the array
+    pub fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    /// whether the array is empty
+    pub fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
+    /// the offset of the array
+    pub fn offset(&self) -> usize {
+        self.offset as usize
+    }
 }
 
-/// returns a new buffer corresponding to the index `i` of the FFI array. It may not exist (null pointer).
-/// `bits` is the number of bits that the native type of this buffer has.
-/// # Panic
-/// This function panics if `i` is larger or equal to `n_buffers`.
+/// interprets the buffer `index` as a [`Buffer`].
 /// # Safety
-/// This function assumes that `ceil(self.length * bits, 8)` is the size of the buffer
+/// The caller must guarantee that the buffer `index` corresponds to a buffer of type `T`.
+/// This function assumes that the buffer created from FFI is valid; this is impossible to prove.
 unsafe fn create_buffer<T: NativeType>(
-    array: Arc<Ffi_ArrowArray>,
+    array: &Ffi_ArrowArray,
+    data_type: &DataType,
+    deallocation: Deallocation,
     index: usize,
-    len: usize,
-) -> Option<Buffer<T>> {
+) -> Result<Buffer<T>> {
     if array.buffers.is_null() {
-        return None;
+        return Err(ArrowError::Ffi("The array buffers are null".to_string()));
     }
     let buffers = array.buffers as *mut *const u8;
+
+    let len = buffer_len(array, data_type, index)?;
 
     assert!(index < array.n_buffers as usize);
     let ptr = *buffers.add(index);
 
     let ptr = NonNull::new(ptr as *mut T);
-    let bytes = ptr.map(|ptr| Bytes::new(ptr, len, Deallocation::Foreign(array)));
+    let bytes = ptr
+        .map(|ptr| Bytes::new(ptr, len, deallocation))
+        .ok_or_else(|| ArrowError::Ffi(format!("The buffer at position {} is null", index)));
 
     bytes.map(Buffer::from_bytes)
 }
@@ -324,29 +447,127 @@ unsafe fn create_buffer<T: NativeType>(
 /// This function panics if `i` is larger or equal to `n_buffers`.
 /// # Safety
 /// This function assumes that `ceil(self.length * bits, 8)` is the size of the buffer
-unsafe fn create_bitmap(array: Arc<Ffi_ArrowArray>, index: usize, len: usize) -> Option<Bitmap> {
+unsafe fn create_bitmap(
+    array: &Ffi_ArrowArray,
+    deallocation: Deallocation,
+    index: usize,
+) -> Option<Bitmap> {
     if array.buffers.is_null() {
         return None;
     }
+    let len = array.length as usize;
     let buffers = array.buffers as *mut *const u8;
 
     assert!(index < array.n_buffers as usize);
     let ptr = *buffers.add(index);
 
-    let bytes_len = len.saturating_add(7) / 8;
+    let bytes_len = bytes_for(len);
     let ptr = NonNull::new(ptr as *mut u8);
-    let bytes = ptr.map(|ptr| Bytes::new(ptr, bytes_len, Deallocation::Foreign(array)));
+    let bytes = ptr.map(|ptr| Bytes::new(ptr, bytes_len, deallocation));
 
     bytes.map(|bytes| Bitmap::from_bytes(bytes, len))
 }
 
-impl Drop for Ffi_ArrowArray {
-    fn drop(&mut self) {
-        match self.release {
-            None => (),
-            Some(release) => unsafe { release(self) },
-        };
+/// Returns the length, in slots, of the buffer `i` (indexed according to the C data interface)
+// Rust implementation uses fixed-sized buffers, which require knowledge of their `len`.
+// for variable-sized buffers, such as the second buffer of a stringArray, we need
+// to fetch offset buffer's len to build the second buffer.
+fn buffer_len(array: &Ffi_ArrowArray, data_type: &DataType, i: usize) -> Result<usize> {
+    Ok(match (data_type, i) {
+        (DataType::Utf8, 1)
+        | (DataType::LargeUtf8, 1)
+        | (DataType::Binary, 1)
+        | (DataType::LargeBinary, 1)
+        | (DataType::List(_), 1)
+        | (DataType::LargeList(_), 1) => {
+            // the len of the offset buffer (buffer 1) equals length + 1
+            array.length as usize + 1
+        }
+        (DataType::Utf8, 2) | (DataType::Binary, 2) => {
+            // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
+            let len = buffer_len(array, data_type, 1)?;
+            // first buffer is the null buffer => add(1)
+            let offset_buffer = unsafe { *(array.buffers as *mut *const u8).add(1) };
+            // interpret as i32
+            let offset_buffer = offset_buffer as *const i32;
+            // get last offset
+            (unsafe { *offset_buffer.add(len - 1) }) as usize
+        }
+        (DataType::LargeUtf8, 2) | (DataType::LargeBinary, 2) => {
+            // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
+            let len = buffer_len(array, data_type, 1)?;
+            // first buffer is the null buffer => add(1)
+            let offset_buffer = unsafe { *(array.buffers as *mut *const u8).add(1) };
+            // interpret as i64
+            let offset_buffer = offset_buffer as *const i64;
+            // get last offset
+            (unsafe { *offset_buffer.add(len - 1) }) as usize
+        }
+        // buffer len of primitive types
+        _ => array.length as usize,
+    })
+}
+
+pub fn child<A: ArrowArrayRef>(array: A, index: usize) -> Result<ArrowArrayChild<'static>> {
+    assert!(index < array.array().n_children as usize);
+    assert!(!array.array().children.is_null());
+    assert!(!array.schema().children.is_null());
+    unsafe {
+        let arr_ptr = *array.array().children.add(index);
+        let schema_ptr = *array.schema().children.add(index);
+        // todo: assert non-null
+        let arr_ptr = &*arr_ptr;
+        let schema_ptr = &*schema_ptr;
+        Ok(ArrowArrayChild::from_raw(
+            arr_ptr,
+            schema_ptr,
+            array.parent().clone(),
+        ))
     }
+}
+
+pub trait ArrowArrayRef {
+    fn deallocation(&self) -> Deallocation {
+        Deallocation::Foreign(self.parent().clone())
+    }
+
+    /// returns the null bit buffer.
+    /// Rust implementation uses a buffer that is not part of the array of buffers.
+    /// The C Data interface's null buffer is part of the array of buffers.
+    /// # Safety
+    /// The caller must guarantee that the buffer `index` corresponds to a bitmap.
+    /// This function assumes that the bitmap created from FFI is valid; this is impossible to prove.
+    unsafe fn validity(&self) -> Option<Bitmap> {
+        create_bitmap(self.array(), self.deallocation(), 0)
+    }
+
+    /// # Safety
+    /// The caller must guarantee that the buffer `index` corresponds to a bitmap.
+    /// This function assumes that the bitmap created from FFI is valid; this is impossible to prove.
+    unsafe fn buffer<T: NativeType>(&self, index: usize) -> Result<Buffer<T>> {
+        // +1 to ignore null bitmap
+        let index = index + 1;
+        create_buffer::<T>(self.array(), &self.data_type()?, self.deallocation(), index)
+    }
+
+    /// # Safety
+    /// The caller must guarantee that the buffer `index` corresponds to a bitmap.
+    /// This function assumes that the bitmap created from FFI is valid; this is impossible to prove.
+    unsafe fn bitmap(&self, index: usize) -> Result<Bitmap> {
+        // +1 to ignore null bitmap
+        create_bitmap(self.array(), self.deallocation(), index + 1).ok_or_else(|| {
+            ArrowError::Ffi(format!(
+                "The external buffer at position {} is null.",
+                index - 1
+            ))
+        })
+    }
+
+    fn parent(&self) -> &Arc<ArrowArray>;
+    fn array(&self) -> &Ffi_ArrowArray;
+    fn schema(&self) -> &Ffi_ArrowSchema;
+    fn data_type(&self) -> Result<DataType>;
+    fn child(&self, index: usize) -> Result<ArrowArrayChild>;
 }
 
 /// Struct used to move an Array from and to the C Data Interface.
@@ -370,164 +591,103 @@ impl Drop for Ffi_ArrowArray {
 /// Furthermore, this struct assumes that the incoming data agrees with the C data interface.
 #[derive(Debug)]
 pub struct ArrowArray {
-    // these are ref-counted because they can be shared by multiple buffers.
     array: Arc<Ffi_ArrowArray>,
     schema: Arc<Ffi_ArrowSchema>,
 }
 
+impl ArrowArrayRef for Arc<ArrowArray> {
+    /// the data_type as declared in the schema
+    fn data_type(&self) -> Result<DataType> {
+        to_field(&self.schema).map(|x| x.data_type().clone())
+    }
+
+    fn parent(&self) -> &Arc<ArrowArray> {
+        &self
+    }
+
+    fn array(&self) -> &Ffi_ArrowArray {
+        self.array.as_ref()
+    }
+
+    fn schema(&self) -> &Ffi_ArrowSchema {
+        self.schema.as_ref()
+    }
+
+    fn child(&self, index: usize) -> Result<ArrowArrayChild> {
+        child(self.clone(), index)
+    }
+}
+
+#[derive(Debug)]
+pub struct ArrowArrayChild<'a> {
+    array: &'a Ffi_ArrowArray,
+    schema: &'a Ffi_ArrowSchema,
+    parent: Arc<ArrowArray>,
+}
+
+impl<'a> ArrowArrayRef for ArrowArrayChild<'a> {
+    /// the data_type as declared in the schema
+    fn data_type(&self) -> Result<DataType> {
+        to_field(self.schema).map(|x| x.data_type().clone())
+    }
+
+    fn parent(&self) -> &Arc<ArrowArray> {
+        &self.parent
+    }
+
+    fn array(&self) -> &Ffi_ArrowArray {
+        self.array
+    }
+
+    fn schema(&self) -> &Ffi_ArrowSchema {
+        self.schema
+    }
+
+    fn child(&self, _: usize) -> Result<ArrowArrayChild> {
+        todo!()
+    }
+}
+
+impl<'a> ArrowArrayChild<'a> {
+    fn from_raw(
+        array: &'a Ffi_ArrowArray,
+        schema: &'a Ffi_ArrowSchema,
+        parent: Arc<ArrowArray>,
+    ) -> Self {
+        Self {
+            array,
+            schema,
+            parent,
+        }
+    }
+}
+
 impl ArrowArray {
-    /// creates a new `ArrowArray`. This is used to export to the C Data Interface.
-    /// # Safety
-    /// See safety of [ArrowArray]
-    pub fn try_new(array: Arc<dyn Array>) -> Result<Self> {
-        let format = from_datatype(array.data_type())?;
-
-        let schema = Arc::new(Ffi_ArrowSchema::new(&format));
-        let array = Arc::new(Ffi_ArrowArray::new(array));
-
-        Ok(ArrowArray { schema, array })
+    pub fn create_empty() -> Self {
+        Self {
+            array: Arc::new(Ffi_ArrowArray::empty()),
+            schema: Arc::new(Ffi_ArrowSchema::empty()),
+        }
     }
 
-    /// creates a new [ArrowArray] from two pointers. Used to import from the C Data Interface.
-    /// # Safety
-    /// See safety of [ArrowArray]
-    /// # Error
-    /// Errors if any of the pointers is null
-    pub unsafe fn try_from_raw(
-        array: *const Ffi_ArrowArray,
-        schema: *const Ffi_ArrowSchema,
-    ) -> Result<Self> {
-        if array.is_null() || schema.is_null() {
-            return Err(ArrowError::Ffi(
-                "At least one of the pointers passed to `try_from_raw` is null".to_string(),
-            ));
-        };
+    pub fn export_to_c(array: Arc<dyn Array>) -> Result<Self> {
+        let field = Field::new("", array.data_type().clone(), array.null_count() != 0);
+
         Ok(Self {
-            array: Arc::from_raw(array as *mut Ffi_ArrowArray),
-            schema: Arc::from_raw(schema as *mut Ffi_ArrowSchema),
+            array: Arc::new(Ffi_ArrowArray::new(array)),
+            schema: Arc::new(Ffi_ArrowSchema::try_new(field)?),
         })
     }
 
-    /// creates a new empty [ArrowArray]. Used to import from the C Data Interface.
-    /// # Safety
-    /// See safety of [ArrowArray]
-    pub unsafe fn empty() -> Self {
-        let schema = Arc::new(Ffi_ArrowSchema::empty());
-        let array = Arc::new(Ffi_ArrowArray::empty());
-        ArrowArray { schema, array }
-    }
-
-    /// exports [ArrowArray] to the C Data Interface
-    pub fn into_raw(this: ArrowArray) -> (*const Ffi_ArrowArray, *const Ffi_ArrowSchema) {
-        (Arc::into_raw(this.array), Arc::into_raw(this.schema))
-    }
-
-    /// returns the null bit buffer.
-    /// Rust implementation uses a buffer that is not part of the array of buffers.
-    /// The C Data interface's null buffer is part of the array of buffers.
-    pub fn validity(&self) -> Option<Bitmap> {
-        let len = self.array.length;
-        unsafe { create_bitmap(self.array.clone(), 0, len as usize) }
-    }
-
-    /// Returns the length, in slots, of the buffer `i` (indexed according to the C data interface)
-    // Rust implementation uses fixed-sized buffers, which require knowledge of their `len`.
-    // for variable-sized buffers, such as the second buffer of a stringArray, we need
-    // to fetch offset buffer's len to build the second buffer.
-    fn buffer_len(&self, i: usize) -> Result<usize> {
-        let data_type = &self.data_type()?;
-
-        Ok(match (data_type, i) {
-            (DataType::Utf8, 1)
-            | (DataType::LargeUtf8, 1)
-            | (DataType::Binary, 1)
-            | (DataType::LargeBinary, 1) => {
-                // the len of the offset buffer (buffer 1) equals length + 1
-                self.array.length as usize + 1
-            }
-            (DataType::Utf8, 2) | (DataType::Binary, 2) => {
-                // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
-                let len = self.buffer_len(1)?;
-                // first buffer is the null buffer => add(1)
-                let offset_buffer = unsafe { *(self.array.buffers as *mut *const u8).add(1) };
-                // interpret as i32
-                let offset_buffer = offset_buffer as *const i32;
-                // get last offset
-                (unsafe { *offset_buffer.add(len - 1) }) as usize
-            }
-            (DataType::LargeUtf8, 2) | (DataType::LargeBinary, 2) => {
-                // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
-                let len = self.buffer_len(1)?;
-                // first buffer is the null buffer => add(1)
-                let offset_buffer = unsafe { *(self.array.buffers as *mut *const u8).add(1) };
-                // interpret as i64
-                let offset_buffer = offset_buffer as *const i64;
-                // get last offset
-                (unsafe { *offset_buffer.add(len - 1) }) as usize
-            }
-            // buffer len of primitive types
-            _ => self.array.length as usize,
-        })
-    }
-
-    /// returns all buffers, as organized by Rust (i.e. null buffer is skipped)
-    /// # Safety
-    /// The caller must guarantee that the buffer `index` corresponds to a buffer of type `T`.
-    /// This function assumes that the buffer created from FFI is valid; this is impossible to prove.
-    pub unsafe fn buffer<T: NativeType>(&self, index: usize) -> Result<Buffer<T>> {
-        // + 1: skip null buffer
-        let index = (index + 1) as usize;
-
-        let len = self.buffer_len(index)?;
-
-        create_buffer(self.array.clone(), index, len).ok_or_else(|| {
-            ArrowError::Ffi(format!(
-                "The external buffer at position {} is null.",
-                index - 1
-            ))
-        })
-    }
-
-    /// returns all buffers, as organized by Rust (i.e. null buffer is skipped)
-    /// # Safety
-    /// The caller must guarantee that the buffer `index` corresponds to a bitmap.
-    /// This function assumes that the buffer created from FFI is valid; this is impossible to prove.
-    pub unsafe fn bitmap(&self, index: usize) -> Result<Bitmap> {
-        // + 1: skip null buffer
-        let index = (index + 1) as usize;
-
-        let len = bytes_for(self.array.length as usize);
-
-        create_bitmap(self.array.clone(), index, len).ok_or_else(|| {
-            ArrowError::Ffi(format!(
-                "The external buffer at position {} is null.",
-                index - 1
-            ))
-        })
-    }
-
-    /// the length of the array
-    pub fn len(&self) -> usize {
-        self.array.length as usize
-    }
-
-    /// whether the array is empty
-    pub fn is_empty(&self) -> bool {
-        self.array.length == 0
-    }
-
-    /// the offset of the array
-    pub fn offset(&self) -> usize {
-        self.array.offset as usize
+    pub fn references(&self) -> (*mut Ffi_ArrowArray, *mut Ffi_ArrowSchema) {
+        (
+            self.array.as_ref() as *const Ffi_ArrowArray as *mut Ffi_ArrowArray,
+            self.schema.as_ref() as *const Ffi_ArrowSchema as *mut Ffi_ArrowSchema,
+        )
     }
 
     /// the null count of the array
     pub fn null_count(&self) -> usize {
         self.array.null_count as usize
-    }
-
-    /// the data_type as declared in the schema
-    pub fn data_type(&self) -> Result<DataType> {
-        to_datatype(self.schema.format())
     }
 }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -15,48 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Contains declarations to bind to the [C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html).
-//!
-//! Generally, this module is divided in two main interfaces:
-//! One interface maps C ABI to native Rust types, i.e. convert c-pointers, c_char, to native rust.
-//! This is handled by [Ffi_ArrowSchema] and [Ffi_ArrowArray].
-//!
-//! The second interface maps native Rust types to the Rust-specific implementation of Arrow such as `format` to `Datatype`,
-//! `Buffer`, etc. This is handled by `ArrowArray`.
-//!
-//! ```rust
-//! # use std::sync::Arc;
-//! # use arrow2::array::{Array, Primitive, Int32Array};
-//! # use arrow2::error::{Result, ArrowError};
-//! # use arrow2::ffi::ArrowArray;
-//! # use arrow2::datatypes::DataType;
-//! # use std::convert::TryFrom;
-//! # fn main() -> Result<()> {
-//! // create an array natively
-//! let array = Arc::new(Primitive::from(&[Some(1i32), None, Some(3)]).to(DataType::Int32)) as Arc<dyn Array>;
-//!
-//! // export it
-//! let array = ArrowArray::try_from(array)?;
-//! let (array, schema) = ArrowArray::into_raw(array);
-//!
-//! // consumed and used by something else...
-//!
-//! // import it
-//! let array = unsafe { ArrowArray::try_from_raw(array, schema) }?;
-//! let array = Box::<dyn Array>::try_from(array)?;
-//!
-//! // perform some operation
-//! let array = array.as_any().downcast_ref::<Int32Array>().unwrap();
-//!
-//! // verify
-//! let expected = Primitive::from(&[Some(1i32), None, Some(3)]).to(DataType::Int32);
-//! assert_eq!(array, &expected);
-//!
-//! // (drop/release)
-//! Ok(())
-//! }
-//! ```
-
 mod array;
 #[allow(clippy::module_inception)]
 mod ffi;
@@ -69,6 +27,4 @@ trait ToFfi {
 }
 
 pub use array::try_from;
-pub use ffi::ArrowArray;
-pub use ffi::ArrowArrayRef;
-pub use ffi::{child, Ffi_ArrowArray, Ffi_ArrowSchema};
+pub use ffi::{create_empty, export_to_c, ArrowArray, ArrowArrayRef};

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -68,5 +68,7 @@ trait ToFfi {
     fn offset(&self) -> usize;
 }
 
+pub use array::try_from;
 pub use ffi::ArrowArray;
-pub(crate) use ffi::Ffi_ArrowArray;
+pub use ffi::ArrowArrayRef;
+pub use ffi::{child, Ffi_ArrowArray, Ffi_ArrowSchema};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod compute;
 pub mod io;
 pub mod record_batch;
 pub mod temporal_conversions;
+pub use alloc::total_allocated_bytes;
 
 #[cfg(feature = "benchmarks")]
 pub mod bits;


### PR DESCRIPTION
This PR:

* Fixes the FFI implementation to output the correct number of buffers (it was always 3, now it depends on `DataType`)
* Adds support for nested types (`[Large]List` and `Struct`)
* Adds FFI integration tests against pyarrow==4
* Exposes function with currently allocated bytes (to check them as part of the integration tests)

MIRI reports no leaks or UB in unit-tests. Allocations from C++ and Rust report no leaks in integration tests.