### PR TITLE
Adds roundtrip test over parquet

### DIFF
--- a/src/compute/arithmetics/time.rs
+++ b/src/compute/arithmetics/time.rs
@@ -156,20 +156,19 @@ where
 /// assert_eq!(result, expected);
 ///
 /// ```
-pub fn subtract_duration<T, D>(
+pub fn subtract_duration<T>(
     time: &PrimitiveArray<T>,
-    duration: &PrimitiveArray<D>,
+    duration: &PrimitiveArray<i64>,
 ) -> Result<PrimitiveArray<T>>
 where
     f64: AsPrimitive<T>,
     T: NativeType + Sub<T, Output = T>,
-    D: NativeType + AsPrimitive<f64>,
 {
     let scale = create_scale(time.data_type(), duration.data_type())?;
 
     // Closure for the binary operation. The closure contains the scale
     // required to add a duration to the timestamp array.
-    let op = move |a: T, b: D| a - (b.as_() * scale).as_();
+    let op = move |a: T, b: i64| a - (b as f64 * scale).as_();
 
     binary(time, duration, time.data_type().clone(), op)
 }
@@ -552,26 +551,6 @@ mod tests {
         .to(DataType::Time32(TimeUnit::Second));
 
         assert_eq!(result, expected);
-
-        // Testing Time64
-        let time_64 = Primitive::from(&vec![
-            Some(100000i64),
-            Some(200000i64),
-            None,
-            Some(300000i64),
-        ])
-        .to(DataType::Time64(TimeUnit::Second));
-
-        let result = add_duration(&time_64, &duration).unwrap();
-        let expected = Primitive::from(&vec![
-            Some(100010i64),
-            Some(200020i64),
-            None,
-            Some(300030i64),
-        ])
-        .to(DataType::Time64(TimeUnit::Second));
-
-        assert_eq!(result, expected);
     }
 
     #[test]
@@ -596,26 +575,6 @@ mod tests {
             Some(299970i32),
         ])
         .to(DataType::Time32(TimeUnit::Second));
-
-        assert_eq!(result, expected);
-
-        // Testing Time64
-        let time_64 = Primitive::from(&vec![
-            Some(100000i64),
-            Some(200000i64),
-            None,
-            Some(300000i64),
-        ])
-        .to(DataType::Time64(TimeUnit::Second));
-
-        let result = subtract_duration(&time_64, &duration).unwrap();
-        let expected = Primitive::from(&vec![
-            Some(99990i64),
-            Some(199980i64),
-            None,
-            Some(299970i64),
-        ])
-        .to(DataType::Time64(TimeUnit::Second));
 
         assert_eq!(result, expected);
     }

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -25,7 +25,7 @@
 #[allow(clippy::redundant_field_names)]
 pub mod gen;
 
-mod common;
+pub(crate) mod common;
 mod convert;
 
 pub use convert::fb_to_schema;

--- a/src/io/parquet/read/binary.rs
+++ b/src/io/parquet/read/binary.rs
@@ -1,0 +1,33 @@
+use parquet2::{metadata::ColumnDescriptor, read::CompressedPage};
+
+use crate::{
+    array::{BinaryArray, Offset},
+    bitmap::MutableBitmap,
+    buffer::MutableBuffer,
+    error::{ArrowError, Result},
+};
+
+use super::utf8::*;
+
+pub fn iter_to_array<O, I, E>(mut iter: I, descriptor: &ColumnDescriptor) -> Result<BinaryArray<O>>
+where
+    ArrowError: From<E>,
+    O: Offset,
+    I: Iterator<Item = std::result::Result<CompressedPage, E>>,
+{
+    // todo: push metadata from the file to get this capacity
+    let capacity = 0;
+    let mut values = MutableBuffer::<u8>::with_capacity(0);
+    let mut offsets = MutableBuffer::<O>::with_capacity(1 + capacity);
+    offsets.push(O::default());
+    let mut validity = MutableBitmap::with_capacity(capacity);
+    iter.try_for_each(|page| {
+        extend_from_page(page?, &descriptor, &mut offsets, &mut values, &mut validity)
+    })?;
+
+    Ok(BinaryArray::from_data(
+        offsets.into(),
+        values.into(),
+        validity.into(),
+    ))
+}

