### PR TITLE
Special-case filter single array record batch in filter_record_batch

### DIFF
--- a/benches/filter_kernels.rs
+++ b/benches/filter_kernels.rs
@@ -16,9 +16,12 @@
 // under the License.
 extern crate arrow2;
 
+use std::sync::Arc;
+
 use arrow2::array::*;
-use arrow2::compute::filter::{build_filter, filter, Filter};
-use arrow2::datatypes::DataType;
+use arrow2::compute::filter::{build_filter, filter, filter_record_batch, Filter};
+use arrow2::datatypes::{DataType, Field, Schema};
+use arrow2::record_batch::RecordBatch;
 use arrow2::util::bench_util::*;
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -119,6 +122,15 @@ fn add_benchmark(c: &mut Criterion) {
     });
     c.bench_function("filter context string low selectivity", |b| {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
+    });
+
+    let field = Field::new("c1", data_array.data_type().clone(), true);
+    let schema = Schema::new(vec![field]);
+
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(data_array)]).unwrap();
+
+    c.bench_function("filter single record batch", |b| {
+        b.iter(|| filter_record_batch(&batch, &filter_array))
     });
 }
 

--- a/benches/filter_kernels.rs
+++ b/benches/filter_kernels.rs
@@ -124,6 +124,8 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_built_filter(&sparse_filter, &data_array))
     });
 
+    let data_array = create_primitive_array::<f32>(size, DataType::Float32, 0.0);
+
     let field = Field::new("c1", data_array.data_type().clone(), true);
     let schema = Schema::new(vec![field]);
 

--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -254,16 +254,16 @@ pub fn filter(array: &dyn Array, filter: &BooleanArray) -> Result<Box<dyn Array>
 /// Therefore, it is considered undefined behavior to pass `filter` with null values.
 pub fn filter_record_batch(
     record_batch: &RecordBatch,
-    filter: &BooleanArray,
+    filter_values: &BooleanArray,
 ) -> Result<RecordBatch> {
     let num_colums = record_batch.columns().len();
 
     let filtered_arrays = match num_colums {
         1 => {
-            vec![super::filter::filter(record_batch.columns()[0].as_ref(), filter)?.into()]
+            vec![filter(record_batch.columns()[0].as_ref(), filter_values)?.into()]
         }
         _ => {
-            let filter = build_filter(filter)?;
+            let filter = build_filter(filter_values)?;
             record_batch
                 .columns()
                 .iter()


### PR DESCRIPTION
Gives a speed up for single-column batches.

Closes #234

```
filter single record batch                                                                            
                        time:   [229.93 us 231.52 us 233.29 us]
                        change: [-54.913% -54.501% -54.106%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
```