### PR TITLE
Added arrow version of parquet statistics.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ ahash = { version = "0.7", optional = true }
 
 [dependencies.parquet2]
 git = "https://github.com/jorgecarleitao/parquet2"
-rev = "1d298d9820b5f426ab66e78b9d3450deb4a32581"
+rev = "f86ba6f65fede75dd7b9f7dd6b0fe3e271d2aa58"
 default-features = false
 features = ["snappy", "gzip", "lz4", "zstd", "brotli"]
 optional = true

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,12 @@ impl From<::std::io::Error> for ArrowError {
     }
 }
 
+impl From<std::str::Utf8Error> for ArrowError {
+    fn from(error: std::str::Utf8Error) -> Self {
+        ArrowError::External("".to_string(), Box::new(error))
+    }
+}
+
 impl Display for ArrowError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/src/io/csv/mod.rs
+++ b/src/io/csv/mod.rs
@@ -16,11 +16,5 @@ impl From<chrono::ParseError> for ArrowError {
     }
 }
 
-impl From<std::str::Utf8Error> for ArrowError {
-    fn from(error: std::str::Utf8Error) -> Self {
-        ArrowError::External("".to_string(), Box::new(error))
-    }
-}
-
 pub mod read;
 pub mod write;

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -6,6 +6,7 @@ mod fixed_size_binary;
 mod primitive;
 mod record_batch;
 pub mod schema;
+pub mod statistics;
 mod utf8;
 mod utils;
 
