### PR TITLE
Added support to read and write delta-encoded parquet.

### DIFF
--- a/.github/workflows/integration-parquet.yml
+++ b/.github/workflows/integration-parquet.yml
@@ -46,5 +46,7 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install --upgrade pip
-          pip install pyarrow
+          pip install pyarrow pyspark
           python main.py
+          # test delta encoding against spark (pyarrow does not support it)
+          python main_spark.py

--- a/arrow-parquet-integration-testing/main_spark.py
+++ b/arrow-parquet-integration-testing/main_spark.py
@@ -1,0 +1,32 @@
+"""
+Verifies that spark can correctly read a delta-encoded utf8 column written by arrow2.
+"""
+import os
+import pyspark.sql
+
+from main import _prepare, _expected
+
+_file = "generated_primitive"
+_version = "2"
+_encoding = "delta"
+column = ("utf8_nullable", 24)
+
+expected = _expected(_file)
+expected = next(c for i, c in enumerate(expected) if i == column[1])
+expected = expected.combine_chunks().tolist()
+
+path = _prepare(_file, _version, _encoding, [column[1]])
+
+spark = pyspark.sql.SparkSession.builder.config(
+    # see https://stackoverflow.com/a/62024670/931303
+    "spark.sql.parquet.enableVectorizedReader",
+    "false",
+).getOrCreate()
+
+df = spark.read.parquet(path)
+
+r = df.select(column[0]).collect()
+os.remove(path)
+
+result = [r[column[0]] for r in r]
+assert expected == result

--- a/arrow-parquet-integration-testing/src/main.rs
+++ b/arrow-parquet-integration-testing/src/main.rs
@@ -1,8 +1,10 @@
 use std::fs::File;
+use std::sync::Arc;
 use std::{collections::HashMap, convert::TryFrom, io::Read};
 
+use arrow2::datatypes::DataType;
 use arrow2::error::Result;
