### PR TITLE
Faster IPC write

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,3 +142,7 @@ harness = false
 [[bench]]
 name = "aggregate"
 harness = false
+
+[[bench]]
+name = "write_ipc"
+harness = false

--- a/benches/write_ipc.rs
+++ b/benches/write_ipc.rs
@@ -1,0 +1,45 @@
+use std::io::Cursor;
+use std::sync::Arc;
+
+use arrow2::record_batch::RecordBatch;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use arrow2::array::*;
+use arrow2::datatypes::{DataType, Field, Schema};
+use arrow2::error::Result;
+use arrow2::io::ipc::write::*;
+use arrow2::util::bench_util::{create_boolean_array, create_primitive_array, create_string_array};
+
+fn write(array: &dyn Array) -> Result<()> {
+    let field = Field::new("c1", array.data_type().clone(), true);
+    let schema = Schema::new(vec![field]);
+    let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![clone(array).into()])?;
+
+    let mut writer = Cursor::new(vec![]);
+    let mut writer = FileWriter::try_new(&mut writer, &schema)?;
+
+    writer.write(&batch)
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    (0..=10).step_by(2).for_each(|i| {
+        let array = &create_primitive_array::<i64>(1024 * 2usize.pow(i), DataType::Int64, 0.1);
+        let a = format!("write i64 2^{}", 10 + i);
+        c.bench_function(&a, |b| b.iter(|| write(array).unwrap()));
+    });
+
+    (0..=10).step_by(2).for_each(|i| {
+        let array = &create_boolean_array(1024 * 2usize.pow(i), 0.1, 0.5);
+        let a = format!("write bool 2^{}", 10 + i);
+        c.bench_function(&a, |b| b.iter(|| write(array).unwrap()));
+    });
+
+    (0..=10).step_by(2).for_each(|i| {
+        let array = &create_string_array::<i32>(1024 * 2usize.pow(i), 0.1);
+        let a = format!("write utf8 2^{}", 10 + i);
+        c.bench_function(&a, |b| b.iter(|| write(array).unwrap()));
+    });
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -17,7 +17,7 @@ pub trait Index: NativeType {
 /// # Safety
 /// Do not implement.
 pub unsafe trait Offset:
-    Index + NaturalDataType + Num + Ord + std::ops::AddAssign + num::CheckedAdd
+    Index + NaturalDataType + Num + Ord + std::ops::AddAssign + std::ops::Sub + num::CheckedAdd
 {
     fn is_large() -> bool;
 

--- a/src/io/ipc/write/serialize.rs
+++ b/src/io/ipc/write/serialize.rs
@@ -23,6 +23,7 @@ use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, IntervalUnit},
     io::ipc::gen::Message,
+    trusted_len::TrustedLen,
     types::{days_ms, NativeType},
 };
 
