### PR TITLE
Add support to merge sort with a limit

### DIFF
--- a/src/compute/merge_sort/mod.rs
+++ b/src/compute/merge_sort/mod.rs
@@ -98,7 +98,7 @@ pub fn take_arrays<I: IntoIterator<Item = MergeSlice>>(
     let limit = limit.min(len);
     let mut growable = make_growable(arrays, false, limit);
 
-    if limit == len {
+    if limit != len {
         let mut current_len = 0;
         for (index, start, len) in slices {
             if len + current_len >= limit {


### PR DESCRIPTION
Closes #221 

# Backward incompatible changes

The functions `compute::merge_sort::take_arrays` and `compute::merge_sort::merge_sort` now expects a third argument, `Option<usize>`, denoting an optional limit. To migrate, add `None` to their calls.

