### PR TITLE
Added experimental support to round-trip dictionary arrays on parquet

### DIFF
--- a/.github/workflows/integration-parquet.yml
+++ b/.github/workflows/integration-parquet.yml
@@ -48,5 +48,5 @@ jobs:
           pip install --upgrade pip
           pip install pyarrow pyspark
           python main.py
-          # test delta encoding against spark (pyarrow does not support it)
+          # test against spark
           python main_spark.py

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ hex = { version = "^0.4", optional = true }
 
 # for IPC compression
 lz4 = { version = "1.23.1", optional = true }
-zstd = { version = "^0.6", optional = true }
+zstd = { version = "0.9", optional = true }
 
 rand = { version = "0.8", optional = true }
 
@@ -58,7 +58,7 @@ futures = { version = "0.3", optional = true }
 # for faster hashing
 ahash = { version = "0.7", optional = true }
 
-parquet2 = { version = "0.1", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { version = "0.2", optional = true, default_features = false, features = ["stream"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/arrow-parquet-integration-testing/main.py
+++ b/arrow-parquet-integration-testing/main.py
@@ -65,7 +65,8 @@ def variations():
             "generated_datetime",
             "generated_decimal",
             "generated_interval",
-            # requires writing Dictionary
+            # see https://issues.apache.org/jira/browse/ARROW-13486 and
+            # https://issues.apache.org/jira/browse/ARROW-13487
             # "generated_dictionary",
             # requires writing Struct
             # "generated_duplicate_fieldnames",

--- a/arrow-parquet-integration-testing/src/main.rs
+++ b/arrow-parquet-integration-testing/src/main.rs
@@ -162,6 +162,7 @@ fn main() -> Result<()> {
         .fields()
         .iter()
         .map(|x| match x.data_type() {
+            DataType::Dictionary(_, _) => Encoding::RleDictionary,
             DataType::Utf8 | DataType::LargeUtf8 => {
                 if utf8_encoding == "delta" {
                     Encoding::DeltaLengthByteArray

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -250,14 +250,19 @@ mod tests {
                     .iter()
                     .map(|x| x.map(|x| x as u32))
                     .collect::<Vec<_>>();
-                Box::new(PrimitiveArray::<u32>::from(values).to(DataType::UInt32))
+                Box::new(PrimitiveArray::<u32>::from(values))
+            }
+            6 => {
+                let keys = PrimitiveArray::<i32>::from([Some(0), Some(1), None, Some(1)]);
+                let values = Arc::new(PrimitiveArray::<i32>::from_slice([10, 200]));
+                Box::new(DictionaryArray::<i32>::from_data(keys, values))
             }
             _ => unreachable!(),
         }
     }
 
-    pub fn pyarrow_nullable_statistics(column: usize) -> Box<dyn Statistics> {
-        match column {
+    pub fn pyarrow_nullable_statistics(column: usize) -> Option<Box<dyn Statistics>> {
+        Some(match column {
             0 => Box::new(PrimitiveStatistics::<i64> {
                 data_type: DataType::Int64,
                 distinct_count: None,
@@ -300,8 +305,9 @@ mod tests {
                 min_value: Some(0),
                 max_value: Some(9),
             }),
+            6 => return None,
             _ => unreachable!(),
-        }
+        })
     }
 
     // these values match the values in `integration`
@@ -331,8 +337,8 @@ mod tests {
         }
     }
 
-    pub fn pyarrow_required_statistics(column: usize) -> Box<dyn Statistics> {
-        match column {
+    pub fn pyarrow_required_statistics(column: usize) -> Option<Box<dyn Statistics>> {
+        Some(match column {
             0 => Box::new(PrimitiveStatistics::<i64> {
                 data_type: DataType::Int64,
                 null_count: Some(0),
@@ -353,11 +359,11 @@ mod tests {
                 max_value: Some("def".to_string()),
             }),
             _ => unreachable!(),
-        }
+        })
     }
 
-    pub fn pyarrow_nested_nullable_statistics(column: usize) -> Box<dyn Statistics> {
-        match column {
+    pub fn pyarrow_nested_nullable_statistics(column: usize) -> Option<Box<dyn Statistics>> {
+        Some(match column {
             3 => Box::new(PrimitiveStatistics::<i16> {
                 data_type: DataType::Int16,
                 distinct_count: None,
@@ -390,7 +396,7 @@ mod tests {
                 min_value: Some(0),
                 max_value: Some(9),
             }),
-        }
+        })
     }
 }
 

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -12,7 +12,7 @@ mod utils;
 
 use crate::{
     array::Array,
-    datatypes::{DataType, TimeUnit},
+    datatypes::{DataType, IntervalUnit, TimeUnit},
     error::{ArrowError, Result},
 };
 
@@ -23,17 +23,13 @@ pub use parquet2::{
     error::ParquetError,
     metadata::{ColumnChunkMetaData, ColumnDescriptor, RowGroupMetaData},
     read::{
-        decompress, streaming_iterator, CompressedPage, Decompressor, Page, PageHeader,
+        decompress, get_page_iterator as _get_page_iterator, read_metadata as _read_metadata,
+        streaming_iterator, CompressedPage, Decompressor, Page, PageHeader, PageIterator,
         StreamingIterator,
     },
     schema::{
         types::{LogicalType, ParquetType, PhysicalType, PrimitiveConvertedType},
         TimeUnit as ParquetTimeUnit, TimestampType,
-    },
-};
-use parquet2::{
-    read::{
-        get_page_iterator as _get_page_iterator, read_metadata as _read_metadata, PageIterator,
     },
     types::int96_to_i64_ns,
 };
@@ -56,185 +52,98 @@ pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
     Ok(_read_metadata(reader)?)
 }
 
-fn page_iter_i64<I: StreamingIterator<Item = std::result::Result<Page, ParquetError>>>(
-    iter: I,
-    metadata: &ColumnChunkMetaData,
-    data_type: DataType,
-) -> Result<Box<dyn Array>> {
-    if metadata.descriptor().max_rep_level() > 0 {
-        let inner = match data_type {
-            DataType::List(ref inner) => inner.data_type(),
-            DataType::LargeList(ref inner) => inner.data_type(),
-            _ => unimplemented!(),
-        };
-
-        match inner {
-            DataType::UInt64 => {
-                primitive::iter_to_array_nested(iter, metadata, data_type, |x: i64| x as u64)
-            }
-            _ => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i64| x as i64),
-        }
-    } else {
-        match data_type {
-            DataType::UInt64 => {
-                primitive::iter_to_array(iter, metadata, data_type, |x: i64| x as u64)
-            }
-            _ => primitive::iter_to_array(iter, metadata, data_type, |x: i64| x as i64),
-        }
-    }
-}
-
-fn page_iter_i32<I: StreamingIterator<Item = std::result::Result<Page, ParquetError>>>(
-    iter: I,
-    metadata: &ColumnChunkMetaData,
-    data_type: DataType,
-) -> Result<Box<dyn Array>> {
-    use DataType::*;
-
-    if metadata.descriptor().max_rep_level() > 0 {
-        let inner = match data_type {
-            List(ref inner) => inner.data_type(),
-            LargeList(ref inner) => inner.data_type(),
-            _ => unimplemented!(),
-        };
-
-        match inner {
-            UInt8 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x as u8),
-            UInt16 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x as u16),
-            UInt32 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x as u32),
-            Int8 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x as i8),
-            Int16 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x as i16),
-            _ => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x),
-        }
-    } else {
-        match data_type {
-            UInt8 => primitive::iter_to_array(iter, metadata, data_type, |x: i32| x as u8),
-            UInt16 => primitive::iter_to_array(iter, metadata, data_type, |x: i32| x as u16),
-            UInt32 => primitive::iter_to_array(iter, metadata, data_type, |x: i32| x as u32),
-            Int8 => primitive::iter_to_array(iter, metadata, data_type, |x: i32| x as i8),
-            Int16 => primitive::iter_to_array(iter, metadata, data_type, |x: i32| x as i16),
-            _ => primitive::iter_to_array(iter, metadata, data_type, |x: i32| x),
-        }
-    }
-}
-
-fn page_iter_byte_array<I: StreamingIterator<Item = std::result::Result<Page, ParquetError>>>(
-    iter: I,
-    metadata: &ColumnChunkMetaData,
-    data_type: DataType,
-) -> Result<Box<dyn Array>> {
-    use DataType::*;
-
-    if metadata.descriptor().max_rep_level() > 0 {
-        let inner = match data_type {
-            List(ref inner) => inner.data_type(),
-            LargeList(ref inner) => inner.data_type(),
-            _ => unimplemented!(),
-        };
-
-        match inner {
-            Binary | Utf8 => binary::iter_to_array_nested::<i32, _, _>(iter, metadata, data_type),
-            LargeBinary | LargeUtf8 => {
-                binary::iter_to_array_nested::<i64, _, _>(iter, metadata, data_type)
-            }
-            other => Err(ArrowError::NotYetImplemented(format!(
-                "Can't read {:?} from parquet",
-                other
-            ))),
-        }
-    } else {
-        match data_type {
-            Binary | Utf8 => binary::iter_to_array::<i32, _, _>(iter, metadata, &data_type),
-            LargeBinary | LargeUtf8 => {
-                binary::iter_to_array::<i64, _, _>(iter, metadata, &data_type)
-            }
-            other => Err(ArrowError::NotYetImplemented(format!(
-                "Can't read {:?} from parquet",
-                other
-            ))),
-        }
-    }
-}
-
-fn page_iter_fixed_len_byte_array<
-    I: StreamingIterator<Item = std::result::Result<Page, ParquetError>>,
->(
-    iter: I,
-    metadata: &ColumnChunkMetaData,
-    data_type: DataType,
-) -> Result<Box<dyn Array>> {
-    use DataType::*;
-    Ok(match data_type {
-        FixedSizeBinary(size) => Box::new(fixed_size_binary::iter_to_array(iter, size, metadata)?),
-        other => {
-            return Err(ArrowError::NotYetImplemented(format!(
-                "Can't read {:?} from parquet",
-                other
-            )))
-        }
-    })
-}
-
 pub fn page_iter_to_array<I: StreamingIterator<Item = std::result::Result<Page, ParquetError>>>(
     iter: &mut I,
     metadata: &ColumnChunkMetaData,
     data_type: DataType,
 ) -> Result<Box<dyn Array>> {
-    match metadata.descriptor().base_type() {
-        ParquetType::PrimitiveType {
-            physical_type,
-            converted_type,
-            logical_type,
-            ..
-        } => match (physical_type, converted_type, logical_type) {
-            (PhysicalType::Int32, _, _) => page_iter_i32(iter, metadata, data_type),
-            (PhysicalType::Int64, _, _) => page_iter_i64(iter, metadata, data_type),
-            (PhysicalType::Float, None, None) => {
-                primitive::iter_to_array(iter, metadata, DataType::Float32, |x: f32| x)
-            }
-            (PhysicalType::Double, None, None) => {
-                primitive::iter_to_array(iter, metadata, DataType::Float64, |x: f64| x)
-            }
-            (PhysicalType::Boolean, None, None) => {
-                Ok(Box::new(boolean::iter_to_array(iter, metadata)?))
-            }
-            (PhysicalType::ByteArray, _, _) => page_iter_byte_array(iter, metadata, data_type),
-            (PhysicalType::FixedLenByteArray(_), _, _) => {
-                page_iter_fixed_len_byte_array(iter, metadata, data_type)
-            }
-            (PhysicalType::Int96, _, _) => primitive::iter_to_array(
-                iter,
-                metadata,
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
-                int96_to_i64_ns,
-            ),
-            (p, c, l) => Err(ArrowError::NotYetImplemented(format!(
-                "The conversion of ({:?}, {:?}, {:?}) to arrow still not implemented",
-                p, c, l
-            ))),
+    use DataType::*;
+    match data_type {
+        // INT32
+        UInt8 => primitive::iter_to_array(iter, metadata, data_type, |x: i32| x as u8),
+        UInt16 => primitive::iter_to_array(iter, metadata, data_type, |x: i32| x as u16),
+        UInt32 => primitive::iter_to_array(iter, metadata, data_type, |x: i32| x as u32),
+        Int8 => primitive::iter_to_array(iter, metadata, data_type, |x: i32| x as i8),
+        Int16 => primitive::iter_to_array(iter, metadata, data_type, |x: i32| x as i16),
+        Int32 | Date32 | Time32(_) | Interval(IntervalUnit::YearMonth) => {
+            primitive::iter_to_array(iter, metadata, data_type, |x: i32| x as i32)
+        }
+
+        Timestamp(TimeUnit::Nanosecond, None) => match metadata.descriptor().type_() {
+            ParquetType::PrimitiveType { physical_type, .. } => match physical_type {
+                PhysicalType::Int96 => primitive::iter_to_array(
+                    iter,
+                    metadata,
+                    DataType::Timestamp(TimeUnit::Nanosecond, None),
+                    int96_to_i64_ns,
+                ),
+                _ => primitive::iter_to_array(iter, metadata, data_type, |x: i64| x),
+            },
+            _ => unreachable!(),
         },
-        _ => {
-            // get all primitives in the type_ and their max rep levels
-            match metadata.descriptor().type_() {
-                ParquetType::PrimitiveType {
-                    physical_type,
-                    converted_type,
-                    logical_type,
-                    ..
-                } => match (physical_type, converted_type, logical_type) {
-                    (PhysicalType::Boolean, None, None) => {
-                        boolean::iter_to_array_nested(iter, metadata, data_type)
-                    }
-                    (PhysicalType::Int64, _, _) => page_iter_i64(iter, metadata, data_type),
-                    (PhysicalType::Int32, _, _) => page_iter_i32(iter, metadata, data_type),
-                    (PhysicalType::ByteArray, _, _) => {
-                        page_iter_byte_array(iter, metadata, data_type)
-                    }
-                    _ => todo!(),
+
+        // INT64
+        Int64 | Date64 | Time64(_) | Duration(_) | Timestamp(_, _) => {
+            primitive::iter_to_array(iter, metadata, data_type, |x: i64| x)
+        }
+        UInt64 => primitive::iter_to_array(iter, metadata, data_type, |x: i64| x as u64),
+
+        Float32 => primitive::iter_to_array(iter, metadata, data_type, |x: f32| x),
+        Float64 => primitive::iter_to_array(iter, metadata, data_type, |x: f64| x),
+
+        Boolean => Ok(Box::new(boolean::iter_to_array(iter, metadata)?)),
+
+        Binary | Utf8 => binary::iter_to_array::<i32, _, _>(iter, metadata, &data_type),
+        LargeBinary | LargeUtf8 => binary::iter_to_array::<i64, _, _>(iter, metadata, &data_type),
+        FixedSizeBinary(size) => Ok(Box::new(fixed_size_binary::iter_to_array(
+            iter, size, metadata,
+        )?)),
+
+        List(ref inner) => match inner.data_type() {
+            UInt8 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x as u8),
+            UInt16 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x as u16),
+            UInt32 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x as u32),
+            Int8 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x as i8),
+            Int16 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x as i16),
+            Int32 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i32| x as i32),
+
+            Timestamp(TimeUnit::Nanosecond, None) => match metadata.descriptor().type_() {
+                ParquetType::PrimitiveType { physical_type, .. } => match physical_type {
+                    PhysicalType::Int96 => primitive::iter_to_array_nested(
+                        iter,
+                        metadata,
+                        DataType::Timestamp(TimeUnit::Nanosecond, None),
+                        int96_to_i64_ns,
+                    ),
+                    _ => primitive::iter_to_array(iter, metadata, data_type, |x: i64| x),
                 },
                 _ => unreachable!(),
+            },
+
+            // INT64
+            Int64 | Date64 | Time64(_) | Duration(_) | Timestamp(_, _) => {
+                primitive::iter_to_array_nested(iter, metadata, data_type, |x: i64| x)
             }
-        }
+            UInt64 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: i64| x as u64),
+
+            Float32 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: f32| x),
+            Float64 => primitive::iter_to_array_nested(iter, metadata, data_type, |x: f64| x),
+
+            Boolean => boolean::iter_to_array_nested(iter, metadata, data_type),
+
+            Binary | Utf8 => binary::iter_to_array_nested::<i32, _, _>(iter, metadata, data_type),
+            LargeBinary | LargeUtf8 => {
+                binary::iter_to_array_nested::<i64, _, _>(iter, metadata, data_type)
+            }
+            other => Err(ArrowError::NotYetImplemented(format!(
+                "The conversion of {:?} to arrow still not implemented",
+                other
+            ))),
+        },
+        other => Err(ArrowError::NotYetImplemented(format!(
+            "The conversion of {:?} to arrow still not implemented",
+            other
+        ))),
     }
 }
 