-use arrow2::io::parquet::write::RowGroupIterator;
+use arrow2::io::parquet::write::{Encoding, RowGroupIterator};
 use arrow2::io::{
     json_integration::ArrowJson,
     parquet::write::{write_file, CompressionCodec, Version, WriteOptions},
@@ -68,6 +70,18 @@ fn main() -> Result<()> {
                 .required(true)
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("projection")
+                .long("projection")
+                .required(false)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("encoding-utf8")
+                .long("encoding-utf8")
+                .required(true)
+                .takes_value(true),
+        )
         .get_matches();
     let json_file = matches
         .value_of("json")
@@ -78,8 +92,59 @@ fn main() -> Result<()> {
     let version = matches
         .value_of("version")
         .expect("must provide version of parquet");
+    let projection = matches.value_of("projection");
+    let utf8_encoding = matches
+        .value_of("encoding-utf8")
+        .expect("must provide utf8 type encoding");
+
+    let projection = projection.map(|x| {
+        x.split(',')
+            .map(|x| x.parse::<usize>().unwrap())
+            .collect::<Vec<_>>()
+    });
 
     let (schema, batches) = read_gzip_json("1.0.0-littleendian", json_file);
+
+    let schema = if let Some(projection) = &projection {
+        let fields = schema
+            .fields()
+            .iter()
+            .enumerate()
+            .filter_map(|(i, f)| {
+                if projection.contains(&i) {
+                    Some(f.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        Schema::new(fields)
+    } else {
+        schema
+    };
+
+    let batches = if let Some(projection) = &projection {
+        batches
+            .iter()
+            .map(|batch| {
+                let columns = batch
+                    .columns()
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, f)| {
+                        if projection.contains(&i) {
+                            Some(f.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
+                RecordBatch::try_new(Arc::new(schema.clone()), columns).unwrap()
+            })
+            .collect::<Vec<_>>()
+    } else {
+        batches
+    };
 
     let version = if version == "1" {
         Version::V1
@@ -93,7 +158,23 @@ fn main() -> Result<()> {
         version,
     };
 
-    let row_groups = RowGroupIterator::try_new(batches.into_iter().map(Ok), &schema, options)?;
+    let encodings = schema
+        .fields()
+        .iter()
+        .map(|x| match x.data_type() {
+            DataType::Utf8 | DataType::LargeUtf8 => {
+                if utf8_encoding == "delta" {
+                    Encoding::DeltaLengthByteArray
+                } else {
+                    Encoding::Plain
+                }
+            }
+            _ => Encoding::Plain,
+        })
+        .collect();
+
+    let row_groups =
+        RowGroupIterator::try_new(batches.into_iter().map(Ok), &schema, options, encodings)?;
     let parquet_schema = row_groups.parquet_schema().clone();
 
     let mut writer = File::create(write_path)?;

--- a/examples/parquet_write.rs
+++ b/examples/parquet_write.rs
@@ -7,7 +7,7 @@ use arrow2::{
     datatypes::{Field, Schema},
     error::Result,
     io::parquet::write::{
-        array_to_page, write_file, CompressionCodec, DynIter, Version, WriteOptions,
+        array_to_page, write_file, CompressionCodec, DynIter, Encoding, Version, WriteOptions,
     },
 };
 
@@ -19,6 +19,7 @@ fn write_single_array(path: &str, array: &dyn Array, field: Field) -> Result<()>
         compression: CompressionCodec::Uncompressed,
         version: Version::V2,
     };
+    let encoding = Encoding::Plain;
 
     // map arrow fields to parquet fields
     let parquet_schema = to_parquet_schema(&schema)?;
@@ -32,7 +33,7 @@ fn write_single_array(path: &str, array: &dyn Array, field: Field) -> Result<()>
     let row_groups = once(Result::Ok(DynIter::new(once(Ok(DynIter::new(
         once(array)
             .zip(parquet_schema.columns().to_vec().into_iter())
-            .map(|(array, descriptor)| array_to_page(array, descriptor, options)),
+            .map(|(array, descriptor)| array_to_page(array, descriptor, options, encoding)),
     ))))));
 
     // Create a new empty file

--- a/examples/parquet_write_record.rs
+++ b/examples/parquet_write_record.rs
@@ -8,6 +8,7 @@ use arrow2::{
     io::parquet::write::{write_file, CompressionCodec, RowGroupIterator, Version, WriteOptions},
     record_batch::RecordBatch,
 };
+use parquet2::schema::Encoding;
 
 fn write_batch(path: &str, batch: RecordBatch) -> Result<()> {
     let schema = batch.schema().clone();
@@ -20,7 +21,8 @@ fn write_batch(path: &str, batch: RecordBatch) -> Result<()> {
 
     let iter = vec![Ok(batch)];
 
-    let row_groups = RowGroupIterator::try_new(iter.into_iter(), &schema, options)?;
+    let row_groups =
+        RowGroupIterator::try_new(iter.into_iter(), &schema, options, vec![Encoding::Plain])?;
 
     // Create a new empty file
     let mut file = File::create(path)?;

--- a/src/array/binary/iterator.rs
+++ b/src/array/binary/iterator.rs
@@ -6,6 +6,7 @@ use crate::{
 
 use super::BinaryArray;
 
+#[derive(Debug, Clone)]
 pub struct BinaryValueIter<'a, O: Offset> {
     array: &'a BinaryArray<O>,
     index: usize,

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -21,7 +21,11 @@ pub unsafe trait Offset:
 {
     fn is_large() -> bool;
 
+    fn to_isize(&self) -> isize;
+
     fn from_usize(value: usize) -> Option<Self>;
+
+    fn from_isize(value: isize) -> Option<Self>;
 }
 
 unsafe impl Offset for i32 {
@@ -34,6 +38,16 @@ unsafe impl Offset for i32 {
     fn from_usize(value: usize) -> Option<Self> {
         Self::try_from(value).ok()
     }
+
+    #[inline]
+    fn from_isize(value: isize) -> Option<Self> {
+        Self::try_from(value).ok()
+    }
+
+    #[inline]
+    fn to_isize(&self) -> isize {
+        *self as isize
+    }
 }
 
 unsafe impl Offset for i64 {
@@ -45,6 +59,16 @@ unsafe impl Offset for i64 {
     #[inline]
     fn from_usize(value: usize) -> Option<Self> {
         Some(value as i64)
+    }
+
+    #[inline]
+    fn from_isize(value: isize) -> Option<Self> {
+        Self::try_from(value).ok()
+    }
+
+    #[inline]
+    fn to_isize(&self) -> isize {
+        *self as isize
     }
 }
 

--- a/src/array/utf8/iterator.rs
+++ b/src/array/utf8/iterator.rs
@@ -7,6 +7,7 @@ use crate::{
 use super::Utf8Array;
 
 /// Iterator of values of an `Utf8Array`.
+#[derive(Debug, Clone)]
 pub struct Utf8ValuesIter<'a, O: Offset> {
     array: &'a Utf8Array<O>,
     index: usize,

--- a/src/bitmap/utils/iterator.rs
+++ b/src/bitmap/utils/iterator.rs
@@ -4,6 +4,7 @@ use super::get_bit_unchecked;
 
 /// An iterator over bits according to the [LSB](https://en.wikipedia.org/wiki/Bit_numbering#Least_significant_bit),
 /// i.e. the bytes `[4u8, 128u8]` correspond to `[false, false, true, false, ..., true]`.
+#[derive(Debug, Clone)]
 pub struct BitmapIter<'a> {
     bytes: &'a [u8],
     index: usize,

--- a/src/bitmap/utils/zip_validity.rs
+++ b/src/bitmap/utils/zip_validity.rs
@@ -10,6 +10,16 @@ pub struct ZipValidity<'a, T, I: Iterator<Item = T>> {
     has_validity: bool,
 }
 
+impl<'a, T, I: Iterator<Item = T> + Clone> Clone for ZipValidity<'a, T, I> {
+    fn clone(&self) -> Self {
+        Self {
+            values: self.values.clone(),
+            validity_iter: self.validity_iter.clone(),
+            has_validity: self.has_validity,
+        }
+    }
+}
+
 impl<'a, T, I: Iterator<Item = T>> ZipValidity<'a, T, I> {
     #[inline]
     pub fn new(values: I, validity: &'a Option<Bitmap>) -> Self {

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -429,6 +429,7 @@ mod tests_integration {
                         array.as_ref(),
                         type_,
                         options,
+                        Encoding::Plain,
                     ))))
                 },
             ));

--- a/src/io/parquet/read/binary/nested.rs
+++ b/src/io/parquet/read/binary/nested.rs
@@ -11,7 +11,7 @@ use parquet2::{
 
 use super::super::nested_utils::*;
 use super::super::utils;
-use super::basic::read_required;
+use super::basic::read_plain_required;
 use crate::{
     array::{Array, BinaryArray, Offset, Utf8Array},
     bitmap::MutableBitmap,
@@ -85,7 +85,7 @@ fn read<O: Offset>(
                     validity,
                 )
             } else {
-                read_required(values_buffer, additional, offsets, values)
+                read_plain_required(values_buffer, additional, offsets, values)
             }
 
             let def_levels = RLEDecoder::new(

--- a/src/io/parquet/write/binary/mod.rs
+++ b/src/io/parquet/write/binary/mod.rs
@@ -2,5 +2,5 @@ mod basic;
 mod nested;
 
 pub use basic::array_to_page;
-pub(super) use basic::ord_binary;
+pub(super) use basic::{encode_delta, ord_binary};
 pub use nested::array_to_page as nested_array_to_page;

--- a/src/io/parquet/write/binary/nested.rs
+++ b/src/io/parquet/write/binary/nested.rs
@@ -1,3 +1,4 @@
+use parquet2::schema::Encoding;
 use parquet2::{metadata::ColumnDescriptor, read::CompressedPage, write::WriteOptions};
 
 use super::super::{levels, utils};
@@ -55,5 +56,6 @@ where
         statistics,
         descriptor,
         options,
+        Encoding::Plain,
     )
 }

--- a/src/io/parquet/write/boolean/basic.rs
+++ b/src/io/parquet/write/boolean/basic.rs
@@ -2,6 +2,7 @@ use parquet2::{
     encoding::hybrid_rle::bitpacked_encode,
     metadata::ColumnDescriptor,
     read::CompressedPage,
+    schema::Encoding,
     statistics::{serialize_statistics, BooleanStatistics, ParquetStatistics, Statistics},
     write::WriteOptions,
 };
@@ -80,6 +81,7 @@ pub fn array_to_page(
         statistics,
         descriptor,
         options,
+        Encoding::Plain,
     )
 }
 

--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -1,3 +1,4 @@
+use parquet2::schema::Encoding;
 use parquet2::{metadata::ColumnDescriptor, read::CompressedPage, write::WriteOptions};
 
 use super::super::{levels, utils};
@@ -54,5 +55,6 @@ where
         statistics,
         descriptor,
         options,
+        Encoding::Plain,
     )
 }

--- a/src/io/parquet/write/fixed_len_bytes.rs
+++ b/src/io/parquet/write/fixed_len_bytes.rs
@@ -1,5 +1,5 @@
 use parquet2::{
-    compression::create_codec, metadata::ColumnDescriptor, read::CompressedPage,
+    compression::create_codec, metadata::ColumnDescriptor, read::CompressedPage, schema::Encoding,
     write::WriteOptions,
 };
 
@@ -64,5 +64,6 @@ pub fn array_to_page(
         None,
         descriptor,
         options,
+        Encoding::Plain,
     )
 }

--- a/src/io/parquet/write/primitive/basic.rs
+++ b/src/io/parquet/write/primitive/basic.rs
@@ -1,6 +1,7 @@
 use parquet2::{
     metadata::ColumnDescriptor,
     read::CompressedPage,
+    schema::Encoding,
     statistics::{serialize_statistics, ParquetStatistics, PrimitiveStatistics, Statistics},
     types::NativeType,
     write::WriteOptions,
@@ -84,6 +85,7 @@ where
         statistics,
         descriptor,
         options,
+        Encoding::Plain,
     )
 }
 

--- a/src/io/parquet/write/primitive/nested.rs
+++ b/src/io/parquet/write/primitive/nested.rs
@@ -1,3 +1,4 @@
+use parquet2::schema::Encoding;
 use parquet2::{
     metadata::ColumnDescriptor, read::CompressedPage, types::NativeType, write::WriteOptions,
 };
@@ -61,5 +62,6 @@ where
         statistics,
         descriptor,
         options,
+        Encoding::Plain,
     )
 }

--- a/src/io/parquet/write/utf8/nested.rs
+++ b/src/io/parquet/write/utf8/nested.rs
@@ -1,3 +1,4 @@
+use parquet2::schema::Encoding;
 use parquet2::{metadata::ColumnDescriptor, read::CompressedPage, write::WriteOptions};
 
 use super::super::{levels, utils};
@@ -55,5 +56,6 @@ where
         statistics,
         descriptor,
         options,
+        Encoding::Plain,
     )
 }


### PR DESCRIPTION
This PR adds support to read and write [Delta-length encoded](https://github.com/apache/parquet-format/blob/master/Encodings.md#delta-length-byte-array-delta_length_byte_array--6) utf8 and binary to and from parquet. This encoding lends well to both arrow and compression, as values are encoded back to back.

Reading and writing with this encoding results in a higher compression at no performance difference. The major downside is that pyarrow does not support it and spark seems to require a config option to support it 🙄

```
write utf8 2^20         time:   [20.590 ms 20.744 ms 20.920 ms]
write utf8 delta 2^20   time:   [19.031 ms 19.108 ms 19.194 ms]
```

This PR includes:
* an integration test against pyspark (reading from arrow2)
* a round-trip across arrow2

integration tests against pyarrow are skipped since pyarrow does not support this encoding yet. Filed [ARROW-13388]( https://issues.apache.org/jira/browse/ARROW-13388) to track it.