### PR TITLE
Add `UnionArray`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ venv/bin/python parquet_integration/write_parquet.py
 
 ## Features in pyarrow not in this crate
 
-Too many to enumerate; e.g. nested dictionary arrays, union, map, nested parquet.
+Too many to enumerate; e.g. nested dictionary arrays, map, nested parquet.
 
 ## How to develop
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ venv/bin/python parquet_integration/write_parquet.py
 * IPC supports big endian
 * `MutableArray` API to work in-memory in-place.
 * faster IPC reader (different design that avoids an extra copy of all data)
-* IPC supports 2.0 (compression)
+* IPC supports 2.0 feather (compression)
 * FFI support for dictionary-encoded arrays
+* All arrow types implemented pass the IPC integration tests against other implementations
 
 ### Parquet
 
@@ -81,7 +82,7 @@ venv/bin/python parquet_integration/write_parquet.py
 ## Features in the original not available in this crate
 
 * Parquet read and write of struct and nested lists.
-* Union and Map types
+* Map types
 
 ## Features in this crate not in pyarrow
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ venv/bin/python parquet_integration/write_parquet.py
 * IPC supports big endian
 * `MutableArray` API to work in-memory in-place.
 * faster IPC reader (different design that avoids an extra copy of all data)
-* IPC supports 2.0 feather (compression)
-* FFI support for dictionary-encoded arrays
-* All arrow types implemented pass the IPC integration tests against other implementations
+* IPC supports 2.0 (compression)
+* FFI support for dictionary-encoded arrays and union array
+* All implemented arrow types pass IPC integration tests against other implementations
 
 ### Parquet
 

--- a/arrow-flight/src/utils.rs
+++ b/arrow-flight/src/utils.rs
@@ -26,6 +26,7 @@ use arrow2::{
     datatypes::*,
     error::{ArrowError, Result},
     io::ipc,
+    io::ipc::gen::Schema::MetadataVersion,
     io::ipc::read::read_record_batch,
     io::ipc::write,
     io::ipc::write::common::{encoded_batch, DictionaryTracker, EncodedData, IpcWriteOptions},
@@ -168,6 +169,7 @@ pub fn flight_data_to_arrow_batch(
                 None,
                 is_little_endian,
                 &dictionaries_by_field,
+                MetadataVersion::V5,
                 &mut reader,
                 0,
             )

--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -193,3 +193,38 @@ class TestCase(unittest.TestCase):
         b.validate(full=True)
         assert a.to_pylist() == b.to_pylist()
         assert a.type == b.type
+
+    def test_sparse_union(self):
+        """
+        Python -> Rust -> Python
+        """
+        a = pyarrow.UnionArray.from_sparse(
+            pyarrow.array([0, 1, 1, 0, 1], pyarrow.int8()),
+            [
+                pyarrow.array(["a", "", "", "", "c"], pyarrow.utf8()),
+                pyarrow.array([0, 1, 2, None, 0], pyarrow.int64()),
+            ],
+        )
+        b = arrow_pyarrow_integration_testing.round_trip(a)
+
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type
+
+    def test_dense_union(self):
+        """
+        Python -> Rust -> Python
+        """
+        a = pyarrow.UnionArray.from_dense(
+            pyarrow.array([0, 1, 1, 0, 1], pyarrow.int8()),
+            pyarrow.array([0, 1, 2, 3, 4], type=pyarrow.int32()),
+            [
+                pyarrow.array(["a", "", "", "", "c"], pyarrow.utf8()),
+                pyarrow.array([0, 1, 2, None, 0], pyarrow.int64()),
+            ],
+        )
+        b = arrow_pyarrow_integration_testing.round_trip(a)
+
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type

--- a/guide/src/high_level.md
+++ b/guide/src/high_level.md
@@ -145,6 +145,7 @@ There is a many-to-one relationship between `DataType` and an Array (i.e. a phys
 | `FixedSizeBinary(_)`  | `FixedSizeBinaryArray`    |
 | `FixedSizeList(_,_)`  | `FixedSizeListArray`      |
 | `Struct(_)`           | `StructArray`             |
+| `Union(_,_,_)`        | `UnionArray`              |
 | `Dictionary(UInt8,_)` | `DictionaryArray<u8>`     |
 | `Dictionary(UInt16,_)`| `DictionaryArray<u16>`    |
 | `Dictionary(UInt32,_)`| `DictionaryArray<u32>`    |

--- a/integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -25,6 +25,7 @@ use arrow2::{
     datatypes::*,
     io::ipc,
     io::ipc::gen::Message::{Message, MessageHeader},
+    io::ipc::gen::Schema::MetadataVersion,
     record_batch::RecordBatch,
 };
 use arrow_flight::flight_descriptor::*;
@@ -295,6 +296,7 @@ async fn record_batch_from_message(
         None,
         true,
         &dictionaries_by_field,
+        MetadataVersion::V5,
         &mut reader,
         0,
     );

--- a/src/array/display.rs
+++ b/src/array/display.rs
@@ -222,7 +222,18 @@ pub fn get_value_display<'a>(array: &'a dyn Array) -> Box<dyn Fn(usize) -> Strin
                 string
             })
         }
