### PR TITLE
Made reading of parquet not allocate levels.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,8 +152,8 @@ jobs:
           key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.lock') }}
       - name: Setup toolchain
         run: |
-          rustup toolchain install nightly-2021-03-25
-          rustup default nightly-2021-03-25
+          rustup toolchain install nightly
+          rustup default nightly
           rustup component add rustfmt miri
       - name: Run
         env:
@@ -259,11 +259,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /github/home/target
-          key: ${{ runner.os }}-amd64-target-wasm32-cache-nightly-2021-03-25
+          key: ${{ runner.os }}-amd64-target-wasm32-cache-nightly
       - name: Setup toolchain
         run: |
-          rustup toolchain install nightly-2021-03-25
-          rustup override set nightly-2021-03-25
+          rustup toolchain install nightly
+          rustup override set nightly
           rustup component add rustfmt
           rustup target add wasm32-unknown-unknown
       - name: Build arrow crate
@@ -299,8 +299,8 @@ jobs:
           key: ${{ runner.os }}-amd64-target-simd-cache-
       - name: Setup toolchain
         run: |
-          rustup toolchain install nightly-2021-03-24
-          rustup default nightly-2021-03-24
+          rustup toolchain install nightly
+          rustup default nightly
       - name: Run
         run: |
           export CARGO_HOME="/github/home/.cargo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ ahash = { version = "0.7", optional = true }
 
 [dependencies.parquet2]
 git = "https://github.com/jorgecarleitao/parquet2"
-rev = "c582beb69fdaef294174288d47e06af086ce8ee5"
+rev = "6884ecaac9cb75814012f46d874ef04c5d69dae9"
 optional = true
 
 [dev-dependencies]

--- a/src/io/parquet/read/utils.rs
+++ b/src/io/parquet/read/utils.rs
@@ -28,22 +28,6 @@ impl<'a> Iterator for BinaryIter<'a> {
     }
 }
 
-#[inline]
-pub fn split_buffer_v1(buffer: &[u8]) -> (&[u8], &[u8]) {
-    let def_level_buffer_length = get_length(&buffer) as usize;
-    (
-        &buffer[4..4 + def_level_buffer_length],
-        &buffer[4 + def_level_buffer_length..],
-    )
-}
-
-pub fn split_buffer_v2(buffer: &[u8], def_level_buffer_length: usize) -> (&[u8], &[u8]) {
-    (
-        &buffer[..def_level_buffer_length],
-        &buffer[def_level_buffer_length..],
-    )
-}
-
 pub fn not_implemented(
     encoding: &Encoding,
     is_optional: bool,


### PR DESCRIPTION
Thus avoiding extra allocations, replacing them by an iterator.