--- a/src/io/parquet/read/fixed_size_binary.rs
+++ b/src/io/parquet/read/fixed_size_binary.rs
@@ -1,14 +1,15 @@
 use parquet2::{
     encoding::{hybrid_rle, Encoding},
     metadata::ColumnDescriptor,
-    read::{decompress_page, BinaryPageDict, CompressedPage, Page},
+    read::{decompress_page, CompressedPage, FixedLenByteArrayPageDict, Page},
     serialization::read::levels,
 };
 
 use crate::{
-    array::{Offset, Utf8Array},
+    array::FixedSizeBinaryArray,
     bitmap::{BitmapIter, MutableBitmap},
     buffer::MutableBuffer,
+    datatypes::DataType,
     error::{ArrowError, Result},
 };
 
@@ -16,19 +17,18 @@ use super::utils;
 
 /// Assumptions: No rep levels
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn read_dict_buffer<O: Offset>(
+pub(crate) fn read_dict_buffer(
     validity_buffer: &[u8],
     indices_buffer: &[u8],
     length: u32,
-    dict: &BinaryPageDict,
-    offsets: &mut MutableBuffer<O>,
+    size: i32,
+    dict: &FixedLenByteArrayPageDict,
     values: &mut MutableBuffer<u8>,
     validity: &mut MutableBitmap,
 ) {
     let length = length as usize;
+    let size = size as usize;
     let dict_values = dict.values();
-    let dict_offsets = dict.offsets();
-    let mut last_offset = *offsets.as_slice_mut().last().unwrap();
 
     // SPEC: Data page format: the bit width used to encode the entry ids stored as 1 byte (max bit width = 32),
     // SPEC: followed by the values encoded using RLE/Bit packed described above (with the given bit width).
@@ -52,13 +52,10 @@ pub(crate) fn read_dict_buffer<O: Offset>(
                     validity.push(is_valid);
                     if is_valid {
                         let index = indices.next().unwrap() as usize;
-                        let dict_offset_i = dict_offsets[index] as usize;
-                        let dict_offset_ip1 = dict_offsets[index + 1] as usize;
-                        let length = dict_offset_ip1 - dict_offset_i;
-                        last_offset += O::from_usize(length).unwrap();
-                        values.extend_from_slice(&dict_values[dict_offset_i..dict_offset_ip1]);
-                    };
-                    offsets.push(last_offset);
+                        values.extend_from_slice(&dict_values[index..(index + 1) * size]);
+                    } else {
+                        values.extend_constant(size, 0);
+                    }
                 }
             }
             hybrid_rle::HybridEncoded::Rle(value, additional) => {
@@ -67,38 +64,34 @@ pub(crate) fn read_dict_buffer<O: Offset>(
                 if is_set {
                     (0..additional).for_each(|_| {
                         let index = indices.next().unwrap() as usize;
-                        let dict_offset_i = dict_offsets[index] as usize;
-                        let dict_offset_ip1 = dict_offsets[index + 1] as usize;
-                        let length = dict_offset_ip1 - dict_offset_i;
-                        last_offset += O::from_usize(length).unwrap();
-                        values.extend_from_slice(&dict_values[dict_offset_i..dict_offset_ip1]);
+                        values.extend_from_slice(&dict_values[index..(index + 1) * size]);
                     })
                 } else {
-                    offsets.extend_constant(additional, last_offset)
+                    values.extend_constant(additional * size, 0)
                 }
             }
         }
     }
 }
 