@@ -37,12 +38,7 @@ fn _write_primitive<T: NativeType>(
     offset: &mut i64,
     is_little_endian: bool,
 ) {
-    write_bytes(
-        &to_le_bytes_bitmap(array.validity(), array.len()),
-        buffers,
-        arrow_data,
-        offset,
-    );
+    write_bitmap(array.validity(), array.len(), buffers, arrow_data, offset);
     write_bytes(
         &to_bytes(array.values(), is_little_endian),
         buffers,
@@ -70,13 +66,15 @@ fn write_boolean(
     _: bool,
 ) {
     let array = array.as_any().downcast_ref::<BooleanArray>().unwrap();
-    write_bytes(
-        &to_le_bytes_bitmap(array.validity(), array.len()),
+
+    write_bitmap(array.validity(), array.len(), buffers, arrow_data, offset);
+    write_bitmap(
+        &Some(array.values().clone()),
+        array.len(),
         buffers,
         arrow_data,
         offset,
     );
-    write_bytes(&to_le_bitmap(array.values()), buffers, arrow_data, offset);
 }
 
 fn write_binary<O: Offset>(
@@ -87,12 +85,7 @@ fn write_binary<O: Offset>(
     is_little_endian: bool,
 ) {
     let array = array.as_any().downcast_ref::<BinaryArray<O>>().unwrap();
-    write_bytes(
-        &to_le_bytes_bitmap(array.validity(), array.len()),
-        buffers,
-        arrow_data,
-        offset,
-    );
+    write_bitmap(array.validity(), array.len(), buffers, arrow_data, offset);
     write_bytes(
         &to_bytes(array.offsets(), is_little_endian),
         buffers,
@@ -115,12 +108,7 @@ fn write_utf8<O: Offset>(
     is_little_endian: bool,
 ) {
     let array = array.as_any().downcast_ref::<Utf8Array<O>>().unwrap();
-    write_bytes(
-        &to_le_bytes_bitmap(array.validity(), array.len()),
-        buffers,
-        arrow_data,
-        offset,
-    );
+    write_bitmap(array.validity(), array.len(), buffers, arrow_data, offset);
     write_bytes(
         &to_bytes(array.offsets(), is_little_endian),
         buffers,
@@ -146,12 +134,7 @@ fn write_fixed_size_binary(
         .as_any()
         .downcast_ref::<FixedSizeBinaryArray>()
         .unwrap();
-    write_bytes(
-        &to_le_bytes_bitmap(array.validity(), array.len()),
-        buffers,
-        arrow_data,
-        offset,
-    );
+    write_bitmap(array.validity(), array.len(), buffers, arrow_data, offset);
     write_bytes(
         &to_bytes(array.values(), is_little_endian),
         buffers,
@@ -169,12 +152,7 @@ fn write_list<O: Offset>(
     is_little_endian: bool,
 ) {
     let array = array.as_any().downcast_ref::<ListArray<O>>().unwrap();
-    write_bytes(
-        &to_le_bytes_bitmap(array.validity(), array.len()),
-        buffers,
-        arrow_data,
-        offset,
-    );
+    write_bitmap(array.validity(), array.len(), buffers, arrow_data, offset);
     write_bytes(
         &to_bytes(array.offsets(), is_little_endian),
         buffers,
@@ -200,12 +178,7 @@ pub fn write_struct(
     is_little_endian: bool,
 ) {
     let array = array.as_any().downcast_ref::<StructArray>().unwrap();
-    write_bytes(
-        &to_le_bytes_bitmap(array.validity(), array.len()),
-        buffers,
-        arrow_data,
-        offset,
-    );
+    write_bitmap(array.validity(), array.len(), buffers, arrow_data, offset);
     array.values().iter().for_each(|array| {
         write(
             array.as_ref(),
@@ -227,12 +200,7 @@ fn write_fixed_size_list(
     is_little_endian: bool,
 ) {
     let array = array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
-    write_bytes(
-        &to_le_bytes_bitmap(array.validity(), array.len()),
-        buffers,
-        arrow_data,
-        offset,
-    );
+    write_bitmap(array.validity(), array.len(), buffers, arrow_data, offset);
     write(
         array.values().as_ref(),
         buffers,
@@ -476,6 +444,53 @@ fn write_bytes(
     *offset += total_len;
 }
 
+/// writes `bytes` to `arrow_data` updating `buffers` and `offset` and guaranteeing a 8 byte boundary.
+fn write_bytes_from_iter<I: TrustedLen<Item = u8>>(
+    bytes: I,
+    buffers: &mut Vec<Schema::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    offset: &mut i64,
+) {
+    let len = bytes.size_hint().0;
+    let pad_len = pad_to_8(len as u32);
+    let total_len: i64 = (len + pad_len) as i64;
+    // assert_eq!(len % 8, 0, "Buffer width not a multiple of 8 bytes");
+    buffers.push(Schema::Buffer::new(*offset, total_len));
+    arrow_data.extend(bytes);
+    arrow_data.extend_from_slice(&vec![0u8; pad_len][..]);
+    *offset += total_len;
+}
+
+fn write_bitmap(
+    bitmap: &Option<Bitmap>,
+    length: usize,
+    buffers: &mut Vec<Schema::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    offset: &mut i64,
+) {
+    match bitmap {
+        Some(bitmap) => {
+            assert_eq!(bitmap.len(), length);
+            if bitmap.offset() != 0 {
+                // case where we can't slice the bitmap as the offsets are not multiple of 8
+                let bytes = Bitmap::from_trusted_len_iter(bitmap.iter());
+                write_bytes(bytes.as_slice(), buffers, arrow_data, offset)
+            } else {
+                write_bytes(bitmap.as_slice(), buffers, arrow_data, offset)
+            }
+        }
+        None => {
+            // in IPC, the null bitmap is always be present
+            write_bytes_from_iter(
+                std::iter::repeat(1).take(length.saturating_add(7) / 8),
+                buffers,
+                arrow_data,
+                offset,
+            )
+        }
+    }
+}
+
 /// converts the buffer to a bytes in little endian
 #[inline]
 fn to_bytes<T: NativeType>(values: &[T], is_little_endian: bool) -> Vec<u8> {
@@ -493,32 +508,5 @@ fn to_bytes<T: NativeType>(values: &[T], is_little_endian: bool) -> Vec<u8> {
             .map(|x| x.as_ref().to_vec())
             .flatten()
             .collect::<Vec<_>>()
-    }
-}
-
-#[inline]
-fn to_le_bitmap(bitmap: &Bitmap) -> Vec<u8> {
-    if bitmap.offset() != 0 {
-        // case where we can't slice the bitmap as the offsets are not multiple of 8
-        Bitmap::from_trusted_len_iter(bitmap.iter())
-            .as_slice()
-            .to_vec()
-    } else {
-        bitmap.as_slice().to_vec()
-    }
-}
-
-#[inline]
-fn to_le_bytes_bitmap(bitmap: &Option<Bitmap>, length: usize) -> Vec<u8> {
-    match bitmap {
-        Some(bitmap) => {
-            assert_eq!(bitmap.len(), length);
-            to_le_bitmap(bitmap)
-        }
-        None => {
-            // in IPC, the null bitmap is always be present
-            let bitmap = Bitmap::from_trusted_len_iter(std::iter::repeat(true).take(length));
-            bitmap.as_slice().to_vec()
-        }
     }
 }

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -175,6 +175,34 @@ mod tests {
         read::{read_file_metadata, FileReader},
     };
 
+    fn test_round_trip(batch: RecordBatch) -> Result<()> {
+        let mut result = Vec::<u8>::new();
+
+        // write IPC version 5
+        {
+            let options = IpcWriteOptions::try_new(8, false, gen::Schema::MetadataVersion::V5)?;
+            let mut writer =
+                FileWriter::try_new_with_options(&mut result, batch.schema(), options)?;
+            writer.write(&batch)?;
+            writer.finish()?;
+        }
+        let mut reader = Cursor::new(result);
+        let metadata = read_file_metadata(&mut reader)?;
+        let schema = metadata.schema().clone();
+
+        let reader = FileReader::new(&mut reader, metadata);
+
+        // read expected JSON output
+        let (expected_schema, expected_batches) = (batch.schema().clone(), vec![batch]);
+
+        assert_eq!(schema.as_ref(), expected_schema.as_ref());
+
+        let batches = reader.collect::<Result<Vec<_>>>()?;
+
+        assert_eq!(batches, expected_batches);
+        Ok(())
+    }
+
     fn test_file(version: &str, file_name: &str) -> Result<()> {
         let (schema, batches) = read_gzip_json(version, file_name);
 
@@ -300,5 +328,32 @@ mod tests {
     fn write_100_decimal() -> Result<()> {
         test_file("1.0.0-littleendian", "generated_decimal")?;
         test_file("1.0.0-bigendian", "generated_decimal")
+    }
+
+    #[test]
+    fn write_sliced_utf8() -> Result<()> {
+        use crate::array::{Array, Utf8Array};
+        use std::sync::Arc;
+        let array =
+            Arc::new(Utf8Array::<i32>::from_slice(["aa", "bb"]).slice(1, 1)) as Arc<dyn Array>;
+        let batch = RecordBatch::try_from_iter(vec![("a", array)]).unwrap();
+        test_round_trip(batch)
+    }
+
+    #[test]
+    fn write_sliced_list() -> Result<()> {
+        use crate::array::{MutableListArray, MutablePrimitiveArray, TryExtend};
+
+        let data = vec![
+            Some(vec![Some(1i32), Some(2), Some(3)]),
+            None,
+            Some(vec![Some(4), None, Some(6)]),
+        ];
+
+        let mut array = MutableListArray::<i32, MutablePrimitiveArray<i32>>::new();
+        array.try_extend(data).unwrap();
+        let array = array.into_arc();
+        let batch = RecordBatch::try_from_iter(vec![("a", array)]).unwrap();
+        test_round_trip(batch)
     }
 }


### PR DESCRIPTION
```
write i64 2^20          time:   [6.0850 ms 6.1489 ms 6.2148 ms]                           
                        change: [-88.115% -87.932% -87.756%] (p = 0.00 < 0.05)

write bool 2^20         time:   [23.463 us 23.651 us 23.838 us]                             
                        change: [-32.607% -32.010% -31.422%] (p = 0.00 < 0.05)

write utf8 2^20         time:   [1.5520 ms 1.5613 ms 1.5710 ms]                             
                        change: [-98.498% -98.483% -98.467%] (p = 0.00 < 0.05)
```

This also reduces the size of the file for sliced arrays by only writing required values (e.g. not write values that have been sliced away).

Closes #192 