### PR TITLE
Simplified index trait

### DIFF
--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -68,8 +68,8 @@ impl<O: Offset> BinaryArray<O> {
         let offsets = self.offsets.as_slice();
         let offset = offsets[i];
         let offset_1 = offsets[i + 1];
-        let length = (offset_1 - offset).to_usize().unwrap();
-        let offset = offset.to_usize().unwrap();
+        let length = (offset_1 - offset).to_usize();
+        let offset = offset.to_usize();
 
         &self.values.as_slice()[offset..offset + length]
     }
@@ -80,8 +80,8 @@ impl<O: Offset> BinaryArray<O> {
     pub unsafe fn value_unchecked(&self, i: usize) -> &[u8] {
         let offset = *self.offsets.as_ptr().add(i);
         let offset_1 = *self.offsets.as_ptr().add(i + 1);
-        let length = (offset_1 - offset).to_usize().unwrap();
-        let offset = offset.to_usize().unwrap();
+        let length = (offset_1 - offset).to_usize();
+        let offset = offset.to_usize();
 
         std::slice::from_raw_parts(self.values.as_ptr().add(offset), length)
     }

--- a/src/array/equal/list.rs
+++ b/src/array/equal/list.rs
@@ -43,8 +43,8 @@ fn offset_value_equal<O: Offset>(
     rhs_pos: usize,
     len: usize,
 ) -> bool {
-    let lhs_start = lhs_offsets[lhs_pos].to_usize().unwrap();
-    let rhs_start = rhs_offsets[rhs_pos].to_usize().unwrap();
+    let lhs_start = lhs_offsets[lhs_pos].to_usize();
+    let rhs_start = rhs_offsets[rhs_pos].to_usize();
     let lhs_len = lhs_offsets[lhs_pos + len] - lhs_offsets[lhs_pos];
     let rhs_len = rhs_offsets[rhs_pos + len] - rhs_offsets[rhs_pos];
 
@@ -56,7 +56,7 @@ fn offset_value_equal<O: Offset>(
             rhs_validity,
             lhs_start,
             rhs_start,
-            lhs_len.to_usize().unwrap(),
+            lhs_len.to_usize(),
         )
 }
 
@@ -90,10 +90,10 @@ pub(super) fn equal<O: Offset>(
     // however, one is more likely to slice into a list array and get a region that has 0
     // child values.
     // The test that triggered this behaviour had [4, 4] as a slice of 1 value slot.
-    let lhs_child_length = lhs_offsets.get(len).unwrap().to_usize().unwrap()
-        - lhs_offsets.first().unwrap().to_usize().unwrap();
-    let rhs_child_length = rhs_offsets.get(len).unwrap().to_usize().unwrap()
-        - rhs_offsets.first().unwrap().to_usize().unwrap();
+    let lhs_child_length =
+        lhs_offsets.get(len).unwrap().to_usize() - lhs_offsets.first().unwrap().to_usize();
+    let rhs_child_length =
+        rhs_offsets.get(len).unwrap().to_usize() - rhs_offsets.first().unwrap().to_usize();
 
     if lhs_child_length == 0 && lhs_child_length == rhs_child_length {
         return true;
@@ -118,11 +118,9 @@ pub(super) fn equal<O: Offset>(
             rhs_values,
             &child_lhs_validity,
             &child_rhs_validity,
-            lhs_offsets[lhs_start].to_usize().unwrap(),
-            rhs_offsets[rhs_start].to_usize().unwrap(),
-            (lhs_offsets[len] - lhs_offsets[lhs_start])
-                .to_usize()
-                .unwrap(),
+            lhs_offsets[lhs_start].to_usize(),
+            rhs_offsets[rhs_start].to_usize(),
+            (lhs_offsets[len] - lhs_offsets[lhs_start]).to_usize(),
         )
     } else {
         // get a ref of the parent null buffer bytes, to use in testing for nullness

--- a/src/array/equal/utils.rs
+++ b/src/array/equal/utils.rs
@@ -81,16 +81,16 @@ fn logical_list_bitmap<O: Offset>(
     parent_bitmap: &Option<Bitmap>,
     child_bitmap: &Option<Bitmap>,
 ) -> Option<Bitmap> {
-    let first_offset = offsets.first().unwrap().to_usize().unwrap();
-    let last_offset = offsets.get(offsets.len() - 1).unwrap().to_usize().unwrap();
+    let first_offset = offsets.first().unwrap().to_usize();
+    let last_offset = offsets.get(offsets.len() - 1).unwrap().to_usize();
     let length = last_offset - first_offset;
 
     match (parent_bitmap, child_bitmap) {
         (Some(parent_bitmap), Some(child_bitmap)) => {
             let mut buffer = MutableBitmap::with_capacity(length);
             offsets.windows(2).enumerate().for_each(|(index, window)| {
-                let start = window[0].to_usize().unwrap();
-                let end = window[1].to_usize().unwrap();
+                let start = window[0].to_usize();
+                let end = window[1].to_usize();
                 let mask = parent_bitmap.get_bit(index);
                 (start..end).for_each(|child_index| {
                     let is_set = mask && child_bitmap.get_bit(child_index);
@@ -102,8 +102,8 @@ fn logical_list_bitmap<O: Offset>(
         (None, Some(child_bitmap)) => {
             let mut buffer = MutableBitmap::with_capacity(length);
             offsets.windows(2).for_each(|window| {
-                let start = window[0].to_usize().unwrap();
-                let end = window[1].to_usize().unwrap();
+                let start = window[0].to_usize();
+                let end = window[1].to_usize();
                 (start..end).for_each(|child_index| {
                     buffer.push(child_bitmap.get_bit(child_index));
                 });
@@ -113,8 +113,8 @@ fn logical_list_bitmap<O: Offset>(
         (Some(parent_bitmap), None) => {
             let mut buffer = MutableBitmap::with_capacity(length);
             offsets.windows(2).enumerate().for_each(|(index, window)| {
-                let start = window[0].to_usize().unwrap();
-                let end = window[1].to_usize().unwrap();
+                let start = window[0].to_usize();
+                let end = window[1].to_usize();
                 let mask = parent_bitmap.get_bit(index);
                 (start..end).for_each(|_| {
                     buffer.push(mask);

--- a/src/array/equal/variable_size.rs
+++ b/src/array/equal/variable_size.rs
@@ -11,8 +11,8 @@ fn offset_value_equal<O: Offset>(
     rhs_pos: usize,
     len: usize,
 ) -> bool {
-    let lhs_start = lhs_offsets[lhs_pos].to_usize().unwrap();
-    let rhs_start = rhs_offsets[rhs_pos].to_usize().unwrap();
+    let lhs_start = lhs_offsets[lhs_pos].to_usize();
+    let rhs_start = rhs_offsets[rhs_pos].to_usize();
     let lhs_len = lhs_offsets[lhs_pos + len] - lhs_offsets[lhs_pos];
     let rhs_len = rhs_offsets[rhs_pos + len] - rhs_offsets[rhs_pos];
 
@@ -22,7 +22,7 @@ fn offset_value_equal<O: Offset>(
             rhs_values,
             lhs_start,
             rhs_start,
-            lhs_len.to_usize().unwrap(),
+            lhs_len.to_usize(),
         )
 }
 

--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -29,8 +29,8 @@ fn extend_offset_values<O: Offset>(
             &offsets[start..start + len + 1],
         );
 
-        let end = offsets[start + len].to_usize().unwrap();
-        let start = offsets[start].to_usize().unwrap();
+        let end = offsets[start + len].to_usize();
+        let start = offsets[start].to_usize();
         let len = end - start;
         growable.values.extend(index, start, len)
     } else {
@@ -46,11 +46,7 @@ fn extend_offset_values<O: Offset>(
                 *last_offset += len;
 
                 // append value
-                inner_values.extend(
-                    index,
-                    offsets[i].to_usize().unwrap(),
-                    len.to_usize().unwrap(),
-                );
+                inner_values.extend(index, offsets[i].to_usize(), len.to_usize());
             }
             // append offset
             new_offsets.push(*last_offset);

--- a/src/array/growable/utils.rs
+++ b/src/array/growable/utils.rs
@@ -68,8 +68,8 @@ pub(super) fn extend_offset_values<O: Offset>(
     start: usize,
     len: usize,
 ) {
-    let start_values = offsets[start].to_usize().unwrap();
-    let end_values = offsets[start + len].to_usize().unwrap();
+    let start_values = offsets[start].to_usize();
+    let end_values = offsets[start + len].to_usize();
     let new_values = &values[start_values..end_values];
     buffer.extend_from_slice(new_values);
 }

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -78,9 +78,9 @@ impl<O: Offset> ListArray<O> {
             let offsets = self.offsets.as_slice();
             let offset = offsets[i];
             let offset_1 = offsets[i + 1];
-            let length = (offset_1 - offset).to_usize().unwrap();
+            let length = (offset_1 - offset).to_usize();
 
-            self.values.slice(offset.to_usize().unwrap(), length)
+            self.values.slice(offset.to_usize(), length)
         }
     }
 
@@ -91,9 +91,9 @@ impl<O: Offset> ListArray<O> {
     pub unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array> {
         let offset = *self.offsets.as_ptr().add(i);
         let offset_1 = *self.offsets.as_ptr().add(i + 1);
-        let length = (offset_1 - offset).to_usize().unwrap();
+        let length = (offset_1 - offset).to_usize();
 
-        self.values.slice(offset.to_usize().unwrap(), length)
+        self.values.slice(offset.to_usize(), length)
     }
 
     pub fn slice(&self, offset: usize, length: usize) -> Self {

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -9,7 +9,7 @@ use crate::{
 
 /// Trait describing any type that can be used to index a slot of an array.
 pub trait Index: NativeType {
-    fn to_usize(&self) -> Option<usize>;
+    fn to_usize(&self) -> usize;
 }
 
 /// Trait describing types that can be used as offsets as per Arrow specification.
@@ -50,29 +50,29 @@ unsafe impl Offset for i64 {
 
 impl Index for i32 {
     #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        usize::try_from(*self).ok()
+    fn to_usize(&self) -> usize {
+        *self as usize
     }
 }
 
 impl Index for i64 {
     #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        usize::try_from(*self).ok()
+    fn to_usize(&self) -> usize {
+        *self as usize
     }
 }
 
 impl Index for u32 {
     #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        usize::try_from(*self).ok()
+    fn to_usize(&self) -> usize {
+        *self as usize
     }
 }
 
 impl Index for u64 {
     #[inline]
-    fn to_usize(&self) -> Option<usize> {
-        usize::try_from(*self).ok()
+    fn to_usize(&self) -> usize {
+        *self as usize
     }
 }
 
@@ -87,9 +87,7 @@ pub fn check_offsets<O: Offset>(offsets: &Buffer<O>, values_len: usize) -> usize
     let offsets = offsets.as_slice();
 
     let last_offset = offsets[len];
-    let last_offset = last_offset
-        .to_usize()
-        .expect("The last offset of the array is larger than usize::MAX");
+    let last_offset = last_offset.to_usize();
 
     assert_eq!(
         values_len, last_offset,
@@ -102,12 +100,8 @@ pub fn check_offsets<O: Offset>(offsets: &Buffer<O>, values_len: usize) -> usize
 pub fn check_offsets_and_utf8<O: Offset>(offsets: &Buffer<O>, values: &Buffer<u8>) -> usize {
     let len = check_offsets(offsets, values.len());
     offsets.as_slice().windows(2).for_each(|window| {
-        let start = window[0]
-            .to_usize()
-            .expect("The last offset of the array is larger than usize::MAX");
-        let end = window[1]
-            .to_usize()
-            .expect("The last offset of the array is larger than usize::MAX");
+        let start = window[0].to_usize();
+        let end = window[1].to_usize();
         assert!(end <= values.len());
         let slice = unsafe { std::slice::from_raw_parts(values.as_ptr().add(start), end - start) };
         std::str::from_utf8(slice).expect("A non-utf8 string was passed.");

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -106,8 +106,8 @@ impl<O: Offset> Utf8Array<O> {
     pub unsafe fn value_unchecked(&self, i: usize) -> &str {
         let offset = *self.offsets.as_ptr().add(i);
         let offset_1 = *self.offsets.as_ptr().add(i + 1);
-        let length = (offset_1 - offset).to_usize().unwrap();
-        let offset = offset.to_usize().unwrap();
+        let length = (offset_1 - offset).to_usize();
+        let offset = offset.to_usize();
 
         // Soundness: `from_data` verifies that each slot is utf8 and offsets are built correctly.
         let slice = std::slice::from_raw_parts(self.values.as_ptr().add(offset), length);
@@ -137,8 +137,8 @@ impl<O: Offset> Utf8Array<O> {
         let offsets = self.offsets.as_slice();
         let offset = offsets[i];
         let offset_1 = offsets[i + 1];
-        let length = (offset_1 - offset).to_usize().unwrap();
-        let offset = offset.to_usize().unwrap();
+        let length = (offset_1 - offset).to_usize();
+        let offset = offset.to_usize();
 
         let slice = &self.values.as_slice()[offset..offset + length];
         // todo: validate utf8 so that we can use the unsafe version

--- a/src/compute/substring.rs
+++ b/src/compute/substring.rs
@@ -54,8 +54,8 @@ fn utf8_substring<O: Offset>(array: &Utf8Array<O>, start: O, length: &Option<O>)
         new_offsets.push(length_so_far);
 
         // we need usize for ranges
-        let start = start.to_usize().unwrap();
-        let length = length.to_usize().unwrap();
+        let start = start.to_usize();
+        let length = length.to_usize();
 
         new_values.extend_from_slice(&values[start..start + length]);
     });

--- a/src/compute/take/binary.rs
+++ b/src/compute/take/binary.rs
@@ -15,10 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{
-    array::{Array, BinaryArray, Offset, PrimitiveArray},
-    error::Result,
-};
+use crate::array::{Array, BinaryArray, Offset, PrimitiveArray};
 
 use super::generic_binary::*;
 use super::Index;
@@ -27,17 +24,17 @@ use super::Index;
 pub fn take<O: Offset, I: Index>(
     values: &BinaryArray<O>,
     indices: &PrimitiveArray<I>,
-) -> Result<BinaryArray<O>> {
+) -> BinaryArray<O> {
     let indices_has_validity = indices.null_count() > 0;
     let values_has_validity = values.null_count() > 0;
 
     let (offsets, values, validity) = match (values_has_validity, indices_has_validity) {
         (false, false) => {
-            take_no_validity::<O, I>(values.offsets(), values.values(), indices.values())?
+            take_no_validity::<O, I>(values.offsets(), values.values(), indices.values())
         }
-        (true, false) => take_values_validity(values, indices.values())?,
-        (false, true) => take_indices_validity(values.offsets(), values.values(), indices)?,
-        (true, true) => take_values_indices_validity(values, indices)?,
+        (true, false) => take_values_validity(values, indices.values()),
+        (false, true) => take_indices_validity(values.offsets(), values.values(), indices),
+        (true, true) => take_values_indices_validity(values, indices),
     };
-    Ok(BinaryArray::<O>::from_data(offsets, values, validity))
+    BinaryArray::<O>::from_data(offsets, values, validity)
 }

--- a/src/compute/take/dict.rs
+++ b/src/compute/take/dict.rs
@@ -15,10 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{
-    array::{DictionaryArray, DictionaryKey, PrimitiveArray},
-    error::Result,
-};
+use crate::array::{DictionaryArray, DictionaryKey, PrimitiveArray};
 
 use super::primitive::take as take_primitive;
 use super::Index;
@@ -27,17 +24,11 @@ use super::Index;
 ///
 /// applies `take` to the keys of the dictionary array and returns a new dictionary array
 /// with the same dictionary values and reordered keys
-pub fn take<K, I>(
-    values: &DictionaryArray<K>,
-    indices: &PrimitiveArray<I>,
-) -> Result<DictionaryArray<K>>
+pub fn take<K, I>(values: &DictionaryArray<K>, indices: &PrimitiveArray<I>) -> DictionaryArray<K>
 where
     K: DictionaryKey,
     I: Index,
 {
-    let keys = take_primitive::<K, I>(values.keys(), indices)?;
-    Ok(DictionaryArray::<K>::from_data(
-        keys,
-        values.values().clone(),
-    ))
+    let keys = take_primitive::<K, I>(values.keys(), indices);
+    DictionaryArray::<K>::from_data(keys, values.values().clone())
 }

--- a/src/compute/take/list.rs
+++ b/src/compute/take/list.rs
@@ -15,12 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{
-    array::{
-        growable::{Growable, GrowableList},
-        Array, ListArray, Offset, PrimitiveArray,
-    },
-    error::Result,
+use crate::array::{
+    growable::{Growable, GrowableList},
+    Array, ListArray, Offset, PrimitiveArray,
 };
 
 use super::Index;
@@ -29,7 +26,7 @@ use super::Index;
 pub fn take<I: Offset, O: Index>(
     values: &ListArray<I>,
     indices: &PrimitiveArray<O>,
-) -> Result<ListArray<I>> {
+) -> ListArray<I> {
     let mut capacity = 0;
     let arrays = indices
         .values()
@@ -55,14 +52,14 @@ pub fn take<I: Offset, O: Index>(
             }
         }
 
-        Ok(growable.into())
+        growable.into()
     } else {
         let mut growable: GrowableList<I> = GrowableList::new(&array_ref, false, capacity);
         for index in 0..indices.len() {
             growable.extend(index, 0, 1);
         }
 
-        Ok(growable.into())
+        growable.into()
     }
 }
 
@@ -91,7 +88,7 @@ mod tests {
         );
 
         let indices = PrimitiveArray::from(&vec![Some(4i32), Some(1), Some(3)]).to(DataType::Int32);
-        let result = take(&array, &indices).unwrap();
+        let result = take(&array, &indices);
 
         let expected_values = Buffer::from([9, 6, 7, 8]);
         let expected_values =
@@ -125,7 +122,7 @@ mod tests {
 
         let indices =
             PrimitiveArray::from(&vec![Some(4i32), None, Some(2), Some(3)]).to(DataType::Int32);
-        let result = take(&array, &indices).unwrap();
+        let result = take(&array, &indices);
 
         let data_expected = vec![
             Some(vec![Some(9i32)]),
@@ -156,7 +153,7 @@ mod tests {
 
         let indices =
             PrimitiveArray::from(&vec![Some(3i32), None, Some(1), Some(0)]).to(DataType::Int32);
-        let result = take(&array, &indices).unwrap();
+        let result = take(&array, &indices);
 
         let data_expected = vec![
             Some(vec![Some(6i32), Some(7), Some(8)]),
@@ -193,7 +190,7 @@ mod tests {
         );
 
         let indices = PrimitiveArray::from(&vec![Some(0i32), Some(1)]).to(DataType::Int32);
-        let result = take(&nested, &indices).unwrap();
+        let result = take(&nested, &indices);
 
         // expected data
         let expected_values = Buffer::from([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/src/compute/take/list.rs
+++ b/src/compute/take/list.rs
@@ -23,7 +23,6 @@ use crate::{
     error::Result,
 };
 
-use super::maybe_usize;
 use super::Index;
 
 /// `take` implementation for ListArrays
@@ -35,13 +34,13 @@ pub fn take<I: Offset, O: Index>(
     let arrays = indices
         .values()
         .iter()
-        .map(|i| {
-            let index = maybe_usize::<O>(*i)?;
+        .map(|index| {
+            let index = index.to_usize();
             let slice = values.slice(index, 1);
             capacity += slice.len();
-            Ok(slice)
+            slice
         })
-        .collect::<Result<Vec<ListArray<I>>>>()?;
+        .collect::<Vec<ListArray<I>>>();
 
     let array_ref: Vec<&dyn Array> = arrays.iter().map(|v| v as &dyn Array).collect();
 

--- a/src/compute/take/mod.rs
+++ b/src/compute/take/mod.rs
@@ -23,7 +23,7 @@ use crate::{
         PrimitiveArray, StructArray, Utf8Array,
     },
     datatypes::{DataType, IntervalUnit},
-    error::{ArrowError, Result},
+    error::Result,
 };
 
 pub use crate::array::Index;
@@ -183,11 +183,6 @@ pub fn can_take(data_type: &DataType) -> bool {
         ),
         _ => false,
     }
-}
-
-#[inline(always)]
-fn maybe_usize<I: Index>(index: I) -> Result<usize> {
-    index.to_usize().ok_or(ArrowError::KeyOverflowError)
 }
 
 #[cfg(test)]

--- a/src/compute/take/mod.rs
+++ b/src/compute/take/mod.rs
@@ -18,10 +18,7 @@
 //! Defines take kernel for [`Array`]
 
 use crate::{
-    array::{
-        new_empty_array, Array, BinaryArray, BooleanArray, DictionaryArray, ListArray, NullArray,
-        PrimitiveArray, StructArray, Utf8Array,
-    },
+    array::{new_empty_array, Array, NullArray, PrimitiveArray},
     datatypes::{DataType, IntervalUnit},
     error::Result,
 };
@@ -41,9 +38,9 @@ macro_rules! downcast_take {
     ($type: ty, $values: expr, $indices: expr) => {{
         let values = $values
             .as_any()
-            .downcast_ref::<PrimitiveArray<$type>>()
+            .downcast_ref()
             .expect("Unable to downcast to a primitive array");
-        Ok(Box::new(primitive::take::<$type, _>(&values, $indices)?))
+        Ok(Box::new(primitive::take::<$type, _>(&values, $indices)))
     }};
 }
 
@@ -51,9 +48,9 @@ macro_rules! downcast_dict_take {
     ($type: ty, $values: expr, $indices: expr) => {{
         let values = $values
             .as_any()
-            .downcast_ref::<DictionaryArray<$type>>()
+            .downcast_ref()
             .expect("Unable to downcast to a primitive array");
-        Ok(Box::new(dict::take::<$type, _>(&values, $indices)?))
+        Ok(Box::new(dict::take::<$type, _>(&values, $indices)))
     }};
 }
 
@@ -65,8 +62,8 @@ pub fn take<O: Index>(values: &dyn Array, indices: &PrimitiveArray<O>) -> Result
     match values.data_type() {
         DataType::Null => Ok(Box::new(NullArray::from_data(indices.len()))),
         DataType::Boolean => {
-            let values = values.as_any().downcast_ref::<BooleanArray>().unwrap();
-            Ok(Box::new(boolean::take::<O>(values, indices)?))
+            let values = values.as_any().downcast_ref().unwrap();
+            Ok(Box::new(boolean::take::<O>(values, indices)))
         }
         DataType::Int8 => downcast_take!(i8, values, indices),
         DataType::Int16 => downcast_take!(i16, values, indices),
@@ -88,20 +85,20 @@ pub fn take<O: Index>(values: &dyn Array, indices: &PrimitiveArray<O>) -> Result
         DataType::Float64 => downcast_take!(f64, values, indices),
         DataType::Decimal(_, _) => downcast_take!(i128, values, indices),
         DataType::Utf8 => {
-            let values = values.as_any().downcast_ref::<Utf8Array<i32>>().unwrap();
-            Ok(Box::new(utf8::take::<i32, _>(values, indices)?))
+            let values = values.as_any().downcast_ref().unwrap();
+            Ok(Box::new(utf8::take::<i32, _>(values, indices)))
         }
         DataType::LargeUtf8 => {
-            let values = values.as_any().downcast_ref::<Utf8Array<i64>>().unwrap();
-            Ok(Box::new(utf8::take::<i64, _>(values, indices)?))
+            let values = values.as_any().downcast_ref().unwrap();
+            Ok(Box::new(utf8::take::<i64, _>(values, indices)))
         }
         DataType::Binary => {
-            let values = values.as_any().downcast_ref::<BinaryArray<i32>>().unwrap();
-            Ok(Box::new(binary::take::<i32, _>(values, indices)?))
+            let values = values.as_any().downcast_ref().unwrap();
+            Ok(Box::new(binary::take::<i32, _>(values, indices)))
         }
         DataType::LargeBinary => {
-            let values = values.as_any().downcast_ref::<BinaryArray<i64>>().unwrap();
-            Ok(Box::new(binary::take::<i64, _>(values, indices)?))
+            let values = values.as_any().downcast_ref().unwrap();
+            Ok(Box::new(binary::take::<i64, _>(values, indices)))
         }
         DataType::Dictionary(key_type, _) => match key_type.as_ref() {
             DataType::Int8 => downcast_dict_take!(i8, values, indices),
@@ -115,16 +112,16 @@ pub fn take<O: Index>(values: &dyn Array, indices: &PrimitiveArray<O>) -> Result
             _ => unreachable!(),
         },
         DataType::Struct(_) => {
-            let array = values.as_any().downcast_ref::<StructArray>().unwrap();
+            let array = values.as_any().downcast_ref().unwrap();
             Ok(Box::new(structure::take::<_>(array, indices)?))
         }
         DataType::List(_) => {
-            let array = values.as_any().downcast_ref::<ListArray<i32>>().unwrap();
-            Ok(Box::new(list::take::<i32, O>(array, indices)?))
+            let array = values.as_any().downcast_ref().unwrap();
+            Ok(Box::new(list::take::<i32, O>(array, indices)))
         }
         DataType::LargeList(_) => {
-            let array = values.as_any().downcast_ref::<ListArray<i64>>().unwrap();
-            Ok(Box::new(list::take::<i64, O>(array, indices)?))
+            let array = values.as_any().downcast_ref().unwrap();
+            Ok(Box::new(list::take::<i64, O>(array, indices)))
         }
         t => unimplemented!("Take not supported for data type {:?}", t),
     }
@@ -190,11 +187,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::datatypes::Field;
-    use crate::{
-        array::{Int32Array, UInt32Array},
-        bitmap::MutableBitmap,
-        types::NativeType,
-    };
+    use crate::{array::*, bitmap::MutableBitmap, types::NativeType};
 
     use super::*;
 

--- a/src/compute/take/primitive.rs
+++ b/src/compute/take/primitive.rs
@@ -23,27 +23,24 @@ use crate::{
     types::NativeType,
 };
 
-use super::maybe_usize;
 use super::Index;
 
 // take implementation when neither values nor indices contain nulls
 fn take_no_validity<T: NativeType, I: Index>(
     values: &[T],
     indices: &[I],
-) -> Result<(Buffer<T>, Option<Bitmap>)> {
-    let values = indices
-        .iter()
-        .map(|index| Result::Ok(values[maybe_usize::<I>(*index)?]));
-    let buffer = MutableBuffer::try_from_trusted_len_iter(values)?;
+) -> (Buffer<T>, Option<Bitmap>) {
+    let values = indices.iter().map(|index| values[index.to_usize()]);
+    let buffer = MutableBuffer::from_trusted_len_iter(values);
 
-    Ok((buffer.into(), None))
+    (buffer.into(), None)
 }
 
 // take implementation when only values contain nulls
 fn take_values_validity<T: NativeType, I: Index>(
     values: &PrimitiveArray<T>,
     indices: &[I],
-) -> Result<(Buffer<T>, Option<Bitmap>)> {
+) -> (Buffer<T>, Option<Bitmap>) {
     let mut null = MutableBitmap::with_capacity(indices.len());
 
     let null_values = values.validity().as_ref().unwrap();
@@ -51,28 +48,28 @@ fn take_values_validity<T: NativeType, I: Index>(
     let values_values = values.values();
 
     let values = indices.iter().map(|index| {
-        let index = maybe_usize::<I>(*index)?;
+        let index = index.to_usize();
         if null_values.get_bit(index) {
             null.push(true);
         } else {
             null.push(false);
         }
-        Result::Ok(values_values[index])
+        values_values[index]
     });
-    let buffer = MutableBuffer::try_from_trusted_len_iter(values)?;
+    let buffer = MutableBuffer::from_trusted_len_iter(values);
 
-    Ok((buffer.into(), null.into()))
+    (buffer.into(), null.into())
 }
 
 // take implementation when only indices contain nulls
 fn take_indices_validity<T: NativeType, I: Index>(
     values: &[T],
     indices: &PrimitiveArray<I>,
-) -> Result<(Buffer<T>, Option<Bitmap>)> {
+) -> (Buffer<T>, Option<Bitmap>) {
     let validity = indices.validity().as_ref().unwrap();
     let values = indices.values().iter().map(|index| {
-        let index = maybe_usize::<I>(*index)?;
-        Result::Ok(match values.get(index) {
+        let index = index.to_usize();
+        match values.get(index) {
             Some(value) => *value,
             None => {
                 if !validity.get_bit(index) {
@@ -81,19 +78,19 @@ fn take_indices_validity<T: NativeType, I: Index>(
                     panic!("Out-of-bounds index {}", index)
                 }
             }
-        })
+        }
     });
 
-    let buffer = MutableBuffer::try_from_trusted_len_iter(values)?;
+    let buffer = MutableBuffer::from_trusted_len_iter(values);
 
-    Ok((buffer.into(), indices.validity().clone()))
+    (buffer.into(), indices.validity().clone())
 }
 
 // take implementation when both values and indices contain nulls
 fn take_values_indices_validity<T: NativeType, I: Index>(
     values: &PrimitiveArray<T>,
     indices: &PrimitiveArray<I>,
-) -> Result<(Buffer<T>, Option<Bitmap>)> {
+) -> (Buffer<T>, Option<Bitmap>) {
     let mut bitmap = MutableBitmap::with_capacity(indices.len());
 
     let values_validity = values.validity().as_ref().unwrap();
@@ -101,17 +98,17 @@ fn take_values_indices_validity<T: NativeType, I: Index>(
     let values_values = values.values();
     let values = indices.iter().map(|index| match index {
         Some(index) => {
-            let index = maybe_usize::<I>(*index)?;
+            let index = index.to_usize();
             bitmap.push(values_validity.get_bit(index));
-            Result::Ok(values_values[index])
+            values_values[index]
         }
         None => {
             bitmap.push(false);
-            Ok(T::default())
+            T::default()
         }
     });
-    let buffer = MutableBuffer::try_from_trusted_len_iter(values)?;
-    Ok((buffer.into(), bitmap.into()))
+    let buffer = MutableBuffer::from_trusted_len_iter(values);
+    (buffer.into(), bitmap.into())
 }
 
 /// `take` implementation for primitive arrays
@@ -122,10 +119,10 @@ pub fn take<T: NativeType, I: Index>(
     let indices_has_validity = indices.null_count() > 0;
     let values_has_validity = values.null_count() > 0;
     let (buffer, validity) = match (values_has_validity, indices_has_validity) {
-        (false, false) => take_no_validity::<T, I>(values.values(), indices.values())?,
-        (true, false) => take_values_validity::<T, I>(values, indices.values())?,
-        (false, true) => take_indices_validity::<T, I>(values.values(), indices)?,
-        (true, true) => take_values_indices_validity::<T, I>(values, indices)?,
+        (false, false) => take_no_validity::<T, I>(values.values(), indices.values()),
+        (true, false) => take_values_validity::<T, I>(values, indices.values()),
+        (false, true) => take_indices_validity::<T, I>(values.values(), indices),
+        (true, true) => take_values_indices_validity::<T, I>(values, indices),
     };
 
     Ok(PrimitiveArray::<T>::from_data(

--- a/src/compute/take/structure.rs
+++ b/src/compute/take/structure.rs
@@ -23,7 +23,6 @@ use crate::{
     error::Result,
 };
 
-use super::maybe_usize;
 use super::Index;
 
 #[inline]
@@ -35,23 +34,21 @@ fn take_validity<I: Index>(
     match (validity, indices_validity) {
         (None, _) => Ok(indices_validity.clone()),
         (Some(validity), None) => {
-            let iter = indices.values().iter().map(|x| {
-                let index = maybe_usize(*x)?;
-                Result::Ok(validity.get_bit(index))
+            let iter = indices.values().iter().map(|index| {
+                let index = index.to_usize();
+                validity.get_bit(index)
             });
-            Ok(MutableBitmap::try_from_trusted_len_iter(iter)?.into())
+            Ok(MutableBitmap::from_trusted_len_iter(iter).into())
         }
         (Some(validity), _) => {
-            let iter = indices.iter().map(|x| {
-                Result::Ok(match x {
-                    Some(x) => {
-                        let index = maybe_usize(*x)?;
-                        validity.get_bit(index)
-                    }
-                    None => false,
-                })
+            let iter = indices.iter().map(|x| match x {
+                Some(index) => {
+                    let index = index.to_usize();
+                    validity.get_bit(index)
+                }
+                None => false,
             });
-            Ok(MutableBitmap::try_from_trusted_len_iter(iter)?.into())
+            Ok(MutableBitmap::from_trusted_len_iter(iter).into())
         }
     }
 }

--- a/src/compute/take/utf8.rs
+++ b/src/compute/take/utf8.rs
@@ -15,10 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::{
-    array::{Array, Offset, PrimitiveArray, Utf8Array},
-    error::Result,
-};
+use crate::array::{Array, Offset, PrimitiveArray, Utf8Array};
 
 use super::generic_binary::*;
 use super::Index;
@@ -27,19 +24,19 @@ use super::Index;
 pub fn take<O: Offset, I: Index>(
     values: &Utf8Array<O>,
     indices: &PrimitiveArray<I>,
-) -> Result<Utf8Array<O>> {
+) -> Utf8Array<O> {
     let indices_has_validity = indices.null_count() > 0;
     let values_has_validity = values.null_count() > 0;
 
     let (offsets, values, validity) = match (values_has_validity, indices_has_validity) {
         (false, false) => {
-            take_no_validity::<O, I>(values.offsets(), values.values(), indices.values())?
+            take_no_validity::<O, I>(values.offsets(), values.values(), indices.values())
         }
-        (true, false) => take_values_validity(values, indices.values())?,
-        (false, true) => take_indices_validity(values.offsets(), values.values(), indices)?,
-        (true, true) => take_values_indices_validity(values, indices)?,
+        (true, false) => take_values_validity(values, indices.values()),
+        (false, true) => take_indices_validity(values.offsets(), values.values(), indices),
+        (true, true) => take_values_indices_validity(values, indices),
     };
-    Ok(unsafe { Utf8Array::<O>::from_data_unchecked(offsets, values, validity) })
+    unsafe { Utf8Array::<O>::from_data_unchecked(offsets, values, validity) }
 }
 
 #[cfg(test)]
@@ -74,17 +71,16 @@ mod tests {
     }
 
     #[test]
-    fn all_cases() -> Result<()> {
+    fn all_cases() {
         let cases = _all_cases::<i32>();
         for (indices, input, expected) in cases {
-            let output = take(&input, &indices)?;
+            let output = take(&input, &indices);
             assert_eq!(expected, output);
         }
         let cases = _all_cases::<i64>();
         for (indices, input, expected) in cases {
-            let output = take(&input, &indices)?;
+            let output = take(&input, &indices);
             assert_eq!(expected, output);
         }
-        Ok(())
     }
 }

--- a/src/io/ipc/read/deserialize.rs
+++ b/src/io/ipc/read/deserialize.rs
@@ -389,7 +389,7 @@ where
     // Older versions of the IPC format sometimes do not report an offset
     .or_else(|_| Result::Ok(MutableBuffer::<O>::from(&[O::default()]).into()))?;
 
-    let last_offset = offsets.as_slice()[offsets.len() - 1].to_usize().unwrap();
+    let last_offset = offsets.as_slice()[offsets.len() - 1].to_usize();
     let values = read_buffer(
         buffers,
         last_offset,
@@ -435,7 +435,7 @@ where
     // Older versions of the IPC format sometimes do not report an offset
     .or_else(|_| Result::Ok(MutableBuffer::<O>::from(&[O::default()]).into()))?;
 
-    let last_offset = offsets.as_slice()[offsets.len() - 1].to_usize().unwrap();
+    let last_offset = offsets.as_slice()[offsets.len() - 1].to_usize();
     let values = read_buffer(
         buffers,
         last_offset,


### PR DESCRIPTION
This simplifies the Index trait, causing the `take` kernel to be between 2-4x faster.

```
take i32 512            time:   [862.79 ns 868.21 ns 874.56 ns]                          
                        change: [-33.747% -32.998% -32.118%] (p = 0.00 < 0.05)

take i32 1024           time:   [1.5185 us 1.5282 us 1.5390 us]                           
                        change: [-38.903% -38.083% -37.321%] (p = 0.00 < 0.05)
                        Performance has improved.

take i32 nulls 512      time:   [813.90 ns 828.49 ns 844.77 ns]                                
                        change: [-73.764% -73.410% -73.046%] (p = 0.00 < 0.05)
                        Performance has improved.

take i32 nulls 1024     time:   [1.2617 us 1.2700 us 1.2802 us]                                 
                        change: [-79.456% -79.195% -78.923%] (p = 0.00 < 0.05)
                        Performance has improved.

take bool 512           time:   [1.3314 us 1.3423 us 1.3559 us]                           
                        change: [-48.515% -47.616% -46.754%] (p = 0.00 < 0.05)
                        Performance has improved.

take bool 1024          time:   [2.3967 us 2.4097 us 2.4241 us]                            
                        change: [-49.693% -49.181% -48.634%] (p = 0.00 < 0.05)
                        Performance has improved.

take bool nulls 512     time:   [1.7849 us 1.7980 us 1.8129 us]                                 
                        change: [-30.458% -29.507% -28.549%] (p = 0.00 < 0.05)
                        Performance has improved.

take bool nulls 1024    time:   [4.0829 us 4.1156 us 4.1566 us]                                  
                        change: [-22.465% -21.353% -20.220%] (p = 0.00 < 0.05)
                        Performance has improved.

take str 512            time:   [5.7814 us 5.8284 us 5.8844 us]                          
                        change: [-50.540% -50.045% -49.548%] (p = 0.00 < 0.05)
                        Performance has improved.

take str 1024           time:   [10.532 us 10.618 us 10.707 us]                           
                        change: [-52.220% -51.457% -50.761%] (p = 0.00 < 0.05)
                        Performance has improved.

take str null indices 512                                                                             
                        time:   [6.0364 us 6.0863 us 6.1460 us]
                        change: [-51.986% -51.569% -51.101%] (p = 0.00 < 0.05)
                        Performance has improved.

take str null indices 1024                                                                             
                        time:   [11.522 us 11.605 us 11.703 us]
                        change: [-54.016% -53.406% -52.797%] (p = 0.00 < 0.05)
                        Performance has improved.

take str null values 1024                                                                             
                        time:   [23.020 us 23.204 us 23.409 us]
                        change: [-45.559% -45.176% -44.730%] (p = 0.00 < 0.05)
                        Performance has improved.

take str null values null indices 1024                                                                             
                        time:   [20.564 us 20.742 us 20.949 us]
                        change: [-43.480% -42.673% -41.946%] (p = 0.00 < 0.05)
                        Performance has improved.
```

the tradeoff is that 32bit systems will panic instead of error when the index does not fit `usize`. Most of the code already panics under this condition, so this is not a regression.