-pub(crate) fn read_optional<O: Offset>(
+pub(crate) fn read_optional(
     validity_buffer: &[u8],
     values_buffer: &[u8],
     length: u32,
-    offsets: &mut MutableBuffer<O>,
+    size: i32,
     values: &mut MutableBuffer<u8>,
     validity: &mut MutableBitmap,
 ) {
     let length = length as usize;
-    let mut last_offset = *offsets.as_slice_mut().last().unwrap();
+    let size = size as usize;
 
-    // values_buffer: first 4 bytes are len, remaining is values
-    let mut values_iterator = utils::BinaryIter::new(values_buffer);
+    assert_eq!(values_buffer.len() % size, 0);
+    let mut values_iterator = values_buffer.chunks_exact(size);
 
     let validity_iterator = hybrid_rle::Decoder::new(&validity_buffer, 1);
 
     validity.reserve(length);
-    values.reserve(length);
+    values.reserve(length * size);
     for run in validity_iterator {
         match run {
             hybrid_rle::HybridEncoded::Bitpacked(packed) => {
@@ -109,10 +102,10 @@ pub(crate) fn read_optional<O: Offset>(
                     validity.push(is_valid);
                     if is_valid {
                         let value = values_iterator.next().unwrap();
-                        last_offset += O::from_usize(value.len()).unwrap();
                         values.extend_from_slice(value);
+                    } else {
+                        values.extend_constant(size, 0)
                     }
-                    offsets.push(last_offset);
                 }
             }
             hybrid_rle::HybridEncoded::Rle(value, additional) => {
@@ -121,64 +114,48 @@ pub(crate) fn read_optional<O: Offset>(
                 if is_set {
                     (0..additional).for_each(|_| {
                         let value = values_iterator.next().unwrap();
-                        last_offset += O::from_usize(value.len()).unwrap();
-                        offsets.push(last_offset);
                         values.extend_from_slice(value)
                     })
                 } else {
-                    offsets.extend_constant(additional, last_offset)
+                    values.extend_constant(additional * size, 0)
                 }
             }
         }
     }
 }
 
-pub(crate) fn read_required<O: Offset>(
-    buffer: &[u8],
-    length: u32,
-    offsets: &mut MutableBuffer<O>,
-    values: &mut MutableBuffer<u8>,
-) {
-    let length = length as usize;
-    let mut last_offset = *offsets.as_slice_mut().last().unwrap();
-
-    let values_iterator = utils::BinaryIter::new(buffer);
-
-    offsets.reserve(length);
-    for value in values_iterator {
-        last_offset += O::from_usize(value.len()).unwrap();
-        values.extend_from_slice(value);
-        offsets.push(last_offset);
-    }
+pub(crate) fn read_required(buffer: &[u8], length: u32, size: i32, values: &mut MutableBuffer<u8>) {
+    assert_eq!(buffer.len(), length as usize * size as usize);
+    values.extend_from_slice(buffer);
 }
 
-pub fn iter_to_array<O, I, E>(mut iter: I, descriptor: &ColumnDescriptor) -> Result<Utf8Array<O>>
+pub fn iter_to_array<I, E>(
+    mut iter: I,
+    size: i32,
+    descriptor: &ColumnDescriptor,
+) -> Result<FixedSizeBinaryArray>
 where
     ArrowError: From<E>,
-    O: Offset,
     I: Iterator<Item = std::result::Result<CompressedPage, E>>,
 {
-    // todo: push metadata from the file to get this capacity
     let capacity = 0;
     let mut values = MutableBuffer::<u8>::with_capacity(0);
-    let mut offsets = MutableBuffer::<O>::with_capacity(1 + capacity);
-    offsets.push(O::default());
     let mut validity = MutableBitmap::with_capacity(capacity);
     iter.try_for_each(|page| {
-        extend_from_page(page?, &descriptor, &mut offsets, &mut values, &mut validity)
+        extend_from_page(page?, size, &descriptor, &mut values, &mut validity)
     })?;
 
-    Ok(Utf8Array::from_data(
-        offsets.into(),
+    Ok(FixedSizeBinaryArray::from_data(
+        DataType::FixedSizeBinary(size),
         values.into(),
         validity.into(),
     ))
 }
 
-pub(crate) fn extend_from_page<O: Offset>(
+pub(crate) fn extend_from_page(
     page: CompressedPage,
+    size: i32,
     descriptor: &ColumnDescriptor,
-    offsets: &mut MutableBuffer<O>,
     values: &mut MutableBuffer<u8>,
     validity: &mut MutableBitmap,
 ) -> Result<()> {
@@ -194,12 +171,12 @@ pub(crate) fn extend_from_page<O: Offset>(
                 (Encoding::PlainDictionary, Some(dict), true) => {
                     // split in two buffers: def_levels and data
                     let (validity_buffer, values_buffer) = utils::split_buffer_v1(&page.buffer);
-                    read_dict_buffer::<O>(
+                    read_dict_buffer(
                         validity_buffer,
                         values_buffer,
                         page.header.num_values as u32,
+                        size,
                         dict.as_any().downcast_ref().unwrap(),
-                        offsets,
                         values,
                         validity,
                     )
@@ -207,17 +184,17 @@ pub(crate) fn extend_from_page<O: Offset>(
                 (Encoding::Plain, None, true) => {
                     // split in two buffers: def_levels and data
                     let (validity_buffer, values_buffer) = utils::split_buffer_v1(&page.buffer);
-                    read_optional::<O>(
+                    read_optional(
                         validity_buffer,
                         values_buffer,
                         page.header.num_values as u32,
-                        offsets,
+                        size,
                         values,
                         validity,
                     )
                 }
                 (Encoding::Plain, None, false) => {
-                    read_required::<O>(&page.buffer, page.header.num_values as u32, offsets, values)
+                    read_required(&page.buffer, page.header.num_values as u32, size, values)
                 }
                 _ => {
                     return Err(utils::not_implemented(
@@ -237,12 +214,12 @@ pub(crate) fn extend_from_page<O: Offset>(
                 (Encoding::PlainDictionary, Some(dict), true) => {
                     let (validity_buffer, values_buffer) =
                         utils::split_buffer_v2(&page.buffer, def_level_buffer_length);
-                    read_dict_buffer::<O>(
+                    read_dict_buffer(
                         validity_buffer,
                         values_buffer,
                         page.header.num_values as u32,
+                        size,
                         dict.as_any().downcast_ref().unwrap(),
-                        offsets,
                         values,
                         validity,
                     )
@@ -250,17 +227,17 @@ pub(crate) fn extend_from_page<O: Offset>(
                 (Encoding::Plain, None, true) => {
                     let (validity_buffer, values_buffer) =
                         utils::split_buffer_v2(&page.buffer, def_level_buffer_length);
-                    read_optional::<O>(
+                    read_optional(
                         validity_buffer,
                         values_buffer,
                         page.header.num_values as u32,
-                        offsets,
+                        size,
                         values,
                         validity,
                     )
                 }
                 (Encoding::Plain, None, false) => {
-                    read_required::<O>(&page.buffer, page.header.num_values as u32, offsets, values)
+                    read_required(&page.buffer, page.header.num_values as u32, size, values)
                 }
                 _ => {
                     return Err(utils::not_implemented(

--- a/src/io/parquet/read/primitive.rs
+++ b/src/io/parquet/read/primitive.rs
@@ -17,13 +17,17 @@ use crate::{
     types::NativeType as ArrowNativeType,
 };
 
-fn read_dict_buffer_optional<T: NativeType + ArrowNativeType>(
+fn read_dict_buffer_optional<T, A>(
     buffer: &[u8],
     length: u32,
     dict: &PrimitivePageDict<T>,
-    values: &mut MutableBuffer<T>,
+    values: &mut MutableBuffer<A>,
     validity: &mut MutableBitmap,
-) {
+) where
+    T: NativeType,
+    A: ArrowNativeType,
+    T: num::cast::AsPrimitive<A>,
+{
     let (validity_buffer, indices_buffer) = utils::split_buffer_v1(buffer);
 
     let length = length as usize;
@@ -50,9 +54,9 @@ fn read_dict_buffer_optional<T: NativeType + ArrowNativeType>(
                 for is_valid in BitmapIter::new(packed, 0, len) {
                     validity.push(is_valid);
                     let value = if is_valid {
-                        dict_values[indices.next().unwrap() as usize]
+                        dict_values[indices.next().unwrap() as usize].as_()
                     } else {
-                        T::default()
+                        A::default()
                     };
                     values.push(value);
                 }
@@ -63,24 +67,28 @@ fn read_dict_buffer_optional<T: NativeType + ArrowNativeType>(
                 if is_set {
                     (0..additional).for_each(|_| {
                         let index = indices.next().unwrap() as usize;
-                        let value = dict_values[index];
+                        let value = dict_values[index].as_();
                         values.push(value)
                     })
                 } else {
-                    values.extend_constant(additional, T::default())
+                    values.extend_constant(additional, A::default())
                 }
             }
         }
     }
 }
 
-fn read_nullable<T: NativeType + ArrowNativeType>(
+fn read_nullable<T, A>(
     validity_buffer: &[u8],
     values_buffer: &[u8],
     length: u32,
-    values: &mut MutableBuffer<T>,
+    values: &mut MutableBuffer<A>,
     validity: &mut MutableBitmap,
-) {
+) where
+    T: NativeType,
+    A: ArrowNativeType,
+    T: num::cast::AsPrimitive<A>,
+{
     let length = length as usize;
 
     let mut chunks = values_buffer.chunks_exact(std::mem::size_of::<T>());
@@ -98,9 +106,9 @@ fn read_nullable<T: NativeType + ArrowNativeType>(
                 for is_valid in BitmapIter::new(packed, 0, len) {
                     validity.push(is_valid);
                     let value = if is_valid {
-                        types::decode(chunks.next().unwrap())
+                        types::decode::<T>(chunks.next().unwrap()).as_()
                     } else {
-                        T::default()
+                        A::default()
                     };
                     values.push(value);
                 }
@@ -110,22 +118,23 @@ fn read_nullable<T: NativeType + ArrowNativeType>(
                 validity.extend_constant(additional, is_set);
                 if is_set {
                     (0..additional).for_each(|_| {
-                        let value = types::decode(chunks.next().unwrap());
+                        let value = types::decode::<T>(chunks.next().unwrap()).as_();
                         values.push(value)
                     })
                 } else {
-                    values.extend_constant(additional, T::default())
+                    values.extend_constant(additional, A::default())
                 }
             }
         }
     }
 }
 
-fn read_required<T: NativeType + ArrowNativeType>(
-    values_buffer: &[u8],
-    length: u32,
-    values: &mut MutableBuffer<T>,
-) {
+fn read_required<T, A>(values_buffer: &[u8], length: u32, values: &mut MutableBuffer<A>)
+where
+    T: NativeType,
+    A: ArrowNativeType,
+    T: num::cast::AsPrimitive<A>,
+{
     // todo: for little endian machines this can be replaced by `extend_from_slice`
     // via transmute.
     let length = length as usize;
@@ -133,26 +142,30 @@ fn read_required<T: NativeType + ArrowNativeType>(
 
     let chunks = values_buffer[..length * size].chunks_exact(size);
 
-    let iter = chunks.map(|chunk| types::decode::<T>(chunk));
+    let iter = chunks.map(|chunk| types::decode::<T>(chunk).as_());
 
     values.extend(iter);
 }
 
-pub fn iter_to_array<T, I, E>(
+pub fn iter_to_array<T, A, I, E>(
     mut iter: I,
     descriptor: &ColumnDescriptor,
     data_type: DataType,
-) -> Result<PrimitiveArray<T>>
+) -> Result<PrimitiveArray<A>>
 where
     ArrowError: From<E>,
-    T: NativeType + ArrowNativeType,
+    T: NativeType,
+    A: ArrowNativeType,
+    T: num::cast::AsPrimitive<A>,
     I: Iterator<Item = std::result::Result<CompressedPage, E>>,
 {
     // todo: push metadata from the file to get this capacity
     let capacity = 0;
-    let mut values = MutableBuffer::<T>::with_capacity(capacity);
+    let mut values = MutableBuffer::<A>::with_capacity(capacity);
     let mut validity = MutableBitmap::with_capacity(capacity);
-    iter.try_for_each(|page| extend_from_page(page?, &descriptor, &mut values, &mut validity))?;
+    iter.try_for_each(|page| {
+        extend_from_page::<T, A>(page?, &descriptor, &mut values, &mut validity)
+    })?;
 
     Ok(PrimitiveArray::from_data(
         data_type,
@@ -161,12 +174,17 @@ where
     ))
 }
 
-fn extend_from_page<T: NativeType + ArrowNativeType>(
+fn extend_from_page<T, A>(
     page: CompressedPage,
     descriptor: &ColumnDescriptor,
-    values: &mut MutableBuffer<T>,
+    values: &mut MutableBuffer<A>,
     validity: &mut MutableBitmap,
-) -> Result<()> {
+) -> Result<()>
+where
+    T: NativeType,
+    A: ArrowNativeType,
+    T: num::cast::AsPrimitive<A>,
+{
     let page = decompress_page(page)?;
     assert_eq!(descriptor.max_rep_level(), 0);
     let is_optional = descriptor.max_def_level() == 1;
@@ -175,7 +193,7 @@ fn extend_from_page<T: NativeType + ArrowNativeType>(
             assert_eq!(page.header.definition_level_encoding, Encoding::Rle);
 
             match (&page.header.encoding, &page.dictionary_page, is_optional) {
-                (Encoding::PlainDictionary, Some(dict), true) => read_dict_buffer_optional::<T>(
+                (Encoding::PlainDictionary, Some(dict), true) => read_dict_buffer_optional::<T, A>(
                     &page.buffer,
                     page.header.num_values as u32,
                     dict.as_any().downcast_ref().unwrap(),
@@ -184,7 +202,7 @@ fn extend_from_page<T: NativeType + ArrowNativeType>(
                 ),
                 (Encoding::Plain, None, true) => {
                     let (validity_buffer, values_buffer) = utils::split_buffer_v1(&page.buffer);
-                    read_nullable::<T>(
+                    read_nullable::<T, A>(
                         validity_buffer,
                         values_buffer,
                         page.header.num_values as u32,
@@ -193,7 +211,7 @@ fn extend_from_page<T: NativeType + ArrowNativeType>(
                     )
                 }
                 (Encoding::Plain, None, false) => {
-                    read_required::<T>(&page.buffer, page.header.num_values as u32, values)
+                    read_required::<T, A>(&page.buffer, page.header.num_values as u32, values)
                 }
                 _ => {
                     return Err(utils::not_implemented(
@@ -207,7 +225,7 @@ fn extend_from_page<T: NativeType + ArrowNativeType>(
             }
         }
         Page::V2(page) => match (&page.header.encoding, &page.dictionary_page, is_optional) {
-            (Encoding::PlainDictionary, Some(dict), true) => read_dict_buffer_optional::<T>(
+            (Encoding::PlainDictionary, Some(dict), true) => read_dict_buffer_optional::<T, A>(
                 &page.buffer,
                 page.header.num_values as u32,
                 dict.as_any().downcast_ref().unwrap(),
@@ -218,7 +236,7 @@ fn extend_from_page<T: NativeType + ArrowNativeType>(
                 let def_level_buffer_length = page.header.definition_levels_byte_length as usize;
                 let (validity_buffer, values_buffer) =
                     utils::split_buffer_v2(&page.buffer, def_level_buffer_length);
-                read_nullable::<T>(
+                read_nullable::<T, A>(
                     validity_buffer,
                     values_buffer,
                     page.header.num_values as u32,
@@ -227,7 +245,7 @@ fn extend_from_page<T: NativeType + ArrowNativeType>(
                 )
             }
             (Encoding::Plain, None, false) => {
-                read_required::<T>(&page.buffer, page.header.num_values as u32, values)
+                read_required::<T, A>(&page.buffer, page.header.num_values as u32, values)
             }
             _ => {
                 return Err(utils::not_implemented(

--- a/src/io/parquet/read/schema/mod.rs
+++ b/src/io/parquet/read/schema/mod.rs
@@ -10,6 +10,8 @@ pub use metadata::read_schema_from_metadata;
 pub use parquet2::metadata::{FileMetaData, KeyValue, SchemaDescriptor};
 pub use parquet2::schema::types::ParquetType;
 
+pub(crate) use convert::{from_byte_array, from_fixed_len_byte_array, from_int32, from_int64};
+
 pub fn get_schema(metadata: &FileMetaData) -> Result<Schema> {
     let schema = read_schema_from_metadata(metadata.key_value_metadata())?;
     Ok(schema).transpose().unwrap_or_else(|| {

--- a/src/io/parquet/write/binary.rs
+++ b/src/io/parquet/write/binary.rs
@@ -1,0 +1,70 @@
+use parquet2::{
+    compression::create_codec,
+    encoding::Encoding,
+    read::{CompressedPage, PageV1},
+    schema::{CompressionCodec, DataPageHeader},
+};
+
+use super::utils;
+use crate::{
+    array::{Array, BinaryArray, Offset},
+    error::Result,
+};
+
+pub fn array_to_page_v1<O: Offset>(
+    array: &BinaryArray<O>,
+    compression: CompressionCodec,
+    is_optional: bool,
+) -> Result<CompressedPage> {
+    let validity = array.validity();
+
+    let mut buffer = utils::write_def_levels(is_optional, validity, array.len())?;
+
+    // append the non-null values
+    if is_optional {
+        array.iter().for_each(|x| {
+            if let Some(x) = x {
+                // BYTE_ARRAY: first 4 bytes denote length in littleendian.
+                let len = (x.len() as u32).to_le_bytes();
+                buffer.extend_from_slice(&len);
+                buffer.extend_from_slice(x);
+            }
+        })
+    } else {
+        array.values_iter().for_each(|x| {
+            // BYTE_ARRAY: first 4 bytes denote length in littleendian.
+            let len = (x.len() as u32).to_le_bytes();
+            buffer.extend_from_slice(&len);
+            buffer.extend_from_slice(x);
+        })
+    }
+    let uncompressed_page_size = buffer.len();
+
+    let codec = create_codec(&compression)?;
+    let buffer = if let Some(mut codec) = codec {
+        // todo: remove this allocation by extending `buffer` directly.
+        // needs refactoring `compress`'s API.
+        let mut tmp = vec![];
+        codec.compress(&buffer, &mut tmp)?;
+        tmp
+    } else {
+        buffer
+    };
+
+    let header = DataPageHeader {
+        num_values: array.len() as i32,
+        encoding: Encoding::Plain,
+        definition_level_encoding: Encoding::Rle,
+        repetition_level_encoding: Encoding::Rle,
+        statistics: None,
+    };
+
+    Ok(CompressedPage::V1(PageV1 {
+        buffer,
+        header,
+        compression,
+        uncompressed_page_size,
+        dictionary_page: None,
+        statistics: None,
+    }))
+}

--- a/src/io/parquet/write/fixed_len_bytes.rs
+++ b/src/io/parquet/write/fixed_len_bytes.rs
@@ -1,0 +1,64 @@
+use parquet2::{
+    compression::create_codec,
+    encoding::Encoding,
+    read::{CompressedPage, PageV1},
+    schema::{CompressionCodec, DataPageHeader},
+};
+
+use super::utils;
+use crate::{
+    array::{Array, FixedSizeBinaryArray},
+    error::Result,
+};
+
+pub fn array_to_page_v1(
+    array: &FixedSizeBinaryArray,
+    compression: CompressionCodec,
+    is_optional: bool,
+) -> Result<CompressedPage> {
+    let validity = array.validity();
+
+    let mut buffer = utils::write_def_levels(is_optional, validity, array.len())?;
+
+    if is_optional {
+        // append the non-null values
+        array.iter().for_each(|x| {
+            if let Some(x) = x {
+                buffer.extend_from_slice(x);
+            }
+        });
+    } else {
+        // append all values
+        buffer.extend_from_slice(array.values());
+    }
+
+    let uncompressed_page_size = buffer.len();
+
+    let codec = create_codec(&compression)?;
+    let buffer = if let Some(mut codec) = codec {
+        // todo: remove this allocation by extending `buffer` directly.
+        // needs refactoring `compress`'s API.
+        let mut tmp = vec![];
+        codec.compress(&buffer, &mut tmp)?;
+        tmp
+    } else {
+        buffer
+    };
+
+    let header = DataPageHeader {
+        num_values: array.len() as i32,
+        encoding: Encoding::Plain,
+        definition_level_encoding: Encoding::Rle,
+        repetition_level_encoding: Encoding::Rle,
+        statistics: None,
+    };
+
+    Ok(CompressedPage::V1(PageV1 {
+        buffer,
+        header,
+        compression,
+        uncompressed_page_size,
+        dictionary_page: None,
+        statistics: None,
+    }))
+}

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -1,11 +1,13 @@
+mod binary;
 mod boolean;
+mod fixed_len_bytes;
 mod primitive;
 mod schema;
 mod utf8;
 mod utils;
 
 use crate::datatypes::*;
-use crate::error::Result;
+use crate::error::{ArrowError, Result};
 use crate::{array::*, io::parquet::read::is_type_nullable};
 
 pub use parquet2::{
@@ -93,7 +95,29 @@ pub fn array_to_page(array: &dyn Array, type_: &ParquetType) -> Result<Compresse
             compression,
             is_optional,
         ),
-        _ => todo!(),
+        DataType::Binary => binary::array_to_page_v1::<i32>(
+            array.as_any().downcast_ref().unwrap(),
+            compression,
+            is_optional,
+        ),
+        DataType::LargeBinary => binary::array_to_page_v1::<i64>(
+            array.as_any().downcast_ref().unwrap(),
+            compression,
+            is_optional,
+        ),
+        DataType::Null => {
+            let array = Int32Array::new_null(DataType::Int32, array.len());
+            primitive::array_to_page_v1::<i32, i32>(&array, compression, is_optional)
+        }
+        DataType::FixedSizeBinary(_) => fixed_len_bytes::array_to_page_v1(
+            array.as_any().downcast_ref().unwrap(),
+            compression,
+            is_optional,
+        ),
+        other => Err(ArrowError::NotYetImplemented(format!(
+            "Writing the data type {:?} is not yet implemented",
+            other
+        ))),
     }
 }
 

--- a/src/io/parquet/write/primitive.rs
+++ b/src/io/parquet/write/primitive.rs
@@ -27,13 +27,21 @@ where
 
     let mut buffer = utils::write_def_levels(is_optional, validity, array.len())?;
 
-    // append the non-null values
-    array.iter().for_each(|x| {
-        if let Some(x) = x {
+    if is_optional {
+        // append the non-null values
+        array.iter().for_each(|x| {
+            if let Some(x) = x {
+                let parquet_native: R = x.as_();
+                buffer.extend_from_slice(parquet_native.to_le_bytes().as_ref())
+            }
+        });
+    } else {
+        // append all values
+        array.values().iter().for_each(|x| {
             let parquet_native: R = x.as_();
             buffer.extend_from_slice(parquet_native.to_le_bytes().as_ref())
-        }
-    });
+        });
+    }
     let uncompressed_page_size = buffer.len();
 
     let codec = create_codec(&compression)?;

--- a/src/io/parquet/write/schema.rs
+++ b/src/io/parquet/write/schema.rs
@@ -217,13 +217,18 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
                 name, repetition, None, None, fields, None,
             )?)
         }
-        DataType::Union(_) => Err(ArrowError::NotYetImplemented(
-            "Union still in progress".to_string(),
-        )),
         DataType::Dictionary(_, value) => {
             let dict_field = Field::new(name.as_str(), value.as_ref().clone(), field.is_nullable());
             to_parquet_type(&dict_field)
         }
+        DataType::FixedSizeBinary(size) => Ok(ParquetType::try_from_primitive(
+            name,
+            PhysicalType::FixedLenByteArray(*size),
+            repetition,
+            None,
+            None,
+            None,
+        )?),
         /*
         DataType::Interval(_) => {
             Type::primitive_type_builder(name, PhysicalType::FIXED_LEN_BYTE_ARRAY)
@@ -276,6 +281,9 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
                 .build()
         }
         */
-        _ => todo!(),
+        other => Err(ArrowError::NotYetImplemented(format!(
+            "Writing the data type {:?} is not yet implemented",
+            other
+        ))),
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,7 +7,7 @@ mod bit_chunk;
 pub use bit_chunk::{BitChunk, BitChunkIter};
 pub mod simd;
 
-use crate::datatypes::{DataType, IntervalUnit};
+use crate::datatypes::{DataType, IntervalUnit, TimeUnit};
 
 /// Trait denoting anything that has a natural, constant type.
 /// For example, `i32` has a natural datatype, [`DataType::Int32`].
@@ -117,7 +117,8 @@ create_relation!(
     i32,
     &DataType::Int32
         | &DataType::Date32
-        | &DataType::Time32(_)
+        | &DataType::Time32(TimeUnit::Millisecond)
+        | &DataType::Time32(TimeUnit::Second)
         | &DataType::Interval(IntervalUnit::YearMonth)
 );
 
@@ -125,7 +126,8 @@ create_relation!(
     i64,
     &DataType::Int64
         | &DataType::Date64
-        | &DataType::Time64(_)
+        | &DataType::Time64(TimeUnit::Microsecond)
+        | &DataType::Time64(TimeUnit::Nanosecond)
         | &DataType::Timestamp(_, _)
         | &DataType::Duration(_)
 );


### PR DESCRIPTION
This PR adds the remaining implementations to read and write primitive types to and from parquet.

As demo, this adds a test performing a round-trip of the file used in IPC tests, `generated_primitive.json.gz`, demonstrating that we can reliably read and write to and from parquet.

* the file contains most base types (`i8-i64`, `u8-u64`, `f32` and `f64`, `utf8`, `fixedSizedBinary`)
* The file has multiple columns and multiple record batches, demonstrating that this supports multiple columns (column chunks) and record batches (row groups).
* this tests both little endian IPC and big endian IPC, demonstrating that endianess is in general correct (we do `big endian IPC -> little endian in-memory -> parquet -> little endian in-memory).

This still does not export the arrow schema, which is required to preserve arrow-specific information such as types that parquet does not natively support (e.g. `LargeUtf8`).