### PR TITLE
Added integration tests for parquet write

### DIFF
--- a/.github/workflows/integration-parquet.yml
+++ b/.github/workflows/integration-parquet.yml
@@ -1,0 +1,50 @@
+name: Integration parquet
+
+on: [push, pull_request]
+
+jobs:
+  docker:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup Rust toolchain
+        run: |
+          rustup toolchain install stable
+          rustup default stable
+          rustup component add rustfmt clippy
+      - name: Cache Cargo
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/.cargo
+          key: cargo-parquet-cache-
+      - name: Cache Rust dependencies
+        uses: actions/cache@v2
+        with:
+          path: /home/runner/target
+          key: ${{ runner.os }}-amd64-target-parquet-cache
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Build
+        run: |
+          export CARGO_HOME="/home/runner/.cargo"
+          export CARGO_TARGET_DIR="/home/runner/target"
+
+          cd arrow-parquet-integration-testing
+
+          cargo build
+      - name: Run
+        run: |
+          export CARGO_HOME="/home/runner/.cargo"
+          export CARGO_TARGET_DIR="/home/runner/target"
+
+          cd arrow-parquet-integration-testing
+
+          python -m venv venv
+          source venv/bin/activate
+          pip install --upgrade pip
+          pip install pyarrow
+          python main.py

