### PR TITLE
Added support to write non-native parquet types

### DIFF
--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -3,12 +3,17 @@ mod primitive;
 mod schema;
 mod utf8;
 
-use parquet2::{compression::CompressionCodec, read::CompressedPage};
-
 use crate::array::*;
 use crate::datatypes::*;
 use crate::error::Result;
 
+pub use parquet2::{
+    compression::CompressionCodec,
+    metadata::SchemaDescriptor,
+    read::CompressedPage,
+    read::{get_page_iterator, read_metadata},
+    write::write_file,
+};
 pub use schema::to_parquet_type;
 
 pub fn array_to_page(array: &dyn Array) -> Result<CompressedPage> {
@@ -18,18 +23,51 @@ pub fn array_to_page(array: &dyn Array) -> Result<CompressedPage> {
         DataType::Boolean => {
             boolean::array_to_page_v1(array.as_any().downcast_ref().unwrap(), compression)
         }
-        DataType::Int32 => {
-            primitive::array_to_page_v1::<i32>(array.as_any().downcast_ref().unwrap(), compression)
+        // casts below MUST match the casts done at the metadata (field -> parquet type).
+        DataType::UInt8 => primitive::array_to_page_v1::<u8, i32>(
+            array.as_any().downcast_ref().unwrap(),
+            compression,
+        ),
+        DataType::UInt16 => primitive::array_to_page_v1::<u16, i32>(
+            array.as_any().downcast_ref().unwrap(),
+            compression,
+        ),
+        DataType::UInt32 => primitive::array_to_page_v1::<u32, i32>(
+            array.as_any().downcast_ref().unwrap(),
+            compression,
+        ),
+        DataType::UInt64 => primitive::array_to_page_v1::<u64, i64>(
+            array.as_any().downcast_ref().unwrap(),
+            compression,
+        ),
+        DataType::Int8 => primitive::array_to_page_v1::<i8, i32>(
+            array.as_any().downcast_ref().unwrap(),
+            compression,
+        ),
+        DataType::Int16 => primitive::array_to_page_v1::<i16, i32>(
+            array.as_any().downcast_ref().unwrap(),
+            compression,
+        ),
+        DataType::Int32 | DataType::Date32 | DataType::Time32(_) => {
+            primitive::array_to_page_v1::<i32, i32>(
+                array.as_any().downcast_ref().unwrap(),
+                compression,
+            )
         }
-        DataType::Int64 => {
-            primitive::array_to_page_v1::<i64>(array.as_any().downcast_ref().unwrap(), compression)
+        DataType::Int64 | DataType::Date64 | DataType::Time64(_) | DataType::Timestamp(_, _) => {
+            primitive::array_to_page_v1::<i64, i64>(
+                array.as_any().downcast_ref().unwrap(),
+                compression,
+            )
         }
-        DataType::Float32 => {
-            primitive::array_to_page_v1::<f32>(array.as_any().downcast_ref().unwrap(), compression)
-        }
-        DataType::Float64 => {
-            primitive::array_to_page_v1::<f64>(array.as_any().downcast_ref().unwrap(), compression)
-        }
+        DataType::Float32 => primitive::array_to_page_v1::<f32, f32>(
+            array.as_any().downcast_ref().unwrap(),
+            compression,
+        ),
+        DataType::Float64 => primitive::array_to_page_v1::<f64, f64>(
+            array.as_any().downcast_ref().unwrap(),
+            compression,
+        ),
         DataType::Utf8 => {
             utf8::array_to_page_v1::<i32>(array.as_any().downcast_ref().unwrap(), compression)
         }
@@ -42,18 +80,11 @@ pub fn array_to_page(array: &dyn Array) -> Result<CompressedPage> {
 
 #[cfg(test)]
 mod tests {
-    use std::io::{Cursor, Read, Seek};
-
     use super::*;
-
-    use parquet2::{
-        metadata::SchemaDescriptor,
-        read::{get_page_iterator, read_metadata},
-        write::write_file,
-    };
 
     use crate::error::Result;
     use crate::io::parquet::read::page_iter_to_array;
+    use std::io::{Cursor, Read, Seek};
 
     use super::super::tests::*;
 
@@ -72,14 +103,14 @@ mod tests {
 
     fn round_trip_optional(column: usize) -> Result<()> {
         let array = pyarrow_nullable(column);
+        let field = Field::new("a1", array.data_type().clone(), true);
+
+        let parquet_type = to_parquet_type(&field)?;
+        let schema = SchemaDescriptor::new("root".to_string(), vec![parquet_type]);
 
         let row_groups = std::iter::once(Result::Ok(std::iter::once(Ok(std::iter::once(
             array_to_page(array.as_ref()),
         )))));
-
-        let field = Field::new("a1", array.data_type().clone(), true);
-        let parquet_type = to_parquet_type(&field)?;
-        let schema = SchemaDescriptor::new("root".to_string(), vec![parquet_type]);
 
         let mut writer = Cursor::new(vec![]);
         write_file(


### PR DESCRIPTION
So far, only native parquet types (i.e. whose physical representation was supported by parquet) was supported. This PR adds support for non-native types.

We still need to add integration tests against pyarrow for the writer.
