### PR TITLE
Simplified write API and added arrow metadata to metadata keys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ multiversion = "0.6.1"
 
 [dependencies.parquet2]
 git = "https://github.com/jorgecarleitao/parquet2"
-rev = "e1595ecc845a52f9a55a9e2142de5ac1be9ab0e4"
+rev = "79ea253793eb60a6f9cbdc57af0f2bca9afc2171"
 default-features = false
 features = ["snappy", "gzip", "lz4", "zstd", "brotli"]
 optional = true

--- a/benches/write_parquet.rs
+++ b/benches/write_parquet.rs
@@ -3,47 +3,25 @@ use std::io::Cursor;
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use arrow2::array::*;
-use arrow2::datatypes::DataType;
+use arrow2::datatypes::{DataType, Field, Schema};
 use arrow2::error::Result;
-use arrow2::io::parquet::write::array_to_page;
+use arrow2::io::parquet::write::*;
 use arrow2::util::bench_util::{create_boolean_array, create_primitive_array, create_string_array};
 
-use parquet2::{
-    compression::CompressionCodec, metadata::SchemaDescriptor, schema::io_message::from_message,
-    write::write_file,
-};
-
 fn write(array: &dyn Array) -> Result<()> {
-    let (physical, converted) = match array.data_type() {
-        DataType::Int32 => ("INT32", ""),
-        DataType::Int64 => ("INT64", ""),
-        DataType::Float32 => ("FLOAT", ""),
-        DataType::Float64 => ("DOUBLE", ""),
-        DataType::Boolean => ("BOOLEAN", ""),
-        DataType::Utf8 => ("BYTE_ARRAY", "(UTF8)"),
-        _ => todo!(),
-    };
-    let schema = SchemaDescriptor::new(
-        "test".to_string(),
-        vec![from_message(&format!(
-            "message schema {{ OPTIONAL {} col {}; }}",
-            physical, converted
-        ))?],
-    );
-    let parquet_type = &schema.fields()[0];
+    let field = Field::new("c1", array.data_type().clone(), true);
+    let schema = Schema::new(vec![field]);
+
+    let compression = CompressionCodec::Uncompressed;
+
+    let parquet_type = to_parquet_type(&field)?;
 
     let row_groups = std::iter::once(Result::Ok(std::iter::once(Ok(std::iter::once(
-        array_to_page(array, parquet_type, CompressionCodec::Uncompressed),
+        array_to_page(array, &parquet_type, compression),
     )))));
 
     let mut writer = Cursor::new(vec![]);
-    write_file(
-        &mut writer,
-        schema,
-        CompressionCodec::Uncompressed,
-        row_groups,
-    )
-    .unwrap();
+    write_file(&mut writer, row_groups, schema, compression, None)?;
     Ok(())
 }
 

--- a/examples/parquet_write.rs
+++ b/examples/parquet_write.rs
@@ -3,39 +3,45 @@ use std::iter::once;
 
 use arrow2::{
     array::{Array, Int32Array},
-    datatypes::Field,
+    datatypes::{Field, Schema},
     error::Result,
-    io::parquet::write::{
-        array_to_page, to_parquet_type, write_file, CompressionCodec, SchemaDescriptor,
-    },
+    io::parquet::write::{array_to_page, to_parquet_type, write_file, CompressionCodec},
 };
 
-fn write_single_array(path: &str, array: &dyn Array, field: &Field) -> Result<()> {
-    // Create a new empty file
-    let mut file = File::create(path)?;
+fn write_single_array(path: &str, array: &dyn Array, field: Field) -> Result<()> {
+    let schema = Schema::new(vec![field]);
 
-    // convert arrows' logical type into a parquet type.
-    let parquet_type = to_parquet_type(&field)?;
-
+    // declare the compression
     let compression = CompressionCodec::Uncompressed;
 
-    // Declare the row groups iterator. This must be an iterator of iterators of iterators:
+    // map arrow fields to parquet fields
+    let parquet_types = schema
+        .fields()
+        .iter()
+        .map(to_parquet_type)
+        .collect::<Result<Vec<_>>>()?;
+
+    // Declare the row group iterator. This must be an iterator of iterators of iterators:
     // * first iterator of row groups
     // * second iterator of column chunks
     // * third iterator of pages
-    // an array can always be divided in multiple pages via `.slice(offset, length)` (`O(1)`).
+    // an array can be divided in multiple pages via `.slice(offset, length)` (`O(1)`).
     // All column chunks within a row group MUST have the same length.
-    let row_groups = once(Result::Ok(once(Result::Ok(once(array_to_page(
-        array,
-        &parquet_type,
-        compression,
-    ))))));
+    let row_groups = once(Result::Ok(once(Ok(once(array)
+        .zip(parquet_types.iter())
+        .map(|(array, type_)| array_to_page(array, type_, compression))))));
 
-    // Create a parquet schema descriptor with all parquet types.
-    let schema = SchemaDescriptor::new("root".to_string(), vec![parquet_type]);
+    // Create a new empty file
+    let mut file = File::create(path)?;
 
     // Write the file. Note that, at present, any error results in a corrupted file.
-    Ok(write_file(&mut file, schema, compression, row_groups)?)
+    Ok(write_file(
+        &mut file,
+        row_groups,
+        &schema,
+        CompressionCodec::Uncompressed,
+        None,
+    )?)
 }
 
 fn main() -> Result<()> {
@@ -49,5 +55,5 @@ fn main() -> Result<()> {
         Some(6),
     ]);
     let field = Field::new("c1", array.data_type().clone(), true);
-    write_single_array("test.parquet", &array, &field)
+    write_single_array("test.parquet", &array, field)
 }

