### PR TITLE
Simplified `new` signature of growable API

### DIFF
--- a/examples/growable.rs
+++ b/examples/growable.rs
@@ -1,0 +1,38 @@
+use arrow2::array::growable::{Growable, GrowablePrimitive};
+use arrow2::array::{Array, PrimitiveArray};
+
+fn main() {
+    // say we have two sorted arrays
+    let array0 = PrimitiveArray::<i64>::from_slice(&[1, 2, 5]);
+    let array1 = PrimitiveArray::<i64>::from_slice(&[3, 4, 6]);
+
+    // and we found a way to compute the slices that sort them:
+    // (array_index, start of the slice, length of the slice)
+    let slices = &[
+        // [1, 2] from array0
+        (0, 0, 2),
+        // [3, 4] from array1
+        (1, 0, 2),
+        // [5] from array0
+        (0, 2, 1),
+        // [6] from array1
+        (1, 2, 1),
+    ];
+
+    // we can build a new array out of these slices as follows:
+    // first, declare the growable out of the arrays. Since we are not extending with nulls,
+    // we use `false`. We also pre-allocate, as we know that we will need all entries.
+    let capacity = array0.len() + array1.len();
+    let use_validity = false;
+    let mut growable = GrowablePrimitive::new(vec![&array0, &array1], use_validity, capacity);
+
+    // next, extend the growable:
+    for slice in slices {
+        growable.extend(slice.0, slice.1, slice.2);
+    }
+    // finally, convert it to the array (this is `O(1)`)
+    let result: PrimitiveArray<i64> = growable.into();
+
+    let expected = PrimitiveArray::<i64>::from_slice(&[1, 2, 3, 4, 5, 6]);
+    assert_eq!(result, expected);
+}

