### PR TITLE
Improved API to create a nested natural type.

### DIFF
--- a/src/array/binary/from.rs
+++ b/src/array/binary/from.rs
@@ -1,19 +1,15 @@
 use std::{iter::FromIterator, sync::Arc};
 
-use super::BinaryArray;
 use crate::{
-    array::Offset,
+    array::{Array, Builder, IntoArray, Offset, ToArray, TryFromIterator},
     bitmap::{Bitmap, MutableBitmap},
     buffer::{Buffer, MutableBuffer},
-};
-use crate::{
-    array::{Array, Builder, IntoArray, TryFromIterator},
-    trusted_len::TrustedLen,
-};
-use crate::{
     datatypes::DataType,
     error::{ArrowError, Result as ArrowResult},
+    trusted_len::TrustedLen,
 };
+
+use super::BinaryArray;
 
 impl<O: Offset> BinaryArray<O> {
     pub fn from_slice<T: AsRef<[u8]>, P: AsRef<[T]>>(slice: P) -> Self {
@@ -125,8 +121,14 @@ impl<O: Offset> BinaryPrimitive<O> {
     }
 }
 
+impl<O: Offset> ToArray for BinaryPrimitive<O> {
+    fn to_arc(self, _: &DataType) -> Arc<dyn Array> {
+        Arc::new(self.to())
+    }
+}
+
 impl<O: Offset> IntoArray for BinaryPrimitive<O> {
-    fn into_arc(self, _: &DataType) -> Arc<dyn Array> {
+    fn into_arc(self) -> Arc<dyn Array> {
         Arc::new(self.to())
     }
 }

--- a/src/array/fixed_size_binary/from.rs
+++ b/src/array/fixed_size_binary/from.rs
@@ -1,7 +1,7 @@
 use std::{iter::FromIterator, sync::Arc};
 
 use super::FixedSizeBinaryArray;
-use crate::array::{Array, Builder, IntoArray, TryFromIterator};
+use crate::array::{Array, Builder, ToArray, TryFromIterator};
 use crate::bitmap::MutableBitmap;
 use crate::buffer::MutableBuffer;
 use crate::{
@@ -102,8 +102,8 @@ impl FixedSizeBinaryPrimitive {
     }
 }
 
-impl IntoArray for FixedSizeBinaryPrimitive {
-    fn into_arc(self, data_type: &DataType) -> Arc<dyn Array> {
+impl ToArray for FixedSizeBinaryPrimitive {
+    fn to_arc(self, data_type: &DataType) -> Arc<dyn Array> {
         Arc::new(self.to(data_type.clone()))
     }
 }

--- a/src/array/fixed_size_list/from.rs
+++ b/src/array/fixed_size_list/from.rs
@@ -1,7 +1,7 @@
 use std::{iter::FromIterator, sync::Arc};
 
 use crate::{
-    array::{Array, Builder, IntoArray, TryFromIterator},
+    array::{Array, Builder, ToArray, TryFromIterator},
     bitmap::MutableBitmap,
     datatypes::DataType,
     error::Result,
@@ -16,11 +16,11 @@ pub struct FixedSizeListPrimitive<B: Builder<T>, T> {
     phantom: std::marker::PhantomData<T>,
 }
 
-impl<A: Builder<T>, T> FixedSizeListPrimitive<A, T> {
+impl<A: Builder<T> + ToArray, T> FixedSizeListPrimitive<A, T> {
     pub fn to(self, data_type: DataType) -> FixedSizeListArray {
         let values = self
             .values
-            .into_arc(FixedSizeListArray::get_child_and_size(&data_type).0);
+            .to_arc(FixedSizeListArray::get_child_and_size(&data_type).0);
         FixedSizeListArray::from_data(data_type, values, self.validity.into())
     }
 }
@@ -88,8 +88,8 @@ where
     }
 }
 
-impl<B: Builder<T>, T> IntoArray for FixedSizeListPrimitive<B, T> {
-    fn into_arc(self, data_type: &DataType) -> Arc<dyn Array> {
+impl<B: Builder<T> + ToArray, T> ToArray for FixedSizeListPrimitive<B, T> {
+    fn to_arc(self, data_type: &DataType) -> Arc<dyn Array> {
         Arc::new(self.to(data_type.clone()))
     }
 }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -379,8 +379,14 @@ pub type UInt32Array = PrimitiveArray<u32>;
 pub type UInt64Array = PrimitiveArray<u64>;
 
 /// A trait describing the ability of a struct to convert itself to a Arc'ed [`Array`].
+pub trait ToArray {
+    fn to_arc(self, data_type: &DataType) -> std::sync::Arc<dyn Array>;
+}
+
+/// A trait describing the ability of a struct to convert itself to a Arc'ed [`Array`],
+/// with its [`DataType`] automatically deducted.
 pub trait IntoArray {
-    fn into_arc(self, data_type: &DataType) -> std::sync::Arc<dyn Array>;
+    fn into_arc(self) -> std::sync::Arc<dyn Array>;
 }
 
 /// A trait describing the ability of a struct to create itself from a falible iterator
@@ -390,7 +396,7 @@ pub trait TryFromIterator<A>: Sized {
 }
 
 /// A trait describing the ability of a struct to build itself from an iterator into an [`Array`].
-pub trait Builder<T>: TryFromIterator<Option<T>> + IntoArray {
+pub trait Builder<T>: TryFromIterator<Option<T>> {
     /// Create the builder with a capacity
     fn with_capacity(capacity: usize) -> Self;
 

--- a/src/array/utf8/from.rs
+++ b/src/array/utf8/from.rs
@@ -1,7 +1,7 @@
 use std::{iter::FromIterator, sync::Arc};
 
 use crate::{
-    array::{Array, Builder, IntoArray, Offset, TryFromIterator},
+    array::{Array, Builder, IntoArray, Offset, ToArray, TryFromIterator},
     bitmap::{Bitmap, MutableBitmap},
     buffer::{Buffer, MutableBuffer},
     datatypes::DataType,
@@ -312,8 +312,14 @@ impl<O: Offset> Utf8Primitive<O> {
     }
 }
 
+impl<O: Offset> ToArray for Utf8Primitive<O> {
+    fn to_arc(self, _: &DataType) -> Arc<dyn Array> {
+        Arc::new(self.to())
+    }
+}
+
 impl<O: Offset> IntoArray for Utf8Primitive<O> {
-    fn into_arc(self, _: &DataType) -> Arc<dyn Array> {
+    fn into_arc(self) -> Arc<dyn Array> {
         Arc::new(self.to())
     }
 }


### PR DESCRIPTION
This enables creating nested arrays of primitive types without having to be explicit about the datatype (it is inferred). E.g.

```rust
let data = vec![Some("a"), Some("b"), Some("a")];

let data = data.into_iter().map(Result::Ok);
let a = DictionaryPrimitive::<i32, Utf8Primitive<i32>, &str>::try_from_iter(data)?;
let a = a.into_arc(); // Arc<DictionaryArray<i32>>
```

Closes  #104