### PR TITLE
Discoverability functions for kernels

### DIFF
--- a/src/compute/length.rs
+++ b/src/compute/length.rs
@@ -63,6 +63,26 @@ pub fn length(array: &dyn Array) -> Result<Box<dyn Array>> {
     }
 }
 
+/// Checks if an array of type `datatype` can perform lenght operation
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::length::can_length;
+/// use arrow2::datatypes::{DataType};
+///
+/// let data_type = DataType::Utf8;
+/// assert_eq!(can_length(&data_type), true);
+
+/// let data_type = DataType::Int8;
+/// assert_eq!(can_length(&data_type), false);
+/// ```
+pub fn can_length(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Utf8 | DataType::LargeUtf8 => true,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -103,5 +123,54 @@ mod tests {
     #[test]
     fn utf8() {
         length_test_string::<i32>()
+    }
+
+    #[test]
+    fn consistency() {
+        use crate::array::new_null_array;
+        use crate::datatypes::DataType::*;
+        use crate::datatypes::TimeUnit;
+
+        let datatypes = vec![
+            Null,
+            Boolean,
+            UInt8,
+            UInt16,
+            UInt32,
+            UInt64,
+            Int8,
+            Int16,
+            Int32,
+            Int64,
+            Float32,
+            Float64,
+            Timestamp(TimeUnit::Second, None),
+            Timestamp(TimeUnit::Millisecond, None),
+            Timestamp(TimeUnit::Microsecond, None),
+            Timestamp(TimeUnit::Nanosecond, None),
+            Time64(TimeUnit::Microsecond),
+            Time64(TimeUnit::Nanosecond),
+            Date32,
+            Time32(TimeUnit::Second),
+            Time32(TimeUnit::Millisecond),
+            Date64,
+            Utf8,
+            LargeUtf8,
+            Binary,
+            LargeBinary,
+            Duration(TimeUnit::Second),
+            Duration(TimeUnit::Millisecond),
+            Duration(TimeUnit::Microsecond),
+            Duration(TimeUnit::Nanosecond),
+        ];
+
+        datatypes.clone().into_iter().for_each(|d1| {
+            let array = new_null_array(d1.clone(), 10);
+            if can_length(&d1) {
+                assert!(length(array.as_ref()).is_ok());
+            } else {
+                assert!(length(array.as_ref()).is_err());
+            }
+        });
     }
 }

--- a/src/compute/merge_sort/mod.rs
+++ b/src/compute/merge_sort/mod.rs
@@ -15,7 +15,7 @@
 //! 1. compute the array of slices `v` that construct a new sorted array from `a0` and `a1`.
 //! 2. `take_arrays` from `a0` and `a1`, creating the sorted array.
 //!
-//! In the extreme case where the two arrays are already sorted betwen then (e.g. `[0, 2]`, `[3, 4]`),
+//! In the extreme case where the two arrays are already sorted between then (e.g. `[0, 2]`, `[3, 4]`),
 //! we need two slices, `v = vec![(0, 0, a0.len()), (1, 0, a1.len())]`. The higher the
 //! inter-leave between the two arrays, the more slices will be needed, and
 //! generally the more expensive the `take` operation will be.

--- a/src/compute/substring.rs
+++ b/src/compute/substring.rs
@@ -91,6 +91,26 @@ pub fn substring(array: &dyn Array, start: i64, length: &Option<u64>) -> Result<
     }
 }
 
+/// Checks if an array of type `datatype` can perform substring operation
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::substring::can_substring;
+/// use arrow2::datatypes::{DataType};
+///
+/// let data_type = DataType::Utf8;
+/// assert_eq!(can_substring(&data_type), true);
+
+/// let data_type = DataType::Null;
+/// assert_eq!(can_substring(&data_type), false);
+/// ```
+pub fn can_substring(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::LargeUtf8 | DataType::Utf8 => true,
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -237,5 +257,54 @@ mod tests {
     #[test]
     fn without_nulls_large_string() -> Result<()> {
         without_nulls::<i64>()
+    }
+
+    #[test]
+    fn consistency() {
+        use crate::array::new_null_array;
+        use crate::datatypes::DataType::*;
+        use crate::datatypes::TimeUnit;
+
+        let datatypes = vec![
+            Null,
+            Boolean,
+            UInt8,
+            UInt16,
+            UInt32,
+            UInt64,
+            Int8,
+            Int16,
+            Int32,
+            Int64,
+            Float32,
+            Float64,
+            Timestamp(TimeUnit::Second, None),
+            Timestamp(TimeUnit::Millisecond, None),
+            Timestamp(TimeUnit::Microsecond, None),
+            Timestamp(TimeUnit::Nanosecond, None),
+            Time64(TimeUnit::Microsecond),
+            Time64(TimeUnit::Nanosecond),
+            Date32,
+            Time32(TimeUnit::Second),
+            Time32(TimeUnit::Millisecond),
+            Date64,
+            Utf8,
+            LargeUtf8,
+            Binary,
+            LargeBinary,
+            Duration(TimeUnit::Second),
+            Duration(TimeUnit::Millisecond),
+            Duration(TimeUnit::Microsecond),
+            Duration(TimeUnit::Nanosecond),
+        ];
+
+        datatypes.clone().into_iter().for_each(|d1| {
+            let array = new_null_array(d1.clone(), 10);
+            if can_substring(&d1) {
+                assert!(substring(array.as_ref(), 0, &None).is_ok());
+            } else {
+                assert!(substring(array.as_ref(), 0, &None).is_err());
+            }
+        });
     }
 }

--- a/src/compute/temporal.rs
+++ b/src/compute/temporal.rs
@@ -112,6 +112,32 @@ pub fn hour(array: &dyn Array) -> Result<PrimitiveArray<u32>> {
     }
 }
 
