### PR TITLE
Generalized sort to accept indices other than i32.

### DIFF
--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -8,8 +8,9 @@ use crate::{
 };
 
 /// Trait describing any type that can be used to index a slot of an array.
-pub trait Index: NativeType {
+pub trait Index: NativeType + NaturalDataType {
     fn to_usize(&self) -> usize;
+    fn from_usize(index: usize) -> Option<Self>;
 }
 
 /// Trait describing types that can be used as offsets as per Arrow specification.
@@ -17,13 +18,11 @@ pub trait Index: NativeType {
 /// # Safety
 /// Do not implement.
 pub unsafe trait Offset:
-    Index + NaturalDataType + Num + Ord + std::ops::AddAssign + std::ops::Sub + num::CheckedAdd
+    Index + Num + Ord + std::ops::AddAssign + std::ops::Sub + num::CheckedAdd
 {
     fn is_large() -> bool;
 
     fn to_isize(&self) -> isize;
-
-    fn from_usize(value: usize) -> Option<Self>;
 
     fn from_isize(value: isize) -> Option<Self>;
 }
@@ -32,11 +31,6 @@ unsafe impl Offset for i32 {
     #[inline]
     fn is_large() -> bool {
         false
-    }
-
-    #[inline]
-    fn from_usize(value: usize) -> Option<Self> {
-        Self::try_from(value).ok()
     }
 
     #[inline]
@@ -57,11 +51,6 @@ unsafe impl Offset for i64 {
     }
 
     #[inline]
-    fn from_usize(value: usize) -> Option<Self> {
-        Some(value as i64)
-    }
-
-    #[inline]
     fn from_isize(value: isize) -> Option<Self> {
         Self::try_from(value).ok()
     }
@@ -77,12 +66,22 @@ impl Index for i32 {
     fn to_usize(&self) -> usize {
         *self as usize
     }
+
+    #[inline]
+    fn from_usize(value: usize) -> Option<Self> {
+        Self::try_from(value).ok()
+    }
 }
 
 impl Index for i64 {
     #[inline]
     fn to_usize(&self) -> usize {
         *self as usize
+    }
+
+    #[inline]
+    fn from_usize(value: usize) -> Option<Self> {
+        Self::try_from(value).ok()
     }
 }
 
@@ -91,12 +90,22 @@ impl Index for u32 {
     fn to_usize(&self) -> usize {
         *self as usize
     }
+
+    #[inline]
+    fn from_usize(value: usize) -> Option<Self> {
+        Self::try_from(value).ok()
+    }
 }
 
 impl Index for u64 {
     #[inline]
     fn to_usize(&self) -> usize {
         *self as usize
+    }
+
+    #[inline]
+    fn from_usize(value: usize) -> Option<Self> {
+        Self::try_from(value).ok()
     }
 }
 

--- a/src/compute/sort/boolean.rs
+++ b/src/compute/sort/boolean.rs
@@ -1,26 +1,25 @@
 use crate::{
-    array::{Array, BooleanArray, Int32Array},
+    array::{Array, BooleanArray, Index, PrimitiveArray},
     buffer::MutableBuffer,
-    datatypes::DataType,
 };
 
 use super::SortOptions;
 
 /// Returns the indices that would sort a [`BooleanArray`].
-pub fn sort_boolean(
+pub fn sort_boolean<I: Index>(
     values: &BooleanArray,
-    value_indices: Vec<i32>,
-    null_indices: Vec<i32>,
+    value_indices: Vec<I>,
+    null_indices: Vec<I>,
     options: &SortOptions,
     limit: Option<usize>,
-) -> Int32Array {
+) -> PrimitiveArray<I> {
     let descending = options.descending;
 
     // create tuples that are used for sorting
     let mut valids = value_indices
         .into_iter()
-        .map(|index| (index, values.value(index as usize)))
-        .collect::<Vec<(i32, bool)>>();
+        .map(|index| (index, values.value(index.to_usize())))
+        .collect::<Vec<(I, bool)>>();
 
     let mut nulls = null_indices;
 
@@ -32,7 +31,7 @@ pub fn sort_boolean(
         nulls.reverse();
     }
 
-    let mut values = MutableBuffer::<i32>::with_capacity(values.len());
+    let mut values = MutableBuffer::<I>::with_capacity(values.len());
 
     if options.nulls_first {
         values.extend_from_slice(nulls.as_slice());
@@ -48,5 +47,5 @@ pub fn sort_boolean(
         values.truncate(limit);
     }
 
-    Int32Array::from_data(DataType::Int32, values.into(), None)
+    PrimitiveArray::<I>::from_data(I::DATA_TYPE, values.into(), None)
 }

--- a/src/compute/sort/common.rs
+++ b/src/compute/sort/common.rs
@@ -1,4 +1,8 @@
-use crate::{array::PrimitiveArray, bitmap::Bitmap, buffer::MutableBuffer, datatypes::DataType};
+use crate::{
+    array::{Index, PrimitiveArray},
+    bitmap::Bitmap,
+    buffer::MutableBuffer,
+};
 
 use super::SortOptions;
 
@@ -7,8 +11,8 @@ use super::SortOptions;
 /// * `get` is only called for `0 <= i < limit`
 /// * `cmp` is only called from the co-domain of `get`.
 #[inline]
-fn k_element_sort_inner<T, G, F>(
-    indices: &mut [i32],
+fn k_element_sort_inner<I: Index, T, G, F>(
+    indices: &mut [I],
     get: G,
     descending: bool,
     limit: usize,
@@ -18,28 +22,28 @@ fn k_element_sort_inner<T, G, F>(
     F: FnMut(&T, &T) -> std::cmp::Ordering,
 {
     if descending {
-        let compare = |lhs: &i32, rhs: &i32| {
-            let lhs = get(*lhs as usize);
-            let rhs = get(*rhs as usize);
+        let compare = |lhs: &I, rhs: &I| {
+            let lhs = get(lhs.to_usize());
+            let rhs = get(rhs.to_usize());
             cmp(&lhs, &rhs).reverse()
         };
         let (before, _, _) = indices.select_nth_unstable_by(limit, compare);
-        let compare = |lhs: &i32, rhs: &i32| {
-            let lhs = get(*lhs as usize);
-            let rhs = get(*rhs as usize);
+        let compare = |lhs: &I, rhs: &I| {
+            let lhs = get(lhs.to_usize());
+            let rhs = get(rhs.to_usize());
             cmp(&lhs, &rhs).reverse()
         };
         before.sort_unstable_by(compare);
     } else {
-        let compare = |lhs: &i32, rhs: &i32| {
-            let lhs = get(*lhs as usize);
-            let rhs = get(*rhs as usize);
+        let compare = |lhs: &I, rhs: &I| {
+            let lhs = get(lhs.to_usize());
+            let rhs = get(rhs.to_usize());
             cmp(&lhs, &rhs)
         };
         let (before, _, _) = indices.select_nth_unstable_by(limit, compare);
-        let compare = |lhs: &i32, rhs: &i32| {
-            let lhs = get(*lhs as usize);
-            let rhs = get(*rhs as usize);
+        let compare = |lhs: &I, rhs: &I| {
+            let lhs = get(lhs.to_usize());
+            let rhs = get(rhs.to_usize());
             cmp(&lhs, &rhs)
         };
         before.sort_unstable_by(compare);
@@ -51,13 +55,14 @@ fn k_element_sort_inner<T, G, F>(
 /// * `get` is only called for `0 <= i < limit`
 /// * `cmp` is only called from the co-domain of `get`.
 #[inline]
-fn sort_unstable_by<T, G, F>(
-    indices: &mut [i32],
+fn sort_unstable_by<I, T, G, F>(
+    indices: &mut [I],
     get: G,
     mut cmp: F,
     descending: bool,
     limit: usize,
 ) where
+    I: Index,
     G: Fn(usize) -> T,
     F: FnMut(&T, &T) -> std::cmp::Ordering,
 {
@@ -67,14 +72,14 @@ fn sort_unstable_by<T, G, F>(
 
     if descending {
         indices.sort_unstable_by(|lhs, rhs| {
-            let lhs = get(*lhs as usize);
-            let rhs = get(*rhs as usize);
+            let lhs = get(lhs.to_usize());
+            let rhs = get(rhs.to_usize());
             cmp(&lhs, &rhs).reverse()
         })
     } else {
         indices.sort_unstable_by(|lhs, rhs| {
-            let lhs = get(*lhs as usize);
-            let rhs = get(*rhs as usize);
+            let lhs = get(lhs.to_usize());
+            let rhs = get(rhs.to_usize());
             cmp(&lhs, &rhs)
         })
     }
@@ -85,15 +90,16 @@ fn sort_unstable_by<T, G, F>(
 /// * `get` is only called for `0 <= i < length`
 /// * `cmp` is only called from the co-domain of `get`.
 #[inline]
-pub(super) fn indices_sorted_unstable_by<T, G, F>(
+pub(super) fn indices_sorted_unstable_by<I, T, G, F>(
     validity: &Option<Bitmap>,
     get: G,
     cmp: F,
     length: usize,
     options: &SortOptions,
     limit: Option<usize>,
-) -> PrimitiveArray<i32>
+) -> PrimitiveArray<I>
 where
+    I: Index,
     G: Fn(usize) -> T,
     F: Fn(&T, &T) -> std::cmp::Ordering,
 {
@@ -104,20 +110,20 @@ where
     let limit = limit.min(length);
 
     let indices = if let Some(validity) = validity {
-        let mut indices = MutableBuffer::<i32>::from_len_zeroed(length);
+        let mut indices = MutableBuffer::<I>::from_len_zeroed(length);
 
         if options.nulls_first {
             let mut nulls = 0;
             let mut valids = 0;
             validity
                 .iter()
-                .zip(0..length as i32)
+                .zip(0..length)
                 .for_each(|(is_valid, index)| {
                     if is_valid {
-                        indices[validity.null_count() + valids] = index;
+                        indices[validity.null_count() + valids] = I::from_usize(index).unwrap();
                         valids += 1;
                     } else {
-                        indices[nulls] = index;
+                        indices[nulls] = I::from_usize(index).unwrap();
                         nulls += 1;
                     }
                 });
@@ -136,18 +142,15 @@ where
             let last_valid_index = length - validity.null_count();
             let mut nulls = 0;
             let mut valids = 0;
-            validity
-                .iter()
-                .zip(0..length as i32)
-                .for_each(|(x, index)| {
-                    if x {
-                        indices[valids] = index;
-                        valids += 1;
-                    } else {
-                        indices[last_valid_index + nulls] = index;
-                        nulls += 1;
-                    }
-                });
+            validity.iter().zip(0..length).for_each(|(x, index)| {
+                if x {
+                    indices[valids] = I::from_usize(index).unwrap();
+                    valids += 1;
+                } else {
+                    indices[last_valid_index + nulls] = I::from_usize(index).unwrap();
+                    nulls += 1;
+                }
+            });
 
             // Soundness:
             // all indices in `indices` are by construction `< array.len() == values.len()`
@@ -162,8 +165,11 @@ where
 
         indices
     } else {
-        let mut indices =
-            unsafe { MutableBuffer::from_trusted_len_iter_unchecked(0..length as i32) };
+        let mut indices = unsafe {
+            MutableBuffer::from_trusted_len_iter_unchecked(
+                (0..length).map(|x| I::from_usize(x).unwrap()),
+            )
+        };
 
         // Soundness:
         // indices are by construction `< values.len()`
@@ -175,5 +181,5 @@ where
 
         indices
     };
-    PrimitiveArray::<i32>::from_data(DataType::Int32, indices.into(), None)
+    PrimitiveArray::<I>::from_data(I::DATA_TYPE, indices.into(), None)
 }

--- a/src/compute/sort/primitive/indices.rs
+++ b/src/compute/sort/primitive/indices.rs
@@ -1,5 +1,5 @@
 use crate::{
-    array::{Array, PrimitiveArray},
+    array::{Array, Index, PrimitiveArray},
     types::NativeType,
 };
 
@@ -7,13 +7,14 @@ use super::super::common;
 use super::super::SortOptions;
 
 /// Unstable sort of indices.
-pub fn indices_sorted_unstable_by<T, F>(
+pub fn indices_sorted_unstable_by<I, T, F>(
     array: &PrimitiveArray<T>,
     cmp: F,
     options: &SortOptions,
     limit: Option<usize>,
-) -> PrimitiveArray<i32>
+) -> PrimitiveArray<I>
 where
+    I: Index,
     T: NativeType,
     F: Fn(&T, &T) -> std::cmp::Ordering,
 {
@@ -47,7 +48,8 @@ mod tests {
     {
         let input = PrimitiveArray::<T>::from(data).to(data_type);
         let expected = Int32Array::from_slice(&expected_data);
-        let output = indices_sorted_unstable_by(&input, ord::total_cmp, &options, limit);
+        let output =
+            indices_sorted_unstable_by::<i32, _, _>(&input, ord::total_cmp, &options, limit);
         assert_eq!(output, expected)
     }
 

--- a/src/compute/sort/utf8.rs
+++ b/src/compute/sort/utf8.rs
@@ -1,24 +1,24 @@
-use crate::array::{Array, Int32Array, Offset, Utf8Array};
+use crate::array::{Array, Index, Offset, PrimitiveArray, Utf8Array};
 use crate::array::{DictionaryArray, DictionaryKey};
 
 use super::common;
 use super::SortOptions;
 
-pub(super) fn indices_sorted_unstable_by<O: Offset>(
+pub(super) fn indices_sorted_unstable_by<I: Index, O: Offset>(
     array: &Utf8Array<O>,
     options: &SortOptions,
     limit: Option<usize>,
-) -> Int32Array {
+) -> PrimitiveArray<I> {
     let get = |idx| unsafe { array.value_unchecked(idx as usize) };
     let cmp = |lhs: &&str, rhs: &&str| lhs.cmp(rhs);
     common::indices_sorted_unstable_by(array.validity(), get, cmp, array.len(), options, limit)
 }
 
-pub(super) fn indices_sorted_unstable_by_dictionary<K: DictionaryKey, O: Offset>(
+pub(super) fn indices_sorted_unstable_by_dictionary<I: Index, K: DictionaryKey, O: Offset>(
     array: &DictionaryArray<K>,
     options: &SortOptions,
     limit: Option<usize>,
-) -> Int32Array {
+) -> PrimitiveArray<I> {
     let keys = array.keys();
 
     let dict = array


### PR DESCRIPTION
This PR generalizes sort to accept indices other than `i32` (i.e. `u32, u64, i32, i64`). Some types may be more advantageous than others depending on the use-case, and since Rust enables this quite easily, we may as well allow it.

Note that this does increase the overall compilation of dependents as `sort` is now a generic over `I` and is thus compiled on the dependent crate.

This is backward incompatible. To recover the original behavior, add `::<i32>` to functions that return indices in `compute::sort`. Change to e.g. `u64` to return a `UInt64Array` instead.

This has no impact in performance.