### PR TITLE
Fixed error about valid time32 and time64.

### DIFF
--- a/src/compute/arithmetics/time.rs
+++ b/src/compute/arithmetics/time.rs
@@ -156,20 +156,19 @@ where
 /// assert_eq!(result, expected);
 ///
 /// ```
-pub fn subtract_duration<T, D>(
+pub fn subtract_duration<T>(
     time: &PrimitiveArray<T>,
-    duration: &PrimitiveArray<D>,
+    duration: &PrimitiveArray<i64>,
 ) -> Result<PrimitiveArray<T>>
 where
     f64: AsPrimitive<T>,
     T: NativeType + Sub<T, Output = T>,
-    D: NativeType + AsPrimitive<f64>,
 {
     let scale = create_scale(time.data_type(), duration.data_type())?;
 
     // Closure for the binary operation. The closure contains the scale
     // required to add a duration to the timestamp array.
-    let op = move |a: T, b: D| a - (b.as_() * scale).as_();
+    let op = move |a: T, b: i64| a - (b as f64 * scale).as_();
 
     binary(time, duration, time.data_type().clone(), op)
 }
@@ -552,26 +551,6 @@ mod tests {
         .to(DataType::Time32(TimeUnit::Second));
 
         assert_eq!(result, expected);
-
-        // Testing Time64
-        let time_64 = Primitive::from(&vec![
-            Some(100000i64),
-            Some(200000i64),
-            None,
-            Some(300000i64),
-        ])
-        .to(DataType::Time64(TimeUnit::Second));
-
-        let result = add_duration(&time_64, &duration).unwrap();
-        let expected = Primitive::from(&vec![
-            Some(100010i64),
-            Some(200020i64),
-            None,
-            Some(300030i64),
-        ])
-        .to(DataType::Time64(TimeUnit::Second));
-
-        assert_eq!(result, expected);
     }
 
     #[test]
@@ -596,26 +575,6 @@ mod tests {
             Some(299970i32),
         ])
         .to(DataType::Time32(TimeUnit::Second));
-
-        assert_eq!(result, expected);
-
-        // Testing Time64
-        let time_64 = Primitive::from(&vec![
-            Some(100000i64),
-            Some(200000i64),
-            None,
-            Some(300000i64),
-        ])
-        .to(DataType::Time64(TimeUnit::Second));
-
-        let result = subtract_duration(&time_64, &duration).unwrap();
-        let expected = Primitive::from(&vec![
-            Some(99990i64),
-            Some(199980i64),
-            None,
-            Some(299970i64),
-        ])
-        .to(DataType::Time64(TimeUnit::Second));
 
         assert_eq!(result, expected);
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,7 +7,7 @@ mod bit_chunk;
 pub use bit_chunk::{BitChunk, BitChunkIter};
 pub mod simd;
 
-use crate::datatypes::{DataType, IntervalUnit};
+use crate::datatypes::{DataType, IntervalUnit, TimeUnit};
 
 /// Trait denoting anything that has a natural, constant type.
 /// For example, `i32` has a natural datatype, [`DataType::Int32`].
@@ -117,7 +117,8 @@ create_relation!(
     i32,
     &DataType::Int32
         | &DataType::Date32
-        | &DataType::Time32(_)
+        | &DataType::Time32(TimeUnit::Millisecond)
+        | &DataType::Time32(TimeUnit::Second)
         | &DataType::Interval(IntervalUnit::YearMonth)
 );
 
@@ -125,7 +126,8 @@ create_relation!(
     i64,
     &DataType::Int64
         | &DataType::Date64
-        | &DataType::Time64(_)
+        | &DataType::Time64(TimeUnit::Microsecond)
+        | &DataType::Time64(TimeUnit::Nanosecond)
         | &DataType::Timestamp(_, _)
         | &DataType::Duration(_)
 );


### PR DESCRIPTION
`Time32` and `Time64` should not accept any `TimeUnit`. This fixes it.