-        Union(_) => todo!(),
+        Union(_, _, _) => {
+            let array = array.as_any().downcast_ref::<UnionArray>().unwrap();
+            let displays = array
+                .fields()
+                .iter()
+                .map(|x| get_display(x.as_ref()))
+                .collect::<Vec<_>>();
+            Box::new(move |row: usize| {
+                let (field, index) = array.index(row);
+                displays[field](index)
+            })
+        }
     }
 }
 

--- a/src/array/equal/mod.rs
+++ b/src/array/equal/mod.rs
@@ -1,5 +1,3 @@
-use std::unimplemented;
-
 use crate::{
     datatypes::{DataType, IntervalUnit},
     types::{days_ms, NativeType},
@@ -19,6 +17,7 @@ mod list;
 mod null;
 mod primitive;
 mod struct_;
+mod union;
 mod utf8;
 
 impl PartialEq for dyn Array {
@@ -323,7 +322,11 @@ pub fn equal(lhs: &dyn Array, rhs: &dyn Array) -> bool {
             let rhs = rhs.as_any().downcast_ref().unwrap();
             fixed_size_list::equal(lhs, rhs)
         }
-        DataType::Union(_) => unimplemented!(),
+        DataType::Union(_, _, _) => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            union::equal(lhs, rhs)
+        }
     }
 }
 

--- a/src/array/equal/mod.rs
+++ b/src/array/equal/mod.rs
@@ -3,10 +3,7 @@ use crate::{
     types::{days_ms, NativeType},
 };
 
-use super::{
-    primitive::PrimitiveArray, Array, BinaryArray, BooleanArray, DictionaryArray, DictionaryKey,
-    FixedSizeBinaryArray, FixedSizeListArray, ListArray, NullArray, Offset, StructArray, Utf8Array,
-};
+use super::*;
 
 mod binary;
 mod boolean;
