### PR TITLE
Added support for IPC 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ prettytable-rs = { version = "^0.8", optional = true }
 flatbuffers = { version = "=0.8.4", optional = true }
 hex = { version = "^0.4", optional = true }
 
+# for IPC compression
+lz4 = { version = "1.23.1", optional = true }
+zstd = { version = "^0.6", optional = true }
+
 rand = { version = "0.7", optional = true }
 
 itertools = { version = "^0.10", optional = true }
@@ -68,11 +72,12 @@ doc-comment = "0.3"
 crossbeam-channel = "0.5.1"
 
 [features]
-default = ["io_csv", "io_json", "io_ipc", "io_json_integration", "io_print", "io_parquet", "regex", "merge_sort", "ahash", "benchmarks"]
+default = ["io_csv", "io_json", "io_ipc", "io_ipc_compression", "io_json_integration", "io_print", "io_parquet", "regex", "merge_sort", "ahash", "benchmarks"]
 merge_sort = ["itertools"]
 io_csv = ["csv", "lazy_static", "regex"]
 io_json = ["serde", "serde_derive", "serde_json", "indexmap"]
 io_ipc = ["flatbuffers"]
+io_ipc_compression = ["lz4", "zstd"]
 io_json_integration = ["io_json", "hex"]
 io_print = ["prettytable-rs"]
 # base64 + io_ipc because arrow schemas are stored as base64-encoded ipc format.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ venv/bin/python parquet_integration/write_parquet.py
 * Generalized parsing of CSV based on logical data types
 * conditional compilation based on cargo `features` to reduce dependencies and size
 * faster IPC reader (different design that avoids an extra copy of all data)
+* IPC supports 2.0 (compression)
 
 ## Features in the original not available in this crate
 

--- a/src/io/ipc/compression.rs
+++ b/src/io/ipc/compression.rs
@@ -1,0 +1,27 @@
+use std::io::Read;
+
+use crate::error::Result;
+
+#[cfg(feature = "io_ipc_compression")]
+pub fn decompress_lz4(input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
+    let mut decoder = lz4::Decoder::new(input_buf)?;
+    decoder.read_exact(output_buf).map_err(|e| e.into())
+}
+
+#[cfg(feature = "io_ipc_compression")]
+pub fn decompress_zstd(input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
+    let mut decoder = zstd::Decoder::new(input_buf)?;
+    decoder.read_exact(output_buf).map_err(|e| e.into())
+}
+
+#[cfg(not(feature = "io_ipc_compression"))]
+pub fn decompress_lz4(input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
+    use crate::error::ArrowError;
+    Err(ArrowError::Ipc("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
+}
+
+#[cfg(not(feature = "io_ipc_compression"))]
+pub fn decompress_zstd(input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
+    use crate::error::ArrowError;
+    Err(ArrowError::Ipc("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
+}

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -26,6 +26,7 @@
 pub mod gen;
 
 pub(crate) mod common;
+mod compression;
 mod convert;
 
 pub use convert::fb_to_schema;

--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -140,7 +140,6 @@ pub fn read_file_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetadata
                     &mut dictionaries_by_field,
                     reader,
                     block_offset,
-                    None,
                 )?;
             }
             t => {
@@ -201,7 +200,6 @@ pub fn read_batch<R: Read + Seek>(
             let batch = message.header_as_record_batch().ok_or_else(|| {
                 ArrowError::Ipc("Unable to read IPC message as record batch".to_string())
             })?;
-            let compression = batch.compression();
             read_record_batch(
                 batch,
                 metadata.schema.clone(),
@@ -209,7 +207,6 @@ pub fn read_batch<R: Read + Seek>(
                 &metadata.dictionaries_by_field,
                 reader,
                 block.offset() as u64 + block.metaDataLength() as u64,
-                compression,
             )
             .map(Some)
         }
@@ -296,13 +293,6 @@ mod tests {
     }
 
     #[test]
-    fn read_generated_200_compression_lz4() -> Result<()> {
-        let result = test_file("2.0.0-compression", "generated_lz4");
-        assert!(result.is_err());
-        Ok(())
-    }
-
-    #[test]
     fn read_generated_100_primitive_large_offsets() -> Result<()> {
         test_file("1.0.0-littleendian", "generated_primitive_large_offsets")?;
         test_file("1.0.0-bigendian", "generated_primitive_large_offsets")
@@ -378,5 +368,15 @@ mod tests {
     fn read_generated_100_interval() -> Result<()> {
         test_file("1.0.0-littleendian", "generated_interval")?;
         test_file("1.0.0-bigendian", "generated_interval")
+    }
+
+    #[test]
+    fn read_generated_200_compression_lz4() -> Result<()> {
+        test_file("2.0.0-compression", "generated_lz4")
+    }
+
+    #[test]
+    fn read_generated_200_compression_zstd() -> Result<()> {
+        test_file("2.0.0-compression", "generated_zstd")
     }
 }

--- a/src/io/ipc/read/stream.rs
+++ b/src/io/ipc/read/stream.rs
@@ -135,6 +135,7 @@ pub fn read_next<R: Read>(
                 &dictionaries_by_field,
                 &mut reader,
                 0,
+                batch.compression(),
             )
             .map(Some)
         }
@@ -155,6 +156,7 @@ pub fn read_next<R: Read>(
                 dictionaries_by_field,
                 &mut dict_reader,
                 0,
+                None,
             )?;
 
             // read the next message until we encounter a RecordBatch

--- a/src/io/ipc/read/stream.rs
+++ b/src/io/ipc/read/stream.rs
@@ -135,7 +135,6 @@ pub fn read_next<R: Read>(
                 &dictionaries_by_field,
                 &mut reader,
                 0,
-                batch.compression(),
             )
             .map(Some)
         }
@@ -156,7 +155,6 @@ pub fn read_next<R: Read>(
                 dictionaries_by_field,
                 &mut dict_reader,
                 0,
-                None,
             )?;
 
             // read the next message until we encounter a RecordBatch
@@ -314,5 +312,15 @@ mod tests {
     #[test]
     fn read_generated_100_decimal() -> Result<()> {
         test_file("1.0.0-littleendian", "generated_decimal")
+    }
+
+    #[test]
+    fn read_generated_200_compression_lz4() -> Result<()> {
+        test_file("2.0.0-compression", "generated_lz4")
+    }
+
+    #[test]
+    fn read_generated_200_compression_zstd() -> Result<()> {
+        test_file("2.0.0-compression", "generated_zstd")
     }
 }


### PR DESCRIPTION
Closes #163

This adds support for IPC format 2.0, which includes compression. The implementation is not the fastest, because it currently requires an extra allocation per buffer, but the roundtrip over the golden files passes, so we can live with it for now. ^_^

Note that this adds a new feature `io_ipc_compression`, to activate the corresponding dependencies. These overlap with `io_parquet`, but it is still good to be aware of.
