### PR TITLE
add unsafe from_data_unchecked

### DIFF
--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -45,7 +45,21 @@ impl<O: Offset> ListArray<O> {
         validity: Option<Bitmap>,
     ) -> Self {
         check_offsets(&offsets, values.len());
+        unsafe { Self::from_data_unchecked(data_type, offsets, values, validity) }
+    }
 
+    /// Create a new ListArray from its data buffers.
+    ///
+    /// # Safety
+    /// `offsets` buffer must be monotonically increasing.
+    ///
+    /// Note that the correctness of the data types are checked.
+    pub unsafe fn from_data_unchecked(
+        data_type: DataType,
+        offsets: Buffer<O>,
+        values: Arc<dyn Array>,
+        validity: Option<Bitmap>,
+    ) -> Self {
         // validate data_type
         let child_data_type = Self::get_child_type(&data_type);
         assert_eq!(


### PR DESCRIPTION
This proposes an unsafe `from_data_unchecked` for `ListArray<O>` and `Utf8Array<O>`.

The rationale for this change is that I cast the inner type of the list data and create a new `ListArray`, where the offsets are unchanged (only cloned).

```rust
let child = list.values();
let offsets = list.offsets();
let child = cast::cast(child, &child_type)?;
let list = ListArray::from_data(child_type, offsets.clone(), Arc::new(*child), list.validity.clone());
```

There was a name collision on the `Utf8Array` so maybe another function name is better.