### PR TITLE
Made CSV read parallelizable.

### DIFF
--- a/examples/csv_read.rs
+++ b/examples/csv_read.rs
@@ -1,0 +1,37 @@
+use arrow2::error::Result;
+use arrow2::io::csv::read;
+use arrow2::record_batch::RecordBatch;
+
+fn read_path(path: &str, projection: Option<&[usize]>) -> Result<RecordBatch> {
+    // Create a CSV reader. This is typically created on the thread that reads the file and
+    // thus owns the read head.
+    let mut reader = read::ReaderBuilder::new().from_path(path)?;
+
+    // Infers the schema using the default inferer. The inferer is just a function that maps a string
+    // to a `DataType`.
+    let schema = read::infer_schema(&mut reader, None, true, &read::infer)?;
+
+    // skip 0 (excluding the header) and read up to 100 rows.
+    // this is IO-intensive and performs minimal CPU work. In particular,
+    // no deserialization is performed.
+    let rows = read::read_rows(&mut reader, 0, 100)?;
+
+    // initializes a parser. A parser is a stateless trait to parse rows.
+    // Its logic must be consistent with `read::infer` above.
+    let parser = read::DefaultParser::default();
+
+    // parse the batches into a `RecordBatch`. This is CPU-intensive, has no IO,
+    // and can be performed on a different thread by passing `rows` through a channel.
+    read::parse(&rows, schema.fields(), projection, 0, &parser)
+}
+
+fn main() -> Result<()> {
+    use std::env;
+    let args: Vec<String> = env::args().collect();
+
+    let file_path = &args[1];
+
+    let batch = read_path(&file_path, None)?;
+    println!("{:?}", batch);
+    Ok(())
+}

--- a/examples/csv_read_parallel.rs
+++ b/examples/csv_read_parallel.rs
@@ -1,0 +1,84 @@
+use crossbeam_channel::unbounded;
+
+use std::sync::Arc;
+use std::thread;
+use std::time::SystemTime;
+
+use arrow2::{error::Result, io::csv::read, record_batch::RecordBatch};
+
+fn parallel_read(path: &str) -> Result<Vec<RecordBatch>> {
+    let batch_size = 100;
+    let has_header = true;
+    let projection = None;
+
+    // prepare a channel to send serialized records from threads
+    let (tx, rx) = unbounded();
+
+    let mut reader = read::ReaderBuilder::new().from_path(path)?;
+    let schema = read::infer_schema(&mut reader, Some(batch_size * 10), has_header, &read::infer)?;
+    let schema = Arc::new(schema);
+
+    let start = SystemTime::now();
+    // spawn a thread to produce `Vec<ByteRecords>` (IO bounded)
+    let child = thread::spawn(move || {
+        let rows = read::read_rows(&mut reader, 0, batch_size).unwrap();
+        let mut line_number = batch_size;
+        let mut size = rows.len();
+        tx.send((rows, line_number)).unwrap();
+        while size > 0 {
+            let rows = read::read_rows(&mut reader, 0, batch_size).unwrap();
+            line_number += batch_size;
+            size = rows.len();
+            tx.send((rows, line_number)).unwrap();
+        }
+    });
+
+    let mut children = Vec::new();
+    // use 3 consumers of to decompress, decode and deserialize.
+    for _ in 0..3 {
+        let rx_consumer = rx.clone();
+        let consumer_schema = schema.clone();
+        let child = thread::spawn(move || {
+            let (rows, line_number) = rx_consumer.recv().unwrap();
+            let start = SystemTime::now();
+            println!("consumer start - {}", line_number);
+            let batch = read::parse(
+                &rows,
+                &consumer_schema.fields(),
+                projection,
+                line_number,
+                &read::DefaultParser::default(),
+            )
+            .unwrap();
+            println!(
+                "consumer end - {:?}: {}",
+                start.elapsed().unwrap(),
+                line_number,
+            );
+            batch
+        });
+        children.push(child);
+    }
+
+    child.join().expect("child thread panicked");
+
+    let batches = children
+        .into_iter()
+        .map(|x| x.join().unwrap())
+        .collect::<Vec<_>>();
+    println!("Finished - {:?}", start.elapsed().unwrap());
+
+    Ok(batches)
+}
+
+fn main() -> Result<()> {
+    use std::env;
+    let args: Vec<String> = env::args().collect();
+    let file_path = &args[1];
+
+    let batches = parallel_read(file_path)?;
+    for batch in batches {
+        println!("{}", batch.num_rows())
+    }
+    Ok(())
+}

