### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ venv/bin/python parquet_integration/write_parquet.py
 * Uses Rust's compiler whenever possible to prove that memory reads are sound
 * Reading parquet is 10-20x faster (single core) and deserialization is parallelizable
 * Writing parquet is 3-10x faster (single core) and serialization is parallelizable
+* MIRI checks on non-IO components (MIRI and file systems are a bit funny atm)
 * parquet IO has no `unsafe`
 * IPC supports big endian
 * More predictable JSON reader


### PR DESCRIPTION
Despite by assertion to the contrary on https://github.com/jorgecarleitao/arrow2/pull/209, it appears that the official rust crate does in fact ignore the output of the MIRI test run (still) 🤦 

Thus restore this item to the readme until we fix it in the official crate

Sorry for the noise @jorgecarleitao 