### PR TITLE
Added support for limited sort

### DIFF
--- a/benches/sort_kernel.rs
+++ b/benches/sort_kernel.rs
@@ -35,11 +35,11 @@ fn bench_lexsort(arr_a: &dyn Array, array_b: &dyn Array) {
         },
     ];
 
-    criterion::black_box(lexsort(&columns).unwrap());
+    criterion::black_box(lexsort(&columns, None).unwrap());
 }
 
 fn bench_sort(arr_a: &dyn Array) {
-    sort(criterion::black_box(arr_a), &SortOptions::default()).unwrap();
+    sort(criterion::black_box(arr_a), &SortOptions::default(), None).unwrap();
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/benches/sort_kernel.rs
+++ b/benches/sort_kernel.rs
@@ -66,6 +66,11 @@ fn add_benchmark(c: &mut Criterion) {
         c.bench_function(&format!("lexsort null 2^{} f32", log2_size), |b| {
             b.iter(|| bench_lexsort(&arr_a, &arr_b))
         });
+
+        let arr_a = create_string_array::<i32>(size, 0.1);
+        c.bench_function(&format!("sort utf8 null 2^{}", log2_size), |b| {
+            b.iter(|| bench_sort(&arr_a))
+        });
     });
 }
 

--- a/src/buffer/mutable.rs
+++ b/src/buffer/mutable.rs
@@ -186,6 +186,15 @@ impl<T: NativeType> MutableBuffer<T> {
         self.len = 0
     }
 
