### PR TITLE
Improved API to read parquet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ multiversion = "0.6.1"
 
 [dependencies.parquet2]
 git = "https://github.com/jorgecarleitao/parquet2"
-rev = "79ea253793eb60a6f9cbdc57af0f2bca9afc2171"
+rev = "942312cf4de2bbb4ae81e9bf75bfd9d8c7666135"
 default-features = false
 features = ["snappy", "gzip", "lz4", "zstd", "brotli"]
 optional = true

--- a/examples/parquet_read_parallel.rs
+++ b/examples/parquet_read_parallel.rs
@@ -52,7 +52,7 @@ fn parallel_read(path: &str) -> Result<Vec<Box<dyn Array>>> {
             println!("consumer start - {} {}", column, row_group);
             let descriptor = metadata_consumer.row_groups[row_group]
                 .column(column)
-                .column_descriptor();
+                .descriptor();
             let array = read::page_iter_to_array(iter.into_iter(), descriptor).unwrap();
             println!(
                 "consumer end - {:?}: {} {}",

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -182,8 +182,7 @@ mod tests_integration {
                             column,
                             &mut reader,
                         )?;
-                        read::page_iter_to_array(pages, column_meta.column_descriptor())
-                            .map(|x| x.into())
+                        read::page_iter_to_array(pages, column_meta.descriptor()).map(|x| x.into())
                     })
                     .collect::<Result<Vec<Arc<dyn Array>>>>()?;
                 RecordBatch::try_new(schema1.clone(), columns)


### PR DESCRIPTION
Adds methods to avoid users having to wrap the parquet errors; they are wrapped on this crate.