--- a/src/array/growable/mod.rs
+++ b/src/array/growable/mod.rs
@@ -53,15 +53,10 @@ macro_rules! dyn_growable {
     ($ty:ty, $arrays:expr, $use_validity:expr, $capacity:expr) => {{
         let arrays = $arrays
             .iter()
-            .map(|array| {
-                array
-                    .as_any()
-                    .downcast_ref::<PrimitiveArray<$ty>>()
-                    .unwrap()
-            })
+            .map(|array| array.as_any().downcast_ref().unwrap())
             .collect::<Vec<_>>();
         Box::new(primitive::GrowablePrimitive::<$ty>::new(
-            &arrays,
+            arrays,
             $use_validity,
             $capacity,
         ))
@@ -103,11 +98,17 @@ pub fn make_growable<'a>(
 
     match data_type {
         DataType::Null => Box::new(null::GrowableNull::new()),
-        DataType::Boolean => Box::new(boolean::GrowableBoolean::new(
-            arrays,
-            use_validity,
-            capacity,
-        )),
+        DataType::Boolean => {
+            let arrays = arrays
+                .iter()
+                .map(|array| array.as_any().downcast_ref().unwrap())
+                .collect::<Vec<_>>();
+            Box::new(boolean::GrowableBoolean::new(
+                arrays,
+                use_validity,
+                capacity,
+            ))
+        }
         DataType::Int8 => dyn_growable!(i8, arrays, use_validity, capacity),
         DataType::Int16 => dyn_growable!(i16, arrays, use_validity, capacity),
         DataType::Int32
@@ -137,10 +138,10 @@ pub fn make_growable<'a>(
         DataType::Utf8 => {
             let arrays = arrays
                 .iter()
-                .map(|array| array.as_any().downcast_ref::<Utf8Array<i32>>().unwrap())
+                .map(|array| array.as_any().downcast_ref().unwrap())
                 .collect::<Vec<_>>();
             Box::new(utf8::GrowableUtf8::<i32>::new(
-                &arrays,
+                arrays,
                 use_validity,
                 capacity,
             ))
@@ -148,45 +149,81 @@ pub fn make_growable<'a>(
         DataType::LargeUtf8 => {
             let arrays = arrays
                 .iter()
-                .map(|array| array.as_any().downcast_ref::<Utf8Array<i64>>().unwrap())
+                .map(|array| array.as_any().downcast_ref().unwrap())
                 .collect::<Vec<_>>();
             Box::new(utf8::GrowableUtf8::<i64>::new(
-                &arrays,
+                arrays,
                 use_validity,
                 capacity,
             ))
         }
-        DataType::Binary => Box::new(binary::GrowableBinary::<i32>::new(
-            arrays,
-            use_validity,
-            capacity,
-        )),
-        DataType::LargeBinary => Box::new(binary::GrowableBinary::<i64>::new(
-            arrays,
-            use_validity,
-            capacity,
-        )),
-        DataType::FixedSizeBinary(_) => Box::new(fixed_binary::GrowableFixedSizeBinary::new(
-            arrays,
-            use_validity,
-            capacity,
-        )),
+        DataType::Binary => {
+            let arrays = arrays
+                .iter()
+                .map(|array| array.as_any().downcast_ref().unwrap())
+                .collect::<Vec<_>>();
+            Box::new(binary::GrowableBinary::<i32>::new(
+                arrays,
+                use_validity,
+                capacity,
+            ))
+        }
+        DataType::LargeBinary => {
+            let arrays = arrays
+                .iter()
+                .map(|array| array.as_any().downcast_ref().unwrap())
+                .collect::<Vec<_>>();
+            Box::new(binary::GrowableBinary::<i64>::new(
+                arrays,
+                use_validity,
+                capacity,
+            ))
+        }
+        DataType::FixedSizeBinary(_) => {
+            let arrays = arrays
+                .iter()
+                .map(|array| array.as_any().downcast_ref().unwrap())
+                .collect::<Vec<_>>();
+            Box::new(fixed_binary::GrowableFixedSizeBinary::new(
+                arrays,
+                use_validity,
+                capacity,
+            ))
+        }
 
-        DataType::List(_) => Box::new(list::GrowableList::<i32>::new(
-            arrays,
-            use_validity,
-            capacity,
-        )),
-        DataType::LargeList(_) => Box::new(list::GrowableList::<i64>::new(
-            arrays,
-            use_validity,
-            capacity,
-        )),
-        DataType::Struct(_) => Box::new(structure::GrowableStruct::new(
-            arrays,
-            use_validity,
-            capacity,
-        )),
+        DataType::List(_) => {
+            let arrays = arrays
+                .iter()
+                .map(|array| array.as_any().downcast_ref().unwrap())
+                .collect::<Vec<_>>();
+            Box::new(list::GrowableList::<i32>::new(
+                arrays,
+                use_validity,
+                capacity,
+            ))
+        }
+        DataType::LargeList(_) => {
+            let arrays = arrays
+                .iter()
+                .map(|array| array.as_any().downcast_ref().unwrap())
+                .collect::<Vec<_>>();
+            Box::new(list::GrowableList::<i64>::new(
+                arrays,
+                use_validity,
+                capacity,
+            ))
+        }
+        DataType::Struct(_) => {
+            let arrays = arrays
+                .iter()
+                .map(|array| array.as_any().downcast_ref().unwrap())
+                .collect::<Vec<_>>();
+            Box::new(structure::GrowableStruct::new(
+                arrays,
+                use_validity,
+                capacity,
+            ))
+        }
         DataType::FixedSizeList(_, _) => todo!(),
         DataType::Union(_) => todo!(),
         DataType::Dictionary(key, _) => match key.as_ref() {

--- a/src/array/growable/primitive.rs
+++ b/src/array/growable/primitive.rs
@@ -155,15 +155,14 @@ mod tests {
 
     #[test]
     fn test_primitive_joining_arrays() {
-        let b = PrimitiveArray::<u8>::from(vec![Some(1), Some(2), Some(3)]).to(DataType::UInt8);
-        let c = PrimitiveArray::<u8>::from(vec![Some(4), Some(5), Some(6)]).to(DataType::UInt8);
+        let b = PrimitiveArray::<u8>::from(vec![Some(1), Some(2), Some(3)]);
+        let c = PrimitiveArray::<u8>::from(vec![Some(4), Some(5), Some(6)]);
         let mut a = GrowablePrimitive::new(vec![&b, &c], false, 4);
         a.extend(0, 0, 2);
         a.extend(1, 1, 2);
         let result: PrimitiveArray<u8> = a.into();
 
-        let expected = PrimitiveArray::<u8>::from(vec![Some(1), Some(2), Some(5), Some(6)])
-            .to(DataType::UInt8);
+        let expected = PrimitiveArray::<u8>::from(vec![Some(1), Some(2), Some(5), Some(6)]);
         assert_eq!(result, expected);
     }
 }

--- a/src/array/growable/structure.rs
+++ b/src/array/growable/structure.rs
@@ -24,7 +24,7 @@ pub struct GrowableStruct<'a> {
 impl<'a> GrowableStruct<'a> {
     /// # Panics
     /// This function panics if any of the `arrays` is not downcastable to `PrimitiveArray<T>`.
-    pub fn new(arrays: &[&'a dyn Array], mut use_validity: bool, capacity: usize) -> Self {
+    pub fn new(arrays: Vec<&'a StructArray>, mut use_validity: bool, capacity: usize) -> Self {
         // if any of the arrays has nulls, insertions from any array requires setting bits
         // as there is at least one array with nulls.
         if arrays.iter().any(|array| array.null_count() > 0) {
@@ -155,7 +155,7 @@ mod tests {
 
         let array = StructArray::from_data(fields.clone(), values.clone(), None);
 
-        let mut a = GrowableStruct::new(&[&array], false, 0);
+        let mut a = GrowableStruct::new(vec![&array], false, 0);
 
         a.extend(0, 1, 2);
         let result: StructArray = a.into();
@@ -174,7 +174,7 @@ mod tests {
 
         let array = StructArray::from_data(fields.clone(), values.clone(), None).slice(1, 3);
 
-        let mut a = GrowableStruct::new(&[&array], false, 0);
+        let mut a = GrowableStruct::new(vec![&array], false, 0);
 
         a.extend(0, 1, 2);
         let result: StructArray = a.into();
@@ -198,7 +198,7 @@ mod tests {
             Some(Bitmap::from_u8_slice(&[0b00000010], 5)),
         );
 
-        let mut a = GrowableStruct::new(&[&array], false, 0);
+        let mut a = GrowableStruct::new(vec![&array], false, 0);
 
         a.extend(0, 1, 2);
         let result: StructArray = a.into();
@@ -218,7 +218,7 @@ mod tests {
 
         let array = StructArray::from_data(fields.clone(), values.clone(), None);
 
-        let mut mutable = GrowableStruct::new(&[&array, &array], false, 0);
+        let mut mutable = GrowableStruct::new(vec![&array, &array], false, 0);
 
         mutable.extend(0, 1, 2);
         mutable.extend(1, 0, 2);

--- a/src/array/growable/utf8.rs
+++ b/src/array/growable/utf8.rs
@@ -24,7 +24,7 @@ pub struct GrowableUtf8<'a, O: Offset> {
 }
 
 impl<'a, O: Offset> GrowableUtf8<'a, O> {
-    pub fn new(arrays: &[&'a Utf8Array<O>], mut use_validity: bool, capacity: usize) -> Self {
+    pub fn new(arrays: Vec<&'a Utf8Array<O>>, mut use_validity: bool, capacity: usize) -> Self {
         // if any of the arrays has nulls, insertions from any array requires setting bits
         // as there is at least one array with nulls.
         if arrays.iter().any(|array| array.null_count() > 0) {
@@ -117,7 +117,7 @@ mod tests {
     fn test_variable_sized_validity() {
         let array = Utf8Array::<i32>::from_iter(vec![Some("a"), Some("bc"), None, Some("defh")]);
 
-        let mut a = GrowableUtf8::new(&[&array], false, 0);
+        let mut a = GrowableUtf8::new(vec![&array], false, 0);
 
         a.extend(0, 1, 2);
 
@@ -134,7 +134,7 @@ mod tests {
         let array = Utf8Array::<i32>::from_iter(vec![Some("a"), Some("bc"), None, Some("defh")]);
         let array = array.slice(1, 3);
 
-        let mut a = GrowableUtf8::new(&[&array], false, 0);
+        let mut a = GrowableUtf8::new(vec![&array], false, 0);
 
         a.extend(0, 0, 3);
 
@@ -149,7 +149,7 @@ mod tests {
         let array = Utf8Array::<i32>::from_iter(vec![Some("a"), Some("bc"), None, Some("defh")]);
         let array = array.slice(1, 3);
 
-        let mut a = GrowableUtf8::new(&[&array], false, 0);
+        let mut a = GrowableUtf8::new(vec![&array], false, 0);
 
         a.extend(0, 0, 3);
 
@@ -164,7 +164,7 @@ mod tests {
         let array1 = Utf8Array::<i32>::from_slice(&["hello", "world"]);
         let array2 = Utf8Array::<i32>::from(&[Some("1"), None]);
 
-        let mut a = GrowableUtf8::new(&[&array1, &array2], false, 5);
+        let mut a = GrowableUtf8::new(vec![&array1, &array2], false, 5);
 
         a.extend(0, 0, 2);
         a.extend(1, 0, 2);
@@ -181,7 +181,7 @@ mod tests {
         let array = Utf8Array::<i32>::from_iter(vec![Some("a"), Some("bc"), None, Some("defh")]);
         let array = array.slice(1, 3);
 
-        let mut a = GrowableUtf8::new(&[&array], true, 0);
+        let mut a = GrowableUtf8::new(vec![&array], true, 0);
 
         a.extend(0, 1, 2);
         a.extend_validity(1);

--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -90,11 +90,9 @@ fn filter_growable<'a>(growable: &mut impl Growable<'a>, chunks: &[(usize, usize
 
 macro_rules! dyn_build_filter {
     ($ty:ty, $array:expr, $filter_count:expr, $chunks:expr) => {{
-        let array = $array
-            .as_any()
-            .downcast_ref::<PrimitiveArray<$ty>>()
-            .unwrap();
-        let mut growable = growable::GrowablePrimitive::<$ty>::new(&[array], false, $filter_count);
+        let array = $array.as_any().downcast_ref().unwrap();
+        let mut growable =
+            growable::GrowablePrimitive::<$ty>::new(vec![array], false, $filter_count);
         filter_growable(&mut growable, &$chunks);
         let array: PrimitiveArray<$ty> = growable.into();
         Box::new(array)
@@ -154,7 +152,7 @@ pub fn build_filter(filter: &BooleanArray) -> Result<Filter> {
         }
         DataType::Utf8 => {
             let array = array.as_any().downcast_ref::<Utf8Array<i32>>().unwrap();
-            let mut growable = growable::GrowableUtf8::<i32>::new(&[array], false, filter_count);
+            let mut growable = growable::GrowableUtf8::<i32>::new(vec![array], false, filter_count);
             filter_growable(&mut growable, &chunks);
             let array: Utf8Array<i32> = growable.into();
             Box::new(array)

--- a/src/compute/take/list.rs
+++ b/src/compute/take/list.rs
@@ -39,10 +39,10 @@ pub fn take<I: Offset, O: Index>(
         })
         .collect::<Vec<ListArray<I>>>();
 
-    let array_ref: Vec<&dyn Array> = arrays.iter().map(|v| v as &dyn Array).collect();
+    let arrays = arrays.iter().collect();
 
     if let Some(validity) = indices.validity() {
-        let mut growable: GrowableList<I> = GrowableList::new(&array_ref, true, capacity);
+        let mut growable: GrowableList<I> = GrowableList::new(arrays, true, capacity);
 
         for index in 0..indices.len() {
             if validity.get_bit(index) {
@@ -54,7 +54,7 @@ pub fn take<I: Offset, O: Index>(
 
         growable.into()
     } else {
-        let mut growable: GrowableList<I> = GrowableList::new(&array_ref, false, capacity);
+        let mut growable: GrowableList<I> = GrowableList::new(arrays, false, capacity);
         for index in 0..indices.len() {
             growable.extend(index, 0, 1);
         }


### PR DESCRIPTION
It also removes an extra allocation that was being done internally and an extra check.

# Backward incompatible changes:

`Growable*::new` now expects a vector (not slice) of references of their corresponding types and no longer panic (the type is by definition correct). To migrate, downcast the vector of arrays prior to passing them to the growable.

```rust
let array = Utf8Array::<i32>::from_iter(vec![Some("a"), Some("bc"), None, Some("defh")]);
let mut a = GrowableUtf8::new(vec![&array], false, 0);
```

I.e. signature change is `new(&[&'a dyn Array], ...) -> new(Vec<&'a A>, ...)` where `A` is the corresponding array type.