### PR TITLE
Added option to write parquet statistics.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ ahash = { version = "0.7", optional = true }
 
 [dependencies.parquet2]
 git = "https://github.com/jorgecarleitao/parquet2"
-rev = "8c3b2361ecf24100f161fdf02832f120adfad62b"
+rev = "1d298d9820b5f426ab66e78b9d3450deb4a32581"
 default-features = false
 features = ["snappy", "gzip", "lz4", "zstd", "brotli"]
 optional = true

--- a/parquet_integration/write_parquet.py
+++ b/parquet_integration/write_parquet.py
@@ -68,7 +68,7 @@ def write_pyarrow(case, size = 1, page_version = 1):
         row_group_size=2**40,
         use_dictionary=False,
         compression=None,
-        write_statistics=False,
+        write_statistics=True,
         data_page_size=2**40,  # i.e. a large number to ensure a single page
         data_page_version="1.0",
     )

--- a/src/io/parquet/read/record_batch.rs
+++ b/src/io/parquet/read/record_batch.rs
@@ -53,6 +53,10 @@ impl<R: Read + Seek> RecordReader<R> {
             remaining_rows: limit.unwrap_or(usize::MAX),
         })
     }
+
+    pub fn schema(&self) -> &Arc<Schema> {
+        &self.schema
+    }
 }
 
 impl<R: Read + Seek> Iterator for RecordReader<R> {

--- a/src/io/parquet/write/binary.rs
+++ b/src/io/parquet/write/binary.rs
@@ -1,22 +1,27 @@
 use parquet2::{
     compression::create_codec,
     encoding::Encoding,
+    metadata::ColumnDescriptor,
     read::{CompressedPage, PageHeader},
-    schema::{CompressionCodec, DataPageHeader},
+    schema::DataPageHeader,
+    statistics::{serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics},
+    write::WriteOptions,
 };
 
 use super::utils;
 use crate::{
     array::{Array, BinaryArray, Offset},
     error::Result,
+    io::parquet::read::is_type_nullable,
 };
 
 pub fn array_to_page_v1<O: Offset>(
     array: &BinaryArray<O>,
-    compression: CompressionCodec,
-    is_optional: bool,
+    options: WriteOptions,
+    descriptor: ColumnDescriptor,
 ) -> Result<CompressedPage> {
     let validity = array.validity();
+    let is_optional = is_type_nullable(descriptor.type_());
 
     let mut buffer = utils::write_def_levels(is_optional, validity, array.len())?;
 
@@ -40,7 +45,13 @@ pub fn array_to_page_v1<O: Offset>(
     }
     let uncompressed_page_size = buffer.len();
 
-    let codec = create_codec(&compression)?;
+    let statistics = if options.write_statistics {
+        Some(build_statistics(array))
+    } else {
+        None
+    };
+
+    let codec = create_codec(&options.compression)?;
     let buffer = if let Some(mut codec) = codec {
         // todo: remove this allocation by extending `buffer` directly.
         // needs refactoring `compress`'s API.
@@ -56,15 +67,53 @@ pub fn array_to_page_v1<O: Offset>(
         encoding: Encoding::Plain,
         definition_level_encoding: Encoding::Rle,
         repetition_level_encoding: Encoding::Rle,
-        statistics: None,
+        statistics,
     });
 
     Ok(CompressedPage::new(
         header,
         buffer,
-        compression,
+        options.compression,
         uncompressed_page_size,
         None,
-        None,
+        descriptor,
     ))
+}
+
+fn build_statistics<O: Offset>(array: &BinaryArray<O>) -> ParquetStatistics {
+    let statistics = &BinaryStatistics {
+        null_count: Some(array.null_count() as i64),
+        distinct_count: None,
+        max_value: array
+            .iter()
+            .flatten()
+            .max_by(|x, y| ord_binary(x, y))
+            .map(|x| x.to_vec()),
+        min_value: array
+            .iter()
+            .flatten()
+            .min_by(|x, y| ord_binary(x, y))
+            .map(|x| x.to_vec()),
+    } as &dyn Statistics;
+    serialize_statistics(statistics)
+}
+
+/// Returns the ordering of two binary values. This corresponds to pyarrows' ordering
+/// of statistics.
+pub(crate) fn ord_binary<'a>(a: &'a [u8], b: &'a [u8]) -> std::cmp::Ordering {
+    use std::cmp::Ordering::*;
+    match (a.is_empty(), b.is_empty()) {
+        (true, true) => return Equal,
+        (true, false) => return Less,
+        (false, true) => return Greater,
+        (false, false) => {}
+    }
+
+    for (v1, v2) in a.iter().zip(b.iter()) {
+        match v1.cmp(v2) {
+            Equal => continue,
+            other => return other,
+        }
+    }
+    Equal
 }

--- a/src/io/parquet/write/primitive.rs
+++ b/src/io/parquet/write/primitive.rs
@@ -1,28 +1,34 @@
 use parquet2::{
     compression::create_codec,
     encoding::Encoding,
+    metadata::ColumnDescriptor,
     read::{CompressedPage, PageHeader},
-    schema::{CompressionCodec, DataPageHeader},
+    schema::DataPageHeader,
+    statistics::{serialize_statistics, ParquetStatistics, PrimitiveStatistics, Statistics},
     types::NativeType,
+    write::WriteOptions,
 };
 
 use super::utils;
 use crate::{
     array::{Array, PrimitiveArray},
     error::Result,
+    io::parquet::read::is_type_nullable,
     types::NativeType as ArrowNativeType,
 };
 
 pub fn array_to_page_v1<T, R>(
     array: &PrimitiveArray<T>,
-    compression: CompressionCodec,
-    is_optional: bool,
+    options: WriteOptions,
+    descriptor: ColumnDescriptor,
 ) -> Result<CompressedPage>
 where
     T: ArrowNativeType,
     R: NativeType,
     T: num::cast::AsPrimitive<R>,
 {
+    let is_optional = is_type_nullable(descriptor.type_());
+
     let validity = array.validity();
 
     let mut buffer = utils::write_def_levels(is_optional, validity, array.len())?;
@@ -44,7 +50,7 @@ where
     }
     let uncompressed_page_size = buffer.len();
 
