### PR TITLE
Use WriteOptions from parquet crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ ahash = { version = "0.7", optional = true }
 
 [dependencies.parquet2]
 git = "https://github.com/jorgecarleitao/parquet2"
-rev = "6884ecaac9cb75814012f46d874ef04c5d69dae9"
+rev = "a37dfc484df5ca2c0aa12c34515a526ce122c764"
 optional = true
 
 [dev-dependencies]

--- a/src/io/parquet/write/boolean.rs
+++ b/src/io/parquet/write/boolean.rs
@@ -7,7 +7,6 @@ use parquet2::{
 };
 
 use super::utils;
-use super::Version;
 use crate::error::Result;
 use crate::{array::*, io::parquet::read::is_type_nullable};
 
@@ -25,13 +24,12 @@ pub fn array_to_page(
     array: &BooleanArray,
     options: WriteOptions,
     descriptor: ColumnDescriptor,
-    version: Version,
 ) -> Result<CompressedPage> {
     let is_optional = is_type_nullable(descriptor.type_());
 
     let validity = array.validity();
 
-    let buffer = utils::write_def_levels(is_optional, validity, array.len(), version)?;
+    let buffer = utils::write_def_levels(is_optional, validity, array.len(), options.version)?;
 
     let definition_levels_byte_length = buffer.len();
 
@@ -50,7 +48,7 @@ pub fn array_to_page(
 
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(buffer, version, options, definition_levels_byte_length)?;
+    let buffer = utils::compress(buffer, options, definition_levels_byte_length)?;
 
     let statistics = if options.write_statistics {
         Some(build_statistics(array))
@@ -60,7 +58,6 @@ pub fn array_to_page(
 
     utils::build_plain_page(
         buffer,
-        version,
         array.len(),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/primitive.rs
+++ b/src/io/parquet/write/primitive.rs
@@ -6,7 +6,7 @@ use parquet2::{
     write::WriteOptions,
 };
 
-use super::{utils, Version};
+use super::utils;
 use crate::{
     array::{Array, PrimitiveArray},
     error::Result,
@@ -18,7 +18,6 @@ pub fn array_to_page<T, R>(
     array: &PrimitiveArray<T>,
     options: WriteOptions,
     descriptor: ColumnDescriptor,
-    version: Version,
 ) -> Result<CompressedPage>
 where
     T: ArrowNativeType,
@@ -29,7 +28,7 @@ where
 
     let validity = array.validity();
 
-    let mut buffer = utils::write_def_levels(is_optional, validity, array.len(), version)?;
+    let mut buffer = utils::write_def_levels(is_optional, validity, array.len(), options.version)?;
 
     let definition_levels_byte_length = buffer.len();
 
@@ -50,7 +49,7 @@ where
     }
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(buffer, version, options, definition_levels_byte_length)?;
+    let buffer = utils::compress(buffer, options, definition_levels_byte_length)?;
 
     let statistics = if options.write_statistics {
         Some(build_statistics(array, descriptor.clone()))
@@ -60,7 +59,6 @@ where
 
     utils::build_plain_page(
         buffer,
-        version,
         array.len(),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/stream.rs
+++ b/src/io/parquet/write/stream.rs
@@ -1,15 +1,16 @@
 use futures::stream::Stream;
 
+use parquet2::write::RowGroupIter;
 use parquet2::{
     metadata::SchemaDescriptor, schema::KeyValue,
     write::stream::write_stream as parquet_write_stream,
 };
-use parquet2::{write::RowGroupIter, write::WriteOptions};
 
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 
 use super::schema::schema_to_metadata_key;
+use super::WriteOptions;
 
 /// Writes
 pub async fn write_stream<'a, W, I>(

--- a/src/io/parquet/write/utf8.rs
+++ b/src/io/parquet/write/utf8.rs
@@ -5,8 +5,8 @@ use parquet2::{
     write::WriteOptions,
 };
 
+use super::binary::ord_binary;
 use super::utils;
-use super::{binary::ord_binary, Version};
 use crate::{
     array::{Array, Offset, Utf8Array},
     error::Result,
@@ -17,12 +17,11 @@ pub fn array_to_page<O: Offset>(
     array: &Utf8Array<O>,
     options: WriteOptions,
     descriptor: ColumnDescriptor,
-    version: Version,
 ) -> Result<CompressedPage> {
     let validity = array.validity();
     let is_optional = is_type_nullable(descriptor.type_());
 
-    let mut buffer = utils::write_def_levels(is_optional, validity, array.len(), version)?;
+    let mut buffer = utils::write_def_levels(is_optional, validity, array.len(), options.version)?;
 
     let definition_levels_byte_length = buffer.len();
 
@@ -46,7 +45,7 @@ pub fn array_to_page<O: Offset>(
     }
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(buffer, version, options, definition_levels_byte_length)?;
+    let buffer = utils::compress(buffer, options, definition_levels_byte_length)?;
 
     let statistics = if options.write_statistics {
         Some(build_statistics(array, descriptor.clone()))
@@ -56,7 +55,6 @@ pub fn array_to_page<O: Offset>(
 
     utils::build_plain_page(
         buffer,
-        version,
         array.len(),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/utils.rs
+++ b/src/io/parquet/write/utils.rs
@@ -65,7 +65,6 @@ pub fn write_def_levels(
 #[allow(clippy::too_many_arguments)]
 pub fn build_plain_page(
     buffer: Vec<u8>,
-    version: Version,
     len: usize,
     null_count: usize,
     uncompressed_page_size: usize,
@@ -74,7 +73,7 @@ pub fn build_plain_page(
     descriptor: ColumnDescriptor,
     options: WriteOptions,
 ) -> Result<CompressedPage> {
-    match version {
+    match options.version {
         Version::V1 => {
             let header = PageHeader::V1(DataPageHeader {
                 num_values: len as i32,
@@ -119,13 +118,12 @@ pub fn build_plain_page(
 
 pub fn compress(
     mut buffer: Vec<u8>,
-    version: Version,
     options: WriteOptions,
     definition_levels_byte_length: usize,
 ) -> Result<Vec<u8>> {
     let codec = create_codec(&options.compression)?;
     Ok(if let Some(mut codec) = codec {
-        match version {
+        match options.version {
             Version::V1 => {
                 // todo: remove this allocation by extending `buffer` directly.
                 // needs refactoring `compress`'s API.


### PR DESCRIPTION
The options in the crate now contains version, and thus the struct can be re-used. Also removed un-needed arguments in internal functions.