### PR TITLE
Simplify API to get values from arrays.

### DIFF
--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -80,22 +80,12 @@ impl<O: Offset> BinaryArray<O> {
     }
 
     #[inline]
-    pub fn offsets(&self) -> &[O] {
-        self.offsets.as_slice()
-    }
-
-    #[inline]
-    pub fn offsets_buffer(&self) -> &Buffer<O> {
+    pub fn offsets(&self) -> &Buffer<O> {
         &self.offsets
     }
 
     #[inline]
-    pub fn values(&self) -> &[u8] {
-        self.values.as_slice()
-    }
-
-    #[inline]
-    pub fn values_buffer(&self) -> &Buffer<u8> {
+    pub fn values(&self) -> &Buffer<u8> {
         &self.values
     }
 }
@@ -171,8 +161,8 @@ mod tests {
         assert_eq!(array.value(1), b"");
         assert_eq!(array.value(2), b"hello2");
         assert_eq!(unsafe { array.value_unchecked(2) }, b"hello2");
-        assert_eq!(array.values(), b"hellohello2");
-        assert_eq!(array.offsets(), &[0, 5, 5, 11]);
+        assert_eq!(array.values().as_slice(), b"hellohello2");
+        assert_eq!(array.offsets().as_slice(), &[0, 5, 5, 11]);
         assert_eq!(
             array.validity(),
             &Some(Bitmap::from_u8_slice(&[0b00000101], 3))
@@ -182,8 +172,8 @@ mod tests {
         assert_eq!(array.is_valid(2), true);
 
         let array2 = BinaryArray::<i32>::from_data(
-            array.offsets_buffer().clone(),
-            array.values_buffer().clone(),
+            array.offsets().clone(),
+            array.values().clone(),
             array.validity().clone(),
         );
         assert_eq!(array, array2);
@@ -192,15 +182,15 @@ mod tests {
         assert_eq!(array.value(0), b"");
         assert_eq!(array.value(1), b"hello2");
         // note how this keeps everything: the offsets were sliced
-        assert_eq!(array.values(), b"hellohello2");
-        assert_eq!(array.offsets(), &[5, 5, 11]);
+        assert_eq!(array.values().as_slice(), b"hellohello2");
+        assert_eq!(array.offsets().as_slice(), &[5, 5, 11]);
     }
 
     #[test]
     fn empty() {
         let array = BinaryArray::<i32>::new_empty();
-        assert_eq!(array.values(), b"");
-        assert_eq!(array.offsets(), &[0]);
+        assert_eq!(array.values().as_slice(), b"");
+        assert_eq!(array.offsets().as_slice(), &[0]);
         assert_eq!(array.validity(), &None);
     }
 }

--- a/src/array/equal/primitive.rs
+++ b/src/array/equal/primitive.rs
@@ -11,8 +11,8 @@ pub(super) fn equal<T: NativeType>(
     rhs_start: usize,
     len: usize,
 ) -> bool {
-    let lhs_values = &lhs.values();
-    let rhs_values = &rhs.values();
+    let lhs_values = lhs.values();
+    let rhs_values = rhs.values();
 
     let lhs_null_count = count_validity(lhs_validity, lhs_start, len);
     let rhs_null_count = count_validity(rhs_validity, rhs_start, len);

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -62,8 +62,8 @@ impl FixedSizeBinaryArray {
     }
 
     #[inline]
-    pub fn values(&self) -> &[u8] {
-        self.values.as_slice()
+    pub fn values(&self) -> &Buffer<u8> {
+        &self.values
     }
 
     #[inline]

--- a/src/array/growable/dictionary.rs
+++ b/src/array/growable/dictionary.rs
@@ -46,7 +46,7 @@ impl<'a, T: DictionaryKey> GrowableDictionary<'a, T> {
         let arrays_keys = arrays.iter().map(|array| array.keys()).collect::<Vec<_>>();
         let keys_values = arrays_keys
             .iter()
-            .map(|array| array.values())
+            .map(|array| array.values().as_slice())
             .collect::<Vec<_>>();
         let keys_validities = arrays_keys
             .iter()

--- a/src/array/growable/primitive.rs
+++ b/src/array/growable/primitive.rs
@@ -35,7 +35,7 @@ impl<'a, T: NativeType> GrowablePrimitive<'a, T> {
             .collect::<Vec<_>>();
         let arrays = arrays
             .iter()
-            .map(|array| array.values())
+            .map(|array| array.values().as_slice())
             .collect::<Vec<_>>();
 
         Self {

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -103,13 +103,8 @@ impl<O: Offset> ListArray<O> {
     }
 
     #[inline]
-    pub fn offsets_buffer(&self) -> &Buffer<O> {
+    pub fn offsets(&self) -> &Buffer<O> {
         &self.offsets
-    }
-
-    #[inline]
-    pub fn offsets(&self) -> &[O] {
-        self.offsets.as_slice()
     }
 
     #[inline]

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -71,16 +71,10 @@ impl<T: NativeType> PrimitiveArray<T> {
         }
     }
 
-    /// The values [`Buffer`]. Often used to clone the buffer.
+    /// The values [`Buffer`].
     #[inline]
-    pub fn values_buffer(&self) -> &Buffer<T> {
+    pub fn values(&self) -> &Buffer<T> {
         &self.values
-    }
-
-    /// The values as a slice.
-    #[inline]
-    pub fn values(&self) -> &[T] {
-        self.values.as_slice()
     }
 
     /// Safe method to retrieve the value at slot `i`.
@@ -139,7 +133,7 @@ mod tests {
         assert_eq!(array.value(0), 1);
         assert_eq!(array.value(1), 0);
         assert_eq!(array.value(2), 10);
-        assert_eq!(array.values(), &[1, 0, 10]);
+        assert_eq!(array.values().as_slice(), &[1, 0, 10]);
         assert_eq!(
             array.validity(),
             &Some(Bitmap::from_u8_slice(&[0b00000101], 3))
@@ -150,7 +144,7 @@ mod tests {
 
         let array2 = PrimitiveArray::<i32>::from_data(
             DataType::Int32,
-            array.values_buffer().clone(),
+            array.values().clone(),
             array.validity().clone(),
         );
         assert_eq!(array, array2);
@@ -158,7 +152,7 @@ mod tests {
         let array = array.slice(1, 2);
         assert_eq!(array.value(0), 0);
         assert_eq!(array.value(1), 10);
-        assert_eq!(array.values(), &[0, 10]);
+        assert_eq!(array.values().as_slice(), &[0, 10]);
     }
 
     #[test]

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -140,25 +140,13 @@ impl<O: Offset> Utf8Array<O> {
 
     /// Returns the offsets of this [`Utf8Array`].
     #[inline]
-    pub fn offsets(&self) -> &[O] {
-        self.offsets.as_slice()
-    }
-
-    /// Returns the offset [`Buffer`] of this [`Utf8Array`].
-    #[inline]
-    pub fn offsets_buffer(&self) -> &Buffer<O> {
+    pub fn offsets(&self) -> &Buffer<O> {
         &self.offsets
     }
 
-    /// Returns the values of this [`Utf8Array`] as a slice of `u8`
+    /// Returns the values of this [`Utf8Array`].
     #[inline]
-    pub fn values(&self) -> &[u8] {
-        self.values.as_slice()
-    }
-
-    /// Returns the values [`Buffer`] of this [`Utf8Array`]
-    #[inline]
-    pub fn values_buffer(&self) -> &Buffer<u8> {
+    pub fn values(&self) -> &Buffer<u8> {
         &self.values
     }
 }
@@ -227,8 +215,8 @@ mod tests {
         assert_eq!(array.value(1), "");
         assert_eq!(array.value(2), "hello2");
         assert_eq!(unsafe { array.value_unchecked(2) }, "hello2");
-        assert_eq!(array.values(), b"hellohello2");
-        assert_eq!(array.offsets(), &[0, 5, 5, 11]);
+        assert_eq!(array.values().as_slice(), b"hellohello2");
+        assert_eq!(array.offsets().as_slice(), &[0, 5, 5, 11]);
         assert_eq!(
             array.validity(),
             &Some(Bitmap::from_u8_slice(&[0b00000101], 3))
@@ -238,8 +226,8 @@ mod tests {
         assert_eq!(array.is_valid(2), true);
 
         let array2 = Utf8Array::<i32>::from_data(
-            array.offsets_buffer().clone(),
-            array.values_buffer().clone(),
+            array.offsets().clone(),
+            array.values().clone(),
             array.validity().clone(),
         );
         assert_eq!(array, array2);
@@ -248,15 +236,15 @@ mod tests {
         assert_eq!(array.value(0), "");
         assert_eq!(array.value(1), "hello2");
         // note how this keeps everything: the offsets were sliced
-        assert_eq!(array.values(), b"hellohello2");
-        assert_eq!(array.offsets(), &[5, 5, 11]);
+        assert_eq!(array.values().as_slice(), b"hellohello2");
+        assert_eq!(array.offsets().as_slice(), &[5, 5, 11]);
     }
 
     #[test]
     fn empty() {
         let array = Utf8Array::<i32>::new_empty();
-        assert_eq!(array.values(), b"");
-        assert_eq!(array.offsets(), &[0]);
+        assert_eq!(array.values().as_slice(), b"");
+        assert_eq!(array.offsets().as_slice(), &[0]);
         assert_eq!(array.validity(), &None);
     }
 }

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -152,6 +152,15 @@ impl<T: NativeType, U: AsRef<[T]>> From<U> for Buffer<T> {
     }
 }
 
+impl<T: NativeType> std::ops::Deref for Buffer<T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
 impl<T: NativeType> FromIterator<T> for Buffer<T> {
     #[inline]
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -273,7 +273,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
 
             let list = ListArray::<i32>::from_data(
                 to_type.clone(),
-                array.offsets_buffer().clone(),
+                array.offsets().clone(),
                 new_values,
                 array.validity().clone(),
             );
@@ -669,7 +669,7 @@ mod tests {
         .unwrap();
 
         let arr = b.as_any().downcast_ref::<ListArray<i32>>().unwrap();
-        assert_eq!(&[0, 1, 2, 3, 4, 5], arr.offsets());
+        assert_eq!(&[0, 1, 2, 3, 4, 5], arr.offsets().as_slice());
         let values = arr.values();
         let c = values
             .as_any()
@@ -692,7 +692,7 @@ mod tests {
         .unwrap();
 
         let arr = b.as_any().downcast_ref::<ListArray<i32>>().unwrap();
-        assert_eq!(&[0, 1, 2, 3, 4, 5], arr.offsets());
+        assert_eq!(&[0, 1, 2, 3, 4, 5], arr.offsets().as_slice());
         let values = arr.values();
         let c = values.as_any().downcast_ref::<Int32Array>().unwrap();
 
@@ -715,7 +715,7 @@ mod tests {
         .unwrap();
 
         let arr = b.as_any().downcast_ref::<ListArray<i32>>().unwrap();
-        assert_eq!(&[0, 1, 2, 3, 4], arr.offsets());
+        assert_eq!(&[0, 1, 2, 3, 4], arr.offsets().as_slice());
         let values = arr.values();
         let c = values.as_any().downcast_ref::<Float64Array>().unwrap();
 

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -85,7 +85,7 @@ where
 {
     PrimitiveArray::<T>::from_data(
         to_type.clone(),
-        from.values_buffer().clone(),
+        from.values().clone(),
         from.validity().clone(),
     )
 }

--- a/src/compute/nullif.rs
+++ b/src/compute/nullif.rs
@@ -46,7 +46,7 @@ pub fn nullif_primitive<T: NativeType>(
 
     Ok(PrimitiveArray::<T>::from_data(
         lhs.data_type().clone(),
-        lhs.values_buffer().clone(),
+        lhs.values().clone(),
         validity,
     ))
 }


### PR DESCRIPTION
With `Buffer` implementing `Deref`, we can further simplify returning array values, thereby simplifying the mental workload of mapping the low-level and high-level APIs.

This PR does just that.