### PR TITLE
Greatly simplified the creation of new primitive arrays

### DIFF
--- a/guide/src/high_level.md
+++ b/guide/src/high_level.md
@@ -21,7 +21,7 @@ assert_eq!(array.len(), 3)
 A `PrimitiveArray` has 3 components:
 
 1. A physical type (`i32`)
-2. A logical type (`DataType::Int32`)
+2. A logical type (e.g. `DataType::Int32`)
 3. Data
 
 The main differences from a `Vec<Option<T>>` are:
@@ -41,6 +41,18 @@ let dates = Primitive::<i32>::from(&[Some(1), None]).to(DataType::Date32);
 ```
 
 `ints` and `dates` have the same in-memory representation but different logic representations (e.g. dates are usually represented as a string).
+
+Some physical types (e.g. `i32`) have a "natural" logical `DataType` (e.g. `DataType::Int32`).
+These types support a more compact notation:
+
+```rust
+# use arrow2::array::{Array, PrimitiveArray, Primitive};
+# use arrow2::datatypes::DataType;
+# fn main() {
+let array: PrimitiveArray<i32> = [Some(1), None, Some(123)].iter().collect();
+assert_eq!(array.len(), 3)
+# }
+```
 
 The following arrays are supported:
 

--- a/src/array/primitive/from_natural.rs
+++ b/src/array/primitive/from_natural.rs
@@ -1,0 +1,73 @@
+use std::iter::FromIterator;
+
+use crate::{
+    buffer::MutableBuffer,
+    trusted_len::TrustedLen,
+    types::{NativeType, NaturalDataType},
+};
+
+use super::{Primitive, PrimitiveArray};
+
+impl<T: NativeType + NaturalDataType, P: AsRef<[Option<T>]>> From<P> for PrimitiveArray<T> {
+    fn from(slice: P) -> Self {
+        Primitive::<T>::from_trusted_len_iter(slice.as_ref().iter().map(|x| x.as_ref()))
+            .to(T::DATA_TYPE)
+    }
+}
+
+impl<T: NativeType + NaturalDataType, Ptr: std::borrow::Borrow<Option<T>>> FromIterator<Ptr>
+    for PrimitiveArray<T>
+{
+    fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
+        Primitive::<T>::from_iter(iter).to(T::DATA_TYPE)
+    }
+}
+
+impl<T: NativeType + NaturalDataType> PrimitiveArray<T> {
+    /// Creates a new array out an iterator over values
+    pub fn from_values<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self::from_data(
+            T::DATA_TYPE,
+            MutableBuffer::<T>::from_iter(iter).into(),
+            None,
+        )
+    }
+}
+
+impl<T: NativeType + NaturalDataType> PrimitiveArray<T> {
+    /// Creates a new array out an iterator over values
+    pub fn from_trusted_len_values_iter<I: TrustedLen<Item = T>>(iter: I) -> Self {
+        Self::from_data(
+            T::DATA_TYPE,
+            MutableBuffer::<T>::from_trusted_len_iter(iter).into(),
+            None,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::array::Array;
+
+    use super::*;
+    use std::iter::FromIterator;
+
+    #[test]
+    fn bla() {
+        let data = vec![Some(1), None, Some(10)];
+
+        let array = PrimitiveArray::from(data.clone());
+        assert_eq!(array.len(), 3);
+
+        let array = PrimitiveArray::from_iter(data);
+        assert_eq!(array.len(), 3);
+
+        let data = vec![1i32, 2, 3];
+
+        let array = PrimitiveArray::from_values(data.clone());
+        assert_eq!(array.len(), 3);
+
+        let array = PrimitiveArray::from_trusted_len_values_iter(data.into_iter());
+        assert_eq!(array.len(), 3);
+    }
+}

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -119,6 +119,7 @@ impl<T: NativeType> Array for PrimitiveArray<T> {
 mod display;
 mod ffi;
 mod from;
+mod from_natural;
 pub use from::Primitive;
 mod iterator;
 pub use iterator::*;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,6 +10,12 @@ pub use simd::Simd;
 
 use crate::datatypes::{DataType, IntervalUnit};
 
+/// Trait denoting anything that has a natural, constant type.
+/// For example, `i32` has a natural datatype, [`DataType::Int32`].
+pub trait NaturalDataType {
+    const DATA_TYPE: DataType;
+}
+
 pub unsafe trait Relation {
     fn is_valid(data_type: &DataType) -> bool;
 }
@@ -21,6 +27,14 @@ macro_rules! create_relation {
             fn is_valid(data_type: &DataType) -> bool {
                 matches!(data_type, $($impl_pattern)|+)
             }
+        }
+    };
+}
+
+macro_rules! natural_type {
+    ($type:ty, $data_type:expr) => {
+        impl NaturalDataType for $type {
+            const DATA_TYPE: DataType = $data_type;
         }
     };
 }
@@ -83,6 +97,17 @@ native!(i64);
 native!(i128);
 native!(f32);
 native!(f64);
+
+natural_type!(u8, DataType::UInt8);
+natural_type!(u16, DataType::UInt16);
+natural_type!(u32, DataType::UInt32);
+natural_type!(u64, DataType::UInt64);
+natural_type!(i8, DataType::Int8);
+natural_type!(i16, DataType::Int16);
+natural_type!(i32, DataType::Int32);
+natural_type!(i64, DataType::Int64);
+natural_type!(f32, DataType::Float32);
+natural_type!(f64, DataType::Float64);
 
 create_relation!(u8, &DataType::UInt8);
 create_relation!(u16, &DataType::UInt16);


### PR DESCRIPTION
This PR allows to write

```
let array: PrimitiveArray<i32> = [Some(1), None, Some(123)]
    .iter()
    .collect();
```

by declaring a "Natural DataType" associated to some physical types. Not all physical types have this relationship (e.g. `i128`), but for those that have, this simplifies a lot the API around creating new primitive arrays by not requiring a `DataType`. For all other types, `from_data` and the `Primitive` API continue to exist.

(how I only remembered about this until now 🤦)