--- a/src/io/ipc/write/mod.rs
+++ b/src/io/ipc/write/mod.rs
@@ -16,10 +16,13 @@
 // under the License.
 
 pub mod common;
+mod schema;
 mod serialize;
 mod stream;
 mod writer;
 
+pub use super::gen::Schema::MetadataVersion;
+pub use schema::schema_to_bytes;
 pub use serialize::{write, write_dictionary};
 pub use stream::StreamWriter;
 pub use writer::FileWriter;

--- a/src/io/ipc/write/schema.rs
+++ b/src/io/ipc/write/schema.rs
@@ -1,0 +1,26 @@
+use flatbuffers::FlatBufferBuilder;
+
+use crate::datatypes::*;
+
+use super::super::{convert, gen};
+use super::MetadataVersion;
+
+/// Converts
+pub fn schema_to_bytes(schema: &Schema, version: MetadataVersion) -> Vec<u8> {
+    let mut fbb = FlatBufferBuilder::new();
+    let schema = {
+        let fb = convert::schema_to_fb_offset(&mut fbb, schema);
+        fb.as_union_value()
+    };
+
+    let mut message = gen::Message::MessageBuilder::new(&mut fbb);
+    message.add_version(version);
+    message.add_header_type(gen::Message::MessageHeader::Schema);
+    message.add_bodyLength(0);
+    message.add_header(schema);
+    // TODO: custom metadata
+    let data = message.finish();
+    fbb.finish(data, None);
+
+    fbb.finished_data().to_vec()
+}

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -3,6 +3,8 @@ use crate::error::ArrowError;
 pub mod read;
 pub mod write;
 
+const ARROW_SCHEMA_META_KEY: &str = "ARROW:schema";
+
 impl From<parquet2::error::ParquetError> for ArrowError {
     fn from(error: parquet2::error::ParquetError) -> Self {
         ArrowError::External("".to_string(), Box::new(error))
@@ -136,20 +138,22 @@ mod tests_integration {
             .iter()
             .map(to_parquet_type)
             .collect::<Result<Vec<_>>>()?;
-        let parquet_schema = SchemaDescriptor::new("root".to_string(), parquet_types.clone());
 
         let row_groups = batches.iter().map(|batch| {
-            let iterator = batch
-                .columns()
-                .iter()
-                .zip(parquet_types.iter())
-                .map(|(array, type_)| Ok(std::iter::once(array_to_page(array.as_ref(), type_))));
+            let iterator =
+                batch
+                    .columns()
+                    .iter()
+                    .zip(parquet_types.iter())
+                    .map(|(array, type_)| {
+                        Ok(std::iter::once(array_to_page(array.as_ref(), type_, codec)))
+                    });
             Ok(iterator)
         });
 
         let mut writer = Cursor::new(vec![]);
 
-        write_file(&mut writer, parquet_schema, codec, row_groups)?;
+        write_file(&mut writer, row_groups, schema, codec, None)?;
 
         Ok(writer.into_inner())
     }

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -14,11 +14,11 @@ use crate::{
 
 pub use schema::{get_schema, is_type_nullable};
 
-pub use parquet2::read::{get_page_iterator, read_metadata};
 pub use parquet2::{
     error::ParquetError,
     metadata::ColumnDescriptor,
     read::CompressedPage,
+    read::{get_page_iterator, read_metadata},
     schema::{
         types::{LogicalType, ParquetType, PhysicalType, PrimitiveConvertedType},
         TimeUnit as ParquetTimeUnit, TimestampType,

--- a/src/io/parquet/read/schema/metadata.rs
+++ b/src/io/parquet/read/schema/metadata.rs
@@ -6,7 +6,7 @@ use crate::datatypes::Schema;
 use crate::error::{ArrowError, Result};
 use crate::io::ipc;
 
-const ARROW_SCHEMA_META_KEY: &str = "ARROW:schema";
+use super::super::super::ARROW_SCHEMA_META_KEY;
 
 /// Reads an arrow schema from Parquet's file metadata. Returns `None` if no schema was found.
 /// # Errors


### PR DESCRIPTION
This is a simplification of the API to write to parquet, making it so that implementation details are hidden from the user.

This also makes the arrow schema be serialized and written to the files' metadata.