### PR TITLE
don't check if use_validity==true

### DIFF
--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -72,7 +72,7 @@ impl<'a, O: Offset> GrowableList<'a, O> {
     pub fn new(arrays: &[&'a dyn Array], mut use_validity: bool, capacity: usize) -> Self {
         // if any of the arrays has nulls, insertions from any array requires setting bits
         // as there is at least one array with nulls.
-        if arrays.iter().any(|array| array.null_count() > 0) {
+        if use_validity || arrays.iter().any(|array| array.null_count() > 0) {
             use_validity = true;
         };
 


### PR DESCRIPTION
If the argument `use_validity` is set to `true` the checks for null count are redundant. This PR makes that the check is skipped in that case.