--- a/arrow-parquet-integration-testing/Cargo.toml
+++ b/arrow-parquet-integration-testing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "arrow-parquet-integration-testing"
+version = "0.1.0"
+authors = ["Jorge C. Leitao <jorgecarleitao@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+clap = "^2.33"
+arrow2 = { path = "../", default-features = false, features = ["io_parquet", "io_json_integration"] }
+flate2 = "^1"
+serde = { version = "^1.0", features = ["rc"] }
+serde_derive = { version = "^1.0" }
+serde_json = { version = "^1.0", features = ["preserve_order"] }

--- a/arrow-parquet-integration-testing/main.py
+++ b/arrow-parquet-integration-testing/main.py
@@ -1,0 +1,49 @@
+import subprocess
+import os
+
+import pyarrow.ipc
+import pyarrow.parquet as pq
+
+
+def get_file_path(file: str):
+    return f"../testing/arrow-testing/data/arrow-ipc-stream/integration/1.0.0-littleendian/{file}.arrow_file"
+
+
+def _prepare(file: str):
+    write = f"{file}.parquet"
+    subprocess.call(["cargo", "run", "--", "--json", file, "--output", write])
+    return write
+
+
+def _expected(file: str):
+    return pyarrow.ipc.RecordBatchFileReader(get_file_path(file)).read_all()
+
+
+for file in [
+    "generated_primitive",
+    "generated_primitive_no_batches",
+    "generated_primitive_zerolength",
+    "generated_null",
+    "generated_null_trivial",
+    "generated_primitive_large_offsets",
+    # requires writing Dictionary
+    # "generated_dictionary",
+    # requires writing Duration
+    # "generated_interval",
+    # requires writing Struct
+    # "generated_duplicate_fieldnames",
+    # requires writing Decimal
+    # "generated_decimal",
+    # requires writing Date64
+    # "generated_datetime",
+    # requires writing un-nested List
+    # "generated_custom_metadata",
+]:
+    expected = _expected(file)
+    path = _prepare(file)
+
+    table = pq.read_table(path)
+    os.remove(path)
+
+    for c1, c2 in zip(expected, table):
+        assert c1 == c2

--- a/arrow-parquet-integration-testing/src/main.rs
+++ b/arrow-parquet-integration-testing/src/main.rs
@@ -1,0 +1,93 @@
+use std::fs::File;
+use std::{collections::HashMap, convert::TryFrom, io::Read};
+
+use arrow2::error::Result;
+use arrow2::io::parquet::write::RowGroupIterator;
+use arrow2::io::{
+    json_integration::ArrowJson,
+    parquet::write::{write_file, CompressionCodec, WriteOptions},
+};
+use arrow2::{datatypes::Schema, io::json_integration::to_record_batch, record_batch::RecordBatch};
+
+use clap::{App, Arg};
+
+use flate2::read::GzDecoder;
+
+/// Read gzipped JSON file
+fn read_gzip_json(version: &str, file_name: &str) -> (Schema, Vec<RecordBatch>) {
+    let path = format!(
+        "../testing/arrow-testing/data/arrow-ipc-stream/integration/{}/{}.json.gz",
+        version, file_name
+    );
+    let file = File::open(path).unwrap();
+    let mut gz = GzDecoder::new(&file);
+    let mut s = String::new();
+    gz.read_to_string(&mut s).unwrap();
+    // convert to Arrow JSON
+    let arrow_json: ArrowJson = serde_json::from_str(&s).unwrap();
+
+    let schema = serde_json::to_value(arrow_json.schema).unwrap();
+    let schema = Schema::try_from(&schema).unwrap();
+
+    // read dictionaries
+    let mut dictionaries = HashMap::new();
+    if let Some(dicts) = arrow_json.dictionaries {
+        for json_dict in dicts {
+            // TODO: convert to a concrete Arrow type
+            dictionaries.insert(json_dict.id, json_dict);
+        }
+    }
+
+    let batches = arrow_json
+        .batches
+        .iter()
+        .map(|batch| to_record_batch(&schema, batch, &dictionaries))
+        .collect::<Result<Vec<_>>>()
+        .unwrap();
+
+    (schema, batches)
+}
+
+fn main() -> Result<()> {
+    let matches = App::new("json-parquet-integration")
+        .arg(
+            Arg::with_name("json")
+                .long("json")
+                .required(true)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("write_path")
+                .long("output")
+                .required(true)
+                .takes_value(true),
+        )
+        .get_matches();
+    let json_file = matches
+        .value_of("json")
+        .expect("must provide path to json file");
+    let write_path = matches
+        .value_of("write_path")
+        .expect("must provide path to write parquet");
+
+    let (schema, batches) = read_gzip_json("1.0.0-littleendian", json_file);
+
+    let options = WriteOptions {
+        write_statistics: true,
+        compression: CompressionCodec::Uncompressed,
+    };
+
+    let row_groups = RowGroupIterator::try_new(batches.into_iter().map(Ok), &schema, options)?;
+    let parquet_schema = row_groups.parquet_schema().clone();
+
+    let mut writer = File::create(write_path)?;
+
+    write_file(
+        &mut writer,
+        row_groups,
+        &schema,
+        parquet_schema,
+        options,
+        None,
+    )
+}

--- a/examples/parquet_write_record.rs
+++ b/examples/parquet_write_record.rs
@@ -1,0 +1,54 @@
+use std::fs::File;
+use std::sync::Arc;
+
+use arrow2::{
+    array::{Array, Int32Array},
+    datatypes::{Field, Schema},
+    error::Result,
+    io::parquet::write::{write_file, CompressionCodec, RowGroupIterator, WriteOptions},
+    record_batch::RecordBatch,
+};
+
+fn write_batch(path: &str, batch: RecordBatch) -> Result<()> {
+    let schema = batch.schema().clone();
+
+    let options = WriteOptions {
+        write_statistics: true,
+        compression: CompressionCodec::Uncompressed,
+    };
+
+    let iter = vec![Ok(batch)];
+
+    let row_groups = RowGroupIterator::try_new(iter.into_iter(), &schema, options)?;
+
+    // Create a new empty file
+    let mut file = File::create(path)?;
+
+    // Write the file. Note that, at present, any error results in a corrupted file.
+    let parquet_schema = row_groups.parquet_schema().clone();
+    write_file(
+        &mut file,
+        row_groups,
+        &schema,
+        parquet_schema,
+        options,
+        None,
+    )
+}
+
+fn main() -> Result<()> {
+    let array = Int32Array::from(&[
+        Some(0),
+        Some(1),
+        Some(2),
+        Some(3),
+        Some(4),
+        Some(5),
+        Some(6),
+    ]);
+    let field = Field::new("c1", array.data_type().clone(), true);
+    let schema = Schema::new(vec![field]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)])?;
+
+    write_batch("test.parquet", batch)
+}

