### PR TITLE
Removed need of unsafe call.

### DIFF
--- a/src/array/growable/boolean.rs
+++ b/src/array/growable/boolean.rs
@@ -63,7 +63,7 @@ impl<'a> Growable<'a> for GrowableBoolean<'a> {
         let array = self.arrays[index];
         let values = array.values();
         let iter = (start..start + len).map(|i| values.get_bit(i));
-        unsafe { self.values.extend_from_trusted_len_iter(iter) };
+        unsafe { self.values.extend_from_trusted_len_iter_unchecked(iter) };
     }
 
     fn extend_validity(&mut self, additional: usize) {

--- a/src/array/growable/utils.rs
+++ b/src/array/growable/utils.rs
@@ -26,14 +26,14 @@ pub(super) fn build_extend_null_bits(array: &dyn Array, use_validity: bool) -> E
             assert!(start + len <= bitmap.len());
             unsafe {
                 let iter = (start..start + len).map(|i| bitmap.get_bit_unchecked(i));
-                validity.extend_from_trusted_len_iter(iter);
+                validity.extend_from_trusted_len_iter_unchecked(iter);
             };
         })
     } else if use_validity {
         Box::new(|validity, _, len| {
             let iter = (0..len).map(|_| true);
             unsafe {
-                validity.extend_from_trusted_len_iter(iter);
+                validity.extend_from_trusted_len_iter_unchecked(iter);
             };
         })
     } else {
@@ -53,7 +53,7 @@ pub(super) fn extend_validity(
         assert!(start + len <= bitmap.len());
         unsafe {
             let iter = (start..start + len).map(|i| bitmap.get_bit_unchecked(i));
-            mutable_validity.extend_from_trusted_len_iter(iter);
+            mutable_validity.extend_from_trusted_len_iter_unchecked(iter);
         };
     } else if use_validity {
         mutable_validity.extend_constant(len, true);


### PR DESCRIPTION
This removes the need for using `unsafe` to extend bitmaps from a trusted len iter.