### PR TITLE
Add extra inlining to speed up take

### DIFF
--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -348,7 +348,6 @@ impl MutableBitmap {
     }
 
     /// Creates a new [`MutableBitmap`] from an iterator of booleans.
-    #[inline]
     pub fn from_trusted_len_iter<I>(iterator: I) -> Self
     where
         I: TrustedLen<Item = bool>,
@@ -363,7 +362,6 @@ impl MutableBitmap {
     }
 
     /// Creates a new [`MutableBitmap`] from an iterator of booleans.
-    #[inline]
     pub fn try_from_trusted_len_iter<E, I>(iterator: I) -> std::result::Result<Self, E>
     where
         I: TrustedLen<Item = std::result::Result<bool, E>>,

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -348,6 +348,7 @@ impl MutableBitmap {
     }
 
     /// Creates a new [`MutableBitmap`] from an iterator of booleans.
+    #[inline]
     pub fn from_trusted_len_iter<I>(iterator: I) -> Self
     where
         I: TrustedLen<Item = bool>,
@@ -362,6 +363,7 @@ impl MutableBitmap {
     }
 
     /// Creates a new [`MutableBitmap`] from an iterator of booleans.
+    #[inline]
     pub fn try_from_trusted_len_iter<E, I>(iterator: I) -> std::result::Result<Self, E>
     where
         I: TrustedLen<Item = std::result::Result<bool, E>>,
@@ -372,6 +374,7 @@ impl MutableBitmap {
     /// Creates a new [`MutableBitmap`] from an falible iterator of booleans.
     /// # Safety
     /// The caller must guarantee that the iterator is `TrustedLen`.
+    #[inline]
     pub unsafe fn try_from_trusted_len_iter_unchecked<E, I>(
         mut iterator: I,
     ) -> std::result::Result<Self, E>

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -374,7 +374,6 @@ impl MutableBitmap {
     /// Creates a new [`MutableBitmap`] from an falible iterator of booleans.
     /// # Safety
     /// The caller must guarantee that the iterator is `TrustedLen`.
-    #[inline]
     pub unsafe fn try_from_trusted_len_iter_unchecked<E, I>(
         mut iterator: I,
     ) -> std::result::Result<Self, E>

--- a/src/buffer/mutable.rs
+++ b/src/buffer/mutable.rs
@@ -372,6 +372,7 @@ impl<T: NativeType> MutableBuffer<T> {
     /// # Safety
     /// This method assumes that the iterator's size is correct and is undefined behavior
     /// to use it on an iterator that reports an incorrect length.
+    // This inline has been validated to offer 50% improvement in operations like `take`.
     #[inline]
     pub unsafe fn extend_from_trusted_len_iter_unchecked<I: Iterator<Item = T>>(
         &mut self,

--- a/src/buffer/mutable.rs
+++ b/src/buffer/mutable.rs
@@ -463,6 +463,7 @@ impl<T: NativeType> MutableBuffer<T> {
     /// # Safety
     /// This method assumes that the iterator's size is correct and is undefined behavior
     /// to use it on an iterator that reports an incorrect length.
+    // This inline has been validated to offer 50% improvement in operations like `take`.
     #[inline]
     pub unsafe fn try_from_trusted_len_iter_unchecked<
         E,

--- a/src/buffer/mutable.rs
+++ b/src/buffer/mutable.rs
@@ -372,6 +372,7 @@ impl<T: NativeType> MutableBuffer<T> {
     /// # Safety
     /// This method assumes that the iterator's size is correct and is undefined behavior
     /// to use it on an iterator that reports an incorrect length.
+    #[inline]
     pub unsafe fn extend_from_trusted_len_iter_unchecked<I: Iterator<Item = T>>(
         &mut self,
         iterator: I,
@@ -461,6 +462,7 @@ impl<T: NativeType> MutableBuffer<T> {
     /// # Safety
     /// This method assumes that the iterator's size is correct and is undefined behavior
     /// to use it on an iterator that reports an incorrect length.
+    #[inline]
     pub unsafe fn try_from_trusted_len_iter_unchecked<
         E,
         I: Iterator<Item = std::result::Result<T, E>>,

--- a/src/compute/take/generic_binary.rs
+++ b/src/compute/take/generic_binary.rs
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 use crate::{
     array::{Array, GenericBinaryArray, Offset, PrimitiveArray},
     bitmap::{Bitmap, MutableBitmap},

--- a/src/compute/take/primitive.rs
+++ b/src/compute/take/primitive.rs
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 use crate::{
     array::{Array, PrimitiveArray},
     bitmap::{Bitmap, MutableBitmap},


### PR DESCRIPTION
They had some inline hints on the methods, but not all the way to `extend_from_trusted_len_iter_unchecked` and  `try_from_trusted_len_iter_unchecked`.

This has changes around 30-50%

```
Benchmarking take i32 512: Collecting 100 samples in estimated 5.0009 s (17M ite                                                                                take i32 512            time:   [300.35 ns 301.92 ns 303.62 ns]
                        change: [-51.942% -51.683% -51.411%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

Benchmarking take i32 1024: Collecting 100 samples in estimated 5.0032 s (7.4M i                                                                                take i32 1024           time:   [674.49 ns 675.96 ns 677.54 ns]
                        change: [-47.687% -47.558% -47.445%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  8 (8.00%) high mild

Benchmarking take i32 nulls 512: Collecting 100 samples in estimated 5.0013 s (9                                                                                take i32 nulls 512      time:   [511.26 ns 511.65 ns 512.11 ns]
                        change: [-1.1965% -0.9889% -0.7859%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

Benchmarking take i32 nulls 1024: Collecting 100 samples in estimated 5.0011 s (                                                                                take i32 nulls 1024     time:   [796.57 ns 797.00 ns 797.49 ns]
                        change: [-12.886% -12.768% -12.652%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe

Benchmarking take str 512: Collecting 100 samples in estimated 5.0041 s (1.6M it                                                                                take str 512            time:   [3.0675 us 3.0691 us 3.0705 us]
                        change: [-19.937% -19.801% -19.674%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

Benchmarking take str 1024: Collecting 100 samples in estimated 5.0202 s (1.0M i                                                                                take str 1024           time:   [4.9393 us 4.9453 us 4.9512 us]
                        change: [-38.380% -38.271% -38.141%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

Benchmarking take str null indices 512: Collecting 100 samples in estimated 5.01                                                                                take str null indices 512                        
                        time:   [2.9738 us 2.9800 us 2.9856 us]
                        change: [-33.972% -33.766% -33.544%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

Benchmarking take str null indices 1024: Collecting 100 samples in estimated 5.0                                                                                take str null indices 1024                        
                        time:   [5.2084 us 5.2177 us 5.2279 us]
                        change: [-35.800% -35.646% -35.513%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild

Benchmarking take str null values 1024: Collecting 100 samples in estimated 5.03                                                                                take str null values 1024                        
                        time:   [11.351 us 11.362 us 11.375 us]
                        change: [-32.987% -32.304% -31.477%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

Benchmarking take str null values null indices 1024: Collecting 100 samples in e                                                                                take str null values null indices 1024                        
                        time:   [10.549 us 10.584 us 10.617 us]
                        change: [-22.214% -21.878% -21.539%] (p = 0.00 < 0.05)
                        Performance has improved.
```