### PR TITLE
Fixed error in slicing bitmap.

### DIFF
--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -216,7 +216,7 @@ impl Bitmap {
     #[inline]
     pub(crate) fn as_slice(&self) -> &[u8] {
         let start = self.offset / 8;
-        let len = self.length.saturating_add(7) / 8;
+        let len = (self.offset() + self.length).saturating_add(7) / 8;
         &self.bytes[start..start + len]
     }
 }
@@ -260,5 +260,16 @@ mod tests {
         assert_eq!(slice, &[0b1]);
 
         assert_eq!(0, b.offset());
+    }
+
+    #[test]
+    fn as_slice_offset_middle() {
+        let b = Bitmap::from_u8_slice(&[0, 0, 0, 0b00010101], 27);
+        let b = b.slice(22, 5);
+
+        let slice = b.as_slice();
+        assert_eq!(slice, &[0, 0b00010101]);
+
+        assert_eq!(6, b.offset());
     }
 }

--- a/src/bitmap/utils/slice_iterator.rs
+++ b/src/bitmap/utils/slice_iterator.rs
@@ -284,4 +284,13 @@ mod tests {
         // the first "11" in the second byte
         assert_eq!(chunks, vec![(0, 2)]);
     }
+
+    #[test]
+    fn remainder_1() {
+        let values = Bitmap::from_u8_slice(&[0, 0, 0b00000000, 0b00010101], 27);
+        let values = values.slice(22, 5);
+        let iter = SlicesIterator::new(&values);
+        let chunks = iter.collect::<Vec<_>>();
+        assert_eq!(chunks, vec![(2, 1), (4, 1)]);
+    }
 }


### PR DESCRIPTION
When the slice has an offset and crosses a byte, we need to also take that byte into account.

Thanks to @ritchie46 for initially reporting it. 👍