### PR TITLE
Improved Primitive API for easiness of use

### DIFF
--- a/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/arrow-pyarrow-integration-testing/src/lib.rs
@@ -28,7 +28,7 @@ use pyo3::{libc::uintptr_t, prelude::*};
 
 use arrow2::array::{Array, Int64Array};
 use arrow2::ffi;
-use arrow2::{array::Primitive, compute};
+use arrow2::{array::PrimitiveBuilder, compute};
 use arrow2::{datatypes::DataType, error::ArrowError};
 
 type ArrayRef = Arc<dyn Array>;
@@ -124,9 +124,10 @@ fn double(array: PyObject, py: Python) -> PyResult<PyObject> {
 #[pyfunction]
 fn double_py(lambda: PyObject, py: Python) -> PyResult<bool> {
     // create
-    let array = Arc::new(Primitive::<i64>::from(vec![Some(1), None, Some(3)]).to(DataType::Int64));
+    let array =
+        Arc::new(PrimitiveBuilder::<i64>::from(vec![Some(1), None, Some(3)]).to(DataType::Int64));
     let expected =
-        Arc::new(Primitive::<i64>::from(vec![Some(2), None, Some(6)]).to(DataType::Int64))
+        Arc::new(PrimitiveBuilder::<i64>::from(vec![Some(2), None, Some(6)]).to(DataType::Int64))
             as ArrayRef;
 
     // to py
@@ -184,7 +185,7 @@ fn round_trip(array: PyObject, py: Python) -> PyResult<PyObject> {
 fn import_primitive(array: PyObject, py: Python) -> PyResult<bool> {
     let array = to_rust(array, py)?;
     let expected =
-        Arc::new(Primitive::<i64>::from(vec![Some(2), None, Some(6)]).to(DataType::Int64))
+        Arc::new(PrimitiveBuilder::<i64>::from(vec![Some(2), None, Some(6)]).to(DataType::Int64))
             as ArrayRef;
 
     Ok(array == expected)
@@ -193,8 +194,9 @@ fn import_primitive(array: PyObject, py: Python) -> PyResult<bool> {
 /// Converts to rust and back to python
 #[pyfunction]
 fn export_primitive(py: Python) -> PyResult<PyObject> {
-    let array = Arc::new(Primitive::<i64>::from(vec![Some(2), None, Some(6)]).to(DataType::Int64))
-        as ArrayRef;
+    let array =
+        Arc::new(PrimitiveBuilder::<i64>::from(vec![Some(2), None, Some(6)]).to(DataType::Int64))
+            as ArrayRef;
 
     let array = to_py(array, py)?;
 

--- a/benches/from_trusted_len_iter.rs
+++ b/benches/from_trusted_len_iter.rs
@@ -1,6 +1,6 @@
 extern crate arrow2;
 
-use arrow2::{array::Primitive, bitmap::*, buffer::*};
+use arrow2::{array::PrimitiveBuilder, bitmap::*, buffer::*};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
@@ -21,7 +21,7 @@ fn add_benchmark(c: &mut Criterion) {
         .into_iter()
         .map(|x| if x % 5 == 0 { Some(x) } else { None });
     c.bench_function("primitive", |b| {
-        b.iter(|| Primitive::from_trusted_len_iter(maybe_values.clone()))
+        b.iter(|| PrimitiveBuilder::from_trusted_len_iter(maybe_values.clone()))
     });
 }
 

--- a/benches/take_kernels.rs
+++ b/benches/take_kernels.rs
@@ -41,7 +41,7 @@ fn create_random_index(size: usize, null_density: f32) -> PrimitiveArray<i32> {
                 None
             }
         })
-        .collect::<Primitive<i32>>()
+        .collect::<PrimitiveBuilder<i32>>()
         .to(DataType::Int32)
 }
 

--- a/guide/src/ffi.md
+++ b/guide/src/ffi.md
@@ -20,16 +20,14 @@ The API to export an `Array` is as follows:
 
 ```rust
 use std::sync::Arc;
-use arrow2::array::{Array, Primitive};
-use arrow2::datatypes::DataType;
+use arrow2::array::{Array, Int32Array};
 use arrow2::ffi::ArrowArray;
 
 # fn main() {
 // Example of an array:
 let array = [Some(1), None, Some(123)]
     .iter()
-    .collect::<Primitive<i32>>()
-    .to(DataType::Int32);
+    .collect::<Int32Array>();
 
 // export the array.
 let ffi_array = ffi::export_to_c(Arc::new(array))?;

--- a/guide/src/high_level.md
+++ b/guide/src/high_level.md
@@ -90,12 +90,12 @@ let data = vec![
     Some(vec![Some(4), None, Some(6)]),
 ];
 
-let a: ListArray<i32> = data
-    .into_iter()
-    .collect::<ListPrimitive<i32, Primitive<i32>, i32>>()
-    .to(ListArray::<i32>::default_datatype(DataType::Int32));
+let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+builder.extend(data); // if the list can't hold all items
 
-let inner: &Arc<dyn Array> = a.values();
+let dates_array: ListArray<i32> = builder.to(ListArray::<i32>::default_datatype(DataType::Date32));
+
+let dates: &Arc<dyn Array> = dates_array.values();
 # }
 ```
 
@@ -107,13 +107,12 @@ Instead, `ListArray` has an inner `Array` representing all its values (available
 Given a trait object `&dyn Array`, we know its logical type via `Array::data_type()` and can use it to downcast the array to its concrete type:
 
 ```rust
-# use arrow2::array::{Array, PrimitiveArray, Primitive};
+# use arrow2::array::{Array, PrimitiveArray};
 # use arrow2::datatypes::DataType;
 # fn main() {
 let array: PrimitiveArray<i32> = [Some(1), None, Some(123)]
     .iter()
-    .collect::<Primitive<i32>>()
-    .to(DataType::Int32);
+    .collect();
 let array = &array as &dyn Array;
 
 let array = array.as_any().downcast_ref::<PrimitiveArray<i32>>().unwrap();
@@ -217,7 +216,7 @@ We've already seen how to create an array from an iterator. Most arrays also imp
 # fn main() {
 let array = Int32Array::from(&[Some(1), None, Some(123)]);
 
-for item in array.iter() {
+for item in &array {
     if let Some(value) = item {
         println!("{}", value);
     } else {

--- a/src/array/boolean/from.rs
+++ b/src/array/boolean/from.rs
@@ -176,7 +176,7 @@ impl<Ptr: std::borrow::Borrow<Option<bool>>> FromIterator<Ptr> for BooleanArray 
 }
 
 impl<Ptr: std::borrow::Borrow<Option<bool>>> TryFromIterator<Ptr> for BooleanArray {
-    fn try_from_iter<I: IntoIterator<Item = ArrowResult<Ptr>>>(iter: I) -> ArrowResult<Self> {
+    fn try_from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> ArrowResult<Self> {
         let iter = iter.into_iter();
         let (lower, _) = iter.size_hint();
 
@@ -184,7 +184,7 @@ impl<Ptr: std::borrow::Borrow<Option<bool>>> TryFromIterator<Ptr> for BooleanArr
 
         let values: Bitmap = iter
             .map(|item| {
-                Ok(if let Some(a) = item?.borrow() {
+                Ok(if let Some(a) = item.borrow() {
                     validity.push(true);
                     *a
                 } else {
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     fn try_from_iter() -> Result<()> {
-        let iter = std::iter::repeat(true).take(2).map(Some).map(Ok);
+        let iter = std::iter::repeat(true).take(2).map(Some);
         let a = BooleanArray::try_from_iter(iter)?;
         assert_eq!(a.len(), 2);
         Ok(())

--- a/src/array/boolean/primitive.rs
+++ b/src/array/boolean/primitive.rs
@@ -37,12 +37,18 @@ impl Builder<bool> for BooleanBuilder {
 }
 
 impl BooleanBuilder {
-    /// Initializes itself with a capacity.
+    /// Initializes an empty [`BooleanBuilder`].
     #[inline]
     pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
+    /// Initializes a [`BooleanBuilder`] with a capacity.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            values: MutableBitmap::new(),
-            validity: MutableBitmap::new(),
+            values: MutableBitmap::with_capacity(capacity),
+            validity: MutableBitmap::with_capacity(capacity),
         }
     }
 }

--- a/src/array/boolean/primitive.rs
+++ b/src/array/boolean/primitive.rs
@@ -14,12 +14,12 @@ use crate::{
 /// single (optional) elements.
 /// The tradeoff is that this struct is not clonable nor `Send + Sync`.
 #[derive(Debug)]
-pub struct BooleanPrimitive {
+pub struct BooleanBuilder {
     values: MutableBitmap,
     validity: MutableBitmap,
 }
 
-impl NullableBuilder for BooleanPrimitive {
+impl NullableBuilder for BooleanBuilder {
     #[inline]
     fn push_null(&mut self) {
         self.values.push(false);
@@ -27,7 +27,7 @@ impl NullableBuilder for BooleanPrimitive {
     }
 }
 
-impl Builder<bool> for BooleanPrimitive {
+impl Builder<bool> for BooleanBuilder {
     /// Pushes a new item to this struct
     #[inline]
     fn push(&mut self, value: bool) {
@@ -36,7 +36,7 @@ impl Builder<bool> for BooleanPrimitive {
     }
 }
 
-impl BooleanPrimitive {
+impl BooleanBuilder {
     /// Initializes itself with a capacity.
     #[inline]
     pub fn new() -> Self {
@@ -47,7 +47,7 @@ impl BooleanPrimitive {
     }
 }
 
-impl<Ptr: std::borrow::Borrow<Option<bool>>> FromIterator<Ptr> for BooleanPrimitive {
+impl<Ptr: std::borrow::Borrow<Option<bool>>> FromIterator<Ptr> for BooleanBuilder {
     fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (lower, _) = iter.size_hint();
@@ -70,14 +70,14 @@ impl<Ptr: std::borrow::Borrow<Option<bool>>> FromIterator<Ptr> for BooleanPrimit
     }
 }
 
-impl Default for BooleanPrimitive {
+impl Default for BooleanBuilder {
     #[inline]
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<Ptr: std::borrow::Borrow<Option<bool>>> TryExtend<Ptr> for BooleanPrimitive {
+impl<Ptr: std::borrow::Borrow<Option<bool>>> TryExtend<Ptr> for BooleanBuilder {
     fn try_extend<T: IntoIterator<Item = Ptr>>(&mut self, iter: T) -> Result<()> {
         let iter = iter.into_iter();
         let (lower, _) = iter.size_hint();
@@ -94,7 +94,7 @@ impl<Ptr: std::borrow::Borrow<Option<bool>>> TryExtend<Ptr> for BooleanPrimitive
     }
 }
 
-impl<Ptr: std::borrow::Borrow<Option<bool>>> TryFromIterator<Ptr> for BooleanPrimitive {
+impl<Ptr: std::borrow::Borrow<Option<bool>>> TryFromIterator<Ptr> for BooleanBuilder {
     fn try_from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Result<Self> {
         let iter = iter.into_iter();
         let (lower, _) = iter.size_hint();
@@ -117,13 +117,13 @@ impl<Ptr: std::borrow::Borrow<Option<bool>>> TryFromIterator<Ptr> for BooleanPri
     }
 }
 
-impl From<BooleanPrimitive> for BooleanArray {
-    fn from(p: BooleanPrimitive) -> Self {
+impl From<BooleanBuilder> for BooleanArray {
+    fn from(p: BooleanBuilder) -> Self {
         Self::from_data(p.values.into(), p.validity.into())
     }
 }
 
-impl IntoArray for BooleanPrimitive {
+impl IntoArray for BooleanBuilder {
     fn into_arc(self) -> Arc<dyn Array> {
         let a: BooleanArray = self.into();
         Arc::new(a)
@@ -138,7 +138,7 @@ mod tests {
 
     #[test]
     fn try_from_iter() -> Result<()> {
-        let a = BooleanPrimitive::try_from_iter((0..2).map(|x| Some(x > 0)))?;
+        let a = BooleanBuilder::try_from_iter((0..2).map(|x| Some(x > 0)))?;
         let a: BooleanArray = a.into();
         assert_eq!(a.len(), 2);
         Ok(())

--- a/src/array/equal/fixed_size_list.rs
+++ b/src/array/equal/fixed_size_list.rs
@@ -80,16 +80,14 @@ mod tests {
         data: T,
     ) -> FixedSizeListArray {
         let data_type = FixedSizeListArray::default_datatype(DataType::Int32, 3);
-        let list = data
-            .as_ref()
-            .iter()
-            .map(|x| {
-                Some(match x {
-                    Some(x) => x.as_ref().iter().map(|x| Some(*x)).collect::<Vec<_>>(),
-                    None => std::iter::repeat(None).take(3).collect::<Vec<_>>(),
-                })
+        let data = data.as_ref().iter().map(|x| {
+            Some(match x {
+                Some(x) => x.as_ref().iter().map(|x| Some(*x)).collect::<Vec<_>>(),
+                None => std::iter::repeat(None).take(3).collect::<Vec<_>>(),
             })
-            .collect::<FixedSizeListPrimitive<Primitive<i32>, i32>>();
+        });
+        let mut list = FixedSizeListPrimitive::new(Primitive::<i32>::new());
+        list.extend(data);
         list.to(data_type)
     }
 

--- a/src/array/equal/fixed_size_list.rs
+++ b/src/array/equal/fixed_size_list.rs
@@ -70,7 +70,7 @@ pub(super) fn equal(
 
 #[cfg(test)]
 mod tests {
-    use crate::array::{FixedSizeListPrimitive, Primitive};
+    use crate::array::{FixedSizeListBuilder, PrimitiveBuilder};
     use crate::{array::equal::tests::test_equal, datatypes::DataType};
 
     use super::*;
@@ -86,7 +86,7 @@ mod tests {
                 None => std::iter::repeat(None).take(3).collect::<Vec<_>>(),
             })
         });
-        let mut list = FixedSizeListPrimitive::new(Primitive::<i32>::new());
+        let mut list = FixedSizeListBuilder::new(PrimitiveBuilder::<i32>::new());
         list.extend(data);
         list.to(data_type)
     }

--- a/src/array/equal/list.rs
+++ b/src/array/equal/list.rs
@@ -155,21 +155,19 @@ pub(super) fn equal<O: Offset>(
 
 #[cfg(test)]
 mod tests {
-    use crate::array::{ListPrimitive, Primitive};
+    use crate::array::{ListPrimitive, Primitive, TryExtend};
     use crate::{array::equal::tests::test_equal, datatypes::DataType};
 
     use super::*;
 
     fn create_list_array<U: AsRef<[i32]>, T: AsRef<[Option<U>]>>(data: T) -> ListArray<i32> {
         let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-        let list = data
-            .as_ref()
-            .iter()
-            .map(|x| {
-                x.as_ref()
-                    .map(|x| x.as_ref().iter().map(|x| Some(*x)).collect::<Vec<_>>())
-            })
-            .collect::<ListPrimitive<i32, Primitive<i32>, i32>>();
+        let iter = data.as_ref().iter().map(|x| {
+            x.as_ref()
+                .map(|x| x.as_ref().iter().map(|x| Some(*x)).collect::<Vec<_>>())
+        });
+        let mut list = ListPrimitive::<i32, _, i32>::new(Primitive::<i32>::new());
+        list.try_extend(iter).unwrap();
         list.to(data_type)
     }
 

--- a/src/array/equal/list.rs
+++ b/src/array/equal/list.rs
@@ -155,7 +155,7 @@ pub(super) fn equal<O: Offset>(
 
 #[cfg(test)]
 mod tests {
-    use crate::array::{ListPrimitive, Primitive, TryExtend};
+    use crate::array::{ListBuilder, PrimitiveBuilder, TryExtend};
     use crate::{array::equal::tests::test_equal, datatypes::DataType};
 
     use super::*;
@@ -166,7 +166,7 @@ mod tests {
             x.as_ref()
                 .map(|x| x.as_ref().iter().map(|x| Some(*x)).collect::<Vec<_>>())
         });
-        let mut list = ListPrimitive::<i32, _, i32>::new(Primitive::<i32>::new());
+        let mut list = ListBuilder::<i32, _, i32>::new(PrimitiveBuilder::<i32>::new());
         list.try_extend(iter).unwrap();
         list.to(data_type)
     }

--- a/src/array/fixed_size_binary/from.rs
+++ b/src/array/fixed_size_binary/from.rs
@@ -11,15 +11,15 @@ use crate::{
 
 /// auxiliary struct used to create a [`BinaryArray`] out of an iterator
 #[derive(Debug)]
-pub struct FixedSizeBinaryPrimitive {
+pub struct FixedSizeBinaryBuilder {
     values: MutableBuffer<u8>,
     validity: MutableBitmap,
     size: Option<usize>,
     current_validity: usize,
 }
 
-impl FixedSizeBinaryPrimitive {
-    /// Initializes a new empty [`FixedSizeBinaryPrimitive`].
+impl FixedSizeBinaryBuilder {
+    /// Initializes a new empty [`FixedSizeBinaryBuilder`].
     pub fn new() -> Self {
         Self::with_capacity(0)
     }
@@ -34,19 +34,19 @@ impl FixedSizeBinaryPrimitive {
     }
 }
 
-impl Default for FixedSizeBinaryPrimitive {
+impl Default for FixedSizeBinaryBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<P: AsRef<[u8]>> FromIterator<Option<P>> for FixedSizeBinaryPrimitive {
+impl<P: AsRef<[u8]>> FromIterator<Option<P>> for FixedSizeBinaryBuilder {
     fn from_iter<I: IntoIterator<Item = Option<P>>>(iter: I) -> Self {
         Self::try_from_iter(iter.into_iter()).unwrap()
     }
 }
 
-impl<P> TryFromIterator<Option<P>> for FixedSizeBinaryPrimitive
+impl<P> TryFromIterator<Option<P>> for FixedSizeBinaryBuilder
 where
     P: AsRef<[u8]>,
 {
@@ -57,7 +57,7 @@ where
     }
 }
 
-impl<P> TryExtend<Option<P>> for FixedSizeBinaryPrimitive
+impl<P> TryExtend<Option<P>> for FixedSizeBinaryBuilder
 where
     P: AsRef<[u8]>,
 {
@@ -72,7 +72,7 @@ where
     }
 }
 
-impl NullableBuilder for FixedSizeBinaryPrimitive {
+impl NullableBuilder for FixedSizeBinaryBuilder {
     #[inline]
     fn push_null(&mut self) {
         if let Some(size) = self.size {
@@ -85,13 +85,13 @@ impl NullableBuilder for FixedSizeBinaryPrimitive {
     }
 }
 
-impl Builder<&[u8]> for FixedSizeBinaryPrimitive {
+impl Builder<&[u8]> for FixedSizeBinaryBuilder {
     #[inline]
     fn try_push(&mut self, values: &[u8]) -> ArrowResult<()> {
         if let Some(size) = self.size {
             if size != values.len() {
                 return Err(ArrowError::InvalidArgumentError(
-                    "FixedSizeBinaryPrimitive received an argument with the wrong number of items"
+                    "FixedSizeBinaryBuilder received an argument with the wrong number of items"
                         .to_string(),
                 ));
             }
@@ -112,7 +112,7 @@ impl Builder<&[u8]> for FixedSizeBinaryPrimitive {
     }
 }
 
-impl FixedSizeBinaryPrimitive {
+impl FixedSizeBinaryBuilder {
     pub fn to(mut self, data_type: DataType) -> FixedSizeBinaryArray {
         let size = *FixedSizeBinaryArray::get_size(&data_type) as usize;
         if let Some(self_size) = self.size {
@@ -127,7 +127,7 @@ impl FixedSizeBinaryPrimitive {
     }
 }
 
-impl ToArray for FixedSizeBinaryPrimitive {
+impl ToArray for FixedSizeBinaryBuilder {
     fn to_arc(self, data_type: &DataType) -> Arc<dyn Array> {
         Arc::new(self.to(data_type.clone()))
     }
@@ -142,7 +142,7 @@ mod tests {
     #[test]
     fn basic() {
         let array =
-            FixedSizeBinaryPrimitive::from_iter(vec![Some(b"ab"), Some(b"bc"), None, Some(b"fh")])
+            FixedSizeBinaryBuilder::from_iter(vec![Some(b"ab"), Some(b"bc"), None, Some(b"fh")])
                 .to(DataType::FixedSizeBinary(2));
         assert_eq!(array.len(), 4);
     }

--- a/src/array/fixed_size_list/from.rs
+++ b/src/array/fixed_size_list/from.rs
@@ -10,13 +10,13 @@ use crate::{
 use super::FixedSizeListArray;
 
 #[derive(Debug)]
-pub struct FixedSizeListPrimitive<B: Builder<T>, T> {
+pub struct FixedSizeListBuilder<B: Builder<T>, T> {
     values: B,
     validity: MutableBitmap,
     phantom: std::marker::PhantomData<T>,
 }
 
-impl<B: Builder<T>, T> FixedSizeListPrimitive<B, T> {
+impl<B: Builder<T>, T> FixedSizeListBuilder<B, T> {
     #[inline]
     pub fn new(values: B) -> Self {
         Self::with_capacity(0, values)
@@ -32,7 +32,7 @@ impl<B: Builder<T>, T> FixedSizeListPrimitive<B, T> {
     }
 }
 
-impl<A: Builder<T> + ToArray, T> FixedSizeListPrimitive<A, T> {
+impl<A: Builder<T> + ToArray, T> FixedSizeListBuilder<A, T> {
     pub fn to(self, data_type: DataType) -> FixedSizeListArray {
         let values = self
             .values
@@ -41,7 +41,7 @@ impl<A: Builder<T> + ToArray, T> FixedSizeListPrimitive<A, T> {
     }
 }
 
-impl<B, T, P> TryExtend<Option<P>> for FixedSizeListPrimitive<B, T>
+impl<B, T, P> TryExtend<Option<P>> for FixedSizeListBuilder<B, T>
 where
     B: Builder<T>,
     P: IntoIterator<Item = Option<T>>,
@@ -57,7 +57,7 @@ where
     }
 }
 
-impl<T, B, P> Extend<Option<P>> for FixedSizeListPrimitive<B, T>
+impl<T, B, P> Extend<Option<P>> for FixedSizeListBuilder<B, T>
 where
     B: Builder<T>,
     P: IntoIterator<Item = Option<T>>,
@@ -67,7 +67,7 @@ where
     }
 }
 
-impl<T, B> NullableBuilder for FixedSizeListPrimitive<B, T>
+impl<T, B> NullableBuilder for FixedSizeListBuilder<B, T>
 where
     B: Builder<T>,
 {
@@ -77,7 +77,7 @@ where
     }
 }
 
-impl<T, B, P> Builder<P> for FixedSizeListPrimitive<B, T>
+impl<T, B, P> Builder<P> for FixedSizeListBuilder<B, T>
 where
     B: Builder<T>,
     P: IntoIterator<Item = Option<T>>,
@@ -101,7 +101,7 @@ where
     }
 }
 
-impl<B: Builder<T> + ToArray, T> ToArray for FixedSizeListPrimitive<B, T> {
+impl<B: Builder<T> + ToArray, T> ToArray for FixedSizeListBuilder<B, T> {
     fn to_arc(self, data_type: &DataType) -> Arc<dyn Array> {
         Arc::new(self.to(data_type.clone()))
     }
@@ -121,7 +121,7 @@ mod tests {
             Some(vec![Some(4), None, Some(6)]),
         ];
 
-        let mut a = FixedSizeListPrimitive::<_, i32>::new(Primitive::<i32>::new());
+        let mut a = FixedSizeListBuilder::<_, i32>::new(PrimitiveBuilder::<i32>::new());
         a.try_extend(data).unwrap();
 
         let list = a.to(FixedSizeListArray::default_datatype(DataType::Int32, 3));

--- a/src/array/growable/dictionary.rs
+++ b/src/array/growable/dictionary.rs
@@ -145,10 +145,10 @@ mod tests {
     fn test_single() -> Result<()> {
         let original_data = vec![Some("a"), Some("b"), Some("a")];
 
-        let data = original_data.clone().into_iter().map(Result::Ok);
-        let array = DictionaryPrimitive::<i32, Utf8Primitive<i32>, &str>::try_from_iter(data)?.to(
-            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
-        );
+        let data = original_data.clone();
+        let mut builder = DictionaryPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        builder.extend(data);
+        let array = builder.into();
 
         // same values, less keys
         let expected = DictionaryArray::<i32>::from_data(
@@ -171,16 +171,16 @@ mod tests {
         let mut original_data1 = vec![Some("a"), Some("b"), None, Some("a")];
         let original_data2 = vec![Some("c"), Some("b"), None, Some("a")];
 
-        let data1 = original_data1.clone().into_iter().map(Result::Ok);
-        let data2 = original_data2.clone().into_iter().map(Result::Ok);
-        let array1 =
-            DictionaryPrimitive::<i32, Utf8Primitive<i32>, &str>::try_from_iter(data1)?.to(
-                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
-            );
-        let array2 =
-            DictionaryPrimitive::<i32, Utf8Primitive<i32>, &str>::try_from_iter(data2)?.to(
-                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
-            );
+        let data1 = original_data1.clone();
+        let data2 = original_data2.clone();
+
+        let mut builder = DictionaryPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        builder.extend(data1);
+        let array1 = builder.into();
+
+        let mut builder = DictionaryPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        builder.extend(data2);
+        let array2 = builder.into();
 
         // same values, less keys
         original_data1.extend(original_data2.iter().cloned());

--- a/src/array/growable/dictionary.rs
+++ b/src/array/growable/dictionary.rs
@@ -146,13 +146,13 @@ mod tests {
         let original_data = vec![Some("a"), Some("b"), Some("a")];
 
         let data = original_data.clone();
-        let mut builder = DictionaryPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        let mut builder = DictionaryBuilder::<i32, _, _>::new(Utf8Builder::<i32>::new());
         builder.extend(data);
         let array = builder.into();
 
         // same values, less keys
         let expected = DictionaryArray::<i32>::from_data(
-            Primitive::from(vec![Some(1), Some(0)]).to(DataType::Int32),
+            PrimitiveBuilder::from(vec![Some(1), Some(0)]).to(DataType::Int32),
             Arc::new(Utf8Array::<i32>::from(&original_data)),
         );
 
@@ -174,18 +174,18 @@ mod tests {
         let data1 = original_data1.clone();
         let data2 = original_data2.clone();
 
-        let mut builder = DictionaryPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        let mut builder = DictionaryBuilder::<i32, _, _>::new(Utf8Builder::<i32>::new());
         builder.extend(data1);
         let array1 = builder.into();
 
-        let mut builder = DictionaryPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        let mut builder = DictionaryBuilder::<i32, _, _>::new(Utf8Builder::<i32>::new());
         builder.extend(data2);
         let array2 = builder.into();
 
         // same values, less keys
         original_data1.extend(original_data2.iter().cloned());
         let expected = DictionaryArray::<i32>::from_data(
-            Primitive::from(vec![Some(1), None, Some(3), None]).to(DataType::Int32),
+            PrimitiveBuilder::from(vec![Some(1), None, Some(3), None]).to(DataType::Int32),
             Arc::new(Utf8Array::<i32>::from_slice(&["a", "b", "c", "b", "a"])),
         );
 

--- a/src/array/growable/fixed_binary.rs
+++ b/src/array/growable/fixed_binary.rs
@@ -110,14 +110,14 @@ mod tests {
     use std::iter::FromIterator;
 
     use super::*;
-    use crate::array::FixedSizeBinaryPrimitive;
+    use crate::array::FixedSizeBinaryBuilder;
     use crate::datatypes::DataType;
 
     /// tests extending from a variable-sized (strings and binary) array w/ offset with nulls
     #[test]
     fn basic() {
         let array =
-            FixedSizeBinaryPrimitive::from_iter(vec![Some(b"ab"), Some(b"bc"), None, Some(b"de")])
+            FixedSizeBinaryBuilder::from_iter(vec![Some(b"ab"), Some(b"bc"), None, Some(b"de")])
                 .to(DataType::FixedSizeBinary(2));
 
         let mut a = GrowableFixedSizeBinary::new(&[&array], false, 0);
@@ -126,7 +126,7 @@ mod tests {
 
         let result: FixedSizeBinaryArray = a.into();
 
-        let expected = FixedSizeBinaryPrimitive::from_iter(vec![Some("bc"), None])
+        let expected = FixedSizeBinaryBuilder::from_iter(vec![Some("bc"), None])
             .to(DataType::FixedSizeBinary(2));
         assert_eq!(result, expected);
     }
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn offsets() {
         let array =
-            FixedSizeBinaryPrimitive::from_iter(vec![Some(b"ab"), Some(b"bc"), None, Some(b"fh")])
+            FixedSizeBinaryBuilder::from_iter(vec![Some(b"ab"), Some(b"bc"), None, Some(b"fh")])
                 .to(DataType::FixedSizeBinary(2));
         let array = array.slice(1, 3);
 
@@ -146,16 +146,16 @@ mod tests {
 
         let result: FixedSizeBinaryArray = a.into();
 
-        let expected = FixedSizeBinaryPrimitive::from_iter(vec![Some(b"bc"), None, Some(b"fh")])
+        let expected = FixedSizeBinaryBuilder::from_iter(vec![Some(b"bc"), None, Some(b"fh")])
             .to(DataType::FixedSizeBinary(2));
         assert_eq!(result, expected);
     }
 
     #[test]
     fn multiple_with_validity() {
-        let array1 = FixedSizeBinaryPrimitive::from_iter(vec![Some("hello"), Some("world")])
+        let array1 = FixedSizeBinaryBuilder::from_iter(vec![Some("hello"), Some("world")])
             .to(DataType::FixedSizeBinary(5));
-        let array2 = FixedSizeBinaryPrimitive::from_iter(vec![Some("12345"), None])
+        let array2 = FixedSizeBinaryBuilder::from_iter(vec![Some("12345"), None])
             .to(DataType::FixedSizeBinary(5));
 
         let mut a = GrowableFixedSizeBinary::new(&[&array1, &array2], false, 5);
@@ -165,7 +165,7 @@ mod tests {
 
         let result: FixedSizeBinaryArray = a.into();
 
-        let expected = FixedSizeBinaryPrimitive::from_iter(vec![
+        let expected = FixedSizeBinaryBuilder::from_iter(vec![
             Some("hello"),
             Some("world"),
             Some("12345"),
@@ -178,7 +178,7 @@ mod tests {
     #[test]
     fn null_offset_validity() {
         let array =
-            FixedSizeBinaryPrimitive::from_iter(vec![Some("aa"), Some("bc"), None, Some("fh")])
+            FixedSizeBinaryBuilder::from_iter(vec![Some("aa"), Some("bc"), None, Some("fh")])
                 .to(DataType::FixedSizeBinary(2));
         let array = array.slice(1, 3);
 
@@ -189,7 +189,7 @@ mod tests {
 
         let result: FixedSizeBinaryArray = a.into();
 
-        let expected = FixedSizeBinaryPrimitive::from_iter(vec![None, Some("fh"), None])
+        let expected = FixedSizeBinaryBuilder::from_iter(vec![None, Some("fh"), None])
             .to(DataType::FixedSizeBinary(2));
         assert_eq!(result, expected);
     }
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn sized_offsets() {
         let array =
-            FixedSizeBinaryPrimitive::from_iter(vec![Some(&[0, 0]), Some(&[0, 1]), Some(&[0, 2])])
+            FixedSizeBinaryBuilder::from_iter(vec![Some(&[0, 0]), Some(&[0, 1]), Some(&[0, 2])])
                 .to(DataType::FixedSizeBinary(2));
         let array = array.slice(1, 2);
         // = [[0, 1], [0, 2]] due to the offset = 1
@@ -209,7 +209,7 @@ mod tests {
 
         let result: FixedSizeBinaryArray = a.into();
 
-        let expected = FixedSizeBinaryPrimitive::from_iter(vec![Some(&[0, 2]), Some(&[0, 1])])
+        let expected = FixedSizeBinaryBuilder::from_iter(vec![Some(&[0, 2]), Some(&[0, 1])])
             .to(DataType::FixedSizeBinary(2));
         assert_eq!(result, expected);
     }

--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -163,7 +163,7 @@ mod tests {
     use super::*;
 
     use crate::array::ListArray;
-    use crate::array::{ListPrimitive, Primitive};
+    use crate::array::{ListBuilder, PrimitiveBuilder};
 
     #[test]
     fn basic() {
@@ -173,7 +173,7 @@ mod tests {
             Some(vec![Some(6i32), Some(7), Some(8)]),
         ];
 
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(data);
         let array: ListArray<i32> = builder.into();
 
@@ -183,7 +183,7 @@ mod tests {
         let result: ListArray<i32> = a.into();
 
         let expected = vec![Some(vec![Some(1i32), Some(2), Some(3)])];
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(expected);
         let expected: ListArray<i32> = builder.into();
 
@@ -197,7 +197,7 @@ mod tests {
             None,
             Some(vec![Some(6i32), Some(7), Some(8)]),
         ];
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(data);
         let array: ListArray<i32> = builder.into();
         let array = array.slice(1, 2);
@@ -208,7 +208,7 @@ mod tests {
         let result: ListArray<i32> = a.into();
 
         let expected = vec![Some(vec![Some(6i32), Some(7), Some(8)])];
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(expected);
         let expected: ListArray<i32> = builder.into();
 
@@ -222,7 +222,7 @@ mod tests {
             None,
             Some(vec![Some(6i32), None, Some(8)]),
         ];
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(data);
         let array: ListArray<i32> = builder.into();
         let array = array.slice(1, 2);
@@ -233,7 +233,7 @@ mod tests {
         let result: ListArray<i32> = a.into();
 
         let expected = vec![Some(vec![Some(6i32), None, Some(8)])];
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(expected);
         let expected: ListArray<i32> = builder.into();
 
@@ -247,7 +247,7 @@ mod tests {
             None,
             Some(vec![Some(6i32), None, Some(8)]),
         ];
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(data_1);
         let array_1: ListArray<i32> = builder.into();
 
@@ -256,7 +256,7 @@ mod tests {
             Some(vec![Some(5i32), None, Some(4)]),
             Some(vec![Some(2i32), Some(1), Some(0)]),
         ];
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(data_2);
         let array_2: ListArray<i32> = builder.into();
 
@@ -273,7 +273,7 @@ mod tests {
             None,
             Some(vec![Some(5i32), None, Some(4)]),
         ];
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(expected_data);
         let expected: ListArray<i32> = builder.into();
 

--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -162,8 +162,8 @@ impl<'a, O: Offset> From<GrowableList<'a, O>> for ListArray<O> {
 mod tests {
     use super::*;
 
+    use crate::array::ListArray;
     use crate::array::{ListPrimitive, Primitive};
-    use crate::{array::ListArray, datatypes::DataType};
 
     #[test]
     fn basic() {
@@ -173,8 +173,9 @@ mod tests {
             Some(vec![Some(6i32), Some(7), Some(8)]),
         ];
 
-        let array: ListPrimitive<i32, Primitive<i32>, i32> = data.into_iter().collect();
-        let array = array.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(data);
+        let array: ListArray<i32> = builder.into();
 
         let mut a = GrowableList::new(&[&array], false, 0);
         a.extend(0, 0, 1);
@@ -182,8 +183,9 @@ mod tests {
         let result: ListArray<i32> = a.into();
 
         let expected = vec![Some(vec![Some(1i32), Some(2), Some(3)])];
-        let expected: ListPrimitive<i32, Primitive<i32>, i32> = expected.into_iter().collect();
-        let expected = expected.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(expected);
+        let expected: ListArray<i32> = builder.into();
 
         assert_eq!(result, expected)
     }
@@ -195,8 +197,9 @@ mod tests {
             None,
             Some(vec![Some(6i32), Some(7), Some(8)]),
         ];
-        let array: ListPrimitive<i32, Primitive<i32>, i32> = data.into_iter().collect();
-        let array = array.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(data);
+        let array: ListArray<i32> = builder.into();
         let array = array.slice(1, 2);
 
         let mut a = GrowableList::new(&[&array], false, 0);
@@ -205,8 +208,9 @@ mod tests {
         let result: ListArray<i32> = a.into();
 
         let expected = vec![Some(vec![Some(6i32), Some(7), Some(8)])];
-        let expected: ListPrimitive<i32, Primitive<i32>, i32> = expected.into_iter().collect();
-        let expected = expected.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(expected);
+        let expected: ListArray<i32> = builder.into();
 
         assert_eq!(result, expected)
     }
@@ -218,8 +222,9 @@ mod tests {
             None,
             Some(vec![Some(6i32), None, Some(8)]),
         ];
-        let array: ListPrimitive<i32, Primitive<i32>, i32> = data.into_iter().collect();
-        let array = array.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(data);
+        let array: ListArray<i32> = builder.into();
         let array = array.slice(1, 2);
 
         let mut a = GrowableList::new(&[&array], false, 0);
@@ -228,8 +233,9 @@ mod tests {
         let result: ListArray<i32> = a.into();
 
         let expected = vec![Some(vec![Some(6i32), None, Some(8)])];
-        let expected: ListPrimitive<i32, Primitive<i32>, i32> = expected.into_iter().collect();
-        let expected = expected.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(expected);
+        let expected: ListArray<i32> = builder.into();
 
         assert_eq!(result, expected)
     }
@@ -241,16 +247,18 @@ mod tests {
             None,
             Some(vec![Some(6i32), None, Some(8)]),
         ];
-        let array_1: ListPrimitive<i32, Primitive<i32>, i32> = data_1.into_iter().collect();
-        let array_1 = array_1.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(data_1);
+        let array_1: ListArray<i32> = builder.into();
 
         let data_2 = vec![
             Some(vec![Some(8i32), Some(7), Some(6)]),
             Some(vec![Some(5i32), None, Some(4)]),
             Some(vec![Some(2i32), Some(1), Some(0)]),
         ];
-        let array_2: ListPrimitive<i32, Primitive<i32>, i32> = data_2.into_iter().collect();
-        let array_2 = array_2.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(data_2);
+        let array_2: ListArray<i32> = builder.into();
 
         let arrays: Vec<&dyn Array> = vec![&array_1, &array_2];
 
@@ -265,8 +273,9 @@ mod tests {
             None,
             Some(vec![Some(5i32), None, Some(4)]),
         ];
-        let expected: ListPrimitive<i32, Primitive<i32>, i32> = expected_data.into_iter().collect();
-        let expected = expected.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(expected_data);
+        let expected: ListArray<i32> = builder.into();
 
         assert_eq!(result, expected);
     }

--- a/src/array/growable/primitive.rs
+++ b/src/array/growable/primitive.rs
@@ -96,69 +96,69 @@ impl<'a, T: NativeType> From<GrowablePrimitive<'a, T>> for PrimitiveArray<T> {
 mod tests {
     use super::*;
 
-    use crate::array::Primitive;
+    use crate::array::PrimitiveBuilder;
     use crate::datatypes::DataType;
 
     /// tests extending from a primitive array w/ offset nor nulls
     #[test]
     fn test_primitive() {
-        let b = Primitive::<u8>::from(vec![Some(1), Some(2), Some(3)]).to(DataType::UInt8);
+        let b = PrimitiveBuilder::<u8>::from(vec![Some(1), Some(2), Some(3)]).to(DataType::UInt8);
         let mut a = GrowablePrimitive::new(&[&b], false, 3);
         a.extend(0, 0, 2);
         let result: PrimitiveArray<u8> = a.into();
-        let expected = Primitive::<u8>::from(vec![Some(1), Some(2)]).to(DataType::UInt8);
+        let expected = PrimitiveBuilder::<u8>::from(vec![Some(1), Some(2)]).to(DataType::UInt8);
         assert_eq!(result, expected);
     }
 
     /// tests extending from a primitive array with offset w/ nulls
     #[test]
     fn test_primitive_offset() {
-        let b = Primitive::<u8>::from(vec![Some(1), Some(2), Some(3)]).to(DataType::UInt8);
+        let b = PrimitiveBuilder::<u8>::from(vec![Some(1), Some(2), Some(3)]).to(DataType::UInt8);
         let b = b.slice(1, 2);
         let mut a = GrowablePrimitive::new(&[&b], false, 2);
         a.extend(0, 0, 2);
         let result: PrimitiveArray<u8> = a.into();
-        let expected = Primitive::<u8>::from(vec![Some(2), Some(3)]).to(DataType::UInt8);
+        let expected = PrimitiveBuilder::<u8>::from(vec![Some(2), Some(3)]).to(DataType::UInt8);
         assert_eq!(result, expected);
     }
 
     /// tests extending from a primitive array with offset and nulls
     #[test]
     fn test_primitive_null_offset() {
-        let b = Primitive::<u8>::from(vec![Some(1), None, Some(3)]).to(DataType::UInt8);
+        let b = PrimitiveBuilder::<u8>::from(vec![Some(1), None, Some(3)]).to(DataType::UInt8);
         let b = b.slice(1, 2);
         let mut a = GrowablePrimitive::new(&[&b], false, 2);
         a.extend(0, 0, 2);
         let result: PrimitiveArray<u8> = a.into();
-        let expected = Primitive::<u8>::from(vec![None, Some(3)]).to(DataType::UInt8);
+        let expected = PrimitiveBuilder::<u8>::from(vec![None, Some(3)]).to(DataType::UInt8);
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_primitive_null_offset_validity() {
-        let b = Primitive::<u8>::from(vec![Some(1), Some(2), Some(3)]).to(DataType::UInt8);
+        let b = PrimitiveBuilder::<u8>::from(vec![Some(1), Some(2), Some(3)]).to(DataType::UInt8);
         let b = b.slice(1, 2);
         let mut a = GrowablePrimitive::new(&[&b], true, 2);
         a.extend(0, 0, 2);
         a.extend_validity(3);
         a.extend(0, 1, 1);
         let result: PrimitiveArray<u8> = a.into();
-        let expected = Primitive::<u8>::from(vec![Some(2), Some(3), None, None, None, Some(3)])
+        let expected = PrimitiveBuilder::<u8>::from(vec![Some(2), Some(3), None, None, None, Some(3)])
             .to(DataType::UInt8);
         assert_eq!(result, expected);
     }
 
     #[test]
     fn test_primitive_joining_arrays() {
-        let b = Primitive::<u8>::from(vec![Some(1), Some(2), Some(3)]).to(DataType::UInt8);
-        let c = Primitive::<u8>::from(vec![Some(4), Some(5), Some(6)]).to(DataType::UInt8);
+        let b = PrimitiveBuilder::<u8>::from(vec![Some(1), Some(2), Some(3)]).to(DataType::UInt8);
+        let c = PrimitiveBuilder::<u8>::from(vec![Some(4), Some(5), Some(6)]).to(DataType::UInt8);
         let mut a = GrowablePrimitive::new(&[&b, &c], false, 4);
         a.extend(0, 0, 2);
         a.extend(1, 1, 2);
         let result: PrimitiveArray<u8> = a.into();
 
         let expected =
-            Primitive::<u8>::from(vec![Some(1), Some(2), Some(5), Some(6)]).to(DataType::UInt8);
+            PrimitiveBuilder::<u8>::from(vec![Some(1), Some(2), Some(5), Some(6)]).to(DataType::UInt8);
         assert_eq!(result, expected);
     }
 }

--- a/src/array/growable/structure.rs
+++ b/src/array/growable/structure.rs
@@ -124,7 +124,7 @@ impl<'a> From<GrowableStruct<'a>> for StructArray {
 mod tests {
     use std::iter::FromIterator;
 
-    use crate::array::{Primitive, Utf8Array};
+    use crate::array::{PrimitiveBuilder, Utf8Array};
     use crate::bitmap::Bitmap;
     use crate::datatypes::{DataType, Field};
 
@@ -139,7 +139,7 @@ mod tests {
             Some("doe"),
         ]));
         let ints: Arc<dyn Array> = Arc::new(
-            Primitive::<i32>::from(vec![Some(1), Some(2), Some(3), Some(4), Some(5)])
+            PrimitiveBuilder::<i32>::from(vec![Some(1), Some(2), Some(3), Some(4), Some(5)])
                 .to(DataType::Int32),
         );
         let fields = vec![
@@ -231,7 +231,7 @@ mod tests {
             Some("aa"),
         ]));
         let expected_int: Arc<dyn Array> = Arc::new(
-            Primitive::<i32>::from(vec![Some(2), Some(3), Some(1), Some(2)]).to(DataType::Int32),
+            PrimitiveBuilder::<i32>::from(vec![Some(2), Some(3), Some(1), Some(2)]).to(DataType::Int32),
         );
 
         let expected = StructArray::from_data(fields, vec![expected_string, expected_int], None);

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -187,7 +187,7 @@ mod from;
 mod iterator;
 pub use iterator::*;
 
-pub use from::ListPrimitive;
+pub use from::ListBuilder;
 
 #[cfg(test)]
 mod tests {

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -343,17 +343,17 @@ pub mod ord;
 
 pub use display::get_display;
 
-pub use binary::{BinaryArray, BinaryPrimitive};
-pub use boolean::{BooleanArray, BooleanPrimitive};
-pub use dictionary::{DictionaryArray, DictionaryKey, DictionaryPrimitive};
-pub use fixed_size_binary::{FixedSizeBinaryArray, FixedSizeBinaryPrimitive};
-pub use fixed_size_list::{FixedSizeListArray, FixedSizeListPrimitive};
-pub use list::{ListArray, ListPrimitive};
+pub use binary::{BinaryArray, BinaryBuilder};
+pub use boolean::{BooleanArray, BooleanBuilder};
+pub use dictionary::{DictionaryArray, DictionaryBuilder, DictionaryKey};
+pub use fixed_size_binary::{FixedSizeBinaryArray, FixedSizeBinaryBuilder};
+pub use fixed_size_list::{FixedSizeListArray, FixedSizeListBuilder};
+pub use list::{ListArray, ListBuilder};
 pub use null::NullArray;
-pub use primitive::{Primitive, PrimitiveArray};
+pub use primitive::{PrimitiveArray, PrimitiveBuilder};
 pub use specification::{Index, Offset};
 pub use struct_::StructArray;
-pub use utf8::{Utf8Array, Utf8Primitive};
+pub use utf8::{Utf8Array, Utf8Builder};
 
 pub use self::ffi::FromFfi;
 use self::ffi::ToFfi;
@@ -407,8 +407,6 @@ pub trait TryExtend<A>: Sized {
 /// A trait describing the ability of a struct to increment itself with a null.
 pub trait NullableBuilder {
     /// Push a new null item to the builder.
-    /// This operation may panic if the container cannot hold more items.
-    /// For example, if all possible keys are exausted when building a dictionary.
     fn push_null(&mut self);
 }
 

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -392,8 +392,8 @@ pub trait IntoArray {
     fn into_arc(self) -> std::sync::Arc<dyn Array>;
 }
 
-/// A trait describing the ability of a struct to create itself from a falible iterator.
-/// Used in the context of creating arrays from non-sized iterators.
+/// A trait describing the ability of a struct to create itself.
+/// Used in the context of creating arrays that hold a finite number of items.
 pub trait TryFromIterator<A>: Sized {
     fn try_from_iter<T: IntoIterator<Item = A>>(iter: T) -> Result<Self>;
 }
@@ -404,18 +404,26 @@ pub trait TryExtend<A>: Sized {
     fn try_extend<T: IntoIterator<Item = A>>(&mut self, iter: T) -> Result<()>;
 }
 
-/// A trait describing the ability of a struct to build an Array incrementally.
-/// There are builders for almost all array types.
-pub trait Builder<T> {
-    /// Push a new item to the builder.
+/// A trait describing the ability of a struct to increment itself with a null.
+pub trait NullableBuilder {
+    /// Push a new null item to the builder.
     /// This operation may panic if the container cannot hold more items.
     /// For example, if all possible keys are exausted when building a dictionary.
-    fn push(&mut self, item: Option<T>);
+    fn push_null(&mut self);
+}
+
+/// A trait describing the ability of a struct to build an Array incrementally.
+/// There are builders for almost all array types.
+pub trait Builder<T>: NullableBuilder {
+    /// Push a new non-null item to the builder.
+    /// This operation may panic if the container cannot hold more items.
+    /// For example, if all possible keys are exausted when building a dictionary.
+    fn push(&mut self, item: T);
 
     /// Fallible version of `push`, on which the operation errors instead of panicking.
     /// prefer this if there is no guarantee that the operation will not fail.
     #[inline]
-    fn try_push(&mut self, item: Option<T>) -> Result<()> {
+    fn try_push(&mut self, item: T) -> Result<()> {
         self.push(item);
         Ok(())
     }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -395,15 +395,18 @@ pub trait IntoArray {
 /// A trait describing the ability of a struct to create itself from a falible iterator.
 /// Used in the context of creating arrays from non-sized iterators.
 pub trait TryFromIterator<A>: Sized {
-    fn try_from_iter<T: IntoIterator<Item = Result<A>>>(iter: T) -> Result<Self>;
+    fn try_from_iter<T: IntoIterator<Item = A>>(iter: T) -> Result<Self>;
+}
+
+/// A trait describing the ability of a struct to extend itself from an iterator.
+/// Used in the context of creating arrays from non-sized iterators.
+pub trait TryExtend<A>: Sized {
+    fn try_extend<T: IntoIterator<Item = A>>(&mut self, iter: T) -> Result<()>;
 }
 
 /// A trait describing the ability of a struct to build an Array incrementally.
 /// There are builders for almost all array types.
-pub trait Builder<T>: TryFromIterator<Option<T>> {
-    /// Create the builder with a capacity
-    fn with_capacity(capacity: usize) -> Self;
-
+pub trait Builder<T> {
     /// Push a new item to the builder.
     /// This operation may panic if the container cannot hold more items.
     /// For example, if all possible keys are exausted when building a dictionary.

--- a/src/array/ord.rs
+++ b/src/array/ord.rs
@@ -283,12 +283,11 @@ pub mod tests {
     fn test_dict() -> Result<()> {
         let data = vec!["a", "b", "c", "a", "a", "c", "c"];
 
-        let data = data.into_iter().map(|x| Result::Ok(Some(x)));
-        let array = DictionaryPrimitive::<i32, Utf8Primitive<i32>, &str>::try_from_iter(data)?;
-        let array = array.to(DataType::Dictionary(
-            Box::new(DataType::Int32),
-            Box::new(DataType::Utf8),
-        ));
+        let data = data.into_iter().map(Some);
+
+        let mut a = DictionaryPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        a.try_extend(data)?;
+        let array = a.into();
 
         let cmp = build_compare(&array, &array)?;
 
@@ -302,12 +301,11 @@ pub mod tests {
     fn test_dict_1() -> Result<()> {
         let data = vec![1, 2, 3, 1, 1, 3, 3];
 
-        let data = data.into_iter().map(|x| Result::Ok(Some(x)));
-        let array = DictionaryPrimitive::<i32, Primitive<i32>, i32>::try_from_iter(data)?;
-        let array = array.to(DataType::Dictionary(
-            Box::new(DataType::Int32),
-            Box::new(DataType::Int32),
-        ));
+        let data = data.into_iter().map(Some);
+
+        let mut a = DictionaryPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        a.try_extend(data)?;
+        let array = a.into();
 
         let cmp = build_compare(&array, &array)?;
 

--- a/src/array/ord.rs
+++ b/src/array/ord.rs
@@ -126,12 +126,12 @@ macro_rules! dyn_dict {
 /// between two [`Array`].
 /// # Example
 /// ```
-/// use arrow2::array::{ord::build_compare, Primitive};
+/// use arrow2::array::{ord::build_compare, PrimitiveBuilder};
 /// use arrow2::datatypes::DataType;
 ///
 /// # fn main() -> arrow2::error::Result<()> {
-/// let array1 = Primitive::from_slice(&[1, 2]).to(DataType::Int32);
-/// let array2 = Primitive::from_slice(&[3, 4]).to(DataType::Int32);
+/// let array1 = PrimitiveBuilder::from_slice(&[1, 2]).to(DataType::Int32);
+/// let array2 = PrimitiveBuilder::from_slice(&[3, 4]).to(DataType::Int32);
 ///
 /// let cmp = build_compare(&array1, &array2)?;
 ///
@@ -218,7 +218,7 @@ pub mod tests {
 
     #[test]
     fn test_i32() -> Result<()> {
-        let array = Primitive::from_slice(vec![1, 2]).to(DataType::Int32);
+        let array = PrimitiveBuilder::from_slice(vec![1, 2]).to(DataType::Int32);
 
         let cmp = build_compare(&array, &array)?;
 
@@ -228,8 +228,8 @@ pub mod tests {
 
     #[test]
     fn test_i32_i32() -> Result<()> {
-        let array1 = Primitive::from_slice(&vec![1]).to(DataType::Int32);
-        let array2 = Primitive::from_slice(&vec![2]).to(DataType::Int32);
+        let array1 = PrimitiveBuilder::from_slice(&vec![1]).to(DataType::Int32);
+        let array2 = PrimitiveBuilder::from_slice(&vec![2]).to(DataType::Int32);
 
         let cmp = build_compare(&array1, &array2)?;
 
@@ -249,7 +249,7 @@ pub mod tests {
 
     #[test]
     fn test_f64() -> Result<()> {
-        let array = Primitive::from_slice(&vec![1.0, 2.0]).to(DataType::Float64);
+        let array = PrimitiveBuilder::from_slice(&vec![1.0, 2.0]).to(DataType::Float64);
 
         let cmp = build_compare(&array, &array)?;
 
@@ -259,7 +259,7 @@ pub mod tests {
 
     #[test]
     fn test_f64_nan() -> Result<()> {
-        let array = Primitive::from_slice(vec![1.0, f64::NAN]).to(DataType::Float64);
+        let array = PrimitiveBuilder::from_slice(vec![1.0, f64::NAN]).to(DataType::Float64);
 
         let cmp = build_compare(&array, &array)?;
 
@@ -269,7 +269,7 @@ pub mod tests {
 
     #[test]
     fn test_f64_zeros() -> Result<()> {
-        let array = Primitive::from_slice(vec![-0.0, 0.0]).to(DataType::Float64);
+        let array = PrimitiveBuilder::from_slice(vec![-0.0, 0.0]).to(DataType::Float64);
 
         let cmp = build_compare(&array, &array)?;
 
@@ -285,7 +285,7 @@ pub mod tests {
 
         let data = data.into_iter().map(Some);
 
-        let mut a = DictionaryPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        let mut a = DictionaryBuilder::<i32, _, _>::new(Utf8Builder::<i32>::new());
         a.try_extend(data)?;
         let array = a.into();
 
@@ -303,7 +303,7 @@ pub mod tests {
 
         let data = data.into_iter().map(Some);
 
-        let mut a = DictionaryPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut a = DictionaryBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         a.try_extend(data)?;
         let array = a.into();
 

--- a/src/array/primitive/display.rs
+++ b/src/array/primitive/display.rs
@@ -181,31 +181,31 @@ display!(f64);
 
 #[cfg(test)]
 mod tests {
-    use super::super::Primitive;
+    use super::super::PrimitiveBuilder;
     use super::*;
 
     #[test]
     fn display_int32() {
-        let array = Primitive::<i32>::from(&[Some(1), None, Some(2)]).to(DataType::Int32);
+        let array = PrimitiveBuilder::<i32>::from(&[Some(1), None, Some(2)]).to(DataType::Int32);
         assert_eq!(format!("{}", array), "Int32[1, , 2]");
     }
 
     #[test]
     fn display_date32() {
-        let array = Primitive::<i32>::from(&[Some(1), None, Some(2)]).to(DataType::Date32);
+        let array = PrimitiveBuilder::<i32>::from(&[Some(1), None, Some(2)]).to(DataType::Date32);
         assert_eq!(format!("{}", array), "Date32[1970-01-02, , 1970-01-03]");
     }
 
     #[test]
     fn display_time32s() {
-        let array = Primitive::<i32>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i32>::from(&[Some(1), None, Some(2)])
             .to(DataType::Time32(TimeUnit::Second));
         assert_eq!(format!("{}", array), "Time32(Second)[00:00:01, , 00:00:02]");
     }
 
     #[test]
     fn display_time32ms() {
-        let array = Primitive::<i32>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i32>::from(&[Some(1), None, Some(2)])
             .to(DataType::Time32(TimeUnit::Millisecond));
         assert_eq!(
             format!("{}", array),
@@ -215,26 +215,26 @@ mod tests {
 
     #[test]
     fn display_interval_d() {
-        let array = Primitive::<i32>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i32>::from(&[Some(1), None, Some(2)])
             .to(DataType::Interval(IntervalUnit::YearMonth));
         assert_eq!(format!("{}", array), "Interval(YearMonth)[1d, , 2d]");
     }
 
     #[test]
     fn display_int64() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(2)]).to(DataType::Int64);
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(2)]).to(DataType::Int64);
         assert_eq!(format!("{}", array), "Int64[1, , 2]");
     }
 
     #[test]
     fn display_date64() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(86400000)]).to(DataType::Date64);
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(86400000)]).to(DataType::Date64);
         assert_eq!(format!("{}", array), "Date64[1970-01-01, , 1970-01-02]");
     }
 
     #[test]
     fn display_time64us() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(2)])
             .to(DataType::Time64(TimeUnit::Microsecond));
         assert_eq!(
             format!("{}", array),
@@ -244,7 +244,7 @@ mod tests {
 
     #[test]
     fn display_time64ns() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(2)])
             .to(DataType::Time64(TimeUnit::Nanosecond));
         assert_eq!(
             format!("{}", array),
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn display_timestamp_s() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(2)])
             .to(DataType::Timestamp(TimeUnit::Second, None));
         assert_eq!(
             format!("{}", array),
@@ -264,7 +264,7 @@ mod tests {
 
     #[test]
     fn display_timestamp_ms() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(2)])
             .to(DataType::Timestamp(TimeUnit::Millisecond, None));
         assert_eq!(
             format!("{}", array),
@@ -274,7 +274,7 @@ mod tests {
 
     #[test]
     fn display_timestamp_us() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(2)])
             .to(DataType::Timestamp(TimeUnit::Microsecond, None));
         assert_eq!(
             format!("{}", array),
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn display_timestamp_ns() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(2)])
             .to(DataType::Timestamp(TimeUnit::Nanosecond, None));
         assert_eq!(
             format!("{}", array),
@@ -294,28 +294,28 @@ mod tests {
 
     #[test]
     fn display_duration_ms() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(2)])
             .to(DataType::Duration(TimeUnit::Millisecond));
         assert_eq!(format!("{}", array), "Duration(Millisecond)[1ms, , 2ms]");
     }
 
     #[test]
     fn display_duration_s() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(2)])
             .to(DataType::Duration(TimeUnit::Second));
         assert_eq!(format!("{}", array), "Duration(Second)[1s, , 2s]");
     }
 
     #[test]
     fn display_duration_us() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(2)])
             .to(DataType::Duration(TimeUnit::Microsecond));
         assert_eq!(format!("{}", array), "Duration(Microsecond)[1us, , 2us]");
     }
 
     #[test]
     fn display_duration_ns() {
-        let array = Primitive::<i64>::from(&[Some(1), None, Some(2)])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1), None, Some(2)])
             .to(DataType::Duration(TimeUnit::Nanosecond));
         assert_eq!(format!("{}", array), "Duration(Nanosecond)[1ns, , 2ns]");
     }