+    /// Shortens the buffer.
+    /// If `len` is greater or equal to the buffers' current length, this has no effect.
+    #[inline]
+    pub fn truncate(&mut self, len: usize) {
+        if len < self.len {
+            self.len = len;
+        }
+    }
+
     /// Returns the data stored in this buffer as a slice.
     #[inline]
     pub fn as_slice(&self) -> &[T] {

--- a/src/compute/merge_sort/mod.rs
+++ b/src/compute/merge_sort/mod.rs
@@ -637,8 +637,8 @@ mod tests {
         let options = SortOptions::default();
 
         // sort individually, potentially in parallel.
-        let a0 = sort(a0, &options)?;
-        let a1 = sort(a1, &options)?;
+        let a0 = sort(a0, &options, None)?;
+        let a1 = sort(a1, &options, None)?;
 
         // merge then. If multiple arrays, this can be applied in parallel.
         let result = merge_sort(a0.as_ref(), a1.as_ref(), &options)?;

--- a/src/compute/sort/boolean.rs
+++ b/src/compute/sort/boolean.rs
@@ -1,0 +1,52 @@
+use crate::{
+    array::{Array, BooleanArray, Int32Array},
+    buffer::MutableBuffer,
+    datatypes::DataType,
+};
+
+use super::SortOptions;
+
+/// Returns the indices that would sort a [`BooleanArray`].
+pub fn sort_boolean(
+    values: &BooleanArray,
+    value_indices: Vec<i32>,
+    null_indices: Vec<i32>,
+    options: &SortOptions,
+    limit: Option<usize>,
+) -> Int32Array {
+    let descending = options.descending;
+
+    // create tuples that are used for sorting
+    let mut valids = value_indices
+        .into_iter()
+        .map(|index| (index, values.value(index as usize)))
+        .collect::<Vec<(i32, bool)>>();
+
+    let mut nulls = null_indices;
+
+    if !descending {
+        valids.sort_by(|a, b| a.1.cmp(&b.1));
+    } else {
+        valids.sort_by(|a, b| a.1.cmp(&b.1).reverse());
+        // reverse to keep a stable ordering
+        nulls.reverse();
+    }
+
+    let mut values = MutableBuffer::<i32>::with_capacity(values.len());
+
+    if options.nulls_first {
+        values.extend_from_slice(nulls.as_slice());
+        valids.iter().for_each(|x| values.push(x.0));
+    } else {
+        // nulls last
+        valids.iter().for_each(|x| values.push(x.0));
+        values.extend_from_slice(nulls.as_slice());
+    }
+
+    // un-efficient; there are much more performant ways of sorting nulls above, anyways.
+    if let Some(limit) = limit {
+        values.truncate(limit);
+    }
+
+    Int32Array::from_data(DataType::Int32, values.into(), None)
+}

--- a/src/compute/sort/common.rs
+++ b/src/compute/sort/common.rs
@@ -1,0 +1,76 @@
+/// # Safety
+/// `indices[i] < values.len()` for all i
+/// `limit < values.len()`
+#[inline]
+unsafe fn k_element_sort_inner<T, G, F>(
+    indices: &mut [i32],
+    get: G,
+    descending: bool,
+    limit: usize,
+    mut cmp: F,
+) where
+    G: Fn(usize) -> T,
+    F: FnMut(&T, &T) -> std::cmp::Ordering,
+{
+    if descending {
+        let compare = |lhs: &i32, rhs: &i32| {
+            let lhs = get(*lhs as usize);
+            let rhs = get(*rhs as usize);
+            cmp(&lhs, &rhs).reverse()
+        };
+        let (before, _, _) = indices.select_nth_unstable_by(limit, compare);
+        let compare = |lhs: &i32, rhs: &i32| {
+            let lhs = get(*lhs as usize);
+            let rhs = get(*rhs as usize);
+            cmp(&lhs, &rhs).reverse()
+        };
+        before.sort_unstable_by(compare);
+    } else {
+        let compare = |lhs: &i32, rhs: &i32| {
+            let lhs = get(*lhs as usize);
+            let rhs = get(*rhs as usize);
+            cmp(&lhs, &rhs)
+        };
+        let (before, _, _) = indices.select_nth_unstable_by(limit, compare);
+        let compare = |lhs: &i32, rhs: &i32| {
+            let lhs = get(*lhs as usize);
+            let rhs = get(*rhs as usize);
+            cmp(&lhs, &rhs)
+        };
+        before.sort_unstable_by(compare);
+    }
+}
+
+/// # Safety
+/// Safe iff
+/// * `indices[i] < values.len()` for all i
+/// * `limit < values.len()`
+#[inline]
+pub(super) unsafe fn sort_unstable_by<T, G, F>(
+    indices: &mut [i32],
+    get: G,
+    mut cmp: F,
+    descending: bool,
+    limit: usize,
+) where
+    G: Fn(usize) -> T,
+    F: FnMut(&T, &T) -> std::cmp::Ordering,
+{
+    if limit != indices.len() {
+        return k_element_sort_inner(indices, get, descending, limit, cmp);
+    }
+
+    if descending {
+        indices.sort_unstable_by(|lhs, rhs| {
+            let lhs = get(*lhs as usize);
+            let rhs = get(*rhs as usize);
+            cmp(&lhs, &rhs).reverse()
+        })
+    } else {
+        indices.sort_unstable_by(|lhs, rhs| {
+            let lhs = get(*lhs as usize);
+            let rhs = get(*rhs as usize);
+            cmp(&lhs, &rhs)
+        })
+    }
+}

--- a/src/compute/sort/common.rs
+++ b/src/compute/sort/common.rs
@@ -1,8 +1,13 @@
+use crate::{array::PrimitiveArray, bitmap::Bitmap, buffer::MutableBuffer, datatypes::DataType};
+
+use super::SortOptions;
+
 /// # Safety
-/// `indices[i] < values.len()` for all i
-/// `limit < values.len()`
+/// This function guarantees that:
+/// * `get` is only called for `0 <= i < limit`
+/// * `cmp` is only called from the co-domain of `get`.
 #[inline]
-unsafe fn k_element_sort_inner<T, G, F>(
+fn k_element_sort_inner<T, G, F>(
     indices: &mut [i32],
     get: G,
     descending: bool,
@@ -42,11 +47,11 @@ unsafe fn k_element_sort_inner<T, G, F>(
 }
 
 /// # Safety
-/// Safe iff
-/// * `indices[i] < values.len()` for all i
-/// * `limit < values.len()`
+/// This function guarantees that:
+/// * `get` is only called for `0 <= i < limit`
+/// * `cmp` is only called from the co-domain of `get`.
 #[inline]
-pub(super) unsafe fn sort_unstable_by<T, G, F>(
+fn sort_unstable_by<T, G, F>(
     indices: &mut [i32],
     get: G,
     mut cmp: F,
@@ -73,4 +78,102 @@ pub(super) unsafe fn sort_unstable_by<T, G, F>(
             cmp(&lhs, &rhs)
         })
     }
+}
+
+/// # Safety
+/// This function guarantees that:
+/// * `get` is only called for `0 <= i < length`
+/// * `cmp` is only called from the co-domain of `get`.
+#[inline]
+pub(super) fn indices_sorted_unstable_by<T, G, F>(
+    validity: &Option<Bitmap>,
+    get: G,
+    cmp: F,
+    length: usize,
+    options: &SortOptions,
+    limit: Option<usize>,
+) -> PrimitiveArray<i32>
+where
+    G: Fn(usize) -> T,
+    F: Fn(&T, &T) -> std::cmp::Ordering,
+{
+    let descending = options.descending;
+
+    let limit = limit.unwrap_or(length);
+    // Safety: without this, we go out of bounds when limit >= length.
+    let limit = limit.min(length);
+
+    let indices = if let Some(validity) = validity {
+        let mut indices = MutableBuffer::<i32>::from_len_zeroed(length);
+
+        if options.nulls_first {
+            let mut nulls = 0;
+            let mut valids = 0;
+            validity
+                .iter()
+                .zip(0..length as i32)
+                .for_each(|(is_valid, index)| {
+                    if is_valid {
+                        indices[validity.null_count() + valids] = index;
+                        valids += 1;
+                    } else {
+                        indices[nulls] = index;
+                        nulls += 1;
+                    }
+                });
+
+            if limit > validity.null_count() {
+                // when limit is larger, we must sort values:
+
+                // Soundness:
+                // all indices in `indices` are by construction `< array.len() == values.len()`
+                // limit is by construction < indices.len()
+                let limit = limit - validity.null_count();
+                let indices = &mut indices.as_mut_slice()[validity.null_count()..];
+                sort_unstable_by(indices, get, cmp, options.descending, limit)
+            }
+        } else {
+            let last_valid_index = length - validity.null_count();
+            let mut nulls = 0;
+            let mut valids = 0;
+            validity
+                .iter()
+                .zip(0..length as i32)
+                .for_each(|(x, index)| {
+                    if x {
+                        indices[valids] = index;
+                        valids += 1;
+                    } else {
+                        indices[last_valid_index + nulls] = index;
+                        nulls += 1;
+                    }
+                });
+
+            // Soundness:
+            // all indices in `indices` are by construction `< array.len() == values.len()`
+            // limit is by construction <= values.len()
+            let limit = limit.min(last_valid_index);
+            let indices = &mut indices.as_mut_slice()[..last_valid_index];
+            sort_unstable_by(indices, get, cmp, options.descending, limit);
+        }
+
+        indices.truncate(limit);
+        indices.shrink_to_fit();
+
+        indices
+    } else {
+        let mut indices =
+            unsafe { MutableBuffer::from_trusted_len_iter_unchecked(0..length as i32) };
+
+        // Soundness:
+        // indices are by construction `< values.len()`
+        // limit is by construction `< values.len()`
+        sort_unstable_by(&mut indices, get, cmp, descending, limit);
+
+        indices.truncate(limit);
+        indices.shrink_to_fit();
+
+        indices
+    };
+    PrimitiveArray::<i32>::from_data(DataType::Int32, indices.into(), None)
 }

--- a/src/compute/sort/lex_sort.rs
+++ b/src/compute/sort/lex_sort.rs
@@ -49,7 +49,7 @@ pub struct SortColumn<'a> {
 ///             nulls_first: false,
 ///         }),
 ///     },
-/// ]).unwrap();
+/// ], None).unwrap();
 ///
 /// let sorted = sorted_columns[0].as_any().downcast_ref::<Int64Array>().unwrap();
 /// assert_eq!(sorted.value(1), -64);

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -14,6 +14,7 @@ use crate::buffer::MutableBuffer;
 use num::ToPrimitive;
 
 mod boolean;
+mod common;
 mod lex_sort;
 mod primitive;
 

--- a/src/compute/sort/primitive/indices.rs
+++ b/src/compute/sort/primitive/indices.rs
@@ -1,20 +1,3 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 use crate::{
     array::{Array, PrimitiveArray},
     buffer::MutableBuffer,
@@ -27,19 +10,72 @@ use super::super::SortOptions;
 /// # Safety
 /// `indices[i] < values.len()` for all i
 #[inline]
-unsafe fn sort_inner<T, F>(indices: &mut [i32], values: &[T], mut cmp: F, descending: bool)
-where
+unsafe fn k_element_sort_inner<T, F>(
+    indices: &mut [i32],
+    values: &[T],
+    descending: bool,
+    limit: usize,
+    mut cmp: F,
+) where
     T: NativeType,
     F: FnMut(&T, &T) -> std::cmp::Ordering,
 {
     if descending {
-        indices.sort_by(|lhs, rhs| {
+        let compare = |lhs: &i32, rhs: &i32| {
+            let lhs = values.get_unchecked(*lhs as usize);
+            let rhs = values.get_unchecked(*rhs as usize);
+            cmp(lhs, rhs).reverse()
+        };
+        let (before, _, _) = indices.select_nth_unstable_by(limit, compare);
+        let compare = |lhs: &i32, rhs: &i32| {
+            let lhs = values.get_unchecked(*lhs as usize);
+            let rhs = values.get_unchecked(*rhs as usize);
+            cmp(lhs, rhs).reverse()
+        };
+        before.sort_unstable_by(compare);
+    } else {
+        let compare = |lhs: &i32, rhs: &i32| {
+            let lhs = values.get_unchecked(*lhs as usize);
+            let rhs = values.get_unchecked(*rhs as usize);
+            cmp(lhs, rhs)
+        };
+        let (before, _, _) = indices.select_nth_unstable_by(limit, compare);
+        let compare = |lhs: &i32, rhs: &i32| {
+            let lhs = values.get_unchecked(*lhs as usize);
+            let rhs = values.get_unchecked(*rhs as usize);
+            cmp(lhs, rhs)
+        };
+        before.sort_unstable_by(compare);
+    }
+}
+
+/// # Safety
+/// Safe iff
+/// * `indices[i] < values.len()` for all i
+/// * `limit < values.len()`
+#[inline]
+unsafe fn sort_unstable_by<T, F>(
+    indices: &mut [i32],
+    values: &[T],
+    mut cmp: F,
+    descending: bool,
+    limit: usize,
+) where
+    T: NativeType,
+    F: FnMut(&T, &T) -> std::cmp::Ordering,
+{
+    if limit != indices.len() {
+        return k_element_sort_inner(indices, values, descending, limit, cmp);
+    }
+
+    if descending {
+        indices.sort_unstable_by(|lhs, rhs| {
             let lhs = values.get_unchecked(*lhs as usize);
             let rhs = values.get_unchecked(*rhs as usize);
             cmp(lhs, rhs).reverse()
         })
     } else {
-        indices.sort_by(|lhs, rhs| {
+        indices.sort_unstable_by(|lhs, rhs| {
             let lhs = values.get_unchecked(*lhs as usize);
             let rhs = values.get_unchecked(*rhs as usize);
             cmp(lhs, rhs)
@@ -47,10 +83,12 @@ where
     }
 }
 
-pub fn indices_sorted_by<T, F>(
+/// Unstable sort of indices.
+pub fn indices_sorted_unstable_by<T, F>(
     array: &PrimitiveArray<T>,
     cmp: F,
     options: &SortOptions,
+    limit: Option<usize>,
 ) -> PrimitiveArray<i32>
 where
     T: NativeType,
@@ -60,7 +98,11 @@ where
     let values = array.values();
     let validity = array.validity();
 
-    if let Some(validity) = validity {
+    let limit = limit.unwrap_or_else(|| array.len());
+    // Safety: without this, we go out of bounds when limit >= array.len().
+    let limit = limit.min(array.len());
+
+    let indices = if let Some(validity) = validity {
         let mut indices = MutableBuffer::<i32>::from_len_zeroed(array.len());
 
         if options.nulls_first {
@@ -69,8 +111,8 @@ where
             validity
                 .iter()
                 .zip(0..array.len() as i32)
-                .for_each(|(x, index)| {
-                    if x {
+                .for_each(|(is_valid, index)| {
+                    if is_valid {
                         indices[validity.null_count() + valids] = index;
                         valids += 1;
                     } else {
@@ -78,15 +120,16 @@ where
                         nulls += 1;
                     }
                 });
-            // Soundness:
-            // all indices in `indices` are by construction `< array.len() == values.len()`
-            unsafe {
-                sort_inner(
-                    &mut indices.as_mut_slice()[validity.null_count()..],
-                    values,
-                    cmp,
-                    options.descending,
-                )
+
+            if limit > validity.null_count() {
+                // when limit is larger, we must sort values:
+
+                // Soundness:
+                // all indices in `indices` are by construction `< array.len() == values.len()`
+                // limit is by construction < indices.len()
+                let limit = limit - validity.null_count();
+                let indices = &mut indices.as_mut_slice()[validity.null_count()..];
+                unsafe { sort_unstable_by(indices, values, cmp, options.descending, limit) }
             }
         } else {
             let last_valid_index = array.len() - validity.null_count();
@@ -107,27 +150,31 @@ where
 
             // Soundness:
             // all indices in `indices` are by construction `< array.len() == values.len()`
-            unsafe {
-                sort_inner(
-                    &mut indices.as_mut_slice()[..last_valid_index],
-                    values,
-                    cmp,
-                    options.descending,
-                )
-            };
+            // limit is by construction <= values.len()
+            let limit = limit.min(last_valid_index);
+            let indices = &mut indices.as_mut_slice()[..last_valid_index];
+            unsafe { sort_unstable_by(indices, values, cmp, options.descending, limit) };
         }
 
-        PrimitiveArray::<i32>::from_data(DataType::Int32, indices.into(), None)
+        indices.truncate(limit);
+        indices.shrink_to_fit();
+
+        indices
     } else {
         let mut indices =
             unsafe { MutableBuffer::from_trusted_len_iter_unchecked(0..values.len() as i32) };
 
         // Soundness:
         // indices are by construction `< values.len()`
-        unsafe { sort_inner(&mut indices, values, cmp, descending) };
+        // limit is by construction `< values.len()`
+        unsafe { sort_unstable_by(&mut indices, values, cmp, descending, limit) };
 
-        PrimitiveArray::<i32>::from_data(DataType::Int32, indices.into(), None)
-    }
+        indices.truncate(limit);
+        indices.shrink_to_fit();
+
+        indices
+    };
+    PrimitiveArray::<i32>::from_data(DataType::Int32, indices.into(), None)
 }
 
 #[cfg(test)]
@@ -136,13 +183,18 @@ mod tests {
     use crate::array::ord;
     use crate::array::*;
 
-    fn test<T>(data: &[Option<T>], data_type: DataType, options: SortOptions, expected_data: &[i32])
-    where
+    fn test<T>(
+        data: &[Option<T>],
+        data_type: DataType,
+        options: SortOptions,
+        limit: Option<usize>,
+        expected_data: &[i32],
+    ) where
         T: NativeType + std::cmp::Ord,
     {
         let input = PrimitiveArray::<T>::from(data).to(data_type);
         let expected = Int32Array::from_slice(&expected_data);
-        let output = indices_sorted_by(&input, ord::total_cmp, &options);
+        let output = indices_sorted_unstable_by(&input, ord::total_cmp, &options, limit);
         assert_eq!(output, expected)
     }
 
@@ -155,6 +207,7 @@ mod tests {
                 descending: false,
                 nulls_first: true,
             },
+            None,
             &[0, 5, 3, 1, 4, 2],
         );
     }
@@ -168,6 +221,7 @@ mod tests {
                 descending: false,
                 nulls_first: false,
             },
+            None,
             &[3, 1, 4, 2, 0, 5],
         );
     }
@@ -181,6 +235,7 @@ mod tests {
                 descending: true,
                 nulls_first: true,
             },
+            None,
             &[0, 5, 2, 1, 4, 3],
         );
     }
@@ -194,7 +249,116 @@ mod tests {
                 descending: true,
                 nulls_first: false,
             },
+            None,
             &[2, 1, 4, 3, 0, 5],
+        );
+    }
+
+    #[test]
+    fn limit_ascending_nulls_first() {
+        // nulls sorted
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: false,
+                nulls_first: true,
+            },
+            Some(2),
+            &[0, 5],
+        );
+
+        // nulls and values sorted
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: false,
+                nulls_first: true,
+            },
+            Some(4),
+            &[0, 5, 3, 1],
+        );
+    }
+
+    #[test]
+    fn limit_ascending_nulls_last() {
+        // values
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: false,
+                nulls_first: false,
+            },
+            Some(2),
+            &[3, 1],
+        );
+
+        // values and nulls
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: false,
+                nulls_first: false,
+            },
+            Some(5),
+            &[3, 1, 4, 2, 0],
+        );
+    }
+
+    #[test]
+    fn limit_descending_nulls_first() {
+        // nulls
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: true,
+                nulls_first: true,
+            },
+            Some(2),
+            &[0, 5],
+        );
+
+        // nulls and values
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: true,
+                nulls_first: true,
+            },
+            Some(4),
+            &[0, 5, 2, 1],
+        );
+    }
+
+    #[test]
+    fn limit_descending_nulls_last() {
+        // values
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: true,
+                nulls_first: false,
+            },
+            Some(2),
+            &[2, 1],
+        );
+
+        // values and nulls
+        test::<i8>(
+            &[None, Some(3), Some(5), Some(2), Some(3), None],
+            DataType::Int8,
+            SortOptions {
+                descending: true,
+                nulls_first: false,
+            },
+            Some(5),
+            &[2, 1, 4, 3, 0],
         );
     }
 }

