### PR TITLE
Improved performance of aggregate of arrays without bit offset.

### DIFF
--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -214,7 +214,7 @@ impl Bitmap {
 impl Bitmap {
     #[inline]
     pub(crate) fn offset(&self) -> usize {
-        self.offset
+        self.offset % 8
     }
 
     #[inline]
@@ -222,7 +222,7 @@ impl Bitmap {
         assert_eq!(self.offset % 8, 0); // slices only make sense when there is no offset
         let start = self.offset % 8;
         let len = self.length.saturating_add(7) / 8;
-        &self.bytes[start..len]
+        &self.bytes[start..start + len]
     }
 }
 

--- a/src/bitmap/utils/chunk_iterator/chunks_exact.rs
+++ b/src/bitmap/utils/chunk_iterator/chunks_exact.rs
@@ -1,0 +1,90 @@
+use std::{convert::TryInto, slice::ChunksExact};
+
+use super::{BitChunk, BitChunkIterExact};
+
+/// An iterator over a [`BitChunk`] from a slice of bytes.
+#[derive(Debug)]
+pub struct BitChunksExact<'a, T: BitChunk> {
+    iter: ChunksExact<'a, u8>,
+    remainder: &'a [u8],
+    phantom: std::marker::PhantomData<T>,
+}
+
+impl<'a, T: BitChunk> BitChunksExact<'a, T> {
+    #[inline]
+    pub fn new(slice: &'a [u8], len: usize) -> Self {
+        let size_of = std::mem::size_of::<T>();
+        let bytes_len = (len + 7) / 8;
+        let (iter, remainder) = if size_of != 1 {
+            // case where a chunk has more than one byte
+            let chunks = slice.chunks_exact(size_of);
+            let remainder_bytes = chunks.remainder();
+            (chunks, remainder_bytes)
+        } else {
+            // case where a chunk is exactly one byte
+            let chunks = &slice[..len / 8];
+            let chunks = chunks.chunks_exact(size_of);
+            (chunks, &slice[slice.len() - 1..bytes_len])
+        };
+
+        Self {
+            iter,
+            remainder,
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.iter.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    #[inline]
+    pub fn remainder(&self) -> T {
+        let remainder_bytes = self.remainder;
+        if remainder_bytes.is_empty() {
+            return T::zero();
+        }
+        let remainder = match remainder_bytes.try_into() {
+            Ok(a) => a,
+            Err(_) => {
+                let mut remainder = T::zero().to_ne_bytes();
+                remainder_bytes
+                    .iter()
+                    .enumerate()
+                    .for_each(|(index, b)| remainder[index] = *b);
+                remainder
+            }
+        };
+        T::from_ne_bytes(remainder)
+    }
+}
+
+impl<T: BitChunk> Iterator for BitChunksExact<'_, T> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().map(|x| match x.try_into() {
+            Ok(a) => T::from_ne_bytes(a),
+            Err(_) => unreachable!(),
+        })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<T: BitChunk> BitChunkIterExact<T> for BitChunksExact<'_, T> {
+    #[inline]
+    fn remainder(&self) -> T {
+        self.remainder()
+    }
+}

--- a/src/bitmap/utils/chunk_iterator/merge.rs
+++ b/src/bitmap/utils/chunk_iterator/merge.rs
@@ -12,7 +12,7 @@ use super::BitChunk;
 /// assert_eq!(result, 0b10101100);
 /// ```
 #[inline]
-pub fn merge_reversed<T>(mut current: T, mut next: T, offset: u32) -> T
+pub fn merge_reversed<T>(mut current: T, mut next: T, offset: usize) -> T
 where
     T: BitChunk,
 {
@@ -23,7 +23,7 @@ where
     // expected = [n5, n6, n7, c0, c1, c2, c3, c4]
 
     // 1. unset most significants of `next` up to `offset`
-    let inverse_offset = std::mem::size_of::<T>() as u32 * 8 - offset;
+    let inverse_offset = std::mem::size_of::<T>() * 8 - offset;
     next <<= inverse_offset;
     // next    =  [n5, n6, n7, 0 , 0 , 0 , 0 , 0 ]
 

--- a/src/bitmap/utils/mod.rs
+++ b/src/bitmap/utils/mod.rs
@@ -3,6 +3,7 @@ mod iterator;
 mod slice_iterator;
 mod zip_validity;
 
+pub use chunk_iterator::{BitChunk, BitChunkIterExact, BitChunks, BitChunksExact};
 pub use iterator::BitmapIter;
 pub use slice_iterator::SlicesIterator;
 pub use zip_validity::{zip_validity, ZipValidity};
@@ -78,8 +79,6 @@ pub fn null_count(slice: &[u8], offset: usize, len: usize) -> usize {
 
     len - count
 }
-
-pub use chunk_iterator::{BitChunk, BitChunks};
 
 #[cfg(test)]
 mod tests {

--- a/src/io/ipc/write/serialize.rs
+++ b/src/io/ipc/write/serialize.rs
@@ -498,7 +498,7 @@ fn to_bytes<T: NativeType>(values: &[T], is_little_endian: bool) -> Vec<u8> {
 
 #[inline]
 fn to_le_bitmap(bitmap: &Bitmap) -> Vec<u8> {
-    if bitmap.offset() % 8 != 0 {
+    if bitmap.offset() != 0 {
         // case where we can't slice the bitmap as the offsets are not multiple of 8
         Bitmap::from_trusted_len_iter(bitmap.iter())
             .as_slice()

--- a/src/types/bit_chunk.rs
+++ b/src/types/bit_chunk.rs
@@ -15,9 +15,9 @@ pub unsafe trait BitChunk:
     + BitAnd<Output = Self>
     + ShlAssign
     + Not<Output = Self>
-    + ShrAssign<u32>
-    + ShlAssign<u32>
-    + Shl<u32, Output = Self>
+    + ShrAssign<usize>
+    + ShlAssign<usize>
+    + Shl<usize, Output = Self>
     + Eq
     + BitAndAssign
     + BitOr<Output = Self>


### PR DESCRIPTION
With this PR:

* sum of nullable equals arrows' official Rust implementation;
* min/max is 30% faster.

This only applies to bitmaps whose offsets are multiples of 8. This is a sufficiently common situation to justify a specialized implementation. The implementation remains `unsafe` free.
