### PR TITLE
expose utils/implementations to public API

### DIFF
--- a/src/array/binary/from.rs
+++ b/src/array/binary/from.rs
@@ -47,9 +47,7 @@ impl<O: Offset, P: AsRef<[u8]>> FromIterator<Option<P>> for BinaryArray<O> {
 /// # Safety
 /// The caller must ensure that `iterator` is `TrustedLen`.
 #[inline]
-pub(crate) unsafe fn trusted_len_unzip<O, I, P>(
-    iterator: I,
-) -> (Option<Bitmap>, Buffer<O>, Buffer<u8>)
+pub unsafe fn trusted_len_unzip<O, I, P>(iterator: I) -> (Option<Bitmap>, Buffer<O>, Buffer<u8>)
 where
     O: Offset,
     P: AsRef<[u8]>,

--- a/src/array/growable/primitive.rs
+++ b/src/array/growable/primitive.rs
@@ -143,8 +143,9 @@ mod tests {
         a.extend_validity(3);
         a.extend(0, 1, 1);
         let result: PrimitiveArray<u8> = a.into();
-        let expected = PrimitiveArray::<u8>::from(vec![Some(2), Some(3), None, None, None, Some(3)])
-            .to(DataType::UInt8);
+        let expected =
+            PrimitiveArray::<u8>::from(vec![Some(2), Some(3), None, None, None, Some(3)])
+                .to(DataType::UInt8);
         assert_eq!(result, expected);
     }
 
@@ -157,8 +158,8 @@ mod tests {
         a.extend(1, 1, 2);
         let result: PrimitiveArray<u8> = a.into();
 
-        let expected =
-            PrimitiveArray::<u8>::from(vec![Some(1), Some(2), Some(5), Some(6)]).to(DataType::UInt8);
+        let expected = PrimitiveArray::<u8>::from(vec![Some(1), Some(2), Some(5), Some(6)])
+            .to(DataType::UInt8);
         assert_eq!(result, expected);
     }
 }

--- a/src/array/growable/structure.rs
+++ b/src/array/growable/structure.rs
@@ -231,7 +231,8 @@ mod tests {
             Some("aa"),
         ]));
         let expected_int: Arc<dyn Array> = Arc::new(
-            PrimitiveArray::<i32>::from(vec![Some(2), Some(3), Some(1), Some(2)]).to(DataType::Int32),
+            PrimitiveArray::<i32>::from(vec![Some(2), Some(3), Some(1), Some(2)])
+                .to(DataType::Int32),
         );
 
         let expected = StructArray::from_data(fields, vec![expected_string, expected_int], None);

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -397,7 +397,7 @@ pub use null::NullArray;
 pub use primitive::*;
 pub use specification::{Index, Offset};
 pub use struct_::StructArray;
-pub use utf8::{MutableUtf8Array, Utf8Array};
+pub use utf8::{MutableUtf8Array, Utf8Array, Utf8ValuesIter};
 
 pub(crate) use self::ffi::buffers_children;
 pub use self::ffi::FromFfi;

--- a/src/buffer/mutable.rs
+++ b/src/buffer/mutable.rs
@@ -263,7 +263,7 @@ impl<T: NativeType> MutableBuffer<T> {
     /// # Safety
     /// The caller must ensure that the buffer was properly initialized up to `len`.
     #[inline]
-    pub(crate) unsafe fn set_len(&mut self, len: usize) {
+    pub unsafe fn set_len(&mut self, len: usize) {
         assert!(len <= self.capacity());
         self.len = len;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod alloc;
+pub mod alloc;
 pub mod array;
 pub mod bitmap;
 pub mod buffer;


### PR DESCRIPTION
This PR proposes exposing some utils/implementations to the public API. 

`Utf8ValuesIter` was already public, but could not be imported, `alloc` is public in arrow-rs and can be useful in edge cases, and 'trusted_len_unzip` is a great utility to have in a public