### PR TITLE
Feature gate the compute module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ doc-comment = "0.3"
 crossbeam-channel = "0.5.1"
 
 [features]
-default = ["io_csv", "io_json", "io_ipc", "io_ipc_compression", "io_json_integration", "io_print", "io_parquet", "regex", "merge_sort", "ahash", "benchmarks"]
+default = ["io_csv", "io_json", "io_ipc", "io_ipc_compression", "io_json_integration", "io_print", "io_parquet", "regex", "merge_sort", "ahash", "benchmarks", "compute"]
 merge_sort = ["itertools"]
 io_csv = ["csv", "lazy_static", "regex"]
 io_json = ["serde", "serde_derive", "serde_json", "indexmap"]
@@ -80,6 +80,8 @@ io_ipc = ["flatbuffers"]
 io_ipc_compression = ["lz4", "zstd"]
 io_json_integration = ["io_json", "hex"]
 io_print = ["prettytable-rs"]
+# the compute kernels. Disabling this significantly reduces compile time.
+compute = []
 # base64 + io_ipc because arrow schemas are stored as base64-encoded ipc format.
 io_parquet = ["parquet2", "io_ipc", "base64", "futures"]
 benchmarks = ["rand"]

--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -31,7 +31,7 @@ name = "arrow_pyarrow_integration_testing"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow2 = { path = "../", default-features = false, features = [] }
+arrow2 = { path = "../", default-features = false, features = ["compute"] }
 pyo3 = { version = "0.12.1", features = ["extension-module"] }
 
 [package.metadata.maturin]

--- a/src/io/ipc/compression.rs
+++ b/src/io/ipc/compression.rs
@@ -1,27 +1,27 @@
-use std::io::Read;
-
 use crate::error::Result;
 
 #[cfg(feature = "io_ipc_compression")]
 pub fn decompress_lz4(input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
+    use std::io::Read;
     let mut decoder = lz4::Decoder::new(input_buf)?;
     decoder.read_exact(output_buf).map_err(|e| e.into())
 }
 
 #[cfg(feature = "io_ipc_compression")]
 pub fn decompress_zstd(input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
+    use std::io::Read;
     let mut decoder = zstd::Decoder::new(input_buf)?;
     decoder.read_exact(output_buf).map_err(|e| e.into())
 }
 
 #[cfg(not(feature = "io_ipc_compression"))]
-pub fn decompress_lz4(input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
+pub fn decompress_lz4(_input_buf: &[u8], _output_buf: &mut [u8]) -> Result<()> {
     use crate::error::ArrowError;
     Err(ArrowError::Ipc("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
 }
 
 #[cfg(not(feature = "io_ipc_compression"))]
-pub fn decompress_zstd(input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
+pub fn decompress_zstd(_input_buf: &[u8], _output_buf: &mut [u8]) -> Result<()> {
     use crate::error::ArrowError;
     Err(ArrowError::Ipc("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod trusted_len;
 pub mod types;
 
+#[cfg(feature = "compute")]
 pub mod compute;
 pub mod io;
 pub mod record_batch;


### PR DESCRIPTION
There are many use-cases that do not require the compute module (e.g. converting CSV to parquet). Yet, the compute module is an expensive unit of compilation and binary size. 

This PR adds a new feature "compute" that disables the `compute` mod from the crate. This significantly improves compile times when that feature is not needed.

```
cargo clean && cargo build --no-default-features --release
Finished release [optimized] target(s) in 36.50s

6.1M libarrow2.rlib

cargo clean && cargo build --no-default-features --features compute --release
Finished release [optimized] target(s) in 1m 15s

14M libarrow2.rlib
```