@@ -323,21 +323,21 @@ mod tests {
     #[test]
     fn display_decimal() {
         let array =
-            Primitive::<i128>::from(&[Some(12345), None, Some(23456)]).to(DataType::Decimal(5, 2));
+            PrimitiveBuilder::<i128>::from(&[Some(12345), None, Some(23456)]).to(DataType::Decimal(5, 2));
         assert_eq!(format!("{}", array), "Decimal(5, 2)[123.45, , 234.56]");
     }
 
     #[test]
     fn display_decimal1() {
         let array =
-            Primitive::<i128>::from(&[Some(12345), None, Some(23456)]).to(DataType::Decimal(5, 1));
+            PrimitiveBuilder::<i128>::from(&[Some(12345), None, Some(23456)]).to(DataType::Decimal(5, 1));
         assert_eq!(format!("{}", array), "Decimal(5, 1)[1234.5, , 2345.6]");
     }
 
     #[test]
     fn display_interval_days_ms() {
         let array =
-            Primitive::<days_ms>::from(&[Some(days_ms::new(1, 1)), None, Some(days_ms::new(2, 2))])
+            PrimitiveBuilder::<days_ms>::from(&[Some(days_ms::new(1, 1)), None, Some(days_ms::new(2, 2))])
                 .to(DataType::Interval(IntervalUnit::DayTime));
         assert_eq!(format!("{}", array), "Interval(DayTime)[1d1ms, , 2d2ms]");
     }

--- a/src/array/primitive/from_natural.rs
+++ b/src/array/primitive/from_natural.rs
@@ -6,11 +6,11 @@ use crate::{
     types::{NativeType, NaturalDataType},
 };
 
-use super::{Primitive, PrimitiveArray};
+use super::{PrimitiveBuilder, PrimitiveArray};
 
 impl<T: NativeType + NaturalDataType, P: AsRef<[Option<T>]>> From<P> for PrimitiveArray<T> {
     fn from(slice: P) -> Self {
-        Primitive::<T>::from_trusted_len_iter(slice.as_ref().iter().map(|x| x.as_ref()))
+        PrimitiveBuilder::<T>::from_trusted_len_iter(slice.as_ref().iter().map(|x| x.as_ref()))
             .to(T::DATA_TYPE)
     }
 }
@@ -19,7 +19,7 @@ impl<T: NativeType + NaturalDataType, Ptr: std::borrow::Borrow<Option<T>>> FromI
     for PrimitiveArray<T>
 {
     fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
-        Primitive::<T>::from_iter(iter).to(T::DATA_TYPE)
+        PrimitiveBuilder::<T>::from_iter(iter).to(T::DATA_TYPE)
     }
 }
 

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -123,7 +123,7 @@ mod display;
 mod ffi;
 mod from;
 mod from_natural;
