### PR TITLE
Not Implemented error on compressed IPC.

### DIFF
--- a/src/io/ipc/read/stream.rs
+++ b/src/io/ipc/read/stream.rs
@@ -135,6 +135,7 @@ pub fn read_next<R: Read>(
                 &dictionaries_by_field,
                 &mut reader,
                 0,
+                batch.compression(),
             )
             .map(Some)
         }
@@ -155,6 +156,7 @@ pub fn read_next<R: Read>(
                 dictionaries_by_field,
                 &mut dict_reader,
                 0,
+                None,
             )?;
 
             // read the next message until we encounter a RecordBatch


### PR DESCRIPTION
Partially addresses #163 : returns a "NotImplementedError" when we trying to read IPC with compression, since it is not yet supported.