+/// Checks if an array of type `datatype` can perform hour operation
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::temporal::can_hour;
+/// use arrow2::datatypes::{DataType, TimeUnit};
+///
+/// let data_type = DataType::Time32(TimeUnit::Second);
+/// assert_eq!(can_hour(&data_type), true);
+
+/// let data_type = DataType::Int8;
+/// assert_eq!(can_hour(&data_type), false);
+/// ```
+pub fn can_hour(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Time32(TimeUnit::Second)
+        | DataType::Time32(TimeUnit::Microsecond)
+        | DataType::Time64(TimeUnit::Microsecond)
+        | DataType::Time64(TimeUnit::Nanosecond)
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Timestamp(_, None) => true,
+        _ => false,
+    }
+}
+
 /// Extracts the hours of a given temporal array as an array of integers
 pub fn year(array: &dyn Array) -> Result<PrimitiveArray<i32>> {
     let final_data_type = DataType::Int32;
@@ -158,6 +184,25 @@ pub fn year(array: &dyn Array) -> Result<PrimitiveArray<i32>> {
     }
 }
 
+/// Checks if an array of type `datatype` can perform year operation
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::temporal::can_year;
+/// use arrow2::datatypes::{DataType};
+///
+/// let data_type = DataType::Date32;
+/// assert_eq!(can_year(&data_type), true);
+
+/// let data_type = DataType::Int8;
+/// assert_eq!(can_year(&data_type), false);
+/// ```
+pub fn can_year(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Date32 | DataType::Date64 | DataType::Timestamp(_, None) => true,
+        _ => false,
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -237,5 +282,103 @@ mod tests {
         let result = year(&array).unwrap();
         let expected = Primitive::<i32>::from(&[Some(2021), None]).to(DataType::Int32);
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn consistency_hour() {
+        use crate::array::new_null_array;
+        use crate::datatypes::DataType::*;
+        use crate::datatypes::TimeUnit;
+
+        let datatypes = vec![
+            Null,
+            Boolean,
+            UInt8,
+            UInt16,
+            UInt32,
+            UInt64,
+            Int8,
+            Int16,
+            Int32,
+            Int64,
+            Float32,
+            Float64,
+            Timestamp(TimeUnit::Second, None),
+            Timestamp(TimeUnit::Millisecond, None),
+            Timestamp(TimeUnit::Microsecond, None),
+            Timestamp(TimeUnit::Nanosecond, None),
+            Time64(TimeUnit::Microsecond),
+            Time64(TimeUnit::Nanosecond),
+            Date32,
+            Time32(TimeUnit::Second),
+            Time32(TimeUnit::Millisecond),
+            Date64,
+            Utf8,
+            LargeUtf8,
+            Binary,
+            LargeBinary,
+            Duration(TimeUnit::Second),
+            Duration(TimeUnit::Millisecond),
+            Duration(TimeUnit::Microsecond),
+            Duration(TimeUnit::Nanosecond),
+        ];
+
+        datatypes.clone().into_iter().for_each(|d1| {
+            let array = new_null_array(d1.clone(), 10);
+            if can_hour(&d1) {
+                assert!(hour(array.as_ref()).is_ok());
+            } else {
+                assert!(hour(array.as_ref()).is_err());
+            }
+        });
+    }
+
+    #[test]
+    fn consistency_year() {
+        use crate::array::new_null_array;
+        use crate::datatypes::DataType::*;
+        use crate::datatypes::TimeUnit;
+
+        let datatypes = vec![
+            Null,
+            Boolean,
+            UInt8,
+            UInt16,
+            UInt32,
+            UInt64,
+            Int8,
+            Int16,
+            Int32,
+            Int64,
+            Float32,
+            Float64,
+            Timestamp(TimeUnit::Second, None),
+            Timestamp(TimeUnit::Millisecond, None),
+            Timestamp(TimeUnit::Microsecond, None),
+            Timestamp(TimeUnit::Nanosecond, None),
+            Time64(TimeUnit::Microsecond),
+            Time64(TimeUnit::Nanosecond),
+            Date32,
+            Time32(TimeUnit::Second),
+            Time32(TimeUnit::Millisecond),
+            Date64,
+            Utf8,
+            LargeUtf8,
+            Binary,
+            LargeBinary,
+            Duration(TimeUnit::Second),
+            Duration(TimeUnit::Millisecond),
+            Duration(TimeUnit::Microsecond),
+            Duration(TimeUnit::Nanosecond),
+        ];
+
+        datatypes.clone().into_iter().for_each(|d1| {
+            let array = new_null_array(d1.clone(), 10);
+            if can_year(&d1) {
+                assert!(year(array.as_ref()).is_ok());
+            } else {
+                assert!(year(array.as_ref()).is_err());
+            }
+        });
     }
 }


### PR DESCRIPTION
Added discoverability functions for the next kernels:

- basic arithmetic
- comparison
- hash
- length
- sort
- substring
- take
- temporal

Closes #57
