### PR TITLE
Added support for FFI of dictionary-encoded arrays

### DIFF
--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -104,7 +104,7 @@ class TestCase(unittest.TestCase):
         data = [
             round(decimal.Decimal(722.82), 2),
             round(decimal.Decimal(-934.11), 2),
-            None
+            None,
         ]
         a = pyarrow.array(data, pyarrow.decimal128(5, 2))
         b = arrow_pyarrow_integration_testing.round_trip(a)
@@ -179,3 +179,17 @@ class TestCase(unittest.TestCase):
             b.validate(full=True)
             assert a.to_pylist() == b.to_pylist()
             assert a.type == b.type
+
+    def test_dict(self):
+        """
+        Python -> Rust -> Python
+        """
+        a = pyarrow.array(
+            ["a", "a", "b", None, "c"],
+            pyarrow.dictionary(pyarrow.int64(), pyarrow.utf8()),
+        )
+        b = arrow_pyarrow_integration_testing.round_trip(a)
+
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type

--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -25,7 +25,7 @@ unsafe impl<O: Offset> ToFfi for BinaryArray<O> {
 
 unsafe impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryArray<O> {
     fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.data_type()?;
+        let data_type = array.field()?.data_type().clone();
         let expected = if O::is_large() {
             DataType::LargeBinary
         } else {

--- a/src/array/boolean/ffi.rs
+++ b/src/array/boolean/ffi.rs
@@ -1,5 +1,6 @@
 use crate::{
     array::{FromFfi, ToFfi},
+    datatypes::DataType,
     ffi,
 };
 
@@ -22,6 +23,8 @@ unsafe impl ToFfi for BooleanArray {
 
 unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for BooleanArray {
     fn try_from_ffi(array: A) -> Result<Self> {
+        let data_type = array.field()?.data_type().clone();
+        assert_eq!(data_type, DataType::Boolean);
         let length = array.array().len();
         let offset = array.array().offset();
         let mut validity = unsafe { array.validity() }?;

--- a/src/array/dictionary/ffi.rs
+++ b/src/array/dictionary/ffi.rs
@@ -1,0 +1,39 @@
+use crate::{
+    array::{FromFfi, PrimitiveArray, ToFfi},
+    error::Result,
+    ffi,
+};
+
+use super::{DictionaryArray, DictionaryKey};
+
+unsafe impl<K: DictionaryKey> ToFfi for DictionaryArray<K> {
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
+        self.keys.buffers()
+    }
+
+    #[inline]
+    fn offset(&self) -> usize {
+        self.offset
+    }
+}
+
+unsafe impl<K: DictionaryKey, A: ffi::ArrowArrayRef> FromFfi<A> for DictionaryArray<K> {
+    fn try_from_ffi(array: A) -> Result<Self> {
+        // keys: similar to PrimitiveArray, but the datatype is the inner one
+        let length = array.array().len();
+        let offset = array.array().offset();
+        let mut validity = unsafe { array.validity() }?;
+        let mut values = unsafe { array.buffer::<K>(0) }?;
+
+        if offset > 0 {
+            values = values.slice(offset, length);
+            validity = validity.map(|x| x.slice(offset, length))
+        }
+        let keys = PrimitiveArray::<K>::from_data(K::DATA_TYPE, values, validity);
+        // values
+        let values = array.dictionary()?.unwrap();
+        let values = ffi::try_from(values)?.into();
+
+        Ok(DictionaryArray::<K>::from_data(keys, values))
+    }
+}

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -6,12 +6,13 @@ use crate::{
     types::{NativeType, NaturalDataType},
 };
 
+mod ffi;
 mod iterator;
 mod mutable;
 pub use iterator::*;
 pub use mutable::*;
 
-use super::{ffi::ToFfi, new_empty_array, primitive::PrimitiveArray, Array};
+use super::{new_empty_array, primitive::PrimitiveArray, Array};
 
 /// Trait denoting [`NativeType`]s that can be used as keys of a dictionary.
 pub trait DictionaryKey: NativeType + NaturalDataType + num::NumCast + num::FromPrimitive {}
@@ -141,16 +142,5 @@ where
         writeln!(f, "keys: {},", self.keys())?;
         writeln!(f, "values: {},", self.values())?;
         write!(f, "}}")
-    }
-}
-
-unsafe impl<K: DictionaryKey> ToFfi for DictionaryArray<K> {
-    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
-        vec![self.keys.validity().as_ref().map(|x| x.as_ptr())]
-    }
-
-    #[inline]
-    fn offset(&self) -> usize {
-        self.offset
     }
 }

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -24,7 +24,7 @@ unsafe impl<O: Offset> ToFfi for ListArray<O> {
 
 unsafe impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for ListArray<O> {
     fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.data_type()?;
+        let data_type = array.field()?.data_type().clone();
         let length = array.array().len();
         let offset = array.array().offset();
         let mut validity = unsafe { array.validity() }?;

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -401,7 +401,7 @@ pub use specification::Offset;
 pub use struct_::StructArray;
 pub use utf8::{MutableUtf8Array, Utf8Array, Utf8ValuesIter};
 
-pub(crate) use self::ffi::buffers_children;
+pub(crate) use self::ffi::buffers_children_dictionary;
 pub use self::ffi::FromFfi;
 pub use self::ffi::ToFfi;
 

--- a/src/array/primitive/ffi.rs
+++ b/src/array/primitive/ffi.rs
@@ -24,7 +24,7 @@ unsafe impl<T: NativeType> ToFfi for PrimitiveArray<T> {
 
 unsafe impl<T: NativeType, A: ffi::ArrowArrayRef> FromFfi<A> for PrimitiveArray<T> {
     fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.data_type()?;
+        let data_type = array.field()?.data_type().clone();
         let length = array.array().len();
         let offset = array.array().offset();
         let mut validity = unsafe { array.validity() }?;

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -77,8 +77,8 @@ impl StructArray {
 }
 
 impl StructArray {
-    pub fn get_fields(datatype: &DataType) -> &[Field] {
-        if let DataType::Struct(fields) = datatype {
+    pub fn get_fields(data_type: &DataType) -> &[Field] {
+        if let DataType::Struct(fields) = data_type {
             fields
         } else {
             panic!("Wrong datatype passed to Struct.")
@@ -139,8 +139,8 @@ unsafe impl ToFfi for StructArray {
 
 unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for StructArray {
     fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.data_type()?;
-        let fields = Self::get_fields(&data_type).to_vec();
+        let field = array.field()?;
+        let fields = Self::get_fields(field.data_type()).to_vec();
 
         let length = array.array().len();
         let offset = array.array().offset();

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -67,13 +67,15 @@ pub fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
         DataType::LargeList(_) => Box::new(ListArray::<i64>::try_from_ffi(array)?),
         DataType::Struct(_) => Box::new(StructArray::try_from_ffi(array)?),
         DataType::Dictionary(keys, _) => match keys.as_ref() {
+            DataType::Int8 => Box::new(DictionaryArray::<i8>::try_from_ffi(array)?),
+            DataType::Int16 => Box::new(DictionaryArray::<i16>::try_from_ffi(array)?),
+            DataType::Int32 => Box::new(DictionaryArray::<i32>::try_from_ffi(array)?),
             DataType::Int64 => Box::new(DictionaryArray::<i64>::try_from_ffi(array)?),
-            other => {
-                return Err(ArrowError::NotYetImplemented(format!(
-                    "Reading dictionary of keys \"{}\" is not yet supported.",
-                    other
-                )))
-            }
+            DataType::UInt8 => Box::new(DictionaryArray::<u8>::try_from_ffi(array)?),
+            DataType::UInt16 => Box::new(DictionaryArray::<u16>::try_from_ffi(array)?),
+            DataType::UInt32 => Box::new(DictionaryArray::<u32>::try_from_ffi(array)?),
+            DataType::UInt64 => Box::new(DictionaryArray::<u64>::try_from_ffi(array)?),
+            _ => unreachable!(),
         },
         data_type => {
             return Err(ArrowError::NotYetImplemented(format!(
@@ -89,7 +91,6 @@ pub fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::*;
     use crate::datatypes::TimeUnit;
     use crate::{error::Result, ffi};
     use std::sync::Arc;
@@ -209,7 +210,6 @@ mod tests {
         test_round_trip(array)
     }
 
-    /*
     #[test]
     fn test_dict() -> Result<()> {
         let data = vec![Some("a"), Some("a"), None, Some("b")];
@@ -221,5 +221,4 @@ mod tests {
 
         test_round_trip(array)
     }
-     */
 }

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -32,8 +32,8 @@ use crate::{
 /// * the data type is not supported
 /// * the interface is not valid (e.g. a null pointer)
 pub fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
-    let data_type = array.data_type()?;
-    let array: Box<dyn Array> = match data_type {
+    let field = array.field()?;
+    let array: Box<dyn Array> = match field.data_type() {
         DataType::Boolean => Box::new(BooleanArray::try_from_ffi(array)?),
         DataType::Int8 => Box::new(PrimitiveArray::<i8>::try_from_ffi(array)?),
         DataType::Int16 => Box::new(PrimitiveArray::<i16>::try_from_ffi(array)?),
@@ -199,4 +199,18 @@ mod tests {
 
         test_round_trip(array)
     }
+
+    /*
+    #[test]
+    fn test_dict() -> Result<()> {
+        let data = vec![Some("a"), Some("a"), None, Some("b")];
+
+        let mut array = MutableDictionaryArray::<i32, MutableUtf8Array<i32>>::new();
+        array.try_extend(data)?;
+
+        let array: DictionaryArray<i32> = array.into();
+
+        test_round_trip(array)
+    }
+     */
 }

--- a/src/ffi/ffi.rs
+++ b/src/ffi/ffi.rs
@@ -15,13 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::{
-    ffi::CStr,
-    ffi::CString,
-    ptr::{self, NonNull},
-    sync::Arc,
-};
+use std::{ptr::NonNull, sync::Arc};
 
+use super::schema::{to_field, Ffi_ArrowSchema};
 use crate::{
     array::{buffers_children, Array},
     bitmap::{utils::bytes_for, Bitmap},
@@ -29,296 +25,10 @@ use crate::{
         bytes::{Bytes, Deallocation},
         Buffer,
     },
-    datatypes::{DataType, Field, IntervalUnit, TimeUnit},
+    datatypes::{DataType, Field},
     error::{ArrowError, Result},
     types::NativeType,
 };
-
-#[allow(dead_code)]
-struct SchemaPrivateData {
-    field: Field,
-    children_ptr: Box<[*mut Ffi_ArrowSchema]>,
-}
-
-/// ABI-compatible struct for `ArrowSchema` from C Data Interface
-/// See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>
-/// This was created by bindgen
-#[repr(C)]
-#[derive(Debug)]
-pub struct Ffi_ArrowSchema {
-    format: *const ::std::os::raw::c_char,
-    name: *const ::std::os::raw::c_char,
-    metadata: *const ::std::os::raw::c_char,
-    flags: i64,
-    n_children: i64,
-    children: *mut *mut Ffi_ArrowSchema,
-    dictionary: *mut Ffi_ArrowSchema,
-    release: ::std::option::Option<unsafe extern "C" fn(arg1: *mut Ffi_ArrowSchema)>,
-    private_data: *mut ::std::os::raw::c_void,
-}
-
-// callback used to drop [Ffi_ArrowSchema] when it is exported.
-unsafe extern "C" fn c_release_schema(schema: *mut Ffi_ArrowSchema) {
-    if schema.is_null() {
-        return;
-    }
-    let schema = &mut *schema;
-
-    // take ownership back to release it.
-    CString::from_raw(schema.format as *mut std::os::raw::c_char);
-    CString::from_raw(schema.name as *mut std::os::raw::c_char);
-    let private = Box::from_raw(schema.private_data as *mut SchemaPrivateData);
-    for child in private.children_ptr.iter() {
-        let _ = Box::from_raw(*child);
-    }
-
-    schema.release = None;
-}
-
-impl Ffi_ArrowSchema {
-    /// create a new [`Ffi_ArrowSchema`]. This fails if the fields' [`DataType`] is not supported.
-    fn try_new(field: Field) -> Result<Ffi_ArrowSchema> {
-        let format = to_format(field.data_type())?;
-        let name = field.name().clone();
-
-        // allocate (and hold) the children
-        let children_vec = match field.data_type() {
-            DataType::List(field) => {
-                vec![Box::new(Ffi_ArrowSchema::try_new(field.as_ref().clone())?)]
-            }
-            DataType::LargeList(field) => {
-                vec![Box::new(Ffi_ArrowSchema::try_new(field.as_ref().clone())?)]
-            }
-            DataType::Struct(fields) => fields
-                .iter()
-                .map(|field| Ok(Box::new(Ffi_ArrowSchema::try_new(field.clone())?)))
-                .collect::<Result<Vec<_>>>()?,
-            _ => vec![],
-        };
-        // note: this cannot be done along with the above because the above is fallible and this op leaks.
-        let children_ptr = children_vec
-            .into_iter()
-            .map(Box::into_raw)
-            .collect::<Box<_>>();
-        let n_children = children_ptr.len() as i64;
-
-        let flags = field.is_nullable() as i64 * 2;
-
-        let mut private = Box::new(SchemaPrivateData {
-            field,
-            children_ptr,
-        });
-
-        // <https://arrow.apache.org/docs/format/CDataInterface.html#c.ArrowSchema>
-        Ok(Ffi_ArrowSchema {
-            format: CString::new(format).unwrap().into_raw(),
-            name: CString::new(name).unwrap().into_raw(),
-            metadata: std::ptr::null_mut(),
-            flags,
-            n_children,
-            children: private.children_ptr.as_mut_ptr(),
-            dictionary: std::ptr::null_mut(),
-            release: Some(c_release_schema),
-            private_data: Box::into_raw(private) as *mut ::std::os::raw::c_void,
-        })
-    }
-
-    /// create an empty [Ffi_ArrowSchema]
-    fn empty() -> Self {
-        Self {
-            format: std::ptr::null_mut(),
-            name: std::ptr::null_mut(),
-            metadata: std::ptr::null_mut(),
-            flags: 0,
-            n_children: 0,
-            children: ptr::null_mut(),
-            dictionary: std::ptr::null_mut(),
-            release: None,
-            private_data: std::ptr::null_mut(),
-        }
-    }
-
-    /// returns the format of this schema.
-    pub fn format(&self) -> &str {
-        assert!(!self.format.is_null());
-        // safe because the lifetime of `self.format` equals `self`
-        unsafe { CStr::from_ptr(self.format) }
-            .to_str()
-            .expect("The external API has a non-utf8 as format")
-    }
-
-    /// returns the name of this schema.
-    pub fn name(&self) -> &str {
-        assert!(!self.name.is_null());
-        // safe because the lifetime of `self.name` equals `self`
-        unsafe { CStr::from_ptr(self.name) }.to_str().unwrap()
-    }
-
-    pub fn child(&self, index: usize) -> &Self {
-        assert!(index < self.n_children as usize);
-        assert!(!self.name.is_null());
-        unsafe { self.children.add(index).as_ref().unwrap().as_ref().unwrap() }
-    }
-
-    pub fn nullable(&self) -> bool {
-        (self.flags / 2) & 1 == 1
-    }
-}
-
-impl Drop for Ffi_ArrowSchema {
-    fn drop(&mut self) {
-        match self.release {
-            None => (),
-            Some(release) => unsafe { release(self) },
-        };
-    }
-}
-
-/// See https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings
-fn to_field(schema: &Ffi_ArrowSchema) -> Result<Field> {
-    let data_type = match schema.format() {
-        "n" => DataType::Null,
-        "b" => DataType::Boolean,
-        "c" => DataType::Int8,
-        "C" => DataType::UInt8,
-        "s" => DataType::Int16,
-        "S" => DataType::UInt16,
-        "i" => DataType::Int32,
-        "I" => DataType::UInt32,
-        "l" => DataType::Int64,
-        "L" => DataType::UInt64,
-        "e" => DataType::Float16,
-        "f" => DataType::Float32,
-        "g" => DataType::Float64,
-        "z" => DataType::Binary,
-        "Z" => DataType::LargeBinary,
-        "u" => DataType::Utf8,
-        "U" => DataType::LargeUtf8,
-        "tdD" => DataType::Date32,
-        "tdm" => DataType::Date64,
-        "tts" => DataType::Time32(TimeUnit::Second),
-        "ttm" => DataType::Time32(TimeUnit::Millisecond),
-        "ttu" => DataType::Time64(TimeUnit::Microsecond),
-        "ttn" => DataType::Time64(TimeUnit::Nanosecond),
-        "tDs" => DataType::Duration(TimeUnit::Second),
-        "tDm" => DataType::Duration(TimeUnit::Millisecond),
-        "tDu" => DataType::Duration(TimeUnit::Microsecond),
-        "tDn" => DataType::Duration(TimeUnit::Nanosecond),
-        "tiM" => DataType::Interval(IntervalUnit::YearMonth),
-        "tiD" => DataType::Interval(IntervalUnit::DayTime),
-        "+l" => {
-            let child = schema.child(0);
-            DataType::List(Box::new(to_field(child)?))
-        }
-        "+L" => {
-            let child = schema.child(0);
-            DataType::LargeList(Box::new(to_field(child)?))
-        }
-        "+s" => {
-            let children = (0..schema.n_children as usize)
-                .map(|x| to_field(schema.child(x)))
-                .collect::<Result<Vec<_>>>()?;
-            DataType::Struct(children)
-        }
-        other => {
-            let parts = other.split(':').collect::<Vec<_>>();
-            if parts.len() == 2 && parts[0] == "tss" {
-                DataType::Timestamp(TimeUnit::Second, Some(parts[1].to_string()))
-            } else if parts.len() == 2 && parts[0] == "tsm" {
-                DataType::Timestamp(TimeUnit::Millisecond, Some(parts[1].to_string()))
-            } else if parts.len() == 2 && parts[0] == "tsu" {
-                DataType::Timestamp(TimeUnit::Microsecond, Some(parts[1].to_string()))
-            } else if parts.len() == 2 && parts[0] == "tsn" {
-                DataType::Timestamp(TimeUnit::Nanosecond, Some(parts[1].to_string()))
-            } else if parts.len() == 2 && parts[0] == "d" {
-                let parts = parts[1].split(',').collect::<Vec<_>>();
-                if parts.len() < 2 || parts.len() > 3 {
-                    return Err(ArrowError::Ffi(
-                        "Decimal must contain 2 or 3 comma-separated values".to_string(),
-                    ));
-                };
-                if parts.len() == 3 {
-                    let bit_width = parts[0].parse::<usize>().map_err(|_| {
-                        ArrowError::Ffi("Decimal bit width is not a valid integer".to_string())
-                    })?;
-                    if bit_width != 128 {
-                        return Err(ArrowError::Ffi("Decimal256 is not supported".to_string()));
-                    }
-                }
-                let precision = parts[0].parse::<usize>().map_err(|_| {
-                    ArrowError::Ffi("Decimal precision is not a valid integer".to_string())
-                })?;
-                let scale = parts[1].parse::<usize>().map_err(|_| {
-                    ArrowError::Ffi("Decimal scale is not a valid integer".to_string())
-                })?;
-                DataType::Decimal(precision, scale)
-            } else {
-                return Err(ArrowError::Ffi(format!(
-                    "The datatype \"{}\" is still not supported in Rust implementation",
-                    other
-                )));
-            }
-        }
-    };
-    Ok(Field::new(schema.name(), data_type, schema.nullable()))
-}
-
-/// the inverse of [to_datatype]
-fn to_format(data_type: &DataType) -> Result<String> {
-    Ok(match data_type {
-        DataType::Null => "n",
-        DataType::Boolean => "b",
-        DataType::Int8 => "c",
-        DataType::UInt8 => "C",
-        DataType::Int16 => "s",
-        DataType::UInt16 => "S",
-        DataType::Int32 => "i",
-        DataType::UInt32 => "I",
-        DataType::Int64 => "l",
-        DataType::UInt64 => "L",
-        DataType::Float16 => "e",
-        DataType::Float32 => "f",
-        DataType::Float64 => "g",
-        DataType::Binary => "z",
-        DataType::LargeBinary => "Z",
-        DataType::Utf8 => "u",
-        DataType::LargeUtf8 => "U",
-        DataType::Date32 => "tdD",
-        DataType::Date64 => "tdm",
-        DataType::Time32(TimeUnit::Second) => "tts",
-        DataType::Time32(TimeUnit::Millisecond) => "ttm",
-        DataType::Time64(TimeUnit::Microsecond) => "ttu",
-        DataType::Time64(TimeUnit::Nanosecond) => "ttn",
-        DataType::Duration(TimeUnit::Second) => "tDs",
-        DataType::Duration(TimeUnit::Millisecond) => "tDm",
-        DataType::Duration(TimeUnit::Microsecond) => "tDu",
-        DataType::Duration(TimeUnit::Nanosecond) => "tDn",
-        DataType::Interval(IntervalUnit::YearMonth) => "tiM",
-        DataType::Interval(IntervalUnit::DayTime) => "tiD",
-        DataType::Timestamp(unit, tz) => {
-            let unit = match unit {
-                TimeUnit::Second => "s",
-                TimeUnit::Millisecond => "m",
-                TimeUnit::Microsecond => "u",
-                TimeUnit::Nanosecond => "n",
-            };
-            return Ok(format!(
-                "ts{}:{}",
-                unit,
-                tz.as_ref().map(|x| x.as_ref()).unwrap_or("")
-            ));
-        }
-        DataType::Decimal(precision, scale) => return Ok(format!("d:{},{}", precision, scale)),
-        DataType::List(_) => "+l",
-        DataType::LargeList(_) => "+L",
-        DataType::Struct(_) => "+s",
-        DataType::FixedSizeBinary(size) => return Ok(format!("w{}", size)),
-        DataType::FixedSizeList(_, size) => return Ok(format!("+w:{}", size)),
-        DataType::Union(_) => todo!(),
-        _ => todo!(),
-    }
-    .to_string())
-}
 
 /// ABI-compatible struct for ArrowArray from C Data Interface
 /// See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>
@@ -573,11 +283,9 @@ fn create_child(
     assert!(!array.children.is_null());
     unsafe {
         let arr_ptr = *array.children.add(index);
-        let schema_ptr = *schema.children.add(index);
+        let schema_ptr = schema.child(index);
         assert!(!arr_ptr.is_null());
-        assert!(!schema_ptr.is_null());
         let arr_ptr = &*arr_ptr;
-        let schema_ptr = &*schema_ptr;
         Ok(ArrowArrayChild::from_raw(arr_ptr, schema_ptr, parent))
     }
 }
@@ -608,7 +316,7 @@ pub trait ArrowArrayRef {
         // +1 to ignore null bitmap
         create_buffer::<T>(
             self.array(),
-            &self.data_type()?,
+            self.field()?.data_type(),
             self.deallocation(),
             index + 1,
         )
@@ -629,7 +337,7 @@ pub trait ArrowArrayRef {
     fn parent(&self) -> &Arc<ArrowArray>;
     fn array(&self) -> &Ffi_ArrowArray;
     fn schema(&self) -> &Ffi_ArrowSchema;
-    fn data_type(&self) -> Result<DataType>;
+    fn field(&self) -> Result<Field>;
 }
 
 /// Struct used to move an Array from and to the C Data Interface.
@@ -659,8 +367,8 @@ pub struct ArrowArray {
 
 impl ArrowArrayRef for Arc<ArrowArray> {
     /// the data_type as declared in the schema
-    fn data_type(&self) -> Result<DataType> {
-        to_field(&self.schema).map(|x| x.data_type().clone())
+    fn field(&self) -> Result<Field> {
+        to_field(&self.schema)
     }
 
     fn parent(&self) -> &Arc<ArrowArray> {
@@ -685,8 +393,8 @@ pub struct ArrowArrayChild<'a> {
 
 impl<'a> ArrowArrayRef for ArrowArrayChild<'a> {
     /// the data_type as declared in the schema
-    fn data_type(&self) -> Result<DataType> {
-        to_field(self.schema).map(|x| x.data_type().clone())
+    fn field(&self) -> Result<Field> {
+        to_field(self.schema)
     }
 
     fn parent(&self) -> &Arc<ArrowArray> {

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -3,6 +3,7 @@
 mod array;
 #[allow(clippy::module_inception)]
 mod ffi;
+mod schema;
 
 pub use array::try_from;
 pub use ffi::{create_empty, export_to_c, ArrowArray, ArrowArrayRef};

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -1,0 +1,292 @@
+use std::{ffi::CStr, ffi::CString, ptr};
+
+use crate::{
+    datatypes::{DataType, Field, IntervalUnit, TimeUnit},
+    error::{ArrowError, Result},
+};
+
+#[allow(dead_code)]
+struct SchemaPrivateData {
+    field: Field,
+    children_ptr: Box<[*mut Ffi_ArrowSchema]>,
+}
+
+/// ABI-compatible struct for `ArrowSchema` from C Data Interface
+/// See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>
+/// This was created by bindgen
+#[repr(C)]
+#[derive(Debug)]
+pub struct Ffi_ArrowSchema {
+    format: *const ::std::os::raw::c_char,
+    name: *const ::std::os::raw::c_char,
+    metadata: *const ::std::os::raw::c_char,
+    flags: i64,
+    n_children: i64,
+    children: *mut *mut Ffi_ArrowSchema,
+    dictionary: *mut Ffi_ArrowSchema,
+    release: ::std::option::Option<unsafe extern "C" fn(arg1: *mut Ffi_ArrowSchema)>,
+    private_data: *mut ::std::os::raw::c_void,
+}
+
+// callback used to drop [Ffi_ArrowSchema] when it is exported.
+unsafe extern "C" fn c_release_schema(schema: *mut Ffi_ArrowSchema) {
+    if schema.is_null() {
+        return;
+    }
+    let schema = &mut *schema;
+
+    // take ownership back to release it.
+    CString::from_raw(schema.format as *mut std::os::raw::c_char);
+    CString::from_raw(schema.name as *mut std::os::raw::c_char);
+    let private = Box::from_raw(schema.private_data as *mut SchemaPrivateData);
+    for child in private.children_ptr.iter() {
+        let _ = Box::from_raw(*child);
+    }
+
+    schema.release = None;
+}
+
+impl Ffi_ArrowSchema {
+    /// create a new [`Ffi_ArrowSchema`]. This fails if the fields' [`DataType`] is not supported.
+    pub fn try_new(field: Field) -> Result<Ffi_ArrowSchema> {
+        let format = to_format(field.data_type())?;
+        let name = field.name().clone();
+
+        // allocate (and hold) the children
+        let children_vec = match field.data_type() {
+            DataType::List(field) => {
+                vec![Box::new(Ffi_ArrowSchema::try_new(field.as_ref().clone())?)]
+            }
+            DataType::LargeList(field) => {
+                vec![Box::new(Ffi_ArrowSchema::try_new(field.as_ref().clone())?)]
+            }
+            DataType::Struct(fields) => fields
+                .iter()
+                .map(|field| Ok(Box::new(Ffi_ArrowSchema::try_new(field.clone())?)))
+                .collect::<Result<Vec<_>>>()?,
+            _ => vec![],
+        };
+        // note: this cannot be done along with the above because the above is fallible and this op leaks.
+        let children_ptr = children_vec
+            .into_iter()
+            .map(Box::into_raw)
+            .collect::<Box<_>>();
+        let n_children = children_ptr.len() as i64;
+
+        let flags = field.is_nullable() as i64 * 2;
+
+        let mut private = Box::new(SchemaPrivateData {
+            field,
+            children_ptr,
+        });
+
+        // <https://arrow.apache.org/docs/format/CDataInterface.html#c.ArrowSchema>
+        Ok(Ffi_ArrowSchema {
+            format: CString::new(format).unwrap().into_raw(),
+            name: CString::new(name).unwrap().into_raw(),
+            metadata: std::ptr::null_mut(),
+            flags,
+            n_children,
+            children: private.children_ptr.as_mut_ptr(),
+            dictionary: std::ptr::null_mut(),
+            release: Some(c_release_schema),
+            private_data: Box::into_raw(private) as *mut ::std::os::raw::c_void,
+        })
+    }
+
+    /// create an empty [Ffi_ArrowSchema]
+    pub fn empty() -> Self {
+        Self {
+            format: std::ptr::null_mut(),
+            name: std::ptr::null_mut(),
+            metadata: std::ptr::null_mut(),
+            flags: 0,
+            n_children: 0,
+            children: ptr::null_mut(),
+            dictionary: std::ptr::null_mut(),
+            release: None,
+            private_data: std::ptr::null_mut(),
+        }
+    }
+
+    /// returns the format of this schema.
+    pub fn format(&self) -> &str {
+        assert!(!self.format.is_null());
+        // safe because the lifetime of `self.format` equals `self`
+        unsafe { CStr::from_ptr(self.format) }
+            .to_str()
+            .expect("The external API has a non-utf8 as format")
+    }
+
+    /// returns the name of this schema.
+    pub fn name(&self) -> &str {
+        assert!(!self.name.is_null());
+        // safe because the lifetime of `self.name` equals `self`
+        unsafe { CStr::from_ptr(self.name) }.to_str().unwrap()
+    }
+
+    pub fn child(&self, index: usize) -> &'static Self {
+        assert!(index < self.n_children as usize);
+        assert!(!self.name.is_null());
+        unsafe { self.children.add(index).as_ref().unwrap().as_ref().unwrap() }
+    }
+
+    pub fn nullable(&self) -> bool {
+        (self.flags / 2) & 1 == 1
+    }
+}
+
+impl Drop for Ffi_ArrowSchema {
+    fn drop(&mut self) {
+        match self.release {
+            None => (),
+            Some(release) => unsafe { release(self) },
+        };
+    }
+}
+
+pub fn to_field(schema: &Ffi_ArrowSchema) -> Result<Field> {
+    let data_type = match schema.format() {
+        "n" => DataType::Null,
+        "b" => DataType::Boolean,
+        "c" => DataType::Int8,
+        "C" => DataType::UInt8,
+        "s" => DataType::Int16,
+        "S" => DataType::UInt16,
+        "i" => DataType::Int32,
+        "I" => DataType::UInt32,
+        "l" => DataType::Int64,
+        "L" => DataType::UInt64,
+        "e" => DataType::Float16,
+        "f" => DataType::Float32,
+        "g" => DataType::Float64,
+        "z" => DataType::Binary,
+        "Z" => DataType::LargeBinary,
+        "u" => DataType::Utf8,
+        "U" => DataType::LargeUtf8,
+        "tdD" => DataType::Date32,
+        "tdm" => DataType::Date64,
+        "tts" => DataType::Time32(TimeUnit::Second),
+        "ttm" => DataType::Time32(TimeUnit::Millisecond),
+        "ttu" => DataType::Time64(TimeUnit::Microsecond),
+        "ttn" => DataType::Time64(TimeUnit::Nanosecond),
+        "tDs" => DataType::Duration(TimeUnit::Second),
+        "tDm" => DataType::Duration(TimeUnit::Millisecond),
+        "tDu" => DataType::Duration(TimeUnit::Microsecond),
+        "tDn" => DataType::Duration(TimeUnit::Nanosecond),
+        "tiM" => DataType::Interval(IntervalUnit::YearMonth),
+        "tiD" => DataType::Interval(IntervalUnit::DayTime),
+        "+l" => {
+            let child = schema.child(0);
+            DataType::List(Box::new(to_field(child)?))
+        }
+        "+L" => {
+            let child = schema.child(0);
+            DataType::LargeList(Box::new(to_field(child)?))
+        }
+        "+s" => {
+            let children = (0..schema.n_children as usize)
+                .map(|x| to_field(schema.child(x)))
+                .collect::<Result<Vec<_>>>()?;
+            DataType::Struct(children)
+        }
+        other => {
+            let parts = other.split(':').collect::<Vec<_>>();
+            if parts.len() == 2 && parts[0] == "tss" {
+                DataType::Timestamp(TimeUnit::Second, Some(parts[1].to_string()))
+            } else if parts.len() == 2 && parts[0] == "tsm" {
+                DataType::Timestamp(TimeUnit::Millisecond, Some(parts[1].to_string()))
+            } else if parts.len() == 2 && parts[0] == "tsu" {
+                DataType::Timestamp(TimeUnit::Microsecond, Some(parts[1].to_string()))
+            } else if parts.len() == 2 && parts[0] == "tsn" {
+                DataType::Timestamp(TimeUnit::Nanosecond, Some(parts[1].to_string()))
+            } else if parts.len() == 2 && parts[0] == "d" {
+                let parts = parts[1].split(',').collect::<Vec<_>>();
+                if parts.len() < 2 || parts.len() > 3 {
+                    return Err(ArrowError::Ffi(
+                        "Decimal must contain 2 or 3 comma-separated values".to_string(),
+                    ));
+                };
+                if parts.len() == 3 {
+                    let bit_width = parts[0].parse::<usize>().map_err(|_| {
+                        ArrowError::Ffi("Decimal bit width is not a valid integer".to_string())
+                    })?;
+                    if bit_width != 128 {
+                        return Err(ArrowError::Ffi("Decimal256 is not supported".to_string()));
+                    }
+                }
+                let precision = parts[0].parse::<usize>().map_err(|_| {
+                    ArrowError::Ffi("Decimal precision is not a valid integer".to_string())
+                })?;
+                let scale = parts[1].parse::<usize>().map_err(|_| {
+                    ArrowError::Ffi("Decimal scale is not a valid integer".to_string())
+                })?;
+                DataType::Decimal(precision, scale)
+            } else {
+                return Err(ArrowError::Ffi(format!(
+                    "The datatype \"{}\" is still not supported in Rust implementation",
+                    other
+                )));
+            }
+        }
+    };
+    Ok(Field::new(schema.name(), data_type, schema.nullable()))
+}
+
+/// the inverse of [to_field]
+fn to_format(data_type: &DataType) -> Result<String> {
+    Ok(match data_type {
+        DataType::Null => "n",
+        DataType::Boolean => "b",
+        DataType::Int8 => "c",
+        DataType::UInt8 => "C",
+        DataType::Int16 => "s",
+        DataType::UInt16 => "S",
+        DataType::Int32 => "i",
+        DataType::UInt32 => "I",
+        DataType::Int64 => "l",
+        DataType::UInt64 => "L",
+        DataType::Float16 => "e",
+        DataType::Float32 => "f",
+        DataType::Float64 => "g",
+        DataType::Binary => "z",
+        DataType::LargeBinary => "Z",
+        DataType::Utf8 => "u",
+        DataType::LargeUtf8 => "U",
+        DataType::Date32 => "tdD",
+        DataType::Date64 => "tdm",
+        DataType::Time32(TimeUnit::Second) => "tts",
+        DataType::Time32(TimeUnit::Millisecond) => "ttm",
+        DataType::Time64(TimeUnit::Microsecond) => "ttu",
+        DataType::Time64(TimeUnit::Nanosecond) => "ttn",
+        DataType::Duration(TimeUnit::Second) => "tDs",
+        DataType::Duration(TimeUnit::Millisecond) => "tDm",
+        DataType::Duration(TimeUnit::Microsecond) => "tDu",
+        DataType::Duration(TimeUnit::Nanosecond) => "tDn",
+        DataType::Interval(IntervalUnit::YearMonth) => "tiM",
+        DataType::Interval(IntervalUnit::DayTime) => "tiD",
+        DataType::Timestamp(unit, tz) => {
+            let unit = match unit {
+                TimeUnit::Second => "s",
+                TimeUnit::Millisecond => "m",
+                TimeUnit::Microsecond => "u",
+                TimeUnit::Nanosecond => "n",
+            };
+            return Ok(format!(
+                "ts{}:{}",
+                unit,
+                tz.as_ref().map(|x| x.as_ref()).unwrap_or("")
+            ));
+        }
+        DataType::Decimal(precision, scale) => return Ok(format!("d:{},{}", precision, scale)),
+        DataType::List(_) => "+l",
+        DataType::LargeList(_) => "+L",
+        DataType::Struct(_) => "+s",
+        DataType::FixedSizeBinary(size) => return Ok(format!("w{}", size)),
+        DataType::FixedSizeList(_, size) => return Ok(format!("+w:{}", size)),
+        DataType::Union(_) => todo!(),
+        DataType::Dictionary(index, _) => return to_format(index.as_ref()),
+        _ => todo!(),
+    }
+    .to_string())
+}


### PR DESCRIPTION
out of abundance of caution, I have also ran `cargo valgrind test --lib --no-default-features`, which runs the tests behind valgrind, to make sure no memory leaks are detected.