--- a/src/io/parquet/read/primitive/nested.rs
+++ b/src/io/parquet/read/primitive/nested.rs
@@ -1,9 +1,7 @@
 use parquet2::{
     encoding::Encoding,
-    read::{
-        levels::{get_bit_width, split_buffer_v1, split_buffer_v2, RLEDecoder},
-        Page, PageHeader,
-    },
+    page::{DataPage, DataPageHeader},
+    read::levels::{get_bit_width, split_buffer_v1, split_buffer_v2, RLEDecoder},
     types::NativeType,
 };
 
@@ -112,7 +110,7 @@ fn read<T, A, F>(
 }
 
 pub fn extend_from_page<T, A, F>(
-    page: &Page,
+    page: &DataPage,
     descriptor: &ColumnDescriptor,
     is_nullable: bool,
     nested: &mut Vec<Box<dyn Nested>>,
@@ -128,7 +126,7 @@ where
     let additional = page.num_values();
 
     match page.header() {
-        PageHeader::V1(header) => {
+        DataPageHeader::V1(header) => {
             assert_eq!(header.definition_level_encoding, Encoding::Rle);
             assert_eq!(header.repetition_level_encoding, Encoding::Rle);
 
@@ -170,7 +168,7 @@ where
                 }
             }
         }
-        PageHeader::V2(header) => match (&page.encoding(), page.dictionary_page()) {
+        DataPageHeader::V2(header) => match (&page.encoding(), page.dictionary_page()) {
             (Encoding::Plain, None) => {
                 let def_level_buffer_length = header.definition_levels_byte_length as usize;
                 let rep_level_buffer_length = header.repetition_levels_byte_length as usize;

--- a/src/io/parquet/read/statistics/mod.rs
+++ b/src/io/parquet/read/statistics/mod.rs
@@ -24,6 +24,12 @@ impl PartialEq for &dyn Statistics {
     }
 }
 
+impl PartialEq for Box<dyn Statistics> {
+    fn eq(&self, other: &Self) -> bool {
+        self.data_type() == other.data_type()
+    }
+}
+
 pub fn deserialize_statistics(stats: &dyn ParquetStatistics) -> Result<Box<dyn Statistics>> {
     match stats.physical_type() {
         PhysicalType::Int32 => {

--- a/src/io/parquet/write/binary/basic.rs
+++ b/src/io/parquet/write/binary/basic.rs
@@ -1,7 +1,7 @@
 use parquet2::{
     encoding::{delta_bitpacked, Encoding},
     metadata::ColumnDescriptor,
-    read::CompressedPage,
+    page::CompressedDataPage,
     statistics::{serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics},
     write::WriteOptions,
 };
@@ -14,7 +14,7 @@ use crate::{
     io::parquet::read::is_type_nullable,
 };
 
-pub(super) fn encode_plain<O: Offset>(
+pub(crate) fn encode_plain<O: Offset>(
     array: &BinaryArray<O>,
     is_optional: bool,
     buffer: &mut Vec<u8>,
@@ -44,7 +44,7 @@ pub fn array_to_page<O: Offset>(
     options: WriteOptions,
     descriptor: ColumnDescriptor,
     encoding: Encoding,
-) -> Result<CompressedPage> {
+) -> Result<CompressedDataPage> {
     let validity = array.validity();
     let is_optional = is_type_nullable(descriptor.type_());
 

--- a/src/io/parquet/write/binary/mod.rs
+++ b/src/io/parquet/write/binary/mod.rs
@@ -2,5 +2,6 @@ mod basic;
 mod nested;
 
 pub use basic::array_to_page;
+pub(crate) use basic::encode_plain;
 pub(super) use basic::{encode_delta, ord_binary};
 pub use nested::array_to_page as nested_array_to_page;

--- a/src/io/parquet/write/binary/nested.rs
+++ b/src/io/parquet/write/binary/nested.rs
@@ -1,5 +1,5 @@
 use parquet2::schema::Encoding;
-use parquet2::{metadata::ColumnDescriptor, read::CompressedPage, write::WriteOptions};
+use parquet2::{metadata::ColumnDescriptor, page::CompressedDataPage, write::WriteOptions};
 
 use super::super::{levels, utils};
 use super::basic::{build_statistics, encode_plain};
@@ -14,7 +14,7 @@ pub fn array_to_page<O, OO>(
     options: WriteOptions,
     descriptor: ColumnDescriptor,
     nested: levels::NestedInfo<OO>,
-) -> Result<CompressedPage>
+) -> Result<CompressedDataPage>
 where
     OO: Offset,
     O: Offset,

--- a/src/io/parquet/write/boolean/basic.rs
+++ b/src/io/parquet/write/boolean/basic.rs
@@ -1,7 +1,7 @@
 use parquet2::{
     encoding::hybrid_rle::bitpacked_encode,
     metadata::ColumnDescriptor,
-    read::CompressedPage,
+    page::CompressedDataPage,
     schema::Encoding,
     statistics::{serialize_statistics, BooleanStatistics, ParquetStatistics, Statistics},
     write::WriteOptions,
@@ -43,7 +43,7 @@ pub fn array_to_page(
     array: &BooleanArray,
     options: WriteOptions,
     descriptor: ColumnDescriptor,
-) -> Result<CompressedPage> {
+) -> Result<CompressedDataPage> {
     let is_optional = is_type_nullable(descriptor.type_());
 
     let validity = array.validity();

--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -1,5 +1,5 @@
 use parquet2::schema::Encoding;
-use parquet2::{metadata::ColumnDescriptor, read::CompressedPage, write::WriteOptions};
+use parquet2::{metadata::ColumnDescriptor, page::CompressedDataPage, write::WriteOptions};
 
 use super::super::{levels, utils};
 use super::basic::{build_statistics, encode_plain};
@@ -14,7 +14,7 @@ pub fn array_to_page<O>(
     options: WriteOptions,
     descriptor: ColumnDescriptor,
     nested: levels::NestedInfo<O>,
-) -> Result<CompressedPage>
+) -> Result<CompressedDataPage>
 where
     O: Offset,
 {

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -1,0 +1,196 @@
+use parquet2::encoding::hybrid_rle::encode_u32;
+use parquet2::page::{CompressedDictPage, CompressedPage};
+use parquet2::schema::Encoding;
+use parquet2::write::DynIter;
+use parquet2::{metadata::ColumnDescriptor, write::WriteOptions};
+
+use super::binary::encode_plain as binary_encode_plain;
+use super::primitive::encode_plain as primitive_encode_plain;
+use super::utf8::encode_plain as utf8_encode_plain;
+use crate::array::{Array, DictionaryArray, DictionaryKey, PrimitiveArray};
+use crate::bitmap::Bitmap;
+use crate::datatypes::DataType;
+use crate::error::{ArrowError, Result};
+use crate::io::parquet::read::is_type_nullable;
+use crate::io::parquet::write::utils;
+
+fn encode_keys<K: DictionaryKey>(
+    array: &PrimitiveArray<K>,
+    // todo: merge this to not discard values' validity
+    validity: &Option<Bitmap>,
+    descriptor: ColumnDescriptor,
+    options: WriteOptions,
+) -> Result<CompressedPage> {
+    let is_optional = is_type_nullable(descriptor.type_());
+
+    let mut buffer = vec![];
+
+    if let Some(validity) = validity {
+        let projected_val = array.iter().map(|x| {
+            x.map(|x| validity.get_bit(x.to_usize().unwrap()))
+                .unwrap_or(false)
+        });
+        let projected_val = Bitmap::from_trusted_len_iter(projected_val);
+
+        utils::write_def_levels(
+            &mut buffer,
+            is_optional,
+            &Some(projected_val),
+            array.len(),
+            options.version,
+        )?;
+    } else {
+        utils::write_def_levels(
+            &mut buffer,
+            is_optional,
+            array.validity(),
+            array.len(),
+            options.version,
+        )?;
+    }
+
+    let definition_levels_byte_length = buffer.len();
+
+    // encode indices
+    // compute the required number of bits
+    if let Some(validity) = validity {
+        let keys = array
+            .iter()
+            .flatten()
+            .map(|x| {
+                let index = x.to_usize().unwrap();
+                // discard indices whose values are null, since they are part of the def levels.
+                if validity.get_bit(index) {
+                    Some(index as u32)
+                } else {
+                    None
+                }
+            })
+            .flatten();
+        let num_bits = utils::get_bit_width(keys.clone().max().unwrap_or(0) as u64) as u8;
+
+        let keys = utils::ExactSizedIter::new(keys, array.len() - array.null_count());
+
+        // num_bits as a single byte
+        buffer.push(num_bits);
+
+        // followed by the encoded indices.
+        encode_u32(&mut buffer, keys, num_bits)?;
+    } else {
+        let keys = array.iter().flatten().map(|x| x.to_usize().unwrap() as u32);
+        let num_bits = utils::get_bit_width(keys.clone().max().unwrap_or(0) as u64) as u8;
+
+        let keys = utils::ExactSizedIter::new(keys, array.len() - array.null_count());
+
+        // num_bits as a single byte
+        buffer.push(num_bits);
+
+        // followed by the encoded indices.
+        encode_u32(&mut buffer, keys, num_bits)?;
+    }
+
+    let uncompressed_page_size = buffer.len();
+
+    let buffer = utils::compress(buffer, options, definition_levels_byte_length)?;
+
+    utils::build_plain_page(
+        buffer,
+        array.len(),
+        array.null_count(),
+        uncompressed_page_size,
+        0,
+        definition_levels_byte_length,
+        None,
+        descriptor,
+        options,
+        Encoding::PlainDictionary,
+    )
+    .map(CompressedPage::Data)
+}
+
+macro_rules! dyn_prim {
+    ($from:ty, $to:ty, $array:expr) => {{
+        let values = $array.values().as_any().downcast_ref().unwrap();
+
+        let mut buffer = vec![];
+        primitive_encode_plain::<$from, $to>(values, false, &mut buffer);
+
+        CompressedPage::Dict(CompressedDictPage::new(buffer, values.len()))
+    }};
+}
+
+pub fn array_to_pages<K: DictionaryKey>(
+    array: &DictionaryArray<K>,
+    descriptor: ColumnDescriptor,
+    options: WriteOptions,
+    encoding: Encoding,
+) -> Result<DynIter<'static, Result<CompressedPage>>>
+where
+    PrimitiveArray<K>: std::fmt::Display,
+{
+    match encoding {
+        Encoding::PlainDictionary | Encoding::RleDictionary => {
+            // write DictPage
+            let dict_page = match array.values().data_type() {
+                DataType::Int8 => dyn_prim!(i8, i32, array),
+                DataType::Int16 => dyn_prim!(i16, i32, array),
+                DataType::Int32 | DataType::Date32 | DataType::Time32(_) => {
+                    dyn_prim!(i32, i32, array)
+                }
+                DataType::Int64
+                | DataType::Date64
+                | DataType::Time64(_)
+                | DataType::Timestamp(_, _)
+                | DataType::Duration(_) => dyn_prim!(i64, i64, array),
+                DataType::UInt8 => dyn_prim!(u8, i32, array),
+                DataType::UInt16 => dyn_prim!(u16, i32, array),
+                DataType::UInt32 => dyn_prim!(u32, i32, array),
+                DataType::UInt64 => dyn_prim!(i64, i64, array),
+                DataType::Utf8 => {
+                    let values = array.values().as_any().downcast_ref().unwrap();
+
+                    let mut buffer = vec![];
+                    utf8_encode_plain::<i32>(values, false, &mut buffer);
+                    CompressedPage::Dict(CompressedDictPage::new(buffer, values.len()))
+                }
+                DataType::LargeUtf8 => {
+                    let values = array.values().as_any().downcast_ref().unwrap();
+
+                    let mut buffer = vec![];
+                    utf8_encode_plain::<i64>(values, false, &mut buffer);
+                    CompressedPage::Dict(CompressedDictPage::new(buffer, values.len()))
+                }
+                DataType::Binary => {
+                    let values = array.values().as_any().downcast_ref().unwrap();
+
+                    let mut buffer = vec![];
+                    binary_encode_plain::<i32>(values, false, &mut buffer);
+                    CompressedPage::Dict(CompressedDictPage::new(buffer, values.len()))
+                }
+                DataType::LargeBinary => {
+                    let values = array.values().as_any().downcast_ref().unwrap();
+
+                    let mut buffer = vec![];
+                    binary_encode_plain::<i64>(values, false, &mut buffer);
+                    CompressedPage::Dict(CompressedDictPage::new(buffer, values.len()))
+                }
+                other => {
+                    return Err(ArrowError::NotYetImplemented(format!(
+                        "Writing dictionary arrays to parquet only support data type {:?}",
+                        other
+                    )))
+                }
+            };
+
+            // write DataPage pointing to DictPage
+            let data_page =
+                encode_keys(array.keys(), array.values().validity(), descriptor, options)?;
+
+            let iter = std::iter::once(Ok(dict_page)).chain(std::iter::once(Ok(data_page)));
+            Ok(DynIter::new(Box::new(iter)))
+        }
+        _ => Err(ArrowError::NotYetImplemented(
+            "Dictionary arrays only support dictionary encoding".to_string(),
+        )),
+    }
+}

--- a/src/io/parquet/write/fixed_len_bytes.rs
+++ b/src/io/parquet/write/fixed_len_bytes.rs
@@ -1,6 +1,6 @@
 use parquet2::{
-    compression::create_codec, metadata::ColumnDescriptor, read::CompressedPage, schema::Encoding,
-    write::WriteOptions,
+    compression::create_codec, metadata::ColumnDescriptor, page::CompressedDataPage,
+    schema::Encoding, write::WriteOptions,
 };
 
 use super::utils;
@@ -14,7 +14,7 @@ pub fn array_to_page(
     array: &FixedSizeBinaryArray,
     options: WriteOptions,
     descriptor: ColumnDescriptor,
-) -> Result<CompressedPage> {
+) -> Result<CompressedDataPage> {
     let is_optional = is_type_nullable(descriptor.type_());
     let validity = array.validity();
 

--- a/src/io/parquet/write/primitive/basic.rs
+++ b/src/io/parquet/write/primitive/basic.rs
@@ -1,6 +1,6 @@
 use parquet2::{
     metadata::ColumnDescriptor,
-    read::CompressedPage,
+    page::CompressedDataPage,
     schema::Encoding,
     statistics::{serialize_statistics, ParquetStatistics, PrimitiveStatistics, Statistics},
     types::NativeType,
@@ -15,7 +15,7 @@ use crate::{
     types::NativeType as ArrowNativeType,
 };
 
-pub(super) fn encode_plain<T, R>(array: &PrimitiveArray<T>, is_optional: bool, buffer: &mut Vec<u8>)
+pub(crate) fn encode_plain<T, R>(array: &PrimitiveArray<T>, is_optional: bool, buffer: &mut Vec<u8>)
 where
     T: ArrowNativeType,
     R: NativeType,
@@ -42,7 +42,7 @@ pub fn array_to_page<T, R>(
     array: &PrimitiveArray<T>,
     options: WriteOptions,
     descriptor: ColumnDescriptor,
-) -> Result<CompressedPage>
+) -> Result<CompressedDataPage>
 where
     T: ArrowNativeType,
     R: NativeType,

--- a/src/io/parquet/write/primitive/mod.rs
+++ b/src/io/parquet/write/primitive/mod.rs
@@ -2,4 +2,5 @@ mod basic;
 mod nested;
 
 pub use basic::array_to_page;
+pub(crate) use basic::encode_plain;
 pub use nested::array_to_page as nested_array_to_page;

--- a/src/io/parquet/write/primitive/nested.rs
+++ b/src/io/parquet/write/primitive/nested.rs
@@ -1,6 +1,6 @@
 use parquet2::schema::Encoding;
 use parquet2::{
-    metadata::ColumnDescriptor, read::CompressedPage, types::NativeType, write::WriteOptions,
+    metadata::ColumnDescriptor, page::CompressedDataPage, types::NativeType, write::WriteOptions,
 };
 
 use super::super::levels;
@@ -18,7 +18,7 @@ pub fn array_to_page<T, R, O>(
     options: WriteOptions,
     descriptor: ColumnDescriptor,
     nested: levels::NestedInfo<O>,
-) -> Result<CompressedPage>
+) -> Result<CompressedDataPage>
 where
     T: ArrowNativeType,
     R: NativeType,

--- a/src/io/parquet/write/record_batch.rs
+++ b/src/io/parquet/write/record_batch.rs
@@ -1,5 +1,5 @@
 use super::{
-    array_to_page, to_parquet_schema, DynIter, Encoding, RowGroupIter, SchemaDescriptor,
+    array_to_pages, to_parquet_schema, DynIter, Encoding, RowGroupIter, SchemaDescriptor,
     WriteOptions,
 };
 use crate::{
@@ -59,12 +59,7 @@ impl<I: Iterator<Item = Result<RecordBatch>>> Iterator for RowGroupIterator<I> {
                     .zip(self.parquet_schema.columns().to_vec().into_iter())
                     .zip(encodings.into_iter())
                     .map(move |((array, type_), encoding)| {
-                        Ok(DynIter::new(std::iter::once(array_to_page(
-                            array.as_ref(),
-                            type_,
-                            options,
-                            encoding,
-                        ))))
+                        array_to_pages(array, type_, options, encoding)
                     }),
             ))
         })

--- a/src/io/parquet/write/utf8/basic.rs
+++ b/src/io/parquet/write/utf8/basic.rs
@@ -1,7 +1,7 @@
 use parquet2::{
     encoding::Encoding,
     metadata::ColumnDescriptor,
-    read::CompressedPage,
+    page::CompressedDataPage,
     statistics::{serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics},
     write::WriteOptions,
 };
@@ -14,7 +14,7 @@ use crate::{
     io::parquet::read::is_type_nullable,
 };
 
-pub(super) fn encode_plain<O: Offset>(
+pub(crate) fn encode_plain<O: Offset>(
     array: &Utf8Array<O>,
     is_optional: bool,
     buffer: &mut Vec<u8>,
@@ -43,7 +43,7 @@ pub fn array_to_page<O: Offset>(
     options: WriteOptions,
     descriptor: ColumnDescriptor,
     encoding: Encoding,
-) -> Result<CompressedPage> {
+) -> Result<CompressedDataPage> {
     let validity = array.validity();
     let is_optional = is_type_nullable(descriptor.type_());
 

--- a/src/io/parquet/write/utf8/mod.rs
+++ b/src/io/parquet/write/utf8/mod.rs
@@ -2,4 +2,5 @@ mod basic;
 mod nested;
 
 pub use basic::array_to_page;
+pub(crate) use basic::encode_plain;
 pub use nested::array_to_page as nested_array_to_page;

--- a/src/io/parquet/write/utf8/nested.rs
+++ b/src/io/parquet/write/utf8/nested.rs
@@ -1,5 +1,5 @@
 use parquet2::schema::Encoding;
-use parquet2::{metadata::ColumnDescriptor, read::CompressedPage, write::WriteOptions};
+use parquet2::{metadata::ColumnDescriptor, page::CompressedDataPage, write::WriteOptions};
 
 use super::super::{levels, utils};
 use super::basic::{build_statistics, encode_plain};
@@ -14,7 +14,7 @@ pub fn array_to_page<O, OO>(
     options: WriteOptions,
     descriptor: ColumnDescriptor,
     nested: levels::NestedInfo<OO>,
-) -> Result<CompressedPage>
+) -> Result<CompressedDataPage>
 where
     OO: Offset,
     O: Offset,


### PR DESCRIPTION
Closes #211. Dictionary-encoding is a popular and important technique to reduce memory usage.

Parquet has an encoding specifically for this (PlainDictionary and RleDictionary). Arrow has "DictionaryArray" specifically for this. This PR bridges these two by allowing arrow2 to read and write dictionary arrays to and from parquet.

The semantics is as follows:

When writing to parquet, it is now possible to use `Encoding::PlainDictionary` and `Encoding::RleDictionary` when writing `DataType::Dictionary` fields. This causes the array to be dictionary-encoded into parquet (two pages: one with values one with indices).

When reading from parquet, if the arrow schema on the metadata contains a field with `DataType::Dictionary` and the pages are dictionary-encoded, we read them to a `DictionaryArray` (all other cases error with not yet implemented).

As before, dictionary-encoded pages without an explicit `DataType::Dictionary` in the schema are read to their "natural", non-dictionary, `DataType`.