@@ -153,7 +154,6 @@ pub fn page_iter_to_array<I: StreamingIterator<Item = std::result::Result<Page, 
             logical_type,
             ..
         } => match (physical_type, converted_type, logical_type) {
-            // todo: apply conversion rules and the like
             (PhysicalType::Int32, _, _) => {
                 page_iter_i32(iter, metadata, converted_type, logical_type)
             }

--- a/src/io/parquet/read/schema/convert.rs
+++ b/src/io/parquet/read/schema/convert.rs
@@ -410,7 +410,7 @@ fn to_list(fields: &[ParquetType], parent_name: &str) -> Result<Option<DataType>
 ///
 /// If this schema is a group type and none of its children is reserved in the
 /// conversion, the result is Ok(None).
-fn to_data_type(type_: &ParquetType) -> Result<Option<DataType>> {
+pub(crate) fn to_data_type(type_: &ParquetType) -> Result<Option<DataType>> {
     match type_ {
         ParquetType::PrimitiveType {
             basic_info,

--- a/src/io/parquet/read/schema/mod.rs
+++ b/src/io/parquet/read/schema/mod.rs
@@ -10,7 +10,7 @@ pub use metadata::read_schema_from_metadata;
 pub use parquet2::metadata::{FileMetaData, KeyValue, SchemaDescriptor};
 pub use parquet2::schema::types::ParquetType;
 
-pub(crate) use convert::{from_byte_array, from_fixed_len_byte_array, from_int32, from_int64};
+pub(crate) use convert::*;
 
 pub fn get_schema(metadata: &FileMetaData) -> Result<Schema> {
     let schema = read_schema_from_metadata(metadata.key_value_metadata())?;

--- a/src/io/parquet/read/statistics/binary.rs
+++ b/src/io/parquet/read/statistics/binary.rs
@@ -1,0 +1,88 @@
+use std::convert::TryFrom;
+
+use crate::datatypes::DataType;
+use parquet2::schema::types::ParquetType;
+use parquet2::statistics::BinaryStatistics as ParquetByteArrayStatistics;
+
+use super::super::schema;
+use super::Statistics;
+use crate::error::{ArrowError, Result};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BinaryStatistics {
+    pub null_count: Option<i64>,
+    pub distinct_count: Option<i64>,
+    pub min_value: Option<Vec<u8>>,
+    pub max_value: Option<Vec<u8>>,
+}
+
+impl Statistics for BinaryStatistics {
+    fn data_type(&self) -> &DataType {
+        &DataType::Binary
+    }
+}
+
+impl From<&ParquetByteArrayStatistics> for BinaryStatistics {
+    fn from(stats: &ParquetByteArrayStatistics) -> Self {
+        Self {
+            null_count: stats.null_count,
+            distinct_count: stats.distinct_count,
+            min_value: stats.min_value.clone(),
+            max_value: stats.max_value.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Utf8Statistics {
+    pub null_count: Option<i64>,
+    pub distinct_count: Option<i64>,
+    pub min_value: Option<String>,
+    pub max_value: Option<String>,
+}
+
+impl Statistics for Utf8Statistics {
+    fn data_type(&self) -> &DataType {
+        &DataType::Utf8
+    }
+}
+
+impl TryFrom<&ParquetByteArrayStatistics> for Utf8Statistics {
+    type Error = ArrowError;
+
+    fn try_from(stats: &ParquetByteArrayStatistics) -> Result<Self> {
+        Ok(Self {
+            null_count: stats.null_count,
+            distinct_count: stats.distinct_count,
+            min_value: stats
+                .min_value
+                .as_ref()
+                .map(|x| std::str::from_utf8(&x).map(|x| x.to_string()))
+                .transpose()?,
+            max_value: stats
+                .max_value
+                .as_ref()
+                .map(|x| std::str::from_utf8(&x).map(|x| x.to_string()))
+                .transpose()?,
+        })
+    }
+}
+
+pub(super) fn statistics_from_byte_array(
+    stats: &ParquetByteArrayStatistics,
+    type_: &ParquetType,
+) -> Result<Box<dyn Statistics>> {
+    let data_type = schema::to_data_type(type_)?.unwrap();
+
+    use DataType::*;
+    Ok(match data_type {
+        Utf8 => Box::new(Utf8Statistics::try_from(stats)?),
+        Binary => Box::new(BinaryStatistics::from(stats)),
+        other => {
+            return Err(ArrowError::NotYetImplemented(format!(
+                "Can't read {:?} from parquet",
+                other
+            )))
+        }
+    })
+}

--- a/src/io/parquet/read/statistics/boolean.rs
+++ b/src/io/parquet/read/statistics/boolean.rs
@@ -1,0 +1,29 @@
+use crate::datatypes::DataType;
+use parquet2::statistics::BooleanStatistics as ParquetBooleanStatistics;
+
+use super::Statistics;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BooleanStatistics {
+    pub null_count: Option<i64>,
+    pub distinct_count: Option<i64>,
+    pub min_value: Option<bool>,
+    pub max_value: Option<bool>,
+}
+
+impl Statistics for BooleanStatistics {
+    fn data_type(&self) -> &DataType {
+        &DataType::Boolean
+    }
+}
+
+impl From<&ParquetBooleanStatistics> for BooleanStatistics {
+    fn from(stats: &ParquetBooleanStatistics) -> Self {
+        Self {
+            null_count: stats.null_count,
+            distinct_count: stats.distinct_count,
+            min_value: stats.min_value,
+            max_value: stats.max_value,
+        }
+    }
+}

--- a/src/io/parquet/read/statistics/mod.rs
+++ b/src/io/parquet/read/statistics/mod.rs
@@ -1,0 +1,69 @@
+use crate::datatypes::DataType;
+use crate::error::ArrowError;
+use parquet2::schema::types::PhysicalType;
+use parquet2::statistics::PrimitiveStatistics as ParquetPrimitiveStatistics;
+use parquet2::statistics::Statistics as ParquetStatistics;
+
+use crate::error::Result;
+
+mod primitive;
+pub use primitive::*;
+mod binary;
+pub use binary::*;
+mod boolean;
+pub use boolean::*;
+
+/// Trait denoting a deserialized parquet statistics (into arrow).
+pub trait Statistics: std::fmt::Debug {
+    fn data_type(&self) -> &DataType;
+}
+
+impl PartialEq for &dyn Statistics {
+    fn eq(&self, other: &Self) -> bool {
+        self.data_type() == other.data_type()
+    }
+}
+
+pub fn deserialize_statistics(stats: &dyn ParquetStatistics) -> Result<Box<dyn Statistics>> {
+    match stats.physical_type() {
+        PhysicalType::Int32 => {
+            let stats = stats.as_any().downcast_ref().unwrap();
+            primitive::statistics_from_i32(stats, stats.descriptor.type_())
+        }
+        PhysicalType::Int64 => {
+            let stats = stats.as_any().downcast_ref().unwrap();
+            primitive::statistics_from_i64(stats, stats.descriptor.type_())
+        }
+        PhysicalType::ByteArray => {
+            let stats = stats.as_any().downcast_ref().unwrap();
+            binary::statistics_from_byte_array(stats, stats.descriptor.type_())
+        }
+        PhysicalType::Boolean => {
+            let stats = stats.as_any().downcast_ref().unwrap();
+            Ok(Box::new(BooleanStatistics::from(stats)))
+        }
+        PhysicalType::Float => {
+            let stats = stats
+                .as_any()
+                .downcast_ref::<ParquetPrimitiveStatistics<f32>>()
+                .unwrap();
+            Ok(Box::new(PrimitiveStatistics::<f32>::from((
+                stats,
+                DataType::Float32,
+            ))))
+        }
+        PhysicalType::Double => {
+            let stats = stats
+                .as_any()
+                .downcast_ref::<ParquetPrimitiveStatistics<f64>>()
+                .unwrap();
+            Ok(Box::new(PrimitiveStatistics::<f64>::from((
+                stats,
+                DataType::Float64,
+            ))))
+        }
+        _ => Err(ArrowError::NotYetImplemented(
+            "Reading Fixed-len array statistics is not yet supported".to_string(),
+        )),
+    }
+}

--- a/src/io/parquet/read/statistics/primitive.rs
+++ b/src/io/parquet/read/statistics/primitive.rs
@@ -1,0 +1,74 @@
+use crate::{datatypes::DataType, types::NativeType};
+use parquet2::schema::types::ParquetType;
+use parquet2::statistics::PrimitiveStatistics as ParquetPrimitiveStatistics;
+use parquet2::types::NativeType as ParquetNativeType;
+
+use super::super::schema;
+use super::Statistics;
+use crate::error::Result;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PrimitiveStatistics<T: NativeType> {
+    pub data_type: DataType,
+    pub null_count: Option<i64>,
+    pub distinct_count: Option<i64>,
+    pub min_value: Option<T>,
+    pub max_value: Option<T>,
+}
+
+impl<T: NativeType> Statistics for PrimitiveStatistics<T> {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+}
+
+impl<T, R> From<(&ParquetPrimitiveStatistics<R>, DataType)> for PrimitiveStatistics<T>
+where
+    T: NativeType,
+    R: ParquetNativeType,
+    R: num::cast::AsPrimitive<T>,
+{
+    fn from((stats, data_type): (&ParquetPrimitiveStatistics<R>, DataType)) -> Self {
+        Self {
+            data_type,
+            null_count: stats.null_count,
+            distinct_count: stats.distinct_count,
+            min_value: stats.min_value.map(|x| x.as_()),
+            max_value: stats.max_value.map(|x| x.as_()),
+        }
+    }
+}
+
+pub(super) fn statistics_from_i32(
+    stats: &ParquetPrimitiveStatistics<i32>,
+    type_: &ParquetType,
+) -> Result<Box<dyn Statistics>> {
+    let data_type = schema::to_data_type(type_)?.unwrap();
+
+    use DataType::*;
+    Ok(match data_type {
+        UInt8 => {
+            Box::new(PrimitiveStatistics::<u8>::from((stats, data_type))) as Box<dyn Statistics>
+        }
+        UInt16 => Box::new(PrimitiveStatistics::<u16>::from((stats, data_type))),
+        UInt32 => Box::new(PrimitiveStatistics::<u32>::from((stats, data_type))),
+        Int8 => Box::new(PrimitiveStatistics::<i8>::from((stats, data_type))),
+        Int16 => Box::new(PrimitiveStatistics::<i16>::from((stats, data_type))),
+        _ => Box::new(PrimitiveStatistics::<i32>::from((stats, data_type))),
+    })
+}
+
+pub(super) fn statistics_from_i64(
+    stats: &ParquetPrimitiveStatistics<i64>,
+    type_: &ParquetType,
+) -> Result<Box<dyn Statistics>> {
+    let data_type = schema::to_data_type(type_)?.unwrap();
+
+    use DataType::*;
+    Ok(match data_type {
+        UInt64 => {
+            Box::new(PrimitiveStatistics::<u64>::from((stats, data_type))) as Box<dyn Statistics>
+        }
+        _ => Box::new(PrimitiveStatistics::<i64>::from((stats, data_type))),
+    })
+}

--- a/src/io/parquet/write/binary.rs
+++ b/src/io/parquet/write/binary.rs
@@ -46,7 +46,7 @@ pub fn array_to_page_v1<O: Offset>(
     let uncompressed_page_size = buffer.len();
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(array))
+        Some(build_statistics(array, descriptor.clone()))
     } else {
         None
     };
@@ -80,8 +80,12 @@ pub fn array_to_page_v1<O: Offset>(
     ))
 }
 
-fn build_statistics<O: Offset>(array: &BinaryArray<O>) -> ParquetStatistics {
+fn build_statistics<O: Offset>(
+    array: &BinaryArray<O>,
+    descriptor: ColumnDescriptor,
+) -> ParquetStatistics {
     let statistics = &BinaryStatistics {
+        descriptor,
         null_count: Some(array.null_count() as i64),
         distinct_count: None,
         max_value: array

--- a/src/io/parquet/write/primitive.rs
+++ b/src/io/parquet/write/primitive.rs
@@ -62,7 +62,7 @@ where
     };
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(array))
+        Some(build_statistics(array, descriptor.clone()))
     } else {
         None
     };
@@ -85,13 +85,17 @@ where
     ))
 }
 
-fn build_statistics<T, R>(array: &PrimitiveArray<T>) -> ParquetStatistics
+fn build_statistics<T, R>(
+    array: &PrimitiveArray<T>,
+    descriptor: ColumnDescriptor,
+) -> ParquetStatistics
 where
     T: ArrowNativeType,
     R: NativeType,
     T: num::cast::AsPrimitive<R>,
 {
     let statistics = &PrimitiveStatistics::<R> {
+        descriptor,
         null_count: Some(array.null_count() as i64),
         distinct_count: None,
         max_value: array

--- a/src/io/parquet/write/utf8.rs
+++ b/src/io/parquet/write/utf8.rs
@@ -59,7 +59,7 @@ pub fn array_to_page_v1<O: Offset>(
     };
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(array))
+        Some(build_statistics(array, descriptor.clone()))
     } else {
         None
     };
@@ -82,8 +82,12 @@ pub fn array_to_page_v1<O: Offset>(
     ))
 }
 
-fn build_statistics<O: Offset>(array: &Utf8Array<O>) -> ParquetStatistics {
+fn build_statistics<O: Offset>(
+    array: &Utf8Array<O>,
+    descriptor: ColumnDescriptor,
+) -> ParquetStatistics {
     let statistics = &BinaryStatistics {
+        descriptor,
         null_count: Some(array.null_count() as i64),
         distinct_count: None,
         max_value: array


### PR DESCRIPTION
This allows users to consume statistics from parquet that are correctly de-serialized to arrow. E.g. Arrow's `u8` corresponds to parquets' `i32`.

The idea here is that, as a user of `arrow2`, I should not care about the implementation detail of the above and instead just be able to get a statistics that is properly de-serialized to arrow's native types, so that e.g. we can apply operations on their values.