### PR TITLE
Optional usage of AHasher in `hash` kernel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ packed_simd = { version = "0.3.4", optional = true, package = "packed_simd_2" }
 
 multiversion = "0.6.1"
 
+# for faster hashing
+ahash = { version = "0.7", optional = true }
+
 [dependencies.parquet2]
 git = "https://github.com/jorgecarleitao/parquet2"
 rev = "bd2b764fe39286e23ef32a6662bc32edd656c840"
@@ -64,7 +67,7 @@ doc-comment = "0.3"
 crossbeam-channel = "0.5.1"
 
 [features]
-default = ["io_csv", "io_json", "io_ipc", "io_json_integration", "io_print", "io_parquet", "regex", "merge_sort", "benchmarks"]
+default = ["io_csv", "io_json", "io_ipc", "io_json_integration", "io_print", "io_parquet", "regex", "merge_sort", "ahash", "benchmarks"]
 merge_sort = ["itertools"]
 io_csv = ["csv", "lazy_static", "regex"]
 io_json = ["serde", "serde_derive", "serde_json", "indexmap"]

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -1,7 +1,22 @@
-use std::{
-    collections::hash_map::DefaultHasher,
-    hash::{Hash, Hasher},
-};
+use std::hash::{Hash, Hasher};
+
+#[cfg(feature = "ahash")]
+use ahash::AHasher as DefaultHasher;
+#[cfg(not(feature = "ahash"))]
+use std::collections::hash_map::DefaultHasher;
+
+#[cfg(feature = "ahash")]
+macro_rules! new_hasher {
+    () => {
+        DefaultHasher::new_with_keys(0, 0)
+    };
+}
+#[cfg(not(feature = "ahash"))]
+macro_rules! new_hasher {
+    () => {
+        DefaultHasher::new()
+    };
+}
 
 use crate::{
     array::{Array, BinaryArray, BooleanArray, Offset, PrimitiveArray, Utf8Array},
@@ -18,7 +33,7 @@ pub fn hash_primitive<T: NativeType + Hash>(array: &PrimitiveArray<T>) -> Primit
     unary(
         array,
         |x| {
-            let mut hasher = DefaultHasher::new();
+            let mut hasher = new_hasher!();
             x.hash(&mut hasher);
             hasher.finish()
         },
@@ -29,7 +44,7 @@ pub fn hash_primitive<T: NativeType + Hash>(array: &PrimitiveArray<T>) -> Primit
 /// Element-wise hash of a [`BooleanArray`]. Validity is preserved.
 pub fn hash_boolean(array: &BooleanArray) -> PrimitiveArray<u64> {
     let iter = array.values_iter().map(|x| {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = new_hasher!();
         x.hash(&mut hasher);
         hasher.finish()
     });
@@ -40,7 +55,7 @@ pub fn hash_boolean(array: &BooleanArray) -> PrimitiveArray<u64> {
 /// Element-wise hash of a [`Utf8Array`]. Validity is preserved.
 pub fn hash_utf8<O: Offset>(array: &Utf8Array<O>) -> PrimitiveArray<u64> {
     let iter = array.values_iter().map(|x| {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = new_hasher!();
         x.hash(&mut hasher);
         hasher.finish()
     });
@@ -51,7 +66,7 @@ pub fn hash_utf8<O: Offset>(array: &Utf8Array<O>) -> PrimitiveArray<u64> {
 /// Element-wise hash of a [`BinaryArray`]. Validity is preserved.
 pub fn hash_binary<O: Offset>(array: &BinaryArray<O>) -> PrimitiveArray<u64> {
     let iter = array.values_iter().map(|x| {
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = new_hasher!();
         x.hash(&mut hasher);
         hasher.finish()
     });


### PR DESCRIPTION
This offers a 2x speedup when hashing an array. `ahasher` is feature gated.