--- a/guide/src/io/parquet_write.md
+++ b/guide/src/io/parquet_write.md
@@ -2,7 +2,8 @@
 
 When compiled with feature `io_parquet`, this crate can be used to write parquet files
 from arrow.
-It makes minimal assumptions on how you to decompose CPU and IO intensive tasks.
+It makes minimal assumptions on how you to decompose CPU and IO intensive tasks, as well
+as an higher-level API to abstract away some of this work into an easy to use API.
 
 First, some notation:
 
@@ -10,8 +11,15 @@ First, some notation:
 * `column chunk`: composed of multiple pages (similar of an `Array`)
 * `row group`: a group of columns with the same length (similar of a `RecordBatch` in Arrow)
 
-Here is how to write a single column chunk into a single row group:
+Here is an example of how to write a single column chunk into a single row group:
 
 ```rust
 {{#include ../../../examples/parquet_write.rs}}
+```
+
+For single-threaded writing, this crate offers an API that encapsulates the above logic. It 
+assumes that a `RecordBatch` is mapped to a single row group with a single page per column.
+
+```rust
+{{#include ../../../examples/parquet_write_record.rs}}
 ```

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -2,6 +2,7 @@ mod binary;
 mod boolean;
 mod fixed_len_bytes;
 mod primitive;
+mod record_batch;
 mod schema;
 mod utf8;
 mod utils;
@@ -23,6 +24,7 @@ pub use parquet2::{
 use parquet2::{
     metadata::SchemaDescriptor, schema::KeyValue, write::write_file as parquet_write_file,
 };
+pub use record_batch::RowGroupIterator;
 use schema::schema_to_metadata_key;
 pub use schema::to_parquet_type;
 

--- a/src/io/parquet/write/record_batch.rs
+++ b/src/io/parquet/write/record_batch.rs
@@ -1,0 +1,58 @@
+use super::{
+    array_to_page, to_parquet_schema, DynIter, RowGroupIter, SchemaDescriptor, WriteOptions,
+};
+use crate::{
+    datatypes::Schema,
+    error::{ArrowError, Result},
+    record_batch::RecordBatch,
+};
+
+/// An iterator adapter that converts an iterator over [`RecordBatch`] into an iterator
+/// of row groups.
+/// Use it to create an iterator consumable by the parquet's API.
+pub struct RowGroupIterator<I: Iterator<Item = Result<RecordBatch>>> {
+    iter: I,
+    options: WriteOptions,
+    parquet_schema: SchemaDescriptor,
+}
+
+impl<I: Iterator<Item = Result<RecordBatch>>> RowGroupIterator<I> {
+    /// Creates a new [`RowGroupIterator`] from an iterator over [`RecordBatch`].
+    pub fn try_new(iter: I, schema: &Schema, options: WriteOptions) -> Result<Self> {
+        let parquet_schema = to_parquet_schema(schema)?;
+
+        Ok(Self {
+            iter,
+            options,
+            parquet_schema,
+        })
+    }
+
+    pub fn parquet_schema(&self) -> &SchemaDescriptor {
+        &self.parquet_schema
+    }
+}
+
+impl<I: Iterator<Item = Result<RecordBatch>>> Iterator for RowGroupIterator<I> {
+    type Item = Result<RowGroupIter<'static, ArrowError>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let options = self.options;
+
+        self.iter.next().map(|batch| {
+            let columns = batch?.columns().to_vec();
+            Ok(DynIter::new(
+                columns
+                    .into_iter()
+                    .zip(self.parquet_schema.columns().to_vec().into_iter())
+                    .map(move |(array, type_)| {
+                        Ok(DynIter::new(std::iter::once(array_to_page(
+                            array.as_ref(),
+                            type_,
+                            options,
+                        ))))
+                    }),
+            ))
+        })
+    }
+}


### PR DESCRIPTION
This adds a test whereby Rust reads IPC golden files and writes them to parquet and then compares the result from parquet with the corresponding read from pyarrow, i.e.

* `.json.gz - (rust) -> parquet - (pyarrow) -> arrow`
* `.arrow - (pyarrow) -> arrow`

and compares both results (in pyarrow)