--- a/src/compute/sort/primitive/indices.rs
+++ b/src/compute/sort/primitive/indices.rs
@@ -5,83 +5,8 @@ use crate::{
     types::NativeType,
 };
 
+use super::super::common::sort_unstable_by;
 use super::super::SortOptions;
-
-/// # Safety
-/// `indices[i] < values.len()` for all i
-#[inline]
-unsafe fn k_element_sort_inner<T, F>(
-    indices: &mut [i32],
-    values: &[T],
-    descending: bool,
-    limit: usize,
-    mut cmp: F,
-) where
-    T: NativeType,
-    F: FnMut(&T, &T) -> std::cmp::Ordering,
-{
-    if descending {
-        let compare = |lhs: &i32, rhs: &i32| {
-            let lhs = values.get_unchecked(*lhs as usize);
-            let rhs = values.get_unchecked(*rhs as usize);
-            cmp(lhs, rhs).reverse()
-        };
-        let (before, _, _) = indices.select_nth_unstable_by(limit, compare);
-        let compare = |lhs: &i32, rhs: &i32| {
-            let lhs = values.get_unchecked(*lhs as usize);
-            let rhs = values.get_unchecked(*rhs as usize);
-            cmp(lhs, rhs).reverse()
-        };
-        before.sort_unstable_by(compare);
-    } else {
-        let compare = |lhs: &i32, rhs: &i32| {
-            let lhs = values.get_unchecked(*lhs as usize);
-            let rhs = values.get_unchecked(*rhs as usize);
-            cmp(lhs, rhs)
-        };
-        let (before, _, _) = indices.select_nth_unstable_by(limit, compare);
-        let compare = |lhs: &i32, rhs: &i32| {
-            let lhs = values.get_unchecked(*lhs as usize);
-            let rhs = values.get_unchecked(*rhs as usize);
-            cmp(lhs, rhs)
-        };
-        before.sort_unstable_by(compare);
-    }
-}
-
-/// # Safety
-/// Safe iff
-/// * `indices[i] < values.len()` for all i
-/// * `limit < values.len()`
-#[inline]
-unsafe fn sort_unstable_by<T, F>(
-    indices: &mut [i32],
-    values: &[T],
-    mut cmp: F,
-    descending: bool,
-    limit: usize,
-) where
-    T: NativeType,
-    F: FnMut(&T, &T) -> std::cmp::Ordering,
-{
-    if limit != indices.len() {
-        return k_element_sort_inner(indices, values, descending, limit, cmp);
-    }
-
-    if descending {
-        indices.sort_unstable_by(|lhs, rhs| {
-            let lhs = values.get_unchecked(*lhs as usize);
-            let rhs = values.get_unchecked(*rhs as usize);
-            cmp(lhs, rhs).reverse()
-        })
-    } else {
-        indices.sort_unstable_by(|lhs, rhs| {
-            let lhs = values.get_unchecked(*lhs as usize);
-            let rhs = values.get_unchecked(*rhs as usize);
-            cmp(lhs, rhs)
-        })
-    }
-}
 
 /// Unstable sort of indices.
 pub fn indices_sorted_unstable_by<T, F>(
@@ -129,7 +54,15 @@ where
                 // limit is by construction < indices.len()
                 let limit = limit - validity.null_count();
                 let indices = &mut indices.as_mut_slice()[validity.null_count()..];
-                unsafe { sort_unstable_by(indices, values, cmp, options.descending, limit) }
+                unsafe {
+                    sort_unstable_by(
+                        indices,
+                        |x: usize| *values.as_slice().get_unchecked(x),
+                        cmp,
+                        options.descending,
+                        limit,
+                    )
+                }
             }
         } else {
             let last_valid_index = array.len() - validity.null_count();
@@ -153,7 +86,15 @@ where
             // limit is by construction <= values.len()
             let limit = limit.min(last_valid_index);
             let indices = &mut indices.as_mut_slice()[..last_valid_index];
-            unsafe { sort_unstable_by(indices, values, cmp, options.descending, limit) };
+            unsafe {
+                sort_unstable_by(
+                    indices,
+                    |x: usize| *values.as_slice().get_unchecked(x),
+                    cmp,
+                    options.descending,
+                    limit,
+                )
+            };
         }
 
         indices.truncate(limit);