-pub use from::Primitive;
+pub use from::PrimitiveBuilder;
 mod iterator;
 pub use iterator::*;
 

--- a/src/array/utf8/from.rs
+++ b/src/array/utf8/from.rs
@@ -1,7 +1,7 @@
 use std::{iter::FromIterator, sync::Arc};
 
 use crate::{
-    array::{Array, Builder, IntoArray, Offset, ToArray, TryFromIterator},
+    array::{Array, Builder, IntoArray, Offset, ToArray, TryExtend, TryFromIterator},
     bitmap::{Bitmap, MutableBitmap},
     buffer::{Buffer, MutableBuffer},
     datatypes::DataType,
@@ -251,7 +251,7 @@ where
     Ok((null.into(), offsets.into(), values.into()))
 }
 
-/// auxiliary struct used to create a [`PrimitiveArray`] out of an iterator
+/// auxiliary struct used to create a [`Utf8Array`] out of an iterator
 #[derive(Debug)]
 pub struct Utf8Primitive<O: Offset> {
     offsets: MutableBuffer<O>,
@@ -262,6 +262,11 @@ pub struct Utf8Primitive<O: Offset> {
 }
 
 impl<O: Offset> Utf8Primitive<O> {
+    /// Initializes a new empty [`Utf8Primitive`].
+    pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
     /// Initializes a new [`Utf8Primitive`] with a pre-allocated capacity of slots.
     pub fn with_capacity(capacity: usize) -> Self {
         Self::with_capacities(capacity, 0)
@@ -282,9 +287,15 @@ impl<O: Offset> Utf8Primitive<O> {
     }
 }
 
+impl<O: Offset> Default for Utf8Primitive<O> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<O: Offset, P: AsRef<str>> FromIterator<Option<P>> for Utf8Primitive<O> {
     fn from_iter<I: IntoIterator<Item = Option<P>>>(iter: I) -> Self {
-        Self::try_from_iter(iter.into_iter().map(Ok)).unwrap()
+        Self::try_from_iter(iter.into_iter()).unwrap()
     }
 }
 
@@ -299,25 +310,33 @@ impl<O: Offset, P> TryFromIterator<Option<P>> for Utf8Primitive<O>
 where
     P: AsRef<str>,
 {
-    fn try_from_iter<I: IntoIterator<Item = ArrowResult<Option<P>>>>(iter: I) -> ArrowResult<Self> {
-        let iterator = iter.into_iter();
-        let (lower, _) = iterator.size_hint();
-        let mut primitive = Self::with_capacity(lower);
-        for item in iterator {
-            match item? {
-                Some(x) => primitive.try_push(Some(&x.as_ref()))?,
-                None => primitive.try_push(None)?,
-            }
-        }
+    fn try_from_iter<I: IntoIterator<Item = Option<P>>>(iter: I) -> ArrowResult<Self> {
+        let mut primitive = Self::new();
+        primitive.try_extend(iter)?;
         Ok(primitive)
     }
 }
 
-impl<O: Offset> Builder<&str> for Utf8Primitive<O> {
-    fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
+impl<O: Offset, P> TryExtend<Option<P>> for Utf8Primitive<O>
+where
+    P: AsRef<str>,
+{
+    fn try_extend<I: IntoIterator<Item = Option<P>>>(&mut self, iter: I) -> ArrowResult<()> {
+        let iter = iter.into_iter();
+        let (lower, _) = iter.size_hint();
+        self.validity.reserve(lower);
+        self.offsets.reserve(lower);
+        for item in iter {
+            match item {
+                Some(x) => self.try_push(Some(x.as_ref()))?,
+                None => self.try_push(None)?,
+            }
+        }
+        Ok(())
     }
+}
 
+impl<O: Offset> Builder<&str> for Utf8Primitive<O> {
     #[inline]
     fn try_push(&mut self, value: Option<&str>) -> ArrowResult<()> {
         match value {

--- a/src/compute/aggregate/sum.rs
+++ b/src/compute/aggregate/sum.rs
@@ -111,13 +111,13 @@ mod tests {
 
     #[test]
     fn test_primitive_array_sum() {
-        let a = Primitive::from_slice(&[1, 2, 3, 4, 5]).to(DataType::Int32);
+        let a = PrimitiveBuilder::from_slice(&[1, 2, 3, 4, 5]).to(DataType::Int32);
         assert_eq!(15, sum(&a).unwrap());
     }
 
     #[test]
     fn test_primitive_array_float_sum() {
-        let a = Primitive::from_slice(&[1.1f64, 2.2, 3.3, 4.4, 5.5]).to(DataType::Float64);
+        let a = PrimitiveBuilder::from_slice(&[1.1f64, 2.2, 3.3, 4.4, 5.5]).to(DataType::Float64);
         assert!((16.5 - sum(&a).unwrap()).abs() < f64::EPSILON);
     }
 

--- a/src/compute/arithmetics/basic/add.rs
+++ b/src/compute/arithmetics/basic/add.rs
@@ -27,13 +27,13 @@ use crate::{
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::basic::add::add;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
-/// let b = Primitive::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
+/// let a = PrimitiveBuilder::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+/// let b = PrimitiveBuilder::from(&vec![Some(5), None, None, Some(6)]).to(DataType::Int32);
 /// let result = add(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![None, None, None, Some(12)]).to(DataType::Int32);
+/// let expected = PrimitiveBuilder::from(&vec![None, None, None, Some(12)]).to(DataType::Int32);
 /// assert_eq!(result, expected)
 /// ```
 pub fn add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
@@ -55,13 +55,13 @@ where
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::basic::add::checked_add;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(100i8), Some(100i8), Some(100i8)]).to(DataType::Int8);
-/// let b = Primitive::from(&vec![Some(0i8), Some(100i8), Some(0i8)]).to(DataType::Int8);
+/// let a = PrimitiveBuilder::from(&vec![Some(100i8), Some(100i8), Some(100i8)]).to(DataType::Int8);
+/// let b = PrimitiveBuilder::from(&vec![Some(0i8), Some(100i8), Some(0i8)]).to(DataType::Int8);
 /// let result = checked_add(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(100i8), None, Some(100i8)]).to(DataType::Int8);
+/// let expected = PrimitiveBuilder::from(&vec![Some(100i8), None, Some(100i8)]).to(DataType::Int8);
 /// assert_eq!(result, expected);
 /// ```
 pub fn checked_add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
@@ -86,13 +86,13 @@ where
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::basic::add::saturating_add;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
-/// let b = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// let a = PrimitiveBuilder::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// let b = PrimitiveBuilder::from(&vec![Some(100i8)]).to(DataType::Int8);
 /// let result = saturating_add(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(127)]).to(DataType::Int8);
+/// let expected = PrimitiveBuilder::from(&vec![Some(127)]).to(DataType::Int8);
 /// assert_eq!(result, expected);
 /// ```
 pub fn saturating_add<T>(
@@ -121,13 +121,13 @@ where
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::basic::add::overflowing_add;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
-/// let b = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+/// let a = PrimitiveBuilder::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+/// let b = PrimitiveBuilder::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
 /// let (result, overflow) = overflowing_add(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(2i8), Some(-56i8)]).to(DataType::Int8);
+/// let expected = PrimitiveBuilder::from(&vec![Some(2i8), Some(-56i8)]).to(DataType::Int8);
 /// assert_eq!(result, expected);
 /// ```
 pub fn overflowing_add<T>(
@@ -202,12 +202,12 @@ where
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::basic::add::add_scalar;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
+/// let a = PrimitiveBuilder::from(&vec![None, Some(6), None, Some(6)]).to(DataType::Int32);
 /// let result = add_scalar(&a, &1i32);
-/// let expected = Primitive::from(&vec![None, Some(7), None, Some(7)]).to(DataType::Int32);
+/// let expected = PrimitiveBuilder::from(&vec![None, Some(7), None, Some(7)]).to(DataType::Int32);
 /// assert_eq!(result, expected)
 /// ```
 pub fn add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
@@ -249,12 +249,12 @@ where
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::basic::add::saturating_add_scalar;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(100i8)]).to(DataType::Int8);
+/// let a = PrimitiveBuilder::from(&vec![Some(100i8)]).to(DataType::Int8);
 /// let result = saturating_add_scalar(&a, &100i8);
-/// let expected = Primitive::from(&vec![Some(127)]).to(DataType::Int8);
+/// let expected = PrimitiveBuilder::from(&vec![Some(127)]).to(DataType::Int8);
 /// assert_eq!(result, expected);
 /// ```
 pub fn saturating_add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
@@ -275,12 +275,12 @@ where
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::basic::add::overflowing_add_scalar;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
+/// let a = PrimitiveBuilder::from(&vec![Some(1i8), Some(100i8)]).to(DataType::Int8);
 /// let (result, overflow) = overflowing_add_scalar(&a, &100i8);
-/// let expected = Primitive::from(&vec![Some(101i8), Some(-56i8)]).to(DataType::Int8);
+/// let expected = PrimitiveBuilder::from(&vec![Some(101i8), Some(-56i8)]).to(DataType::Int8);
 /// assert_eq!(result, expected);
 /// ```
 pub fn overflowing_add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> (PrimitiveArray<T>, Bitmap)

--- a/src/compute/arithmetics/decimal/add.rs
+++ b/src/compute/arithmetics/decimal/add.rs
@@ -41,14 +41,14 @@ use super::{adjusted_precision_scale, max_value, number_digits};
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::add::add;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(1i128), Some(1i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(1i128), Some(2i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(1i128), Some(1i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(1i128), Some(2i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = add(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(2i128), Some(3i128), None, Some(4i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![Some(2i128), Some(3i128), None, Some(4i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -94,14 +94,14 @@ pub fn add(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<Pri
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::add::saturating_add;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = saturating_add(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(99999i128), Some(33300i128), None, Some(33300i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![Some(99999i128), Some(33300i128), None, Some(33300i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -154,14 +154,14 @@ pub fn saturating_add(
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::add::checked_add;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = checked_add(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![None, Some(33300i128), None, Some(33300i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![None, Some(33300i128), None, Some(33300i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -240,13 +240,13 @@ impl ArraySaturatingAdd<PrimitiveArray<i128>> for PrimitiveArray<i128> {
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::add::adaptive_add;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
-/// let b = Primitive::from(&vec![Some(11111_111i128)]).to(DataType::Decimal(8, 3));
+/// let a = PrimitiveBuilder::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(11111_111i128)]).to(DataType::Decimal(8, 3));
 /// let result = adaptive_add(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(22222_221i128)]).to(DataType::Decimal(8, 3));
+/// let expected = PrimitiveBuilder::from(&vec![Some(22222_221i128)]).to(DataType::Decimal(8, 3));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -311,12 +311,12 @@ pub fn adaptive_add(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::Primitive;
+    use crate::array::PrimitiveBuilder;
     use crate::datatypes::DataType;
 
     #[test]
     fn test_add_normal() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(11111i128),
             Some(11100i128),
             None,
@@ -324,7 +324,7 @@ mod tests {
         ])
         .to(DataType::Decimal(5, 2));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(22222i128),
             Some(22200i128),
             None,
@@ -333,7 +333,7 @@ mod tests {
         .to(DataType::Decimal(5, 2));
 
         let result = add(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(33333i128),
             Some(33300i128),
             None,
@@ -350,8 +350,8 @@ mod tests {
 
     #[test]
     fn test_add_decimal_wrong_precision() {
-        let a = Primitive::from(&vec![None]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![None]).to(DataType::Decimal(6, 2));
+        let a = PrimitiveBuilder::from(&vec![None]).to(DataType::Decimal(5, 2));
+        let b = PrimitiveBuilder::from(&vec![None]).to(DataType::Decimal(6, 2));
         let result = add(&a, &b);
 
         if result.is_ok() {
@@ -362,14 +362,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "Overflow in addition presented for precision 5")]
     fn test_add_panic() {
-        let a = Primitive::from(&vec![Some(99999i128)]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![Some(1i128)]).to(DataType::Decimal(5, 2));
+        let a = PrimitiveBuilder::from(&vec![Some(99999i128)]).to(DataType::Decimal(5, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(1i128)]).to(DataType::Decimal(5, 2));
         let _ = add(&a, &b);
     }
 
     #[test]
     fn test_add_saturating() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(11111i128),
             Some(11100i128),
             None,
@@ -377,7 +377,7 @@ mod tests {
         ])
         .to(DataType::Decimal(5, 2));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(22222i128),
             Some(22200i128),
             None,
@@ -386,7 +386,7 @@ mod tests {
         .to(DataType::Decimal(5, 2));
 
         let result = saturating_add(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(33333i128),
             Some(33300i128),
             None,
@@ -403,14 +403,14 @@ mod tests {
 
     #[test]
     fn test_add_saturating_overflow() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(99999i128),
             Some(99999i128),
             Some(99999i128),
             Some(-99999i128),
         ])
         .to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(00001i128),
             Some(00100i128),
             Some(10000i128),
@@ -420,7 +420,7 @@ mod tests {
 
         let result = saturating_add(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(99999i128),
             Some(99999i128),
             Some(99999i128),
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn test_add_checked() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(11111i128),
             Some(11100i128),
             None,
@@ -445,7 +445,7 @@ mod tests {
         ])
         .to(DataType::Decimal(5, 2));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(22222i128),
             Some(22200i128),
             None,
@@ -454,7 +454,7 @@ mod tests {
         .to(DataType::Decimal(5, 2));
 
         let result = checked_add(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(33333i128),
             Some(33300i128),
             None,
@@ -471,10 +471,10 @@ mod tests {
 
     #[test]
     fn test_add_checked_overflow() {
-        let a = Primitive::from(&vec![Some(1i128), Some(99999i128)]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![Some(1i128), Some(1i128)]).to(DataType::Decimal(5, 2));
+        let a = PrimitiveBuilder::from(&vec![Some(1i128), Some(99999i128)]).to(DataType::Decimal(5, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(1i128), Some(1i128)]).to(DataType::Decimal(5, 2));
         let result = checked_add(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![Some(2i128), None]).to(DataType::Decimal(5, 2));
+        let expected = PrimitiveBuilder::from(&vec![Some(2i128), None]).to(DataType::Decimal(5, 2));
         assert_eq!(result, expected);
 
         // Testing trait
@@ -488,11 +488,11 @@ mod tests {
         // 11111.11   -> 7, 2
         // -----------------
         // 11122.2211 -> 9, 4
-        let a = Primitive::from(&vec![Some(11_1111i128)]).to(DataType::Decimal(6, 4));
-        let b = Primitive::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
+        let a = PrimitiveBuilder::from(&vec![Some(11_1111i128)]).to(DataType::Decimal(6, 4));
+        let b = PrimitiveBuilder::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
         let result = adaptive_add(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(11122_2211i128)]).to(DataType::Decimal(9, 4));
+        let expected = PrimitiveBuilder::from(&vec![Some(11122_2211i128)]).to(DataType::Decimal(9, 4));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(9, 4));
@@ -501,11 +501,11 @@ mod tests {
         // 11111.0    -> 6, 1
         // -----------------
         // 11111.1111 -> 9, 4
-        let a = Primitive::from(&vec![Some(1111i128)]).to(DataType::Decimal(5, 4));
-        let b = Primitive::from(&vec![Some(11111_0i128)]).to(DataType::Decimal(6, 1));
+        let a = PrimitiveBuilder::from(&vec![Some(1111i128)]).to(DataType::Decimal(5, 4));
+        let b = PrimitiveBuilder::from(&vec![Some(11111_0i128)]).to(DataType::Decimal(6, 1));
         let result = adaptive_add(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(11111_1111i128)]).to(DataType::Decimal(9, 4));
+        let expected = PrimitiveBuilder::from(&vec![Some(11111_1111i128)]).to(DataType::Decimal(9, 4));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(9, 4));
@@ -514,11 +514,11 @@ mod tests {
         // 11111.111  -> 8, 3
         // -----------------
         // 22222.221  -> 8, 3
-        let a = Primitive::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
-        let b = Primitive::from(&vec![Some(11111_111i128)]).to(DataType::Decimal(8, 3));
+        let a = PrimitiveBuilder::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(11111_111i128)]).to(DataType::Decimal(8, 3));
         let result = adaptive_add(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(22222_221i128)]).to(DataType::Decimal(8, 3));
+        let expected = PrimitiveBuilder::from(&vec![Some(22222_221i128)]).to(DataType::Decimal(8, 3));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(8, 3));
@@ -527,11 +527,11 @@ mod tests {
         //  00.0001 -> 6, 4
         // -----------------
         // 100.0000 -> 7, 4
-        let a = Primitive::from(&vec![Some(99_9999i128)]).to(DataType::Decimal(6, 4));
-        let b = Primitive::from(&vec![Some(00_0001i128)]).to(DataType::Decimal(6, 4));
+        let a = PrimitiveBuilder::from(&vec![Some(99_9999i128)]).to(DataType::Decimal(6, 4));
+        let b = PrimitiveBuilder::from(&vec![Some(00_0001i128)]).to(DataType::Decimal(6, 4));
         let result = adaptive_add(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(7, 4));
+        let expected = PrimitiveBuilder::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(7, 4));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(7, 4));

--- a/src/compute/arithmetics/decimal/div.rs
+++ b/src/compute/arithmetics/decimal/div.rs
@@ -43,14 +43,14 @@ use super::{adjusted_precision_scale, max_value, number_digits};
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::div::div;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(1_00i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(1_00i128), Some(2_00i128), Some(2_00i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(1_00i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(1_00i128), Some(2_00i128), Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = div(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(1_00i128), Some(2_00i128), Some(3_00i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![Some(1_00i128), Some(2_00i128), Some(3_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -112,14 +112,14 @@ pub fn div(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<Pri
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::div::saturating_div;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(999_99i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(000_01i128), Some(2_00i128), Some(2_00i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(999_99i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(000_01i128), Some(2_00i128), Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = saturating_div(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(999_99i128), Some(2_00i128), Some(3_00i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![Some(999_99i128), Some(2_00i128), Some(3_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -177,14 +177,14 @@ pub fn saturating_div(
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::div::checked_div;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(1_00i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(000_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(1_00i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(000_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = checked_div(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![None, None, Some(3_00i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![None, None, Some(3_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -258,13 +258,13 @@ impl ArrayCheckedDiv<PrimitiveArray<i128>> for PrimitiveArray<i128> {
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::div::adaptive_div;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(1000_00i128)]).to(DataType::Decimal(7, 2));
-/// let b = Primitive::from(&vec![Some(10_0000i128)]).to(DataType::Decimal(6, 4));
+/// let a = PrimitiveBuilder::from(&vec![Some(1000_00i128)]).to(DataType::Decimal(7, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(10_0000i128)]).to(DataType::Decimal(6, 4));
 /// let result = adaptive_div(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(9, 4));
+/// let expected = PrimitiveBuilder::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(9, 4));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -335,7 +335,7 @@ pub fn adaptive_div(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::Primitive;
+    use crate::array::PrimitiveBuilder;
     use crate::datatypes::DataType;
 
     #[test]
@@ -344,7 +344,7 @@ mod tests {
         //   123.456 -->     123456
         // --------       ---------
         //     1.800 <--       1800
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(222_222i128),
             Some(10_000i128),
             Some(20_000i128),
@@ -354,7 +354,7 @@ mod tests {
         ])
         .to(DataType::Decimal(7, 3));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(123_456i128),
             Some(2_000i128),
             Some(3_000i128),
@@ -365,7 +365,7 @@ mod tests {
         .to(DataType::Decimal(7, 3));
 
         let result = div(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(1_800i128),
             Some(5_000i128),
             Some(6_666i128),
@@ -384,8 +384,8 @@ mod tests {
 
     #[test]
     fn test_divide_decimal_wrong_precision() {
-        let a = Primitive::from(&vec![None]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![None]).to(DataType::Decimal(6, 2));
+        let a = PrimitiveBuilder::from(&vec![None]).to(DataType::Decimal(5, 2));
+        let b = PrimitiveBuilder::from(&vec![None]).to(DataType::Decimal(6, 2));
         let result = div(&a, &b);
 
         if result.is_ok() {
@@ -396,14 +396,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "Overflow in multiplication presented for precision 5")]
     fn test_divide_panic() {
-        let a = Primitive::from(&vec![Some(99999i128)]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![Some(000_01i128)]).to(DataType::Decimal(5, 2));
+        let a = PrimitiveBuilder::from(&vec![Some(99999i128)]).to(DataType::Decimal(5, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(000_01i128)]).to(DataType::Decimal(5, 2));
         let _ = div(&a, &b);
     }
 
     #[test]
     fn test_divide_saturating() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(222_222i128),
             Some(10_000i128),
             Some(20_000i128),
@@ -413,7 +413,7 @@ mod tests {
         ])
         .to(DataType::Decimal(7, 3));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(123_456i128),
             Some(2_000i128),
             Some(3_000i128),
@@ -424,7 +424,7 @@ mod tests {
         .to(DataType::Decimal(7, 3));
 
         let result = saturating_div(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(1_800i128),
             Some(5_000i128),
             Some(6_666i128),
@@ -439,7 +439,7 @@ mod tests {
 
     #[test]
     fn test_divide_saturating_overflow() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(99999i128),
             Some(99999i128),
             Some(99999i128),
@@ -447,7 +447,7 @@ mod tests {
             Some(99999i128),
         ])
         .to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(-00001i128),
             Some(00001i128),
             Some(00010i128),
@@ -458,7 +458,7 @@ mod tests {
 
         let result = saturating_div(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(-99999i128),
             Some(99999i128),
             Some(99999i128),
@@ -472,7 +472,7 @@ mod tests {
 
     #[test]
     fn test_divide_checked() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(222_222i128),
             Some(10_000i128),
             Some(20_000i128),
@@ -482,7 +482,7 @@ mod tests {
         ])
         .to(DataType::Decimal(7, 3));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(123_456i128),
             Some(2_000i128),
             Some(3_000i128),
@@ -493,7 +493,7 @@ mod tests {
         .to(DataType::Decimal(7, 3));
 
         let result = div(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(1_800i128),
             Some(5_000i128),
             Some(6_666i128),
@@ -508,14 +508,14 @@ mod tests {
 
     #[test]
     fn test_divide_checked_overflow() {
-        let a = Primitive::from(&vec![Some(1_00i128), Some(4_00i128), Some(6_00i128)])
+        let a = PrimitiveBuilder::from(&vec![Some(1_00i128), Some(4_00i128), Some(6_00i128)])
             .to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![Some(000_00i128), None, Some(2_00i128)])
+        let b = PrimitiveBuilder::from(&vec![Some(000_00i128), None, Some(2_00i128)])
             .to(DataType::Decimal(5, 2));
 
         let result = checked_div(&a, &b).unwrap();
         let expected =
-            Primitive::from(&vec![None, None, Some(3_00i128)]).to(DataType::Decimal(5, 2));
+            PrimitiveBuilder::from(&vec![None, None, Some(3_00i128)]).to(DataType::Decimal(5, 2));
 
         assert_eq!(result, expected);
 
@@ -530,11 +530,11 @@ mod tests {
         //    10.0000 -> 6, 4
         // -----------------
         //   100.0000 -> 9, 4
-        let a = Primitive::from(&vec![Some(1000_00i128)]).to(DataType::Decimal(7, 2));
-        let b = Primitive::from(&vec![Some(10_0000i128)]).to(DataType::Decimal(6, 4));
+        let a = PrimitiveBuilder::from(&vec![Some(1000_00i128)]).to(DataType::Decimal(7, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(10_0000i128)]).to(DataType::Decimal(6, 4));
         let result = adaptive_div(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(9, 4));
+        let expected = PrimitiveBuilder::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(9, 4));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(9, 4));
@@ -543,11 +543,11 @@ mod tests {
         //      10.002  -> 5, 3
         // -----------------
         //    1110.877  -> 8, 3
-        let a = Primitive::from(&vec![Some(11111_0i128)]).to(DataType::Decimal(6, 1));
-        let b = Primitive::from(&vec![Some(10_002i128)]).to(DataType::Decimal(5, 3));
+        let a = PrimitiveBuilder::from(&vec![Some(11111_0i128)]).to(DataType::Decimal(6, 1));
+        let b = PrimitiveBuilder::from(&vec![Some(10_002i128)]).to(DataType::Decimal(5, 3));
         let result = adaptive_div(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(1110_877i128)]).to(DataType::Decimal(8, 3));
+        let expected = PrimitiveBuilder::from(&vec![Some(1110_877i128)]).to(DataType::Decimal(8, 3));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(8, 3));
@@ -556,11 +556,11 @@ mod tests {
         //     12345.678  ->  8, 3
         // -----------------
         //         0.999  ->  8, 3
-        let a = Primitive::from(&vec![Some(12345_67i128)]).to(DataType::Decimal(7, 2));
-        let b = Primitive::from(&vec![Some(12345_678i128)]).to(DataType::Decimal(8, 3));
+        let a = PrimitiveBuilder::from(&vec![Some(12345_67i128)]).to(DataType::Decimal(7, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(12345_678i128)]).to(DataType::Decimal(8, 3));
         let result = adaptive_div(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(0_999i128)]).to(DataType::Decimal(8, 3));
+        let expected = PrimitiveBuilder::from(&vec![Some(0_999i128)]).to(DataType::Decimal(8, 3));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(8, 3));

--- a/src/compute/arithmetics/decimal/mul.rs
+++ b/src/compute/arithmetics/decimal/mul.rs
@@ -40,14 +40,14 @@ use super::{adjusted_precision_scale, max_value, number_digits};
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::mul::mul;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(1_00i128), Some(1_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(1_00i128), Some(2_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(1_00i128), Some(1_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(1_00i128), Some(2_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = mul(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(1_00i128), Some(2_00i128), None, Some(4_00i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![Some(1_00i128), Some(2_00i128), None, Some(4_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -110,14 +110,14 @@ pub fn mul(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<Pri
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::mul::saturating_mul;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(999_99i128), Some(1_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(10_00i128), Some(2_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(999_99i128), Some(1_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(10_00i128), Some(2_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = saturating_mul(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(999_99i128), Some(2_00i128), None, Some(4_00i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![Some(999_99i128), Some(2_00i128), None, Some(4_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -173,14 +173,14 @@ pub fn saturating_mul(
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::mul::checked_mul;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(999_99i128), Some(1_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(10_00i128), Some(2_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(999_99i128), Some(1_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(10_00i128), Some(2_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = checked_mul(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![None, Some(2_00i128), None, Some(4_00i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![None, Some(2_00i128), None, Some(4_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -263,13 +263,13 @@ impl ArraySaturatingMul<PrimitiveArray<i128>> for PrimitiveArray<i128> {
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::mul::adaptive_mul;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(11111_0i128), Some(1_0i128)]).to(DataType::Decimal(6, 1));
-/// let b = Primitive::from(&vec![Some(10_002i128), Some(2_000i128)]).to(DataType::Decimal(5, 3));
+/// let a = PrimitiveBuilder::from(&vec![Some(11111_0i128), Some(1_0i128)]).to(DataType::Decimal(6, 1));
+/// let b = PrimitiveBuilder::from(&vec![Some(10_002i128), Some(2_000i128)]).to(DataType::Decimal(5, 3));
 /// let result = adaptive_mul(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(111132_222i128), Some(2_000i128)]).to(DataType::Decimal(9, 3));
+/// let expected = PrimitiveBuilder::from(&vec![Some(111132_222i128), Some(2_000i128)]).to(DataType::Decimal(9, 3));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -339,7 +339,7 @@ pub fn adaptive_mul(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::Primitive;
+    use crate::array::PrimitiveBuilder;
     use crate::datatypes::DataType;
 
     #[test]
@@ -348,7 +348,7 @@ mod tests {
         //   222.22 -->     22222
         // --------       -------
         // 24690.86 <-- 246908642
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(111_11i128),
             Some(10_00i128),
             Some(20_00i128),
@@ -358,7 +358,7 @@ mod tests {
         ])
         .to(DataType::Decimal(7, 2));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(222_22i128),
             Some(2_00i128),
             Some(3_00i128),
@@ -369,7 +369,7 @@ mod tests {
         .to(DataType::Decimal(7, 2));
 
         let result = mul(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(24690_86i128),
             Some(20_00i128),
             Some(60_00i128),
@@ -388,8 +388,8 @@ mod tests {
 
     #[test]
     fn test_multiply_decimal_wrong_precision() {
-        let a = Primitive::from(&vec![None]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![None]).to(DataType::Decimal(6, 2));
+        let a = PrimitiveBuilder::from(&vec![None]).to(DataType::Decimal(5, 2));
+        let b = PrimitiveBuilder::from(&vec![None]).to(DataType::Decimal(6, 2));
         let result = mul(&a, &b);
 
         if result.is_ok() {
@@ -400,14 +400,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "Overflow in multiplication presented for precision 5")]
     fn test_multiply_panic() {
-        let a = Primitive::from(&vec![Some(99999i128)]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![Some(100_00i128)]).to(DataType::Decimal(5, 2));
+        let a = PrimitiveBuilder::from(&vec![Some(99999i128)]).to(DataType::Decimal(5, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(100_00i128)]).to(DataType::Decimal(5, 2));
         let _ = mul(&a, &b);
     }
 
     #[test]
     fn test_multiply_saturating() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(111_11i128),
             Some(10_00i128),
             Some(20_00i128),
@@ -417,7 +417,7 @@ mod tests {
         ])
         .to(DataType::Decimal(7, 2));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(222_22i128),
             Some(2_00i128),
             Some(3_00i128),
@@ -428,7 +428,7 @@ mod tests {
         .to(DataType::Decimal(7, 2));
 
         let result = saturating_mul(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(24690_86i128),
             Some(20_00i128),
             Some(60_00i128),
@@ -447,14 +447,14 @@ mod tests {
 
     #[test]
     fn test_multiply_saturating_overflow() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(99999i128),
             Some(99999i128),
             Some(99999i128),
             Some(99999i128),
         ])
         .to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(-00100i128),
             Some(01000i128),
             Some(10000i128),
@@ -464,7 +464,7 @@ mod tests {
 
         let result = saturating_mul(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(-99999i128),
             Some(99999i128),
             Some(99999i128),
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_multiply_checked() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(111_11i128),
             Some(10_00i128),
             Some(20_00i128),
@@ -491,7 +491,7 @@ mod tests {
         ])
         .to(DataType::Decimal(7, 2));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(222_22i128),
             Some(2_00i128),
             Some(3_00i128),
@@ -502,7 +502,7 @@ mod tests {
         .to(DataType::Decimal(7, 2));
 
         let result = checked_mul(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(24690_86i128),
             Some(20_00i128),
             Some(60_00i128),
@@ -521,10 +521,10 @@ mod tests {
 
     #[test]
     fn test_multiply_checked_overflow() {
-        let a = Primitive::from(&vec![Some(99999i128), Some(1_00i128)]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![Some(10000i128), Some(2_00i128)]).to(DataType::Decimal(5, 2));
+        let a = PrimitiveBuilder::from(&vec![Some(99999i128), Some(1_00i128)]).to(DataType::Decimal(5, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(10000i128), Some(2_00i128)]).to(DataType::Decimal(5, 2));
         let result = checked_mul(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
+        let expected = PrimitiveBuilder::from(&vec![None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 
         assert_eq!(result, expected);
     }
@@ -535,11 +535,11 @@ mod tests {
         //    10.0000 -> 6, 4
         // -----------------
         // 10000.0000 -> 9, 4
-        let a = Primitive::from(&vec![Some(1000_00i128)]).to(DataType::Decimal(7, 2));
-        let b = Primitive::from(&vec![Some(10_0000i128)]).to(DataType::Decimal(6, 4));
+        let a = PrimitiveBuilder::from(&vec![Some(1000_00i128)]).to(DataType::Decimal(7, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(10_0000i128)]).to(DataType::Decimal(6, 4));
         let result = adaptive_mul(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(10000_0000i128)]).to(DataType::Decimal(9, 4));
+        let expected = PrimitiveBuilder::from(&vec![Some(10000_0000i128)]).to(DataType::Decimal(9, 4));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(9, 4));
@@ -548,11 +548,11 @@ mod tests {
         //      10.002  -> 5, 3
         // -----------------
         //  111132.222  -> 9, 3
-        let a = Primitive::from(&vec![Some(11111_0i128)]).to(DataType::Decimal(6, 1));
-        let b = Primitive::from(&vec![Some(10_002i128)]).to(DataType::Decimal(5, 3));
+        let a = PrimitiveBuilder::from(&vec![Some(11111_0i128)]).to(DataType::Decimal(6, 1));
+        let b = PrimitiveBuilder::from(&vec![Some(10_002i128)]).to(DataType::Decimal(5, 3));
         let result = adaptive_mul(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(111132_222i128)]).to(DataType::Decimal(9, 3));
+        let expected = PrimitiveBuilder::from(&vec![Some(111132_222i128)]).to(DataType::Decimal(9, 3));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(9, 3));
@@ -561,11 +561,11 @@ mod tests {
         //     12345.678  ->  8, 3
         // -----------------
         // 152415666.514  -> 11, 3
-        let a = Primitive::from(&vec![Some(12345_67i128)]).to(DataType::Decimal(7, 2));
-        let b = Primitive::from(&vec![Some(12345_678i128)]).to(DataType::Decimal(8, 3));
+        let a = PrimitiveBuilder::from(&vec![Some(12345_67i128)]).to(DataType::Decimal(7, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(12345_678i128)]).to(DataType::Decimal(8, 3));
         let result = adaptive_mul(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(152415666_514i128)]).to(DataType::Decimal(12, 3));
+        let expected = PrimitiveBuilder::from(&vec![Some(152415666_514i128)]).to(DataType::Decimal(12, 3));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(12, 3));

--- a/src/compute/arithmetics/decimal/sub.rs
+++ b/src/compute/arithmetics/decimal/sub.rs
@@ -39,14 +39,14 @@ use super::{adjusted_precision_scale, max_value, number_digits};
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::sub::sub;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(1i128), Some(1i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(1i128), Some(2i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(1i128), Some(1i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(1i128), Some(2i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = sub(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(0i128), Some(-1i128), None, Some(0i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![Some(0i128), Some(-1i128), None, Some(0i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -92,14 +92,14 @@ pub fn sub(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<Pri
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::sub::saturating_sub;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(-99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(-99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = saturating_sub(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(-99999i128), Some(-11100i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![Some(-99999i128), Some(-11100i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -178,14 +178,14 @@ impl ArraySaturatingSub<PrimitiveArray<i128>> for PrimitiveArray<i128> {
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::sub::checked_sub;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(-99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
-/// let b = Primitive::from(&vec![Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
+/// let a = PrimitiveBuilder::from(&vec![Some(-99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
+/// let b = PrimitiveBuilder::from(&vec![Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
 /// let result = checked_sub(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![None, Some(-11100i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
+/// let expected = PrimitiveBuilder::from(&vec![None, Some(-11100i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -237,13 +237,13 @@ pub fn checked_sub(
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::decimal::sub::adaptive_sub;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![Some(99_9999i128)]).to(DataType::Decimal(6, 4));
-/// let b = Primitive::from(&vec![Some(-00_0001i128)]).to(DataType::Decimal(6, 4));
+/// let a = PrimitiveBuilder::from(&vec![Some(99_9999i128)]).to(DataType::Decimal(6, 4));
+/// let b = PrimitiveBuilder::from(&vec![Some(-00_0001i128)]).to(DataType::Decimal(6, 4));
 /// let result = adaptive_sub(&a, &b).unwrap();
-/// let expected = Primitive::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(7, 4));
+/// let expected = PrimitiveBuilder::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(7, 4));
 ///
 /// assert_eq!(result, expected);
 /// ```
@@ -308,12 +308,12 @@ pub fn adaptive_sub(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::Primitive;
+    use crate::array::PrimitiveBuilder;
     use crate::datatypes::DataType;
 
     #[test]
     fn test_subtract_normal() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(11111i128),
             Some(22200i128),
             None,
@@ -321,7 +321,7 @@ mod tests {
         ])
         .to(DataType::Decimal(5, 2));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(22222i128),
             Some(11100i128),
             None,
@@ -330,7 +330,7 @@ mod tests {
         .to(DataType::Decimal(5, 2));
 
         let result = sub(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(-11111i128),
             Some(11100i128),
             None,
@@ -347,8 +347,8 @@ mod tests {
 
     #[test]
     fn test_subtract_decimal_wrong_precision() {
-        let a = Primitive::from(&vec![None]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![None]).to(DataType::Decimal(6, 2));
+        let a = PrimitiveBuilder::from(&vec![None]).to(DataType::Decimal(5, 2));
+        let b = PrimitiveBuilder::from(&vec![None]).to(DataType::Decimal(6, 2));
         let result = sub(&a, &b);
 
         if result.is_ok() {
@@ -359,14 +359,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "Overflow in subtract presented for precision 5")]
     fn test_subtract_panic() {
-        let a = Primitive::from(&vec![Some(-99999i128)]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![Some(1i128)]).to(DataType::Decimal(5, 2));
+        let a = PrimitiveBuilder::from(&vec![Some(-99999i128)]).to(DataType::Decimal(5, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(1i128)]).to(DataType::Decimal(5, 2));
         let _ = sub(&a, &b);
     }
 
     #[test]
     fn test_subtract_saturating() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(11111i128),
             Some(22200i128),
             None,
@@ -374,7 +374,7 @@ mod tests {
         ])
         .to(DataType::Decimal(5, 2));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(22222i128),
             Some(11100i128),
             None,
@@ -383,7 +383,7 @@ mod tests {
         .to(DataType::Decimal(5, 2));
 
         let result = saturating_sub(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(-11111i128),
             Some(11100i128),
             None,
@@ -400,14 +400,14 @@ mod tests {
 
     #[test]
     fn test_subtract_saturating_overflow() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(-99999i128),
             Some(-99999i128),
             Some(-99999i128),
             Some(99999i128),
         ])
         .to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(00001i128),
             Some(00100i128),
             Some(10000i128),
@@ -417,7 +417,7 @@ mod tests {
 
         let result = saturating_sub(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(-99999i128),
             Some(-99999i128),
             Some(-99999i128),
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn test_subtract_checked() {
-        let a = Primitive::from(&vec![
+        let a = PrimitiveBuilder::from(&vec![
             Some(11111i128),
             Some(22200i128),
             None,
@@ -442,7 +442,7 @@ mod tests {
         ])
         .to(DataType::Decimal(5, 2));
 
-        let b = Primitive::from(&vec![
+        let b = PrimitiveBuilder::from(&vec![
             Some(22222i128),
             Some(11100i128),
             None,
@@ -451,7 +451,7 @@ mod tests {
         .to(DataType::Decimal(5, 2));
 
         let result = checked_sub(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(-11111i128),
             Some(11100i128),
             None,
@@ -468,10 +468,10 @@ mod tests {
 
     #[test]
     fn test_subtract_checked_overflow() {
-        let a = Primitive::from(&vec![Some(4i128), Some(-99999i128)]).to(DataType::Decimal(5, 2));
-        let b = Primitive::from(&vec![Some(2i128), Some(1i128)]).to(DataType::Decimal(5, 2));
+        let a = PrimitiveBuilder::from(&vec![Some(4i128), Some(-99999i128)]).to(DataType::Decimal(5, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(2i128), Some(1i128)]).to(DataType::Decimal(5, 2));
         let result = checked_sub(&a, &b).unwrap();
-        let expected = Primitive::from(&vec![Some(2i128), None]).to(DataType::Decimal(5, 2));
+        let expected = PrimitiveBuilder::from(&vec![Some(2i128), None]).to(DataType::Decimal(5, 2));
         assert_eq!(result, expected);
     }
 
@@ -481,11 +481,11 @@ mod tests {
         //  11111.11   -> 7, 2
         // ------------------
         // -11099.9989 -> 9, 4
-        let a = Primitive::from(&vec![Some(11_1111i128)]).to(DataType::Decimal(6, 4));
-        let b = Primitive::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
+        let a = PrimitiveBuilder::from(&vec![Some(11_1111i128)]).to(DataType::Decimal(6, 4));
+        let b = PrimitiveBuilder::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
         let result = adaptive_sub(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(-11099_9989i128)]).to(DataType::Decimal(9, 4));
+        let expected = PrimitiveBuilder::from(&vec![Some(-11099_9989i128)]).to(DataType::Decimal(9, 4));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(9, 4));
@@ -494,11 +494,11 @@ mod tests {
         //     0.1111 -> 5, 4
         // -----------------
         // 11110.8889 -> 9, 4
-        let a = Primitive::from(&vec![Some(11111_0i128)]).to(DataType::Decimal(6, 1));
-        let b = Primitive::from(&vec![Some(1111i128)]).to(DataType::Decimal(5, 4));
+        let a = PrimitiveBuilder::from(&vec![Some(11111_0i128)]).to(DataType::Decimal(6, 1));
+        let b = PrimitiveBuilder::from(&vec![Some(1111i128)]).to(DataType::Decimal(5, 4));
         let result = adaptive_sub(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(11110_8889i128)]).to(DataType::Decimal(9, 4));
+        let expected = PrimitiveBuilder::from(&vec![Some(11110_8889i128)]).to(DataType::Decimal(9, 4));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(9, 4));
@@ -507,11 +507,11 @@ mod tests {
         //  11111.111  -> 8, 3
         // -----------------
         // -00000.001  -> 8, 3
-        let a = Primitive::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
-        let b = Primitive::from(&vec![Some(11111_111i128)]).to(DataType::Decimal(8, 3));
+        let a = PrimitiveBuilder::from(&vec![Some(11111_11i128)]).to(DataType::Decimal(7, 2));
+        let b = PrimitiveBuilder::from(&vec![Some(11111_111i128)]).to(DataType::Decimal(8, 3));
         let result = adaptive_sub(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(-00000_001i128)]).to(DataType::Decimal(8, 3));
+        let expected = PrimitiveBuilder::from(&vec![Some(-00000_001i128)]).to(DataType::Decimal(8, 3));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(8, 3));
@@ -520,11 +520,11 @@ mod tests {
         // -00.0001 -> 6, 4
         // -----------------
         // 100.0000 -> 7, 4
-        let a = Primitive::from(&vec![Some(99_9999i128)]).to(DataType::Decimal(6, 4));
-        let b = Primitive::from(&vec![Some(-00_0001i128)]).to(DataType::Decimal(6, 4));
+        let a = PrimitiveBuilder::from(&vec![Some(99_9999i128)]).to(DataType::Decimal(6, 4));
+        let b = PrimitiveBuilder::from(&vec![Some(-00_0001i128)]).to(DataType::Decimal(6, 4));
         let result = adaptive_sub(&a, &b).unwrap();
 
-        let expected = Primitive::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(7, 4));
+        let expected = PrimitiveBuilder::from(&vec![Some(100_0000i128)]).to(DataType::Decimal(7, 4));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(7, 4));

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -20,7 +20,7 @@
 //! # Description
 //!
 //! The Arithmetics module is composed by basic arithmetics operations that can
-//! be performed on Primitive Arrays. These operations can be the building for
+//! be performed on PrimitiveBuilder Arrays. These operations can be the building for
 //! any implementation using Arrow.
 //!
 //! Whenever possible, each of the operations in these modules has variations
@@ -280,12 +280,12 @@ where
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::negate;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::DataType;
 ///
-/// let a = Primitive::from(&vec![None, Some(6), None, Some(7)]).to(DataType::Int32);
+/// let a = PrimitiveBuilder::from(&vec![None, Some(6), None, Some(7)]).to(DataType::Int32);
 /// let result = negate(&a);
-/// let expected = Primitive::from(&vec![None, Some(-6), None, Some(-7)]).to(DataType::Int32);
+/// let expected = PrimitiveBuilder::from(&vec![None, Some(-6), None, Some(-7)]).to(DataType::Int32);
 /// assert_eq!(result, expected)
 /// ```
 pub fn negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>

--- a/src/compute/arithmetics/time.rs
+++ b/src/compute/arithmetics/time.rs
@@ -68,10 +68,10 @@ fn create_scale(lhs: &DataType, rhs: &DataType) -> Result<f64> {
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::time::add_duration;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::{DataType, TimeUnit};
 ///
-/// let timestamp = Primitive::from(&vec![
+/// let timestamp = PrimitiveBuilder::from(&vec![
 ///     Some(100000i64),
 ///     Some(200000i64),
 ///     None,
@@ -82,11 +82,11 @@ fn create_scale(lhs: &DataType, rhs: &DataType) -> Result<f64> {
 ///     Some("America/New_York".to_string()),
 /// ));
 ///
-/// let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+/// let duration = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
 ///     .to(DataType::Duration(TimeUnit::Second));
 ///
 /// let result = add_duration(&timestamp, &duration).unwrap();
-/// let expected = Primitive::from(&vec![
+/// let expected = PrimitiveBuilder::from(&vec![
 ///     Some(100010i64),
 ///     Some(200020i64),
 ///     None,
@@ -123,10 +123,10 @@ where
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::time::subtract_duration;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::{DataType, TimeUnit};
 ///
-/// let timestamp = Primitive::from(&vec![
+/// let timestamp = PrimitiveBuilder::from(&vec![
 ///     Some(100000i64),
 ///     Some(200000i64),
 ///     None,
@@ -137,11 +137,11 @@ where
 ///     Some("America/New_York".to_string()),
 /// ));
 ///
-/// let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+/// let duration = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
 ///     .to(DataType::Duration(TimeUnit::Second));
 ///
 /// let result = subtract_duration(&timestamp, &duration).unwrap();
-/// let expected = Primitive::from(&vec![
+/// let expected = PrimitiveBuilder::from(&vec![
 ///     Some(99990i64),
 ///     Some(199980i64),
 ///     None,
@@ -179,9 +179,9 @@ where
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::time::subtract_timestamps;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::{DataType, TimeUnit};
-/// let timestamp_a = Primitive::from(&vec![
+/// let timestamp_a = PrimitiveBuilder::from(&vec![
 ///     Some(100_010i64),
 ///     Some(200_020i64),
 ///     None,
@@ -189,7 +189,7 @@ where
 /// ])
 /// .to(DataType::Timestamp(TimeUnit::Second, None));
 ///
-/// let timestamp_b = Primitive::from(&vec![
+/// let timestamp_b = PrimitiveBuilder::from(&vec![
 ///     Some(100_000i64),
 ///     Some(200_000i64),
 ///     None,
@@ -197,7 +197,7 @@ where
 /// ])
 /// .to(DataType::Timestamp(TimeUnit::Second, None));
 ///
-/// let expected = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+/// let expected = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
 ///     .to(DataType::Duration(TimeUnit::Second));
 ///
 /// let result = subtract_timestamps(&timestamp_a, &&timestamp_b).unwrap();
@@ -230,12 +230,12 @@ pub fn subtract_timestamps(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::Primitive;
+    use crate::array::PrimitiveBuilder;
     use crate::datatypes::{DataType, TimeUnit};
 
     #[test]
     fn test_adding_timestamp() {
-        let timestamp = Primitive::from(&vec![
+        let timestamp = PrimitiveBuilder::from(&vec![
             Some(100000i64),
             Some(200000i64),
             None,
@@ -246,11 +246,11 @@ mod tests {
             Some("America/New_York".to_string()),
         ));
 
-        let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+        let duration = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
             .to(DataType::Duration(TimeUnit::Second));
 
         let result = add_duration(&timestamp, &duration).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(100010i64),
             Some(200020i64),
             None,
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_adding_duration_different_scale() {
-        let timestamp = Primitive::from(&vec![
+        let timestamp = PrimitiveBuilder::from(&vec![
             Some(100000i64),
             Some(200000i64),
             None,
@@ -276,7 +276,7 @@ mod tests {
             TimeUnit::Second,
             Some("America/New_York".to_string()),
         ));
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(100010i64),
             Some(200020i64),
             None,
@@ -288,7 +288,7 @@ mod tests {
         ));
 
         // Testing duration in milliseconds
-        let duration = Primitive::from(&vec![
+        let duration = PrimitiveBuilder::from(&vec![
             Some(10_000i64),
             Some(20_000i64),
             None,
@@ -303,7 +303,7 @@ mod tests {
         // The last digits in the nanosecond are not significant enough to
         // be added to the timestamp which is in seconds and doesn't have a
         // fractional value
-        let duration = Primitive::from(&vec![
+        let duration = PrimitiveBuilder::from(&vec![
             Some(10_000_000_999i64),
             Some(20_000_000_000i64),
             None,
@@ -317,27 +317,27 @@ mod tests {
 
     #[test]
     fn test_adding_subtract_timestamps_scale() {
-        let timestamp = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
+        let timestamp = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
             DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
         );
-        let duration = Primitive::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
+        let duration = PrimitiveBuilder::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
             .to(DataType::Duration(TimeUnit::Second));
 
         let expected =
-            Primitive::from(&vec![Some(1_010i64), Some(2_020i64), None, Some(3_030i64)]).to(
+            PrimitiveBuilder::from(&vec![Some(1_010i64), Some(2_020i64), None, Some(3_030i64)]).to(
                 DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
             );
 
         let result = add_duration(&timestamp, &duration).unwrap();
         assert_eq!(result, expected);
 
-        let timestamp = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
+        let timestamp = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
             DataType::Timestamp(TimeUnit::Nanosecond, Some("America/New_York".to_string())),
         );
-        let duration = Primitive::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
+        let duration = PrimitiveBuilder::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
             .to(DataType::Duration(TimeUnit::Second));
 
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(1_000_000_010i64),
             Some(2_000_000_020i64),
             None,
@@ -354,7 +354,7 @@ mod tests {
 
     #[test]
     fn test_subtract_timestamp() {
-        let timestamp = Primitive::from(&vec![
+        let timestamp = PrimitiveBuilder::from(&vec![
             Some(100000i64),
             Some(200000i64),
             None,
@@ -365,11 +365,11 @@ mod tests {
             Some("America/New_York".to_string()),
         ));
 
-        let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+        let duration = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
             .to(DataType::Duration(TimeUnit::Second));
 
         let result = subtract_duration(&timestamp, &duration).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(99990i64),
             Some(199980i64),
             None,
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_subtracting_duration_different_scale() {
-        let timestamp = Primitive::from(&vec![
+        let timestamp = PrimitiveBuilder::from(&vec![
             Some(100000i64),
             Some(200000i64),
             None,
@@ -395,7 +395,7 @@ mod tests {
             TimeUnit::Second,
             Some("America/New_York".to_string()),
         ));
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(99990i64),
             Some(199980i64),
             None,
@@ -407,7 +407,7 @@ mod tests {
         ));
 
         // Testing duration in milliseconds
-        let duration = Primitive::from(&vec![
+        let duration = PrimitiveBuilder::from(&vec![
             Some(10_000i64),
             Some(20_000i64),
             None,
@@ -422,7 +422,7 @@ mod tests {
         // The last digits in the nanosecond are not significant enough to
         // be added to the timestamp which is in seconds and doesn't have a
         // fractional value
-        let duration = Primitive::from(&vec![
+        let duration = PrimitiveBuilder::from(&vec![
             Some(10_000_000_999i64),
             Some(20_000_000_000i64),
             None,
@@ -436,27 +436,27 @@ mod tests {
 
     #[test]
     fn test_subtracting_subtract_timestamps_scale() {
-        let timestamp = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
+        let timestamp = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
             DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
         );
-        let duration = Primitive::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
+        let duration = PrimitiveBuilder::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
             .to(DataType::Duration(TimeUnit::Second));
 
         let expected =
-            Primitive::from(&vec![Some(-990i64), Some(-1_980i64), None, Some(-2_970i64)]).to(
+            PrimitiveBuilder::from(&vec![Some(-990i64), Some(-1_980i64), None, Some(-2_970i64)]).to(
                 DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
             );
 
         let result = subtract_duration(&timestamp, &duration).unwrap();
         assert_eq!(result, expected);
 
-        let timestamp = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
+        let timestamp = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)]).to(
             DataType::Timestamp(TimeUnit::Nanosecond, Some("America/New_York".to_string())),
         );
-        let duration = Primitive::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
+        let duration = PrimitiveBuilder::from(&vec![Some(1i64), Some(2i64), None, Some(3i64)])
             .to(DataType::Duration(TimeUnit::Second));
 
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(-999_999_990i64),
             Some(-1_999_999_980i64),
             None,
@@ -473,7 +473,7 @@ mod tests {
 
     #[test]
     fn test_subtract_timestamps() {
-        let timestamp_a = Primitive::from(&vec![
+        let timestamp_a = PrimitiveBuilder::from(&vec![
             Some(100_010i64),
             Some(200_020i64),
             None,
@@ -481,7 +481,7 @@ mod tests {
         ])
         .to(DataType::Timestamp(TimeUnit::Second, None));
 
-        let timestamp_b = Primitive::from(&vec![
+        let timestamp_b = PrimitiveBuilder::from(&vec![
             Some(100_000i64),
             Some(200_000i64),
             None,
@@ -489,7 +489,7 @@ mod tests {
         ])
         .to(DataType::Timestamp(TimeUnit::Second, None));
 
-        let expected = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+        let expected = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
             .to(DataType::Duration(TimeUnit::Second));
 
         let result = subtract_timestamps(&timestamp_a, &&timestamp_b).unwrap();
@@ -498,7 +498,7 @@ mod tests {
 
     #[test]
     fn test_subtract_timestamps_scale() {
-        let timestamp_a = Primitive::from(&vec![
+        let timestamp_a = PrimitiveBuilder::from(&vec![
             Some(100_000_000i64),
             Some(200_000_000i64),
             None,
@@ -506,7 +506,7 @@ mod tests {
         ])
         .to(DataType::Timestamp(TimeUnit::Millisecond, None));
 
-        let timestamp_b = Primitive::from(&vec![
+        let timestamp_b = PrimitiveBuilder::from(&vec![
             Some(100_010i64),
             Some(200_020i64),
             None,
@@ -514,7 +514,7 @@ mod tests {
         ])
         .to(DataType::Timestamp(TimeUnit::Second, None));
 
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(-10_000i64),
             Some(-20_000i64),
             None,
@@ -528,11 +528,11 @@ mod tests {
 
     #[test]
     fn test_adding_to_time() {
-        let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+        let duration = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
             .to(DataType::Duration(TimeUnit::Second));
 
         // Testing Time32
-        let time_32 = Primitive::from(&vec![
+        let time_32 = PrimitiveBuilder::from(&vec![
             Some(100000i32),
             Some(200000i32),
             None,
@@ -541,7 +541,7 @@ mod tests {
         .to(DataType::Time32(TimeUnit::Second));
 
         let result = add_duration(&time_32, &duration).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(100010i32),
             Some(200020i32),
             None,
@@ -554,11 +554,11 @@ mod tests {
 
     #[test]
     fn test_subtract_to_time() {
-        let duration = Primitive::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
+        let duration = PrimitiveBuilder::from(&vec![Some(10i64), Some(20i64), None, Some(30i64)])
             .to(DataType::Duration(TimeUnit::Second));
 
         // Testing Time32
-        let time_32 = Primitive::from(&vec![
+        let time_32 = PrimitiveBuilder::from(&vec![
             Some(100000i32),
             Some(200000i32),
             None,
@@ -567,7 +567,7 @@ mod tests {
         .to(DataType::Time32(TimeUnit::Second));
 
         let result = subtract_duration(&time_32, &duration).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(99990i32),
             Some(199980i32),
             None,
@@ -580,7 +580,7 @@ mod tests {
 
     #[test]
     fn test_date32() {
-        let duration = Primitive::from(&vec![
+        let duration = PrimitiveBuilder::from(&vec![
             Some(86_400),     // 1 day
             Some(864_000i64), // 10 days
             None,
@@ -588,7 +588,7 @@ mod tests {
         ])
         .to(DataType::Duration(TimeUnit::Second));
 
-        let date_32 = Primitive::from(&vec![
+        let date_32 = PrimitiveBuilder::from(&vec![
             Some(100_000i32),
             Some(100_000i32),
             None,
@@ -597,7 +597,7 @@ mod tests {
         .to(DataType::Date32);
 
         let result = add_duration(&date_32, &duration).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(100_001i32),
             Some(100_010i32),
             None,
@@ -608,7 +608,7 @@ mod tests {
         assert_eq!(result, expected);
 
         let result = subtract_duration(&date_32, &duration).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(99_999i32),
             Some(99_990i32),
             None,
@@ -621,7 +621,7 @@ mod tests {
 
     #[test]
     fn test_date64() {
-        let duration = Primitive::from(&vec![
+        let duration = PrimitiveBuilder::from(&vec![
             Some(10i64),  // 10 milliseconds
             Some(100i64), // 100 milliseconds
             None,
@@ -629,7 +629,7 @@ mod tests {
         ])
         .to(DataType::Duration(TimeUnit::Millisecond));
 
-        let date_64 = Primitive::from(&vec![
+        let date_64 = PrimitiveBuilder::from(&vec![
             Some(100_000i64),
             Some(100_000i64),
             None,
@@ -638,7 +638,7 @@ mod tests {
         .to(DataType::Date64);
 
         let result = add_duration(&date_64, &duration).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(100_010i64),
             Some(100_100i64),
             None,
@@ -649,7 +649,7 @@ mod tests {
         assert_eq!(result, expected);
 
         let result = subtract_duration(&date_64, &duration).unwrap();
-        let expected = Primitive::from(&vec![
+        let expected = PrimitiveBuilder::from(&vec![
             Some(99_990i64),
             Some(99_900i64),
             None,

--- a/src/compute/boolean.rs
+++ b/src/compute/boolean.rs
@@ -362,7 +362,7 @@ mod tests {
 
     #[test]
     fn test_nonnull_array_is_null() {
-        let a = Primitive::from_slice(vec![1, 2, 3, 4]).to(DataType::Int32);
+        let a = PrimitiveBuilder::from_slice(vec![1, 2, 3, 4]).to(DataType::Int32);
 
         let res = is_null(&a);
 
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn test_nonnull_array_with_offset_is_null() {
-        let a = Primitive::from_slice(vec![1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 5, 4, 3, 2, 1])
+        let a = PrimitiveBuilder::from_slice(vec![1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 5, 4, 3, 2, 1])
             .to(DataType::Int32);
         let a = a.slice(8, 4);
 
@@ -386,7 +386,7 @@ mod tests {
 
     #[test]
     fn test_nonnull_array_is_not_null() {
-        let a = Primitive::from_slice(vec![1, 2, 3, 4]).to(DataType::Int32);
+        let a = PrimitiveBuilder::from_slice(vec![1, 2, 3, 4]).to(DataType::Int32);
 
         let res = is_not_null(&a);
 
@@ -397,7 +397,7 @@ mod tests {
 
     #[test]
     fn test_nonnull_array_with_offset_is_not_null() {
-        let a = Primitive::from_slice(vec![1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 5, 4, 3, 2, 1])
+        let a = PrimitiveBuilder::from_slice(vec![1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 5, 4, 3, 2, 1])
             .to(DataType::Int32);
         let a = a.slice(8, 4);
 
@@ -410,7 +410,7 @@ mod tests {
 
     #[test]
     fn test_nullable_array_is_null() {
-        let a = Primitive::from(vec![Some(1), None, Some(3), None]).to(DataType::Int32);
+        let a = PrimitiveBuilder::from(vec![Some(1), None, Some(3), None]).to(DataType::Int32);
 
         let res = is_null(&a);
 
@@ -421,7 +421,7 @@ mod tests {
 
     #[test]
     fn test_nullable_array_with_offset_is_null() {
-        let a = Primitive::from(vec![
+        let a = PrimitiveBuilder::from(vec![
             None,
             None,
             None,
@@ -452,7 +452,7 @@ mod tests {
 
     #[test]
     fn test_nullable_array_is_not_null() {
-        let a = Primitive::from(vec![Some(1), None, Some(3), None]).to(DataType::Int32);
+        let a = PrimitiveBuilder::from(vec![Some(1), None, Some(3), None]).to(DataType::Int32);
 
         let res = is_not_null(&a);
 
@@ -463,7 +463,7 @@ mod tests {
 
     #[test]
     fn test_nullable_array_with_offset_is_not_null() {
-        let a = Primitive::from(vec![
+        let a = PrimitiveBuilder::from(vec![
             None,
             None,
             None,

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -258,7 +258,7 @@ fn cast_list<O: Offset>(array: &ListArray<O>, to_type: &DataType) -> Result<List
 ///   in integer casts return null
 /// * Numeric to boolean: 0 returns `false`, any other value returns `true`
 /// * List to List: the underlying data type is cast
-/// * Primitive to List: a list array with 1 value per slot is created
+/// * PrimitiveBuilder to List: a list array with 1 value per slot is created
 /// * Date32 and Date64: precision lost when going to higher interval
 /// * Time32 and Time64: precision lost when going to higher interval
 /// * Timestamp and Date{32|64}: precision lost when going to higher interval

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -117,8 +117,10 @@ pub(super) fn primitive_to_dictionary_dyn<T: NativeType + Eq + Hash, K: Dictiona
 pub fn primitive_to_dictionary<T: NativeType + Eq + Hash, K: DictionaryKey>(
     from: &PrimitiveArray<T>,
 ) -> Result<DictionaryArray<K>> {
-    let iter = from.iter().map(|x| x.copied()).map(Result::Ok);
-    let primitive = DictionaryPrimitive::<K, Primitive<T>, _>::try_from_iter(iter)?;
+    let iter = from.iter().map(|x| x.copied());
+
+    let mut primitive = DictionaryPrimitive::<K, _, _>::new(Primitive::<T>::new());
+    primitive.try_extend(iter)?;
 
     Ok(primitive.to(DataType::Dictionary(
         Box::new(K::DATA_TYPE),

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -71,7 +71,7 @@ where
     let iter = from
         .iter()
         .map(|v| v.and_then(|x| num::cast::cast::<I, O>(*x)));
-    Primitive::<O>::from_trusted_len_iter(iter).to(to_type.clone())
+    PrimitiveBuilder::<O>::from_trusted_len_iter(iter).to(to_type.clone())
 }
 
 /// Cast [`PrimitiveArray`] to a [`PrimitiveArray`] of the same physical type.
@@ -119,7 +119,7 @@ pub fn primitive_to_dictionary<T: NativeType + Eq + Hash, K: DictionaryKey>(
 ) -> Result<DictionaryArray<K>> {
     let iter = from.iter().map(|x| x.copied());
 
-    let mut primitive = DictionaryPrimitive::<K, _, _>::new(Primitive::<T>::new());
+    let mut primitive = DictionaryBuilder::<K, _, _>::new(PrimitiveBuilder::<T>::new());
     primitive.try_extend(iter)?;
 
     Ok(primitive.to(DataType::Dictionary(

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -86,13 +86,10 @@ pub(super) fn utf8_to_dictionary_dyn<O: Offset, K: DictionaryKey>(
 pub fn utf8_to_dictionary<O: Offset, K: DictionaryKey>(
     from: &Utf8Array<O>,
 ) -> Result<DictionaryArray<K>> {
-    let iter = from.iter().map(Result::Ok);
-    let primitive = DictionaryPrimitive::<K, Utf8Primitive<O>, _>::try_from_iter(iter)?;
+    let mut primitive = DictionaryPrimitive::<K, _, _>::new(Utf8Primitive::<O>::new());
+    primitive.try_extend(from)?;
 
-    Ok(primitive.to(DataType::Dictionary(
-        Box::new(K::DATA_TYPE),
-        Box::new(from.data_type().clone()),
-    )))
+    Ok(primitive.into())
 }
 
 pub(super) fn utf8_to_timestamp_ns_dyn<O: Offset>(from: &dyn Array) -> Result<Box<dyn Array>> {

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -24,7 +24,7 @@ where
         .iter()
         .map(|x| x.and_then::<T, _>(|x| lexical_core::parse(x.as_bytes()).ok()));
 
-    Primitive::<T>::from_trusted_len_iter(iter).to(to.clone())
+    PrimitiveBuilder::<T>::from_trusted_len_iter(iter).to(to.clone())
 }
 
 pub(super) fn utf8_to_primitive_dyn<O: Offset, T>(
@@ -47,7 +47,7 @@ pub fn utf8_to_date32<O: Offset>(from: &Utf8Array<O>) -> PrimitiveArray<i32> {
                 .map(|x| x.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
         })
     });
-    Primitive::<i32>::from_trusted_len_iter(iter).to(DataType::Date32)
+    PrimitiveBuilder::<i32>::from_trusted_len_iter(iter).to(DataType::Date32)
 }
 
 pub(super) fn utf8_to_date32_dyn<O: Offset>(from: &dyn Array) -> Result<Box<dyn Array>> {
@@ -64,7 +64,7 @@ pub fn utf8_to_date64<O: Offset>(from: &Utf8Array<O>) -> PrimitiveArray<i64> {
                 .map(|x| x.timestamp_millis())
         })
     });
-    Primitive::<i64>::from_trusted_len_iter(iter).to(DataType::Date64)
+    PrimitiveBuilder::<i64>::from_trusted_len_iter(iter).to(DataType::Date64)
 }
 
 pub(super) fn utf8_to_date64_dyn<O: Offset>(from: &dyn Array) -> Result<Box<dyn Array>> {
@@ -86,7 +86,7 @@ pub(super) fn utf8_to_dictionary_dyn<O: Offset, K: DictionaryKey>(
 pub fn utf8_to_dictionary<O: Offset, K: DictionaryKey>(
     from: &Utf8Array<O>,
 ) -> Result<DictionaryArray<K>> {
-    let mut primitive = DictionaryPrimitive::<K, _, _>::new(Utf8Primitive::<O>::new());
+    let mut primitive = DictionaryBuilder::<K, _, _>::new(Utf8Builder::<O>::new());
     primitive.try_extend(from)?;
 
     Ok(primitive.into())
@@ -102,7 +102,7 @@ pub fn utf8_to_timestamp_ns<O: Offset>(from: &Utf8Array<O>) -> PrimitiveArray<i6
     let iter = from
         .iter()
         .map(|x| x.and_then(|x| utf8_to_timestamp_ns_scalar(x).ok()));
-    Primitive::<i64>::from_trusted_len_iter(iter)
+    PrimitiveBuilder::<i64>::from_trusted_len_iter(iter)
         .to(DataType::Timestamp(TimeUnit::Nanosecond, None))
 }
 

--- a/src/compute/comparison/primitive.rs
+++ b/src/compute/comparison/primitive.rs
@@ -559,12 +559,12 @@ mod tests {
     fn test_primitive_array_compare_slice() {
         let a = (0..100)
             .map(Some)
-            .collect::<Primitive<i32>>()
+            .collect::<PrimitiveBuilder<i32>>()
             .to(DataType::Int32);
         let a = a.slice(50, 50);
         let b = (100..200)
             .map(Some)
-            .collect::<Primitive<i32>>()
+            .collect::<PrimitiveBuilder<i32>>()
             .to(DataType::Int32);
         let b = b.slice(50, 50);
         let actual = lt(&a, &b).unwrap();
@@ -576,7 +576,7 @@ mod tests {
     fn test_primitive_array_compare_scalar_slice() {
         let a = (0..100)
             .map(Some)
-            .collect::<Primitive<i32>>()
+            .collect::<PrimitiveBuilder<i32>>()
             .to(DataType::Int32);
         let a = a.slice(50, 50);
         let actual = lt_scalar(&a, 200).unwrap();

--- a/src/compute/contains.rs
+++ b/src/compute/contains.rs
@@ -188,8 +188,10 @@ mod tests {
             None
         ]);
 
-        let a: ListPrimitive<i32, Primitive<i32>, i32> = data.into_iter().collect();
-        let a = a.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut primitive = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        primitive.try_extend(data).unwrap();
+
+        let a = primitive.to(ListArray::<i32>::default_datatype(DataType::Int32));
 
         let result = contains(&a, &values).unwrap();
 

--- a/src/compute/contains.rs
+++ b/src/compute/contains.rs
@@ -188,7 +188,7 @@ mod tests {
             None
         ]);
 
-        let mut primitive = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut primitive = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         primitive.try_extend(data).unwrap();
 
         let a = primitive.to(ListArray::<i32>::default_datatype(DataType::Int32));

--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -174,16 +174,16 @@ pub fn build_filter(filter: &BooleanArray) -> Result<Filter> {
 /// Therefore, it is considered undefined behavior to pass `filter` with null values.
 /// # Example
 /// ```rust
-/// # use arrow2::array::{Int32Array, Primitive, BooleanArray};
+/// # use arrow2::array::{Int32Array, PrimitiveBuilder, BooleanArray};
 /// # use arrow2::datatypes::DataType;
 /// # use arrow2::error::Result;
 /// # use arrow2::compute::filter::filter;
 /// # fn main() -> Result<()> {
-/// let array = Primitive::from_slice(&vec![5, 6, 7, 8, 9]).to(DataType::Int32);
+/// let array = PrimitiveBuilder::from_slice(&vec![5, 6, 7, 8, 9]).to(DataType::Int32);
 /// let filter_array = BooleanArray::from_slice(&vec![true, false, false, true, false]);
 /// let c = filter(&array, &filter_array)?;
 /// let c = c.as_any().downcast_ref::<Int32Array>().unwrap();
-/// assert_eq!(c, &Primitive::from_slice(vec![5, 8]).to(DataType::Int32));
+/// assert_eq!(c, &PrimitiveBuilder::from_slice(vec![5, 8]).to(DataType::Int32));
 /// # Ok(())
 /// # }
 /// ```

--- a/src/compute/length.rs
+++ b/src/compute/length.rs
@@ -106,7 +106,7 @@ mod tests {
             let expected = expected
                 .into_iter()
                 .map(|x| x.map(|x| O::from_usize(x).unwrap()))
-                .collect::<Primitive<O>>()
+                .collect::<PrimitiveBuilder<O>>()
                 .to(data_type);
             assert_eq!(expected, result.as_ref());
         })

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -518,8 +518,8 @@ mod tests {
     ) where
         T: NativeType,
     {
-        let input = Primitive::<T>::from(data).to(data_type.clone());
-        let expected = Primitive::<T>::from(expected_data).to(data_type);
+        let input = PrimitiveBuilder::<T>::from(data).to(data_type.clone());
+        let expected = PrimitiveBuilder::<T>::from(expected_data).to(data_type);
         let output = sort(&input, &options).unwrap();
         assert_eq!(expected, output.as_ref())
     }
@@ -551,11 +551,11 @@ mod tests {
         options: SortOptions,
         expected_data: &[Option<&str>],
     ) {
-        let mut input = DictionaryPrimitive::<K, _, _>::new(Utf8Primitive::<i32>::new());
+        let mut input = DictionaryBuilder::<K, _, _>::new(Utf8Builder::<i32>::new());
         input.extend(data.iter().copied());
         let input = input.into();
 
-        let mut expected = DictionaryPrimitive::<K, _, _>::new(Utf8Primitive::<i32>::new());
+        let mut expected = DictionaryBuilder::<K, _, _>::new(Utf8Builder::<i32>::new());
         expected.extend(expected_data.iter().copied());
         let expected = expected.into();
 

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -551,21 +551,13 @@ mod tests {
         options: SortOptions,
         expected_data: &[Option<&str>],
     ) {
-        let input = data.iter().map(|x| Result::Ok(*x));
-        let input =
-            DictionaryPrimitive::<i32, Utf8Primitive<i32>, &str>::try_from_iter(input).unwrap();
-        let input = input.to(DataType::Dictionary(
-            Box::new(DataType::Int32),
-            Box::new(DataType::Utf8),
-        ));
+        let mut input = DictionaryPrimitive::<K, _, _>::new(Utf8Primitive::<i32>::new());
+        input.extend(data.iter().copied());
+        let input = input.into();
 
-        let expected = expected_data.iter().map(|x| Result::Ok(*x));
-        let expected =
-            DictionaryPrimitive::<i32, Utf8Primitive<i32>, &str>::try_from_iter(expected).unwrap();
-        let expected = expected.to(DataType::Dictionary(
-            Box::new(DataType::Int32),
-            Box::new(DataType::Utf8),
-        ));
+        let mut expected = DictionaryPrimitive::<K, _, _>::new(Utf8Primitive::<i32>::new());
+        expected.extend(expected_data.iter().copied());
+        let expected = expected.into();
 
         let output = sort(&input, &options).unwrap();
         assert_eq!(expected, output.as_ref())

--- a/src/compute/sort/primitive/indices.rs
+++ b/src/compute/sort/primitive/indices.rs
@@ -140,7 +140,7 @@ mod tests {
     where
         T: NativeType + std::cmp::Ord,
     {
-        let input = Primitive::<T>::from(data).to(data_type);
+        let input = PrimitiveBuilder::<T>::from(data).to(data_type);
         let expected = Int32Array::from_slice(&expected_data);
         let output = indices_sorted_by(&input, ord::total_cmp, &options);
         assert_eq!(output, expected)

--- a/src/compute/sort/primitive/sort.rs
+++ b/src/compute/sort/primitive/sort.rs
@@ -95,7 +95,7 @@ mod tests {
     use super::*;
 
     use crate::array::ord;
-    use crate::array::Primitive;
+    use crate::array::PrimitiveBuilder;
     use crate::datatypes::DataType;
 
     fn test_sort_primitive_arrays<T>(
@@ -106,8 +106,8 @@ mod tests {
     ) where
         T: NativeType + std::cmp::Ord,
     {
-        let input = Primitive::<T>::from(data).to(data_type.clone());
-        let expected = Primitive::<T>::from(expected_data).to(data_type);
+        let input = PrimitiveBuilder::<T>::from(data).to(data_type.clone());
+        let expected = PrimitiveBuilder::<T>::from(expected_data).to(data_type);
         let output = sort_by(&input, ord::total_cmp, &options);
         assert_eq!(expected, output)
     }

--- a/src/compute/take/list.rs
+++ b/src/compute/take/list.rs
@@ -134,8 +134,9 @@ mod tests {
             Some(vec![Some(2i32), Some(3), Some(4), Some(5)]),
             Some(vec![Some(6i32), Some(7), Some(8)]),
         ];
-        let expected: ListPrimitive<i32, Primitive<i32>, i32> = data_expected.into_iter().collect();
-        let expected = expected.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(data_expected);
+        let expected: ListArray<i32> = builder.into();
 
         assert_eq!(result, expected)
     }
@@ -148,8 +149,9 @@ mod tests {
             Some(vec![Some(9i32)]),
             Some(vec![Some(6i32), Some(7), Some(8)]),
         ];
-        let array: ListPrimitive<i32, Primitive<i32>, i32> = values.into_iter().collect();
-        let array = array.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(values);
+        let array: ListArray<i32> = builder.into();
 
         let indices =
             Primitive::from(&vec![Some(3i32), None, Some(1), Some(0)]).to(DataType::Int32);
@@ -161,8 +163,9 @@ mod tests {
             None,
             Some(vec![Some(2i32), Some(3), Some(4), Some(5)]),
         ];
-        let expected: ListPrimitive<i32, Primitive<i32>, i32> = data_expected.into_iter().collect();
-        let expected = expected.to(ListArray::<i32>::default_datatype(DataType::Int32));
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(data_expected);
+        let expected: ListArray<i32> = builder.into();
 
         assert_eq!(result, expected)
     }

--- a/src/compute/take/list.rs
+++ b/src/compute/take/list.rs
@@ -71,7 +71,7 @@ pub fn take<I: Offset, O: Index>(
 mod tests {
     use super::*;
     use crate::{
-        array::{ListPrimitive, Primitive, PrimitiveArray},
+        array::{ListBuilder, PrimitiveArray, PrimitiveBuilder},
         bitmap::Bitmap,
         buffer::Buffer,
         datatypes::DataType,
@@ -91,7 +91,8 @@ mod tests {
             None,
         );
 
-        let indices = Primitive::from(&vec![Some(4i32), Some(1), Some(3)]).to(DataType::Int32);
+        let indices =
+            PrimitiveBuilder::from(&vec![Some(4i32), Some(1), Some(3)]).to(DataType::Int32);
         let result = take(&array, &indices).unwrap();
 
         let expected_values = Buffer::from([9, 6, 7, 8]);
@@ -125,7 +126,7 @@ mod tests {
         );
 
         let indices =
-            Primitive::from(&vec![Some(4i32), None, Some(2), Some(3)]).to(DataType::Int32);
+            PrimitiveBuilder::from(&vec![Some(4i32), None, Some(2), Some(3)]).to(DataType::Int32);
         let result = take(&array, &indices).unwrap();
 
         let data_expected = vec![
@@ -134,7 +135,7 @@ mod tests {
             Some(vec![Some(2i32), Some(3), Some(4), Some(5)]),
             Some(vec![Some(6i32), Some(7), Some(8)]),
         ];
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(data_expected);
         let expected: ListArray<i32> = builder.into();
 
@@ -149,12 +150,12 @@ mod tests {
             Some(vec![Some(9i32)]),
             Some(vec![Some(6i32), Some(7), Some(8)]),
         ];
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(values);
         let array: ListArray<i32> = builder.into();
 
         let indices =
-            Primitive::from(&vec![Some(3i32), None, Some(1), Some(0)]).to(DataType::Int32);
+            PrimitiveBuilder::from(&vec![Some(3i32), None, Some(1), Some(0)]).to(DataType::Int32);
         let result = take(&array, &indices).unwrap();
 
         let data_expected = vec![
@@ -163,7 +164,7 @@ mod tests {
             None,
             Some(vec![Some(2i32), Some(3), Some(4), Some(5)]),
         ];
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(data_expected);
         let expected: ListArray<i32> = builder.into();
 
@@ -191,7 +192,7 @@ mod tests {
             None,
         );
 
-        let indices = Primitive::from(&vec![Some(0i32), Some(1)]).to(DataType::Int32);
+        let indices = PrimitiveBuilder::from(&vec![Some(0i32), Some(1)]).to(DataType::Int32);
         let result = take(&nested, &indices).unwrap();
 
         // expected data

--- a/src/compute/take/mod.rs
+++ b/src/compute/take/mod.rs
@@ -198,7 +198,7 @@ mod tests {
 
     use crate::datatypes::Field;
     use crate::{
-        array::{Int32Array, Primitive, UInt32Array},
+        array::{Int32Array, PrimitiveBuilder, UInt32Array},
         bitmap::MutableBitmap,
         types::NativeType,
     };
@@ -214,8 +214,8 @@ mod tests {
     where
         T: NativeType,
     {
-        let output = Primitive::<T>::from(data).to(data_type.clone());
-        let expected = Primitive::<T>::from(expected_data).to(data_type);
+        let output = PrimitiveBuilder::<T>::from(data).to(data_type.clone());
+        let expected = PrimitiveBuilder::<T>::from(expected_data).to(data_type);
         let output = take(&output, indices)?;
         assert_eq!(expected, output.as_ref());
         Ok(())
@@ -263,7 +263,7 @@ mod tests {
 
     fn create_test_struct() -> StructArray {
         let boolean = BooleanArray::from_slice(&[true, false, false, true]);
-        let int = Primitive::from_slice(&[42, 28, 19, 31]).to(DataType::Int32);
+        let int = PrimitiveBuilder::from_slice(&[42, 28, 19, 31]).to(DataType::Int32);
         let validity = vec![true, true, false, true]
             .into_iter()
             .collect::<MutableBitmap>()
@@ -349,12 +349,12 @@ mod tests {
         datatypes.into_iter().for_each(|d1| {
             let array = new_null_array(d1.clone(), 10);
             if can_take(&d1) {
-                let indices =
-                    Primitive::<i32>::from(&[Some(1), Some(2), None, Some(3)]).to(DataType::Int32);
+                let indices = PrimitiveBuilder::<i32>::from(&[Some(1), Some(2), None, Some(3)])
+                    .to(DataType::Int32);
                 assert!(take(array.as_ref(), &indices).is_ok());
             } else {
-                let indices =
-                    Primitive::<i32>::from(&[Some(1), Some(2), None, Some(3)]).to(DataType::Int32);
+                let indices = PrimitiveBuilder::<i32>::from(&[Some(1), Some(2), None, Some(3)])
+                    .to(DataType::Int32);
                 assert!(take(array.as_ref(), &indices).is_err());
             }
         });

--- a/src/compute/temporal.rs
+++ b/src/compute/temporal.rs
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn date64_hour() {
-        let array = Primitive::<i64>::from(&[Some(1514764800000), None, Some(1550636625000)])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1514764800000), None, Some(1550636625000)])
             .to(DataType::Date64);
 
         let result = hour(&array).unwrap();
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn date32_hour() {
-        let array = Primitive::<i32>::from(&[Some(15147), None, Some(15148)]).to(DataType::Date32);
+        let array = PrimitiveBuilder::<i32>::from(&[Some(15147), None, Some(15148)]).to(DataType::Date32);
 
         let result = hour(&array).unwrap();
         let expected = UInt32Array::from(&[Some(0), None, Some(0)]);
@@ -229,7 +229,7 @@ mod tests {
     #[test]
     fn time32_second_hour() {
         let array =
-            Primitive::<i32>::from(&[Some(37800), None]).to(DataType::Time32(TimeUnit::Second));
+            PrimitiveBuilder::<i32>::from(&[Some(37800), None]).to(DataType::Time32(TimeUnit::Second));
 
         let result = hour(&array).unwrap();
         let expected = UInt32Array::from(&[Some(10), None]);
@@ -238,7 +238,7 @@ mod tests {
 
     #[test]
     fn time64_micro_hour() {
-        let array = Primitive::<i64>::from(&[Some(37800000000), None])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(37800000000), None])
             .to(DataType::Time64(TimeUnit::Microsecond));
 
         let result = hour(&array).unwrap();
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn timestamp_micro_hour() {
-        let array = Primitive::<i64>::from(&[Some(37800000000), None])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(37800000000), None])
             .to(DataType::Timestamp(TimeUnit::Microsecond, None));
 
         let result = hour(&array).unwrap();
@@ -258,7 +258,7 @@ mod tests {
 
     #[test]
     fn timestamp_date64_year() {
-        let array = Primitive::<i64>::from(&[Some(1514764800000), None]).to(DataType::Date64);
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1514764800000), None]).to(DataType::Date64);
 
         let result = year(&array).unwrap();
         let expected = Int32Array::from(&[Some(2018), None]);
@@ -267,7 +267,7 @@ mod tests {
 
     #[test]
     fn timestamp_date32_year() {
-        let array = Primitive::<i32>::from(&[Some(15147), None]).to(DataType::Date32);
+        let array = PrimitiveBuilder::<i32>::from(&[Some(15147), None]).to(DataType::Date32);
 
         let result = year(&array).unwrap();
         let expected = Int32Array::from(&[Some(2011), None]);
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn timestamp_micro_year() {
-        let array = Primitive::<i64>::from(&[Some(1612025847000000), None])
+        let array = PrimitiveBuilder::<i64>::from(&[Some(1612025847000000), None])
             .to(DataType::Timestamp(TimeUnit::Microsecond, None));
 
         let result = year(&array).unwrap();

--- a/src/compute/window.rs
+++ b/src/compute/window.rs
@@ -66,7 +66,7 @@ pub fn shift(array: &dyn Array, offset: i64) -> Result<Box<dyn Array>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::array::{Int32Array, Primitive};
+    use crate::array::{Int32Array, PrimitiveBuilder};
     use crate::datatypes::DataType;
 
     use super::*;
@@ -83,13 +83,13 @@ mod tests {
 
     #[test]
     fn shift_many() {
-        let array = Primitive::<i32>::from(&[Some(1), None, Some(3)]).to(DataType::Date32);
+        let array = PrimitiveBuilder::<i32>::from(&[Some(1), None, Some(3)]).to(DataType::Date32);
         assert!(shift(&array, 10).is_err());
     }
 
     #[test]
     fn shift_max() {
-        let array = Primitive::<i32>::from(&[Some(1), None, Some(3)]).to(DataType::Date32);
+        let array = PrimitiveBuilder::<i32>::from(&[Some(1), None, Some(3)]).to(DataType::Date32);
         let result = shift(&array, 3).unwrap();
 
         let expected = new_null_array(DataType::Date32, 3);

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -81,7 +81,7 @@ pub fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
 mod tests {
     use super::*;
     use crate::array::*;
-    use crate::{datatypes::DataType, error::Result, ffi};
+    use crate::{error::Result, ffi};
     use std::sync::Arc;
 
     fn test_release(expected: impl Array + 'static) -> Result<()> {
@@ -161,11 +161,10 @@ mod tests {
             Some(vec![Some(4), None, Some(6)]),
         ];
 
-        let data: ListArray<i32> = data
-            .into_iter()
-            .collect::<ListPrimitive<i32, Primitive<i32>, i32>>()
-            .to(ListArray::<i32>::default_datatype(DataType::Int32));
-        //test_release(data)
-        test_round_trip(data)
+        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        builder.extend(data);
+        let array: ListArray<i32> = builder.into();
+
+        test_round_trip(array)
     }
 }

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -161,7 +161,7 @@ mod tests {
             Some(vec![Some(4), None, Some(6)]),
         ];
 
-        let mut builder = ListPrimitive::<i32, _, _>::new(Primitive::<i32>::new());
+        let mut builder = ListBuilder::<i32, _, _>::new(PrimitiveBuilder::<i32>::new());
         builder.extend(data);
         let array: ListArray<i32> = builder.into();
 

--- a/src/io/csv/read/deserialize.rs
+++ b/src/io/csv/read/deserialize.rs
@@ -31,7 +31,7 @@ where
         }
         None => None,
     });
-    Arc::new(Primitive::<T>::from_trusted_len_iter(iter).to(datatype))
+    Arc::new(PrimitiveBuilder::<T>::from_trusted_len_iter(iter).to(datatype))
 }
 
 fn deserialize_boolean<F>(rows: &[ByteRecord], column: usize, op: F) -> Arc<dyn Array>
@@ -224,7 +224,7 @@ mod tests {
     fn date32() -> Result<()> {
         let result = test("1970-01-01,\n2020-03-15,\n1945-05-08,\n", DataType::Date32)?;
         let expected =
-            Primitive::<i32>::from(&[Some(0), Some(18336), Some(-9004)]).to(DataType::Date32);
+            PrimitiveBuilder::<i32>::from(&[Some(0), Some(18336), Some(-9004)]).to(DataType::Date32);
         assert_eq!(expected, result.as_ref());
         Ok(())
     }
@@ -237,7 +237,7 @@ mod tests {
             1900-02-28T12:34:56,\n";
 
         let result = test(input, DataType::Date64)?;
-        let expected = Primitive::<i64>::from(&[
+        let expected = PrimitiveBuilder::<i64>::from(&[
             Some(0),
             Some(1542129070000),
             Some(1542129070011),

--- a/src/io/csv/write/mod.rs
+++ b/src/io/csv/write/mod.rs
@@ -103,9 +103,9 @@ mod tests {
         let c2 = Float64Array::from([Some(123.564532), None, Some(-556132.25)]);
         let c3 = UInt32Array::from_slice(&[3, 2, 1]);
         let c4 = BooleanArray::from(vec![Some(true), Some(false), None]);
-        let c5 = Primitive::<i64>::from([None, Some(1555584887378), Some(1555555555555)])
+        let c5 = PrimitiveBuilder::<i64>::from([None, Some(1555584887378), Some(1555555555555)])
             .to(DataType::Timestamp(TimeUnit::Millisecond, None));
-        let c6 = Primitive::<i32>::from_slice(vec![1234, 24680, 85563])
+        let c6 = PrimitiveBuilder::<i32>::from_slice(vec![1234, 24680, 85563])
             .to(DataType::Time32(TimeUnit::Second));
 
         RecordBatch::try_new(

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -26,7 +26,7 @@ use serde_json::Value;
 use crate::{
     array::{
         Array, BooleanArray, DictionaryArray, DictionaryKey, ListArray, NullArray, Offset,
-        Primitive, PrimitiveArray, StructArray, Utf8Array,
+        PrimitiveBuilder, PrimitiveArray, StructArray, Utf8Array,
     },
     bitmap::MutableBitmap,
     buffer::MutableBuffer,
@@ -86,7 +86,7 @@ fn read_primitive<T: NativeType + NumCast>(
         Value::Bool(number) => num::cast::cast::<i32, T>(*number as i32),
         _ => None,
     });
-    Primitive::from_trusted_len_iter(iter).to(data_type)
+    PrimitiveBuilder::from_trusted_len_iter(iter).to(data_type)
 }
 
 fn read_boolean(rows: &[&Value]) -> BooleanArray {
@@ -197,7 +197,7 @@ fn read_dictionary<K: DictionaryKey>(rows: &[&Value], data_type: DataType) -> Di
             },
             None => None,
         })
-        .collect::<Primitive<K>>()
+        .collect::<PrimitiveBuilder<K>>()
         .to(K::DATA_TYPE);
 
     let values = read(&inner, child.clone());

--- a/src/io/json/read/reader.rs
+++ b/src/io/json/read/reader.rs
@@ -802,9 +802,9 @@ mod tests {
             None,
         ];
 
-        let iter = values.into_iter().map(Result::Ok);
-        let expected = DictionaryPrimitive::<i16, Utf8Primitive<i32>, _>::try_from_iter(iter)?;
-        let expected = expected.to(data_type);
+        let mut builder = DictionaryPrimitive::<i16, _, _>::new(Utf8Primitive::<i32>::new());
+        builder.extend(values);
+        let expected: DictionaryArray<i16> = builder.into();
 
         assert_eq!(expected, result.as_ref());
         Ok(())
@@ -883,9 +883,11 @@ mod tests {
             Some(vec![Some("Send Data")]),
         ];
 
-        let iter = expected.into_iter().map(Result::Ok);
-        let expected = ListPrimitive::<i32, DictionaryPrimitive<u64, Utf8Primitive<i32>, _>, _>::try_from_iter(iter)?;
-        let expected = expected.to(data_type);
+        let mut builder = ListPrimitive::<i32, _, _>::new(DictionaryPrimitive::<u64, _, _>::new(
+            Utf8Primitive::<i32>::new(),
+        ));
+        builder.extend(expected);
+        let expected: ListArray<i32> = builder.into();
 
         assert_eq!(expected, batch.column(0).as_ref());
         Ok(())

--- a/src/io/json/read/reader.rs
+++ b/src/io/json/read/reader.rs
@@ -802,7 +802,7 @@ mod tests {
             None,
         ];
 
-        let mut builder = DictionaryPrimitive::<i16, _, _>::new(Utf8Primitive::<i32>::new());
+        let mut builder = DictionaryBuilder::<i16, _, _>::new(Utf8Builder::<i32>::new());
         builder.extend(values);
         let expected: DictionaryArray<i16> = builder.into();
 
@@ -883,8 +883,8 @@ mod tests {
             Some(vec![Some("Send Data")]),
         ];
 
-        let mut builder = ListPrimitive::<i32, _, _>::new(DictionaryPrimitive::<u64, _, _>::new(
-            Utf8Primitive::<i32>::new(),
+        let mut builder = ListBuilder::<i32, _, _>::new(DictionaryBuilder::<u64, _, _>::new(
+            Utf8Builder::<i32>::new(),
         ));
         builder.extend(expected);
         let expected: ListArray<i32> = builder.into();

--- a/src/io/json/write/mod.rs
+++ b/src/io/json/write/mod.rs
@@ -124,11 +124,11 @@ mod tests {
             .map(|x| x.into_iter().map(Some).collect::<Vec<_>>())
             .map(Some);
 
-        let mut a = ListPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        let mut a = ListBuilder::<i32, _, _>::new(Utf8Builder::<i32>::new());
         a.extend(iter);
         let a = a.to(list_datatype);
 
-        let b = Primitive::from_slice(&vec![1, 2, 3, 4, 5]).to(DataType::Int32);
+        let b = PrimitiveBuilder::from_slice(&vec![1, 2, 3, 4, 5]).to(DataType::Int32);
 
         let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(a), Arc::new(b)]).unwrap();
 
@@ -166,10 +166,9 @@ mod tests {
 
         let iter = iter.into_iter().map(Some);
 
-        let mut a = ListPrimitive::<i32, _, _>::new(ListPrimitive::<i32, _, _>::new(Primitive::<
-            i32,
-        >::new(
-        )));
+        let mut a = ListBuilder::<i32, _, _>::new(ListBuilder::<i32, _, _>::new(
+            PrimitiveBuilder::<i32>::new(),
+        ));
         a.extend(iter);
         let c1 = a.to(list_datatype);
 

--- a/src/io/json/write/mod.rs
+++ b/src/io/json/write/mod.rs
@@ -22,7 +22,6 @@ pub use writer::*;
 
 #[cfg(test)]
 mod tests {
-    use std::iter::FromIterator;
     use std::sync::Arc;
 
     use crate::array::*;
@@ -123,11 +122,11 @@ mod tests {
         let iter = iter
             .into_iter()
             .map(|x| x.into_iter().map(Some).collect::<Vec<_>>())
-            .map(Some)
-            .map(Result::Ok);
-        let a = ListPrimitive::<i32, Utf8Primitive<i32>, _>::try_from_iter(iter)
-            .unwrap()
-            .to(list_datatype);
+            .map(Some);
+
+        let mut a = ListPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        a.extend(iter);
+        let a = a.to(list_datatype);
 
         let b = Primitive::from_slice(&vec![1, 2, 3, 4, 5]).to(DataType::Int32);
 
@@ -166,8 +165,13 @@ mod tests {
         ];
 
         let iter = iter.into_iter().map(Some);
-        let c1 = ListPrimitive::<i32, ListPrimitive<i32, Primitive<i32>, _>, _>::from_iter(iter)
-            .to(list_datatype);
+
+        let mut a = ListPrimitive::<i32, _, _>::new(ListPrimitive::<i32, _, _>::new(Primitive::<
+            i32,
+        >::new(
+        )));
+        a.extend(iter);
+        let c1 = a.to(list_datatype);
 
         let c2 = Utf8Array::<i32>::from(&vec![Some("foo"), Some("bar"), None]);
 

--- a/src/io/json/write/serialize.rs
+++ b/src/io/json/write/serialize.rs
@@ -338,13 +338,13 @@ fn set_column_for_json_rows(
 /// # Example
 /// ```
 /// use std::sync::Arc;
-/// use arrow2::array::Primitive;
+/// use arrow2::array::PrimitiveBuilder;
 /// use arrow2::datatypes::{DataType, Field, Schema};
 /// use arrow2::io::json;
 /// use arrow2::record_batch::RecordBatch;
 ///
 /// let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
-/// let a = Primitive::from_slice(&[1i32, 2, 3]).to(DataType::Int32);
+/// let a = PrimitiveBuilder::from_slice(&[1i32, 2, 3]).to(DataType::Int32);
 /// let batch = RecordBatch::try_new(schema, vec![Arc::new(a)]).unwrap();
 ///
 /// let json_rows = json::write_record_batches(&[batch]);

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -60,9 +60,9 @@ mod tests {
         ];
 
         match column {
-            0 => Box::new(Primitive::<i64>::from(i64_values).to(DataType::Int64)),
+            0 => Box::new(PrimitiveBuilder::<i64>::from(i64_values).to(DataType::Int64)),
             1 => Box::new(
-                Primitive::<f64>::from(&[
+                PrimitiveBuilder::<f64>::from(&[
                     Some(0.0),
                     Some(1.0),
                     None,
@@ -101,7 +101,7 @@ mod tests {
                 Some(true),
             ])),
             4 => Box::new(
-                Primitive::<i64>::from(i64_values)
+                PrimitiveBuilder::<i64>::from(i64_values)
                     .to(DataType::Timestamp(TimeUnit::Millisecond, None)),
             ),
             5 => {
@@ -109,7 +109,7 @@ mod tests {
                     .iter()
                     .map(|x| x.map(|x| x as u32))
                     .collect::<Vec<_>>();
-                Box::new(Primitive::<u32>::from(values).to(DataType::UInt32))
+                Box::new(PrimitiveBuilder::<u32>::from(values).to(DataType::UInt32))
             }
             _ => unreachable!(),
         }
@@ -179,7 +179,7 @@ mod tests {
         ];
 
         match column {
-            0 => Box::new(Primitive::<i64>::from(i64_values).to(DataType::Int64)),
+            0 => Box::new(PrimitiveBuilder::<i64>::from(i64_values).to(DataType::Int64)),
             3 => Box::new(BooleanArray::from_slice(&[
                 true, true, false, false, false, true, true, true, true, true,
             ])),

--- a/src/io/parquet/read/schema/convert.rs
+++ b/src/io/parquet/read/schema/convert.rs
@@ -359,7 +359,7 @@ fn to_list(fields: &[ParquetType], parent_name: &str) -> Result<Option<DataType>
                 to_primitive_type_inner(physical_type, logical_type, converted_type).map(Some)
             } else {
                 Err(ArrowError::ExternalFormat(
-                    "Primitive element type of list must be repeated.".to_string(),
+                    "PrimitiveBuilder element type of list must be repeated.".to_string(),
                 ))
             }
         }

--- a/src/io/print.rs
+++ b/src/io/print.rs
@@ -159,7 +159,7 @@ mod tests {
         let field_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
         let schema = Arc::new(Schema::new(vec![Field::new("d1", field_type, true)]));
 
-        let mut a = DictionaryPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        let mut a = DictionaryBuilder::<i32, _, _>::new(Utf8Builder::<i32>::new());
         a.extend(vec![Some("one"), None, Some("three")]);
         let array = a.into_arc();
 
@@ -189,7 +189,7 @@ mod tests {
     /// formatting that array with `write`
     macro_rules! check_datetime {
         ($ty:ty, $datatype:expr, $value:expr, $EXPECTED_RESULT:expr) => {
-            let array = Primitive::<$ty>::from(&[Some($value), None]).to_arc(&$datatype);
+            let array = PrimitiveBuilder::<$ty>::from(&[Some($value), None]).to_arc(&$datatype);
 
             let schema = Arc::new(Schema::new(vec![Field::new(
                 "f",

--- a/src/io/print.rs
+++ b/src/io/print.rs
@@ -159,11 +159,9 @@ mod tests {
         let field_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
         let schema = Arc::new(Schema::new(vec![Field::new("d1", field_type, true)]));
 
-        let array = DictionaryPrimitive::<i32, Utf8Primitive<i32>, _>::try_from_iter(
-            vec![Ok(Some("one")), Ok(None), Ok(Some("three"))].into_iter(),
-        )
-        .unwrap()
-        .into_arc();
+        let mut a = DictionaryPrimitive::<i32, _, _>::new(Utf8Primitive::<i32>::new());
+        a.extend(vec![Some("one"), None, Some("three")]);
+        let array = a.into_arc();
 
         let batch = RecordBatch::try_new(schema, vec![array])?;
 

--- a/src/record_batch.rs
+++ b/src/record_batch.rs
@@ -57,11 +57,11 @@ impl RecordBatch {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow2::array::Primitive;
+    /// # use arrow2::array::PrimitiveBuilder;
     /// # use arrow2::datatypes::{Schema, Field, DataType};
     /// # use arrow2::record_batch::RecordBatch;
     /// # fn main() -> arrow2::error::Result<()> {
-    /// let id_array = Primitive::from_slice(&[1i32, 2, 3, 4, 5]).to(DataType::Int32);
+    /// let id_array = PrimitiveBuilder::from_slice(&[1i32, 2, 3, 4, 5]).to(DataType::Int32);
     /// let schema = Arc::new(Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false)
     /// ]));
@@ -176,11 +176,11 @@ impl RecordBatch {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow2::array::Primitive;
+    /// # use arrow2::array::PrimitiveBuilder;
     /// # use arrow2::datatypes::{Schema, Field, DataType};
     /// # use arrow2::record_batch::RecordBatch;
     /// # fn main() -> arrow2::error::Result<()> {
-    /// let id_array = Primitive::from_slice(&[1i32, 2, 3, 4, 5]).to(DataType::Int32);
+    /// let id_array = PrimitiveBuilder::from_slice(&[1i32, 2, 3, 4, 5]).to(DataType::Int32);
     /// let schema = Arc::new(Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false)
     /// ]));
@@ -205,11 +205,11 @@ impl RecordBatch {
     ///
     /// ```
     /// # use std::sync::Arc;
-    /// # use arrow2::array::Primitive;
+    /// # use arrow2::array::PrimitiveBuilder;
     /// # use arrow2::datatypes::{Schema, Field, DataType};
     /// # use arrow2::record_batch::RecordBatch;
     /// # fn main() -> arrow2::error::Result<()> {
-    /// let id_array = Primitive::from_slice(&[1i32, 2, 3, 4, 5]).to(DataType::Int32);
+    /// let id_array = PrimitiveBuilder::from_slice(&[1i32, 2, 3, 4, 5]).to(DataType::Int32);
     /// let schema = Arc::new(Schema::new(vec![
     ///     Field::new("id", DataType::Int32, false)
     /// ]));

--- a/src/util/bench_util.rs
+++ b/src/util/bench_util.rs
@@ -47,7 +47,7 @@ where
                 Some(rng.gen())
             }
         })
-        .collect::<Primitive<T>>()
+        .collect::<PrimitiveBuilder<T>>()
         .to(data_type)
 }
 
@@ -71,7 +71,7 @@ where
                 Some(rng.gen())
             }
         })
-        .collect::<Primitive<T>>()
+        .collect::<PrimitiveBuilder<T>>()
         .to(data_type)
 }
 


### PR DESCRIPTION
The primitive/builder API was difficult to use for nested types. This PR refactors it to make it easier.

The main limitations were:

1. `Builder` could not be used as a trait object
2. `.push(None)` for nested types was not easy (it required a type annotation of an iterator type `T`)
3. it was difficult to control the capacity of the values in nested types

This PR addresses all of the above.

It also renames all `XPrimitive` to `XBuilder` to be consistent with the arrow crate and to disambiguate them from the `Primitive` in `PrimitiveArray`.