### PR TITLE
add values_unchecked to primitive and boolean array

### DIFF
--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -68,10 +68,19 @@ impl BooleanArray {
         }
     }
 
-    /// Returns the element at index `i` as &str
+    /// Returns the element at index `i` as bool
     #[inline]
     pub fn value(&self, i: usize) -> bool {
         self.values.get_bit(i)
+    }
+
+    /// Returns the element at index `i` as bool
+    ///
+    /// # Safety
+    /// Caller must be sure that `i < self.len()`
+    #[inline]
+    pub unsafe fn value_unchecked(&self, i: usize) -> bool {
+        self.values.get_bit_unchecked(i)
     }
 
     /// Returns the values bitmap of this [`BooleanArray`].

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -83,6 +83,15 @@ impl<T: NativeType> PrimitiveArray<T> {
     pub fn value(&self, i: usize) -> T {
         self.values()[i]
     }
+
+    /// Returns the element at index `i` as `T`
+    ///
+    /// # Safety
+    /// Caller must be sure that `i < self.len()`
+    #[inline]
+    pub unsafe fn value_unchecked(&self, i: usize) -> T {
+        *self.values().as_ptr().add(i)
+    }
 }
 
 impl<T: NativeType> Array for PrimitiveArray<T> {
@@ -153,6 +162,11 @@ mod tests {
         assert_eq!(array.value(0), 0);
         assert_eq!(array.value(1), 10);
         assert_eq!(array.values().as_slice(), &[0, 10]);
+
+        unsafe {
+            assert_eq!(array.value_unchecked(0), 0);
+            assert_eq!(array.value_unchecked(1), 10);
+        }
     }
 
     #[test]


### PR DESCRIPTION
This PR adds unsafe `value_unchecked` to `PrimitiveArray` and `BooleanArray`, similar to what's already present in `Utf8Array` and `ListArray`