-    let codec = create_codec(&compression)?;
+    let codec = create_codec(&options.compression)?;
     let buffer = if let Some(mut codec) = codec {
         // todo: remove this allocation by extending `buffer` directly.
         // needs refactoring `compress`'s API.
@@ -55,20 +61,55 @@ where
         buffer
     };
 
+    let statistics = if options.write_statistics {
+        Some(build_statistics(array))
+    } else {
+        None
+    };
+
     let header = PageHeader::V1(DataPageHeader {
         num_values: array.len() as i32,
         encoding: Encoding::Plain,
         definition_level_encoding: Encoding::Rle,
         repetition_level_encoding: Encoding::Rle,
-        statistics: None,
+        statistics,
     });
 
     Ok(CompressedPage::new(
         header,
         buffer,
-        compression,
+        options.compression,
         uncompressed_page_size,
         None,
-        None,
+        descriptor,
     ))
+}
+
+fn build_statistics<T, R>(array: &PrimitiveArray<T>) -> ParquetStatistics
+where
+    T: ArrowNativeType,
+    R: NativeType,
+    T: num::cast::AsPrimitive<R>,
+{
+    let statistics = &PrimitiveStatistics::<R> {
+        null_count: Some(array.null_count() as i64),
+        distinct_count: None,
+        max_value: array
+            .iter()
+            .flatten()
+            .map(|x| {
+                let x: R = x.as_();
+                x
+            })
+            .max_by(|x, y| x.ord(y)),
+        min_value: array
+            .iter()
+            .flatten()
+            .map(|x| {
+                let x: R = x.as_();
+                x
+            })
+            .min_by(|x, y| x.ord(y)),
+    } as &dyn Statistics;
+    serialize_statistics(statistics)
 }

--- a/src/io/parquet/write/utf8.rs
+++ b/src/io/parquet/write/utf8.rs
@@ -1,21 +1,28 @@
 use parquet2::{
     compression::create_codec,
     encoding::Encoding,
+    metadata::ColumnDescriptor,
     read::{CompressedPage, PageHeader},
-    schema::{CompressionCodec, DataPageHeader},
+    schema::DataPageHeader,
+    statistics::{serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics},
+    write::WriteOptions,
 };
 
+use super::binary::ord_binary;
 use super::utils;
 use crate::{
     array::{Array, Offset, Utf8Array},
     error::Result,
+    io::parquet::read::is_type_nullable,
 };
 
 pub fn array_to_page_v1<O: Offset>(
     array: &Utf8Array<O>,
-    compression: CompressionCodec,
-    is_optional: bool,
+    options: WriteOptions,
+    descriptor: ColumnDescriptor,
 ) -> Result<CompressedPage> {
+    let is_optional = is_type_nullable(descriptor.type_());
+
     let validity = array.validity();
 
     let mut buffer = utils::write_def_levels(is_optional, validity, array.len())?;
@@ -40,7 +47,7 @@ pub fn array_to_page_v1<O: Offset>(
     }
     let uncompressed_page_size = buffer.len();
 
-    let codec = create_codec(&compression)?;
+    let codec = create_codec(&options.compression)?;
     let buffer = if let Some(mut codec) = codec {
         // todo: remove this allocation by extending `buffer` directly.
         // needs refactoring `compress`'s API.
@@ -51,20 +58,46 @@ pub fn array_to_page_v1<O: Offset>(
         buffer
     };
 
+    let statistics = if options.write_statistics {
+        Some(build_statistics(array))
+    } else {
+        None
+    };
+
     let header = PageHeader::V1(DataPageHeader {
         num_values: array.len() as i32,
         encoding: Encoding::Plain,
         definition_level_encoding: Encoding::Rle,
         repetition_level_encoding: Encoding::Rle,
-        statistics: None,
+        statistics,
     });
 
     Ok(CompressedPage::new(
         header,
         buffer,
-        compression,
+        options.compression,
         uncompressed_page_size,
         None,
-        None,
+        descriptor,
     ))
+}
+
+fn build_statistics<O: Offset>(array: &Utf8Array<O>) -> ParquetStatistics {
+    let statistics = &BinaryStatistics {
+        null_count: Some(array.null_count() as i64),
+        distinct_count: None,
+        max_value: array
+            .iter()
+            .flatten()
+            .map(|x| x.as_bytes())
+            .max_by(|x, y| ord_binary(x, y))
+            .map(|x| x.to_vec()),
+        min_value: array
+            .iter()
+            .flatten()
+            .map(|x| x.as_bytes())
+            .min_by(|x, y| ord_binary(x, y))
+            .map(|x| x.to_vec()),
+    } as &dyn Statistics;
+    serialize_statistics(statistics)
 }


### PR DESCRIPTION
This PR adds support to write parquet statistics. The statistics correspond to the same values as written by pyarrow, which is verified by two integration tests:

* the statistics written by pyarrow are correctly read by arrow2
* the statistics written by arrow2 equal the statistics written by pyarrow