@@ -167,7 +108,15 @@ where
         // Soundness:
         // indices are by construction `< values.len()`
         // limit is by construction `< values.len()`
-        unsafe { sort_unstable_by(&mut indices, values, cmp, descending, limit) };
+        unsafe {
+            sort_unstable_by(
+                &mut indices,
+                |x: usize| *values.as_slice().get_unchecked(x),
+                cmp,
+                descending,
+                limit,
+            )
+        };
 
         indices.truncate(limit);
         indices.shrink_to_fit();

--- a/src/compute/sort/primitive/mod.rs
+++ b/src/compute/sort/primitive/mod.rs
@@ -1,22 +1,5 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 mod indices;
 mod sort;
 
-pub use indices::indices_sorted_by;
+pub use indices::indices_sorted_unstable_by;
 pub use sort::sort_by;

--- a/src/compute/sort/utf8.rs
+++ b/src/compute/sort/utf8.rs
@@ -1,0 +1,37 @@
+use crate::array::{Array, Int32Array, Offset, Utf8Array};
+use crate::array::{DictionaryArray, DictionaryKey};
+
+use super::common;
+use super::SortOptions;
+
+pub(super) fn indices_sorted_unstable_by<O: Offset>(
+    array: &Utf8Array<O>,
+    options: &SortOptions,
+    limit: Option<usize>,
+) -> Int32Array {
+    let get = |idx| unsafe { array.value_unchecked(idx as usize) };
+    let cmp = |lhs: &&str, rhs: &&str| lhs.cmp(rhs);
+    common::indices_sorted_unstable_by(array.validity(), get, cmp, array.len(), options, limit)
+}
+
+pub(super) fn indices_sorted_unstable_by_dictionary<K: DictionaryKey, O: Offset>(
+    array: &DictionaryArray<K>,
+    options: &SortOptions,
+    limit: Option<usize>,
+) -> Int32Array {
+    let keys = array.keys();
+
+    let dict = array
+        .values()
+        .as_any()
+        .downcast_ref::<Utf8Array<O>>()
+        .unwrap();
+
+    let get = |idx| unsafe {
+        let index = keys.value_unchecked(idx as usize);
+        // Note: there is no check that the keys are within bounds of the dictionary.
+        dict.value(index.to_usize().unwrap())
+    };
+    let cmp = |lhs: &&str, rhs: &&str| lhs.cmp(rhs);
+    common::indices_sorted_unstable_by(array.validity(), get, cmp, array.len(), options, limit)
+}


### PR DESCRIPTION
Closes #215

This:

* adds support to sort with a limit.
* adds bench to sort `utf8` with nulls
* improves performance of (unlimited) sort of `utf8` for small arrays by 10-15%
* makes all sorts unstable (most were already)

This change is backward incompatible: all public functions in `compute::sort` now expect an `Option<usize>` denoting the limit of the sort. The migration is to add a new parameter `None` to them.

Bench results (utf8 with `10%` of nulls)

```
sort utf8 null 2^10     time:   [130.62 us 130.75 us 130.86 us]                                
                        change: [-14.887% -14.549% -14.269%] (p = 0.00 < 0.05)
sort utf8 null 2^12     time:   [651.78 us 652.41 us 653.03 us]                                
                        change: [-12.832% -12.593% -12.372%] (p = 0.00 < 0.05)
                        Performance has improved.
sort utf8 null 2^14     time:   [3.0201 ms 3.0244 ms 3.0286 ms]                                 
                        change: [-11.194% -11.032% -10.871%] (p = 0.00 < 0.05)
```