### PR TITLE
Made IPC integration tests run tests that are not run by arrow-rs

### DIFF
--- a/.github/workflows/integration-ipc.yml
+++ b/.github/workflows/integration-ipc.yml
@@ -25,6 +25,9 @@ jobs:
       # which is incompatible with this. Let's monkey patch it
       - name: Fix compilation
         run: cp rust/integration-testing/rust_build.sh ci/scripts/rust_build.sh
+      # unskip many of the tests
+      - name: Test more cases
+        run: git apply rust/integration-testing/unskip.patch
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -30,7 +30,7 @@ publish = false
 logging = ["tracing-subscriber"]
 
 [dependencies]
-arrow2 = { path = "../", features = ["io_ipc", "io_json_integration"], default-features = false }
+arrow2 = { path = "../", features = ["io_ipc", "io_ipc_compression", "io_json_integration"], default-features = false }
 arrow-flight = { path = "../arrow-flight" }
 async-trait = "0.1.41"
 clap = "2.33"

--- a/integration-testing/unskip.patch
+++ b/integration-testing/unskip.patch
@@ -1,0 +1,49 @@
+diff --git a/dev/archery/archery/integration/datagen.py b/dev/archery/archery/integration/datagen.py
+index 62fe17bff..67f72acdc 100644
+--- a/dev/archery/archery/integration/datagen.py
++++ b/dev/archery/archery/integration/datagen.py
+@@ -1526,8 +1526,7 @@ def get_generated_json_files(tempdir=None):
+         .skip_category('Go')    # TODO(ARROW-7901)
+         .skip_category('JS'),   # TODO(ARROW-7900)
+ 
+-        generate_decimal128_case()
+-        .skip_category('Rust'),
++        generate_decimal128_case(),
+ 
+         generate_decimal256_case()
+         .skip_category('Go')  # TODO(ARROW-7948): Decimal + Go
+@@ -1537,8 +1536,7 @@ def get_generated_json_files(tempdir=None):
+         generate_datetime_case(),
+ 
+         generate_interval_case()
+-        .skip_category('JS')  # TODO(ARROW-5239): Intervals + JS
+-        .skip_category('Rust'),
++        .skip_category('JS'),  # TODO(ARROW-5239): Intervals + JS
+ 
+         generate_map_case()
+         .skip_category('Rust'),
+@@ -1555,8 +1553,7 @@ def get_generated_json_files(tempdir=None):
+ 
+         generate_nested_large_offsets_case()
+         .skip_category('Go')
+-        .skip_category('JS')
+-        .skip_category('Rust'),
++        .skip_category('JS'),
+ 
+         generate_unions_case()
+         .skip_category('Go')
+diff --git a/dev/archery/archery/integration/runner.py b/dev/archery/archery/integration/runner.py
+index 6f4c1385a..b46597232 100644
+--- a/dev/archery/archery/integration/runner.py
++++ b/dev/archery/archery/integration/runner.py
+@@ -132,10 +132,8 @@ class IntegrationRunner(object):
+                 skip.add("Go")
+                 skip.add("Java")
+                 skip.add("JS")
+-                skip.add("Rust")
+             if prefix == '2.0.0-compression':
+                 skip.add("JS")
+-                skip.add("Rust")
+ 
+             # See https://github.com/apache/arrow/pull/9822 for how to
+             # disable specific compression type tests.

--- a/integration-testing/unskip.patch
+++ b/integration-testing/unskip.patch
@@ -1,8 +1,8 @@
 diff --git a/dev/archery/archery/integration/datagen.py b/dev/archery/archery/integration/datagen.py
-index 62fe17bff..67f72acdc 100644
+index d0c4b3d6c..bc4b83e68 100644
 --- a/dev/archery/archery/integration/datagen.py
 +++ b/dev/archery/archery/integration/datagen.py
-@@ -1526,8 +1526,7 @@ def get_generated_json_files(tempdir=None):
+@@ -1568,8 +1568,7 @@ def get_generated_json_files(tempdir=None):
          .skip_category('Go')    # TODO(ARROW-7901)
          .skip_category('JS'),   # TODO(ARROW-7900)
  
@@ -12,7 +12,7 @@ index 62fe17bff..67f72acdc 100644
  
          generate_decimal256_case()
          .skip_category('Go')  # TODO(ARROW-7948): Decimal + Go
-@@ -1537,8 +1536,7 @@ def get_generated_json_files(tempdir=None):
+@@ -1579,8 +1578,7 @@ def get_generated_json_files(tempdir=None):
          generate_datetime_case(),
  
          generate_interval_case()
@@ -20,9 +20,9 @@ index 62fe17bff..67f72acdc 100644
 -        .skip_category('Rust'),
 +        .skip_category('JS'),  # TODO(ARROW-5239): Intervals + JS
  
-         generate_map_case()
-         .skip_category('Rust'),
-@@ -1555,8 +1553,7 @@ def get_generated_json_files(tempdir=None):
+         generate_month_day_nano_interval_case()
+         .skip_category('Go')
+@@ -1603,13 +1601,11 @@ def get_generated_json_files(tempdir=None):
  
          generate_nested_large_offsets_case()
          .skip_category('Go')
@@ -32,18 +32,9 @@ index 62fe17bff..67f72acdc 100644
  
          generate_unions_case()
          .skip_category('Go')
-diff --git a/dev/archery/archery/integration/runner.py b/dev/archery/archery/integration/runner.py
-index 6f4c1385a..b46597232 100644
---- a/dev/archery/archery/integration/runner.py
-+++ b/dev/archery/archery/integration/runner.py
-@@ -132,10 +132,8 @@ class IntegrationRunner(object):
-                 skip.add("Go")
-                 skip.add("Java")
-                 skip.add("JS")
--                skip.add("Rust")
-             if prefix == '2.0.0-compression':
-                 skip.add("JS")
--                skip.add("Rust")
+-        .skip_category('JS')
+-        .skip_category('Rust'),
++        .skip_category('JS'),
  
-             # See https://github.com/apache/arrow/pull/9822 for how to
-             # disable specific compression type tests.
+         generate_custom_metadata_case()
+         .skip_category('JS'),


### PR DESCRIPTION
Not sure patching `arrow` is a good idea, since the patch may fail. It should probably be a bit more configurable there.

I will leave this here for some time and re-trigger the job to check that the patch continues to apply for some time.