--- a/examples/parquet_write.rs
+++ b/examples/parquet_write.rs
@@ -35,13 +35,13 @@ fn write_single_array(path: &str, array: &dyn Array, field: Field) -> Result<()>
     let mut file = File::create(path)?;
 
     // Write the file. Note that, at present, any error results in a corrupted file.
-    Ok(write_file(
+    write_file(
         &mut file,
         row_groups,
         &schema,
         CompressionCodec::Uncompressed,
         None,
-    )?)
+    )
 }
 
 fn main() -> Result<()> {

--- a/guide/src/io/csv_reader.md
+++ b/guide/src/io/csv_reader.md
@@ -16,28 +16,24 @@ This crate relies on [the crate `csv`](https://crates.io/crates/csv) to scan and
 As an example, the following infers the schema and reads a CSV by re-using the same reader:
 
 ```rust
-use arrow2::io::csv::read;
-use arrow2::error::Result;
-
-fn read_path(path: &str) -> Result<()> {
-    let mut reader = read::ReaderBuilder::new().from_path(path)?;
-    let parser = read::DefaultParser::default();
-
-    let schema = read::infer_schema(&mut reader, None, true, &infer)?;
-
-    // 0: start from
-    // 100: up to (max batch size)
-    let batch = read::read_batch(&mut reader, &parser, 0, 100, schema, None)?;
-}
+{{#include ../../../examples/csv_read.rs}}
 ```
 
 ## Orchestration and parallelization
 
-Because `csv`'s API is synchronous, the functions above represent the "minimal unit of synchronous work". It is up to you to decide how you want to read the file efficiently:
-whether to read batches in sequence or in parallel, or whether IO supports multiple readers per file.
+Because `csv`'s API is synchronous, the functions above represent the "minimal
+unit of synchronous work", IO and CPU. Note that `rows` above are `Send`,
+which implies that it is possible to run `parse` on a separate thread,
+thereby maximizing IO throughput. The example below shows how to do just that:
+
+```rust
+{{#include ../../../examples/csv_read_parallel.rs}}
+```
 
 ## Customization
 
 In the code above, `parser` and `infer` allow for customization: they declare
-how rows of bytes should be inferred (into a logical type), and processed (into a value of said type). They offer good default options, but you can customize the inference and parsing to your own needs. You can also of course decide to parse everything into memory as `Utf8Array` and delay
-any data transformation.
+how rows of bytes should be inferred (into a logical type), and processed (into a value of said type).
+They offer good default options, but you can customize the inference and parsing to your own needs.
+You can also of course decide to parse everything into memory as `Utf8Array` and
+delay any data transformation.

--- a/src/io/csv/read/infer_schema.rs
+++ b/src/io/csv/read/infer_schema.rs
@@ -11,14 +11,14 @@ use crate::datatypes::{Field, Schema};
 use crate::error::Result;
 
 /// Infer the schema of a CSV file by reading through the first n records of the file,
-/// with `max_read_records` controlling the maximum number of records to read.
+/// with `max_rows` controlling the maximum number of records to read.
 ///
-/// If `max_read_records` is not set, the whole file is read to infer its schema.
+/// If `max_rows` is not set, the whole file is read to infer its schema.
 ///
 /// Return infered schema and number of records used for inference.
 pub fn infer_schema<R: Read + Seek, F: Fn(&str) -> DataType>(
     reader: &mut Reader<R>,
-    max_read_records: Option<usize>,
+    max_rows: Option<usize>,
     has_header: bool,
     infer: &F,
 ) -> Result<Schema> {
@@ -45,7 +45,7 @@ pub fn infer_schema<R: Read + Seek, F: Fn(&str) -> DataType>(
     let mut fields = vec![];
 
     let mut record = StringRecord::new();
-    let max_records = max_read_records.unwrap_or(usize::MAX);
+    let max_records = max_rows.unwrap_or(usize::MAX);
     while records_count < max_records {
         if !reader.read_record(&mut record)? {
             break;


### PR DESCRIPTION
This PR is a small change to the CSV's API to allow multi-threading processing of a CSV. This is achieved by dividing the IO-intensive task from CPU-intensive task, thereby allowing a read head to live on a thread that is not performing the CPU-intensive task of de-serializing the rows.

Together with using `ByteRecords`, this makes the CSV reading fully capable of distributing work across threads.

This follows the same pattern as the parquet reader.

This PR also moves the example in the guide to an example, so that people can run it.