### PR TITLE
Improved performance of reading parquet.

### DIFF
--- a/src/io/parquet/read/primitive.rs
+++ b/src/io/parquet/read/primitive.rs
@@ -91,7 +91,6 @@ fn read_dict_buffer_optional<T, A, F>(
                 let remaining = additional - values.len();
                 let len = std::cmp::min(packed.len() * 8, remaining);
                 for is_valid in BitmapIter::new(packed, 0, len) {
-                    validity.push(is_valid);
                     let value = if is_valid {
                         op(dict_values[indices.next().unwrap() as usize])
                     } else {
@@ -99,6 +98,7 @@ fn read_dict_buffer_optional<T, A, F>(
                     };
                     values.push(value);
                 }
+                validity.extend_from_slice(packed, 0, len);
             }
             hybrid_rle::HybridEncoded::Rle(value, additional) => {
                 let is_set = value[0] == 1;
@@ -140,7 +140,6 @@ fn read_nullable<T, A, F>(
                 let remaining = additional - values.len();
                 let len = std::cmp::min(packed.len() * 8, remaining);
                 for is_valid in BitmapIter::new(packed, 0, len) {
-                    validity.push(is_valid);
                     let value = if is_valid {
                         op(chunks.next().unwrap())
                     } else {
@@ -148,6 +147,7 @@ fn read_nullable<T, A, F>(
                     };
                     values.push(value);
                 }
+                validity.extend_from_slice(packed, 0, len);
             }
             hybrid_rle::HybridEncoded::Rle(value, additional) => {
                 let is_set = value[0] == 1;

--- a/src/io/parquet/read/utf8.rs
+++ b/src/io/parquet/read/utf8.rs
@@ -46,7 +46,6 @@ pub(crate) fn read_dict_buffer<O: Offset>(
                 let remaining = length - (offsets.len() - 1);
                 let len = std::cmp::min(packed.len() * 8, remaining);
                 for is_valid in BitmapIter::new(packed, 0, len) {
-                    validity.push(is_valid);
                     if is_valid {
                         let index = indices.next().unwrap() as usize;
                         let dict_offset_i = dict_offsets[index] as usize;
@@ -57,6 +56,7 @@ pub(crate) fn read_dict_buffer<O: Offset>(
                     };
                     offsets.push(last_offset);
                 }
+                validity.extend_from_slice(packed, 0, len);
             }
             hybrid_rle::HybridEncoded::Rle(value, additional) => {
                 let is_set = value[0] == 1;
@@ -102,7 +102,6 @@ pub(crate) fn read_optional<O: Offset>(
                 let remaining = length - (offsets.len() - 1);
                 let len = std::cmp::min(packed.len() * 8, remaining);
                 for is_valid in BitmapIter::new(packed, 0, len) {
-                    validity.push(is_valid);
                     if is_valid {
                         let value = values_iterator.next().unwrap();
                         last_offset += O::from_usize(value.len()).unwrap();
@@ -110,6 +109,7 @@ pub(crate) fn read_optional<O: Offset>(
                     }
                     offsets.push(last_offset);
                 }
+                validity.extend_from_slice(packed, 0, len);
             }
             hybrid_rle::HybridEncoded::Rle(value, additional) => {
                 let is_set = value[0] == 1;


### PR DESCRIPTION
This improves reading from parquet with nulls by 40% for boolean, 20% for utf8 and 15% for primitive.

The invariant that this PR leverages is that parquet's bitpacked definition levels for non-nested nullable arrays equals arrow's bitmaps (i.e. least significant bit first). Thus, when reading bitpacked definition levels of non-nested types, instead of reading them bit by bit and using `MutableBitmap::push`, we can memcopy the byte slice to the `MutableBitmap`'s buffer directly.

There is a further optimization when performing this operation with offsets, by merging the bytes instead of iterating bit by bit but for now it falls back to bit by bit. This means that both column chunks with a single pages and chunks with pages whose size in elements is a multiple of 8 benefit from this optimization.

```bash
read bool 2^20          time:   [23.493 ms 23.596 ms 23.700 ms]                           
                        change: [-38.908% -38.564% -38.234%] (p = 0.00 < 0.05)

read utf8 2^20          time:   [119.22 ms 119.61 ms 120.03 ms]                           
                        change: [-19.704% -19.243% -18.799%] (p = 0.00 < 0.05)

read i64 2^20           time:   [109.74 ms 109.99 ms 110.24 ms]                          
                        change: [-15.462% -15.170% -14.883%] (p = 0.00 < 0.05)
```

Close #12.