@@ -141,6 +138,18 @@ impl<K: DictionaryKey> PartialEq<DictionaryArray<K>> for DictionaryArray<K> {
 }
 
 impl<K: DictionaryKey> PartialEq<&dyn Array> for DictionaryArray<K> {
+    fn eq(&self, other: &&dyn Array) -> bool {
+        equal(self, *other)
+    }
+}
+
+impl PartialEq<UnionArray> for UnionArray {
+    fn eq(&self, other: &Self) -> bool {
+        equal(self, other)
+    }
+}
+
+impl PartialEq<&dyn Array> for UnionArray {
     fn eq(&self, other: &&dyn Array) -> bool {
         equal(self, *other)
     }

--- a/src/array/equal/union.rs
+++ b/src/array/equal/union.rs
@@ -1,0 +1,5 @@
+use crate::array::{Array, UnionArray};
+
+pub(super) fn equal(lhs: &UnionArray, rhs: &UnionArray) -> bool {
+    lhs.data_type() == rhs.data_type() && lhs.len() == rhs.len() && lhs.iter().eq(rhs.iter())
+}

--- a/src/array/ffi.rs
+++ b/src/array/ffi.rs
@@ -85,7 +85,7 @@ pub fn buffers_children_dictionary(array: &dyn Array) -> BuffersChildren {
         DataType::LargeList(_) => ffi_dyn!(array, ListArray::<i64>),
         DataType::FixedSizeList(_, _) => ffi_dyn!(array, FixedSizeListArray),
         DataType::Struct(_) => ffi_dyn!(array, StructArray),
-        DataType::Union(_) => unimplemented!(),
+        DataType::Union(_, _, _) => unimplemented!(),
         DataType::Dictionary(key_type, _) => match key_type.as_ref() {
             DataType::Int8 => ffi_dict_dyn!(array, DictionaryArray::<i8>),
             DataType::Int16 => ffi_dict_dyn!(array, DictionaryArray::<i16>),

--- a/src/array/ffi.rs
+++ b/src/array/ffi.rs
@@ -85,7 +85,7 @@ pub fn buffers_children_dictionary(array: &dyn Array) -> BuffersChildren {
         DataType::LargeList(_) => ffi_dyn!(array, ListArray::<i64>),
         DataType::FixedSizeList(_, _) => ffi_dyn!(array, FixedSizeListArray),
         DataType::Struct(_) => ffi_dyn!(array, StructArray),
-        DataType::Union(_, _, _) => todo!(),
+        DataType::Union(_, _, _) => ffi_dyn!(array, UnionArray),
         DataType::Dictionary(key_type, _) => match key_type.as_ref() {
             DataType::Int8 => ffi_dict_dyn!(array, DictionaryArray::<i8>),
             DataType::Int16 => ffi_dict_dyn!(array, DictionaryArray::<i16>),

--- a/src/array/ffi.rs
+++ b/src/array/ffi.rs
@@ -85,7 +85,7 @@ pub fn buffers_children_dictionary(array: &dyn Array) -> BuffersChildren {
         DataType::LargeList(_) => ffi_dyn!(array, ListArray::<i64>),
         DataType::FixedSizeList(_, _) => ffi_dyn!(array, FixedSizeListArray),
         DataType::Struct(_) => ffi_dyn!(array, StructArray),
-        DataType::Union(_, _, _) => unimplemented!(),
+        DataType::Union(_, _, _) => todo!(),
         DataType::Dictionary(key_type, _) => match key_type.as_ref() {
             DataType::Int8 => ffi_dict_dyn!(array, DictionaryArray::<i8>),
             DataType::Int16 => ffi_dict_dyn!(array, DictionaryArray::<i16>),

--- a/src/array/growable/mod.rs
+++ b/src/array/growable/mod.rs
@@ -225,7 +225,7 @@ pub fn make_growable<'a>(
             ))
         }
         DataType::FixedSizeList(_, _) => todo!(),
-        DataType::Union(_) => todo!(),
+        DataType::Union(_, _, _) => todo!(),
         DataType::Dictionary(key, _) => match key.as_ref() {
             DataType::UInt8 => dyn_dict_growable!(u8, arrays, use_validity, capacity),
             DataType::UInt16 => dyn_dict_growable!(u16, arrays, use_validity, capacity),

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -188,7 +188,7 @@ impl Display for dyn Array {
             DataType::LargeList(_) => fmt_dyn!(self, ListArray::<i64>, f),
             DataType::FixedSizeList(_, _) => fmt_dyn!(self, FixedSizeListArray, f),
             DataType::Struct(_) => fmt_dyn!(self, StructArray, f),
-            DataType::Union(_, _, _) => unimplemented!(),
+            DataType::Union(_, _, _) => fmt_dyn!(self, UnionArray, f),
             DataType::Dictionary(key_type, _) => match key_type.as_ref() {
                 DataType::Int8 => fmt_dyn!(self, DictionaryArray::<i8>, f),
                 DataType::Int16 => fmt_dyn!(self, DictionaryArray::<i16>, f),

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -242,7 +242,7 @@ pub fn new_empty_array(data_type: DataType) -> Box<dyn Array> {
         DataType::LargeList(_) => Box::new(ListArray::<i64>::new_empty(data_type)),
         DataType::FixedSizeList(_, _) => Box::new(FixedSizeListArray::new_empty(data_type)),
         DataType::Struct(fields) => Box::new(StructArray::new_empty(&fields)),
-        DataType::Union(_, _, _) => unimplemented!(),
+        DataType::Union(_, _, _) => Box::new(UnionArray::new_empty(data_type)),
         DataType::Dictionary(key_type, value_type) => match key_type.as_ref() {
             DataType::Int8 => Box::new(DictionaryArray::<i8>::new_empty(*value_type)),
             DataType::Int16 => Box::new(DictionaryArray::<i16>::new_empty(*value_type)),
@@ -296,7 +296,7 @@ pub fn new_null_array(data_type: DataType, length: usize) -> Box<dyn Array> {
         DataType::LargeList(_) => Box::new(ListArray::<i64>::new_null(data_type, length)),
         DataType::FixedSizeList(_, _) => Box::new(FixedSizeListArray::new_null(data_type, length)),
         DataType::Struct(fields) => Box::new(StructArray::new_null(&fields, length)),
-        DataType::Union(_, _, _) => unimplemented!(),
+        DataType::Union(_, _, _) => todo!(),
         DataType::Dictionary(key_type, value_type) => match key_type.as_ref() {
             DataType::Int8 => Box::new(DictionaryArray::<i8>::new_null(*value_type, length)),
             DataType::Int16 => Box::new(DictionaryArray::<i16>::new_null(*value_type, length)),
@@ -357,7 +357,7 @@ pub fn clone(array: &dyn Array) -> Box<dyn Array> {
         DataType::LargeList(_) => clone_dyn!(array, ListArray::<i64>),
         DataType::FixedSizeList(_, _) => clone_dyn!(array, FixedSizeListArray),
         DataType::Struct(_) => clone_dyn!(array, StructArray),
-        DataType::Union(_, _, _) => unimplemented!(),
+        DataType::Union(_, _, _) => clone_dyn!(array, UnionArray),
         DataType::Dictionary(key_type, _) => match key_type.as_ref() {
             DataType::Int8 => clone_dyn!(array, DictionaryArray::<i8>),
             DataType::Int16 => clone_dyn!(array, DictionaryArray::<i16>),
@@ -503,6 +503,8 @@ mod tests {
             DataType::Utf8,
             DataType::Binary,
             DataType::List(Box::new(Field::new("a", DataType::Binary, true))),
+            DataType::Union(vec![Field::new("a", DataType::Binary, true)], None, true),
+            DataType::Union(vec![Field::new("a", DataType::Binary, true)], None, false),
         ];
         let a = datatypes.into_iter().all(|x| new_empty_array(x).len() == 0);
         assert!(a);

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -296,7 +296,7 @@ pub fn new_null_array(data_type: DataType, length: usize) -> Box<dyn Array> {
         DataType::LargeList(_) => Box::new(ListArray::<i64>::new_null(data_type, length)),
         DataType::FixedSizeList(_, _) => Box::new(FixedSizeListArray::new_null(data_type, length)),
         DataType::Struct(fields) => Box::new(StructArray::new_null(&fields, length)),
-        DataType::Union(_, _, _) => todo!(),
+        DataType::Union(_, _, _) => Box::new(UnionArray::new_null(data_type, length)),
         DataType::Dictionary(key_type, value_type) => match key_type.as_ref() {
             DataType::Int8 => Box::new(DictionaryArray::<i8>::new_null(*value_type, length)),
             DataType::Int16 => Box::new(DictionaryArray::<i16>::new_null(*value_type, length)),

--- a/src/array/union/ffi.rs
+++ b/src/array/union/ffi.rs
@@ -33,7 +33,6 @@ unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for UnionArray {
         let data_type = field.data_type().clone();
         let fields = Self::get_fields(field.data_type());
 
-        // 0 is null bitmap (which was deprecated for the union type)
         let mut types = unsafe { array.buffer::<i8>(0) }?;
         let offsets = if Self::is_sparse(&data_type) {
             None

--- a/src/array/union/ffi.rs
+++ b/src/array/union/ffi.rs
@@ -1,0 +1,59 @@
+use std::sync::Arc;
+
+use crate::{array::FromFfi, error::Result, ffi};
+
+use super::super::{ffi::ToFfi, Array};
+use super::UnionArray;
+
+unsafe impl ToFfi for UnionArray {
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
+        if let Some(offsets) = &self.offsets {
+            vec![
+                None,
+                std::ptr::NonNull::new(self.types.as_ptr() as *mut u8),
+                std::ptr::NonNull::new(offsets.as_ptr() as *mut u8),
+            ]
+        } else {
+            vec![None, std::ptr::NonNull::new(self.types.as_ptr() as *mut u8)]
+        }
+    }
+
+    fn offset(&self) -> usize {
+        self.offset
+    }
+
+    fn children(&self) -> Vec<Arc<dyn Array>> {
+        self.fields.clone()
+    }
+}
+
+unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for UnionArray {
+    fn try_from_ffi(array: A) -> Result<Self> {
+        let field = array.field()?;
+        let data_type = field.data_type().clone();
+        let fields = Self::get_fields(field.data_type());
+
+        // 0 is null bitmap (which was deprecated for the union type)
+        let mut types = unsafe { array.buffer::<i8>(0) }?;
+        let offsets = if Self::is_sparse(&data_type) {
+            None
+        } else {
+            Some(unsafe { array.buffer::<i32>(1) }?)
+        };
+
+        let length = array.array().len();
+        let offset = array.array().offset();
+        let fields = (0..fields.len())
+            .map(|index| {
+                let child = array.child(index)?;
+                Ok(ffi::try_from(child)?.into())
+            })
+            .collect::<Result<Vec<Arc<dyn Array>>>>()?;
+
+        if offset > 0 {
+            types = types.slice(offset, length);
+        };
+
+        Ok(Self::from_data(data_type, types, fields, offsets))
+    }
+}

--- a/src/array/union/iterator.rs
+++ b/src/array/union/iterator.rs
@@ -1,0 +1,55 @@
+use super::{Array, UnionArray};
+use crate::{scalar::Scalar, trusted_len::TrustedLen};
+
+#[derive(Debug, Clone)]
+pub struct UnionIter<'a> {
+    array: &'a UnionArray,
+    current: usize,
+}
+
+impl<'a> UnionIter<'a> {
+    pub fn new(array: &'a UnionArray) -> Self {
+        Self { array, current: 0 }
+    }
+}
+
+impl<'a> Iterator for UnionIter<'a> {
+    type Item = Box<dyn Scalar>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current == self.array.len() {
+            None
+        } else {
+            let old = self.current;
+            self.current += 1;
+            Some(self.array.value(old))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.array.len() - self.current;
+        (len, Some(len))
+    }
+}
+
+impl<'a> IntoIterator for &'a UnionArray {
+    type Item = Box<dyn Scalar>;
+    type IntoIter = UnionIter<'a>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> UnionArray {
+    /// constructs a new iterator
+    #[inline]
+    pub fn iter(&'a self) -> UnionIter<'a> {
+        UnionIter::new(self)
+    }
+}
+
+impl<'a> std::iter::ExactSizeIterator for UnionIter<'a> {}
+
+unsafe impl<'a> TrustedLen for UnionIter<'a> {}

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -1,0 +1,148 @@
+use std::{collections::HashMap, sync::Arc};
+
+use crate::{
+    bitmap::Bitmap,
+    buffer::Buffer,
+    datatypes::{DataType, Field},
+    scalar::{new_scalar, Scalar},
+};
+
+use super::Array;
+
+mod iterator;
+
+/// A union
+// How to read a value at slot i:
+// ```
+// let index = self.types()[i] as usize;
+// let field = self.fields()[index];
+// let offset = self.offsets().map(|x| x[index]).unwrap_or(i);
+// let field = field.as_any().downcast to correct type;
+// let value = field.value(offset);
+// ```
+#[derive(Debug, Clone)]
+pub struct UnionArray {
+    types: Buffer<i8>,
+    fields_hash: HashMap<i8, Arc<dyn Array>>,
+    fields: Vec<Arc<dyn Array>>,
+    offsets: Option<Buffer<i32>>,
+    data_type: DataType,
+    offset: usize,
+}
+
+impl UnionArray {
+    pub fn from_data(
+        data_type: DataType,
+        types: Buffer<i8>,
+        fields: Vec<Arc<dyn Array>>,
+        offsets: Option<Buffer<i32>>,
+    ) -> Self {
+        let fields_hash = if let DataType::Union(f, ids, is_sparse) = &data_type {
+            let ids: Vec<i8> = ids
+                .as_ref()
+                .map(|x| x.iter().map(|x| *x as i8).collect())
+                .unwrap_or_else(|| (0..f.len() as i8).collect());
+            if f.len() != fields.len() {
+                panic!(
+                    "The number of `fields` must equal the number of fields in the Union DataType"
+                )
+            };
+            let same_data_types = f
+                .iter()
+                .zip(fields.iter())
+                .all(|(f, array)| f.data_type() == array.data_type());
+            if !same_data_types {
+                panic!("All fields' datatype in the union must equal the datatypes on the fields.")
+            }
+            if offsets.is_none() != *is_sparse {
+                panic!("Sparsness flag must equal to noness of offsets in UnionArray")
+            }
+            ids.into_iter().zip(fields.iter().cloned()).collect()
+        } else {
+            panic!("Union struct must be created with the corresponding Union DataType")
+        };
+        // not validated:
+        // * `offsets` is valid
+        // * max id < fields.len()
+        Self {
+            data_type,
+            fields_hash,
+            fields,
+            offsets,
+            types,
+            offset: 0,
+        }
+    }
+
+    pub fn offsets(&self) -> &Option<Buffer<i32>> {
+        &self.offsets
+    }
+
+    pub fn fields(&self) -> &Vec<Arc<dyn Array>> {
+        &self.fields
+    }
+
+    pub fn types(&self) -> &Buffer<i8> {
+        &self.types
+    }
+
+    pub fn value(&self, index: usize) -> Box<dyn Scalar> {
+        let field_index = self.types()[index];
+        let field = self.fields_hash[&field_index].as_ref();
+        let offset = self
+            .offsets()
+            .as_ref()
+            .map(|x| x[index] as usize)
+            .unwrap_or(index);
+        new_scalar(field, offset)
+    }
+
+    /// Returns a slice of this [`UnionArray`].
+    /// # Implementation
+    /// This operation is `O(F)` where `F` is the number of fields.
+    /// # Panic
+    /// This function panics iff `offset + length >= self.len()`.
+    #[inline]
+    pub fn slice(&self, offset: usize, length: usize) -> Self {
+        Self {
+            data_type: self.data_type.clone(),
+            fields: self.fields.clone(),
+            fields_hash: self.fields_hash.clone(),
+            types: self.types.clone().slice(offset, length),
+            offsets: self.offsets.clone(),
+            offset: self.offset + offset,
+        }
+    }
+}
+
+impl Array for UnionArray {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn len(&self) -> usize {
+        self.types.len()
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn validity(&self) -> &Option<Bitmap> {
+        &None
+    }
+
+    fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
+        Box::new(self.slice(offset, length))
+    }
+}
+
+impl UnionArray {
+    pub fn get_fields(data_type: &DataType) -> &[Field] {
+        if let DataType::Union(fields, _, _) = data_type {
+            fields
+        } else {
+            panic!("Wrong datatype passed to Struct.")
+        }
+    }
+}

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -9,6 +9,7 @@ use crate::{
 
 use super::{new_empty_array, Array};
 
+mod ffi;
 mod iterator;
 
 /// A union
@@ -168,7 +169,15 @@ impl UnionArray {
         if let DataType::Union(fields, _, _) = data_type {
             fields
         } else {
-            panic!("Wrong datatype passed to Struct.")
+            panic!("Wrong datatype passed to UnionArray.")
+        }
+    }
+
+    pub fn is_sparse(data_type: &DataType) -> bool {
+        if let DataType::Union(_, _, is_sparse) = data_type {
+            *is_sparse
+        } else {
+            panic!("Wrong datatype passed to UnionArray.")
         }
     }
 }

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     scalar::{new_scalar, Scalar},
 };
 
-use super::Array;
+use super::{new_empty_array, Array};
 
 mod iterator;
 
@@ -31,6 +31,32 @@ pub struct UnionArray {
 }
 
 impl UnionArray {
+    pub fn new_empty(data_type: DataType) -> Self {
+        if let DataType::Union(f, _, is_sparse) = &data_type {
+            let fields = f
+                .iter()
+                .map(|x| new_empty_array(x.data_type().clone()).into())
+                .collect();
+
+            let offsets = if *is_sparse {
+                None
+            } else {
+                Some(Buffer::new())
+            };
+
+            Self {
+                data_type,
+                fields_hash: HashMap::new(),
+                fields,
+                offsets,
+                types: Buffer::new(),
+                offset: 0,
+            }
+        } else {
+            panic!("Union struct must be created with the corresponding Union DataType")
+        }
+    }
+
     pub fn from_data(
         data_type: DataType,
         types: Buffer<i8>,

--- a/src/compute/aggregate/memory.rs
+++ b/src/compute/aggregate/memory.rs
@@ -109,7 +109,7 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
                 .sum::<usize>()
                 + validity_size(array.validity())
         }
-        Union(_) => unreachable!(),
+        Union(_, _, _) => unreachable!(),
         Dictionary(keys, _) => match keys.as_ref() {
             Int8 => dyn_dict!(array, i8),
             Int16 => dyn_dict!(array, i16),

--- a/src/compute/aggregate/memory.rs
+++ b/src/compute/aggregate/memory.rs
@@ -109,7 +109,22 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
                 .sum::<usize>()
                 + validity_size(array.validity())
         }
-        Union(_, _, _) => unreachable!(),
+        Union(_, _, _) => {
+            let array = array.as_any().downcast_ref::<UnionArray>().unwrap();
+            let types = array.types().len() * std::mem::size_of::<i8>();
+            let offsets = array
+                .offsets()
+                .as_ref()
+                .map(|x| x.len() * std::mem::size_of::<i32>())
+                .unwrap_or_default();
+            let fields = array
+                .fields()
+                .iter()
+                .map(|x| x.as_ref())
+                .map(estimated_bytes_size)
+                .sum::<usize>();
+            types + offsets + fields
+        }
         Dictionary(keys, _) => match keys.as_ref() {
             Int8 => dyn_dict!(array, i8),
             Int16 => dyn_dict!(array, i16),

--- a/src/datatypes/field.rs
+++ b/src/datatypes/field.rs
@@ -200,8 +200,8 @@ impl Field {
                     ));
                 }
             },
-            DataType::Union(nested_fields) => match &from.data_type {
-                DataType::Union(from_nested_fields) => {
+            DataType::Union(nested_fields, _, _) => match &from.data_type {
+                DataType::Union(from_nested_fields, _, _) => {
                     for from_field in from_nested_fields {
                         let mut is_new_field = true;
                         for self_field in nested_fields.iter_mut() {

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -103,7 +103,8 @@ pub enum DataType {
     /// A nested datatype that contains a number of sub-fields.
     Struct(Vec<Field>),
     /// A nested datatype that can represent slots of differing types.
-    Union(Vec<Field>),
+    /// Third argument represents sparsness
+    Union(Vec<Field>, Option<Vec<i32>>, bool),
     /// A dictionary encoded array (`key_type`, `value_type`), where
     /// each array element is an index of `key_type` into an
     /// associated dictionary of `value_type`.

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -77,6 +77,7 @@ pub fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
             DataType::UInt64 => Box::new(DictionaryArray::<u64>::try_from_ffi(array)?),
             _ => unreachable!(),
         },
+        DataType::Union(_, _, _) => Box::new(UnionArray::try_from_ffi(array)?),
         data_type => {
             return Err(ArrowError::NotYetImplemented(format!(
                 "Reading DataType \"{}\" is not yet supported.",

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -316,7 +316,7 @@ fn to_format(data_type: &DataType) -> Result<String> {
         DataType::Struct(_) => "+s",
         DataType::FixedSizeBinary(size) => return Ok(format!("w{}", size)),
         DataType::FixedSizeList(_, size) => return Ok(format!("+w:{}", size)),
-        DataType::Union(_) => todo!(),
+        DataType::Union(_, _, _) => todo!(),
         DataType::Dictionary(index, _) => return to_format(index.as_ref()),
         _ => todo!(),
     }

--- a/src/io/ipc/read/array/fixed_size_list.rs
+++ b/src/io/ipc/read/array/fixed_size_list.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
 use std::io::{Read, Seek};
 
+use gen::Schema::MetadataVersion;
+
 use crate::array::FixedSizeListArray;
 use crate::datatypes::DataType;
 use crate::error::Result;
@@ -18,6 +20,7 @@ pub fn read_fixed_size_list<R: Read + Seek>(
     block_offset: u64,
     is_little_endian: bool,
     compression: Option<BodyCompression>,
+    version: MetadataVersion,
 ) -> Result<FixedSizeListArray> {
     let field_node = field_nodes.pop_front().unwrap().0;
 
@@ -40,6 +43,7 @@ pub fn read_fixed_size_list<R: Read + Seek>(
         block_offset,
         is_little_endian,
         compression,
+        version,
     )?;
     Ok(FixedSizeListArray::from_data(data_type, values, validity))
 }

--- a/src/io/ipc/read/array/list.rs
+++ b/src/io/ipc/read/array/list.rs
@@ -2,6 +2,8 @@ use std::collections::VecDeque;
 use std::convert::TryInto;
 use std::io::{Read, Seek};
 
+use gen::Schema::MetadataVersion;
+
 use crate::array::{ListArray, Offset};
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
@@ -20,6 +22,7 @@ pub fn read_list<O: Offset, R: Read + Seek>(
     block_offset: u64,
     is_little_endian: bool,
     compression: Option<BodyCompression>,
+    version: MetadataVersion,
 ) -> Result<ListArray<O>>
 where
     Vec<u8>: TryInto<O::Bytes>,
@@ -56,6 +59,7 @@ where
         block_offset,
         is_little_endian,
         compression,
+        version,
     )?;
     Ok(ListArray::from_data(data_type, offsets, values, validity))
 }

--- a/src/io/ipc/read/array/mod.rs
+++ b/src/io/ipc/read/array/mod.rs
@@ -18,3 +18,5 @@ mod null;
 pub use null::*;
 mod dictionary;
 pub use dictionary::*;
+mod union;
+pub use union::*;

--- a/src/io/ipc/read/array/union.rs
+++ b/src/io/ipc/read/array/union.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Seek};
 
 use gen::Schema::MetadataVersion;
 
-use crate::array::StructArray;
+use crate::array::UnionArray;
 use crate::datatypes::DataType;
 use crate::error::Result;
 use crate::io::ipc::gen::Message::BodyCompression;
@@ -12,7 +12,7 @@ use super::super::super::gen;
 use super::super::deserialize::{read, skip, Node};
 use super::super::read_basic::*;
 
-pub fn read_struct<R: Read + Seek>(
+pub fn read_union<R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
     data_type: DataType,
     buffers: &mut VecDeque<&gen::Schema::Buffer>,
@@ -21,21 +21,42 @@ pub fn read_struct<R: Read + Seek>(
     is_little_endian: bool,
     compression: Option<BodyCompression>,
     version: MetadataVersion,
-) -> Result<StructArray> {
+) -> Result<UnionArray> {
     let field_node = field_nodes.pop_front().unwrap().0;
 
-    let validity = read_validity(
+    if version != MetadataVersion::V5 {
+        let _ = buffers.pop_front().unwrap();
+    };
+
+    let types = read_buffer(
         buffers,
-        field_node,
+        field_node.length() as usize,
         reader,
         block_offset,
         is_little_endian,
         compression,
     )?;
 
-    let fields = StructArray::get_fields(&data_type);
+    let offsets = if let DataType::Union(_, _, is_sparse) = data_type {
+        if !is_sparse {
+            Some(read_buffer(
+                buffers,
+                field_node.length() as usize,
+                reader,
+                block_offset,
+                is_little_endian,
+                compression,
+            )?)
+        } else {
+            None
+        }
+    } else {
+        panic!()
+    };
 
-    let values = fields
+    let fields = UnionArray::get_fields(&data_type);
+
+    let fields = fields
         .iter()
         .map(|field| {
             read(
@@ -51,10 +72,10 @@ pub fn read_struct<R: Read + Seek>(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    Ok(StructArray::from_data(fields.to_vec(), values, validity))
+    Ok(UnionArray::from_data(data_type, types, fields, offsets))
 }
 
-pub fn skip_struct(
+pub fn skip_union(
     field_nodes: &mut VecDeque<Node>,
     data_type: &DataType,
     buffers: &mut VecDeque<&gen::Schema::Buffer>,
@@ -62,8 +83,15 @@ pub fn skip_struct(
     let _ = field_nodes.pop_front().unwrap();
 
     let _ = buffers.pop_front().unwrap();
+    if let DataType::Union(_, _, is_sparse) = data_type {
+        if !*is_sparse {
+            let _ = buffers.pop_front().unwrap();
+        }
+    } else {
+        panic!()
+    };
 
-    let fields = StructArray::get_fields(data_type);
+    let fields = UnionArray::get_fields(data_type);
 
     fields
         .iter()

--- a/src/io/ipc/read/common.rs
+++ b/src/io/ipc/read/common.rs
@@ -19,6 +19,8 @@ use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Seek};
 use std::sync::Arc;
 
+use gen::Schema::MetadataVersion;
+
 use crate::array::*;
 use crate::datatypes::{DataType, Field, Schema};
 use crate::error::{ArrowError, Result};
@@ -96,6 +98,7 @@ pub fn read_record_batch<R: Read + Seek>(
     projection: Option<(&[usize], Arc<Schema>)>,
     is_little_endian: bool,
     dictionaries: &[Option<ArrayRef>],
+    version: MetadataVersion,
     reader: &mut R,
     block_offset: u64,
 ) -> Result<RecordBatch> {
@@ -130,6 +133,7 @@ pub fn read_record_batch<R: Read + Seek>(
                     block_offset,
                     is_little_endian,
                     batch.compression(),
+                    version,
                 )),
                 ProjectionResult::NotSelected(field) => {
                     skip(&mut field_nodes, field.data_type(), &mut buffers);
@@ -152,6 +156,7 @@ pub fn read_record_batch<R: Read + Seek>(
                     block_offset,
                     is_little_endian,
                     batch.compression(),
+                    version,
                 )
             })
             .collect::<Result<Vec<_>>>()?;
@@ -199,6 +204,7 @@ pub fn read_dictionary<R: Read + Seek>(
                 None,
                 is_little_endian,
                 dictionaries_by_field,
+                MetadataVersion::V5,
                 reader,
                 block_offset,
             )?;

--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -217,6 +217,7 @@ pub fn read_batch<R: Read + Seek>(
                 projection,
                 metadata.is_little_endian,
                 &metadata.dictionaries_by_field,
+                metadata.version,
                 reader,
                 block.offset() as u64 + block.metaDataLength() as u64,
             )
@@ -413,6 +414,16 @@ mod tests {
     fn read_generated_100_interval() -> Result<()> {
         test_file("1.0.0-littleendian", "generated_interval")?;
         test_file("1.0.0-bigendian", "generated_interval")
+    }
+
+    #[test]
+    fn read_generated_100_union() -> Result<()> {
+        test_file("1.0.0-littleendian", "generated_union")
+    }
+
+    #[test]
+    fn read_generated_017_union() -> Result<()> {
+        test_file("0.17.1", "generated_union")
     }
 
     #[test]

--- a/src/io/ipc/write/serialize.rs
+++ b/src/io/ipc/write/serialize.rs
@@ -16,10 +16,7 @@
 // under the License.
 
 use crate::{
-    array::{
-        Array, BinaryArray, BooleanArray, DictionaryArray, DictionaryKey, FixedSizeBinaryArray,
-        FixedSizeListArray, ListArray, Offset, PrimitiveArray, StructArray, Utf8Array,
-    },
+    array::*,
     bitmap::Bitmap,
     datatypes::{DataType, IntervalUnit},
     endianess::is_native_little_endian,
@@ -233,6 +230,33 @@ pub fn write_struct(
             offset,
             is_little_endian,
         );
+    });
+}
+
+pub fn write_union(
+    array: &dyn Array,
+    buffers: &mut Vec<Schema::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    nodes: &mut Vec<Message::FieldNode>,
+    offset: &mut i64,
+    is_little_endian: bool,
+) {
+    let array = array.as_any().downcast_ref::<UnionArray>().unwrap();
+
+    write_buffer(array.types(), buffers, arrow_data, offset, is_little_endian);
+
+    if let Some(offsets) = array.offsets() {
+        write_buffer(offsets, buffers, arrow_data, offset, is_little_endian);
+    }
+    array.fields().iter().for_each(|array| {
+        write(
+            array.as_ref(),
+            buffers,
+            arrow_data,
+            nodes,
+            offset,
+            is_little_endian,
+        )
     });
 }
 
@@ -467,7 +491,9 @@ pub fn write(
                 true,
             );
         }
-        DataType::Union(_) => unimplemented!(),
+        DataType::Union(_, _, _) => {
+            write_union(array, buffers, arrow_data, nodes, offset, is_little_endian);
+        }
     }
 }
 

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -331,6 +331,17 @@ mod tests {
     }
 
     #[test]
+    fn write_100_union() -> Result<()> {
+        test_file("1.0.0-littleendian", "generated_union")?;
+        test_file("1.0.0-bigendian", "generated_union")
+    }
+
+    #[test]
+    fn write_generated_017_union() -> Result<()> {
+        test_file("0.17.1", "generated_union")
+    }
+
+    #[test]
     fn write_sliced_utf8() -> Result<()> {
         use crate::array::{Array, Utf8Array};
         use std::sync::Arc;

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -255,7 +255,6 @@ pub fn read(rows: &[&Value], data_type: DataType) -> Arc<dyn Array> {
         /*
         DataType::FixedSizeBinary(_) => Box::new(FixedSizeBinaryArray::new_empty(data_type)),
         DataType::FixedSizeList(_, _) => Box::new(FixedSizeListArray::new_empty(data_type)),
-        DataType::Union(_, _, _) => unimplemented!(),
         DataType::Decimal(_, _) => Box::new(PrimitiveArray::<i128>::new_empty(data_type)),
         */
     }

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -255,7 +255,7 @@ pub fn read(rows: &[&Value], data_type: DataType) -> Arc<dyn Array> {
         /*
         DataType::FixedSizeBinary(_) => Box::new(FixedSizeBinaryArray::new_empty(data_type)),
         DataType::FixedSizeList(_, _) => Box::new(FixedSizeListArray::new_empty(data_type)),
-        DataType::Union(_) => unimplemented!(),
+        DataType::Union(_, _, _) => unimplemented!(),
         DataType::Decimal(_, _) => Box::new(PrimitiveArray::<i128>::new_empty(data_type)),
         */
     }

--- a/src/io/json_integration/mod.rs
+++ b/src/io/json_integration/mod.rs
@@ -138,5 +138,7 @@ pub struct ArrowJsonColumn {
     pub data: Option<Vec<Value>>,
     #[serde(rename = "OFFSET")]
     pub offset: Option<Vec<Value>>, // leaving as Value as 64-bit offsets are strings
+    #[serde(rename = "TYPE_ID")]
+    pub type_id: Option<Vec<Value>>, // for union types
     pub children: Option<Vec<ArrowJsonColumn>>,
 }

--- a/src/io/json_integration/write.rs
+++ b/src/io/json_integration/write.rs
@@ -25,6 +25,7 @@ pub fn from_record_batch(batch: &RecordBatch) -> ArrowJsonBatch {
                     validity: Some(validity),
                     data: Some(data),
                     offset: None,
+                    type_id: None,
                     children: None,
                 }
             }
@@ -34,6 +35,7 @@ pub fn from_record_batch(batch: &RecordBatch) -> ArrowJsonBatch {
                 validity: None,
                 data: None,
                 offset: None,
+                type_id: None,
                 children: None,
             },
         };

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -130,7 +130,7 @@ pub fn new_scalar(array: &dyn Array, index: usize) -> Box<dyn Scalar> {
         }
         FixedSizeBinary(_) => todo!(),
         FixedSizeList(_, _) => todo!(),
-        Union(_) => todo!(),
+        Union(_, _, _) => todo!(),
         Dictionary(_, _) => todo!(),
     }
 }


### PR DESCRIPTION
* Added `UnionArray`
    * equality
    * `Display`
    * read and write IPC (V4 and V5)
    * write to string (`io::print::write`)
    * produce and consume FFI
    * `UnionArray::iter()` with an iterator over values via the `Scalar` API
    * memory estimation (`compute::aggregate::memory`)
* Added roundtrip tests against IPC
* changed IPC read APIs to support different IPC versions (Union validity changed from V4 to V5 and reading it requires knowing which version the file was written as)  (#282)
* changed `DataType::Union` to contain necessary metadata for IPC and FFI (#281)

I verified that integration tests against C++ pass when union is not skipped.

Closes #281 and #282 