### PR TITLE
Removed some inline

### DIFF
--- a/src/compute/arithmetics/basic/add.rs
+++ b/src/compute/arithmetics/basic/add.rs
@@ -36,7 +36,6 @@ use crate::{
 /// let expected = Primitive::from(&vec![None, None, None, Some(12)]).to(DataType::Int32);
 /// assert_eq!(result, expected)
 /// ```
-#[inline]
 pub fn add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
     T: NativeType + Add<Output = T>,
@@ -211,7 +210,6 @@ where
 /// let expected = Primitive::from(&vec![None, Some(7), None, Some(7)]).to(DataType::Int32);
 /// assert_eq!(result, expected)
 /// ```
-#[inline]
 pub fn add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + Add<Output = T>,
@@ -234,7 +232,6 @@ where
 /// let expected = Int8Array::from(&[None, None, None, None]);
 /// assert_eq!(result, expected);
 /// ```
-#[inline]
 pub fn checked_add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + CheckedAdd<Output = T> + Zero,
@@ -260,7 +257,6 @@ where
 /// let expected = Primitive::from(&vec![Some(127)]).to(DataType::Int8);
 /// assert_eq!(result, expected);
 /// ```
-#[inline]
 pub fn saturating_add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + SaturatingAdd<Output = T>,
@@ -287,7 +283,6 @@ where
 /// let expected = Primitive::from(&vec![Some(101i8), Some(-56i8)]).to(DataType::Int8);
 /// assert_eq!(result, expected);
 /// ```
-#[inline]
 pub fn overflowing_add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> (PrimitiveArray<T>, Bitmap)
 where
     T: NativeType + OverflowingAdd<Output = T>,

--- a/src/compute/arithmetics/basic/div.rs
+++ b/src/compute/arithmetics/basic/div.rs
@@ -27,7 +27,6 @@ use crate::{
 /// let expected = Int32Array::from(&[Some(2), Some(1)]);
 /// assert_eq!(result, expected)
 /// ```
-#[inline]
 pub fn div<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
     T: NativeType + Div<Output = T>,
@@ -108,7 +107,6 @@ where
 /// let expected = Int32Array::from(&[None, Some(3), None, Some(3)]);
 /// assert_eq!(result, expected)
 /// ```
-#[inline]
 pub fn div_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + Div<Output = T>,
@@ -130,7 +128,6 @@ where
 /// let expected = Int8Array::from(&[Some(-1i8)]);
 /// assert_eq!(result, expected);
 /// ```
-#[inline]
 pub fn checked_div_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + CheckedDiv<Output = T> + Zero,

--- a/src/compute/arithmetics/basic/mul.rs
+++ b/src/compute/arithmetics/basic/mul.rs
@@ -35,7 +35,6 @@ use crate::{
 /// let expected = Int32Array::from(&[None, None, None, Some(36)]);
 /// assert_eq!(result, expected)
 /// ```
-#[inline]
 pub fn mul<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
     T: NativeType + Mul<Output = T>,
@@ -206,7 +205,6 @@ where
 /// let expected = Int32Array::from(&[None, Some(12), None, Some(12)]);
 /// assert_eq!(result, expected)
 /// ```
-#[inline]
 pub fn mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + Mul<Output = T>,
@@ -229,7 +227,6 @@ where
 /// let expected = Int8Array::from(&[None, None, None, None]);
 /// assert_eq!(result, expected);
 /// ```
-#[inline]
 pub fn checked_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + CheckedMul<Output = T> + Zero,
@@ -254,7 +251,6 @@ where
 /// let expected = Int8Array::from(&[Some(-128i8)]);
 /// assert_eq!(result, expected);
 /// ```
-#[inline]
 pub fn saturating_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + SaturatingMul<Output = T>,
@@ -280,7 +276,6 @@ where
 /// let expected = Int8Array::from(&[Some(100i8), Some(16i8)]);
 /// assert_eq!(result, expected);
 /// ```
-#[inline]
 pub fn overflowing_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> (PrimitiveArray<T>, Bitmap)
 where
     T: NativeType + OverflowingMul<Output = T>,

--- a/src/compute/arithmetics/basic/pow.rs
+++ b/src/compute/arithmetics/basic/pow.rs
@@ -20,7 +20,6 @@ use crate::{
 /// let expected = Float32Array::from(&[Some(4f32), None]);
 /// assert_eq!(expected, actual);
 /// ```
-#[inline]
 pub fn powf_scalar<T>(array: &PrimitiveArray<T>, exponent: T) -> PrimitiveArray<T>
 where
     T: NativeType + Pow<T, Output = T>,
@@ -42,7 +41,6 @@ where
 /// let expected = Int8Array::from(&[Some(1i8), None, None]);
 /// assert_eq!(expected, actual);
 /// ```
-#[inline]
 pub fn checked_powf_scalar<T>(array: &PrimitiveArray<T>, exponent: usize) -> PrimitiveArray<T>
 where
     T: NativeType + Zero + One + CheckedMul,

--- a/src/compute/arithmetics/basic/sub.rs
+++ b/src/compute/arithmetics/basic/sub.rs
@@ -35,7 +35,6 @@ use crate::{
 /// let expected = Int32Array::from(&[None, None, None, Some(0)]);
 /// assert_eq!(result, expected)
 /// ```
-#[inline]
 pub fn sub<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
     T: NativeType + Sub<Output = T>,
@@ -206,7 +205,6 @@ where
 /// let expected = Int32Array::from(&[None, Some(5), None, Some(5)]);
 /// assert_eq!(result, expected)
 /// ```
-#[inline]
 pub fn sub_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + Sub<Output = T>,
@@ -229,7 +227,6 @@ where
 /// let expected = Int8Array::from(&[None, None, None, None]);
 /// assert_eq!(result, expected);
 /// ```
-#[inline]
 pub fn checked_sub_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + CheckedSub<Output = T> + Zero,
@@ -254,7 +251,6 @@ where
 /// let expected = Int8Array::from(&[Some(-128i8)]);
 /// assert_eq!(result, expected);
 /// ```
-#[inline]
 pub fn saturating_sub_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
     T: NativeType + SaturatingSub<Output = T>,
@@ -280,7 +276,6 @@ where
 /// let expected = Int8Array::from(&[Some(-99i8), Some(56i8)]);
 /// assert_eq!(result, expected);
 /// ```
-#[inline]
 pub fn overflowing_sub_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> (PrimitiveArray<T>, Bitmap)
 where
     T: NativeType + OverflowingSub<Output = T>,

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -179,7 +179,6 @@ pub enum Operator {
 }
 
 /// Perform arithmetic operations on two primitive arrays based on the Operator enum
-#[inline]
 fn arithmetic_primitive<T>(
     lhs: &PrimitiveArray<T>,
     op: Operator,
@@ -197,7 +196,6 @@ where
 }
 
 /// Performs primitive operation on an array and and scalar
-#[inline]
 pub fn arithmetic_primitive_scalar<T>(
     lhs: &PrimitiveArray<T>,
     op: Operator,
@@ -227,7 +225,6 @@ where
 /// let expected = Primitive::from(&vec![None, Some(-6), None, Some(-7)]).to(DataType::Int32);
 /// assert_eq!(result, expected)
 /// ```
-#[inline]
 pub fn negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + Neg<Output = T>,


### PR DESCRIPTION
These inlines were being unrolled all the way to the buffer creation, which is detrimental to binary size and does not offer any advantage as there are `match`es that effectively branch the code.