### PR TITLE
Removed order implementation for `days_ms` / `Interval(DayTime)`

### DIFF
--- a/src/array/ord.rs
+++ b/src/array/ord.rs
@@ -4,10 +4,7 @@ use std::cmp::Ordering;
 
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
-use crate::{
-    array::*,
-    types::{days_ms, NativeType},
-};
+use crate::{array::*, types::NativeType};
 
 /// Compare the values at two arbitrary indices in two arrays.
 pub type DynComparator<'a> = Box<dyn Fn(usize, usize) -> Ordering + 'a>;
@@ -180,7 +177,6 @@ pub fn build_compare<'a>(left: &'a dyn Array, right: &'a dyn Array) -> Result<Dy
         | (Duration(Nanosecond), Duration(Nanosecond)) => compare_primitives::<i64>(left, right),
         (Float32, Float32) => compare_f32(left, right),
         (Float64, Float64) => compare_f64(left, right),
-        (Interval(DayTime), Interval(DayTime)) => compare_primitives::<days_ms>(left, right),
         (Utf8, Utf8) => compare_string::<i32>(left, right),
         (LargeUtf8, LargeUtf8) => compare_string::<i64>(left, right),
         (Dictionary(key_type_lhs, _), Dictionary(key_type_rhs, _)) => {

--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -25,7 +25,6 @@
 use crate::array::*;
 use crate::datatypes::{DataType, IntervalUnit};
 use crate::error::{ArrowError, Result};
-use crate::types::days_ms;
 
 mod boolean;
 mod primitive;
@@ -110,17 +109,6 @@ pub fn compare(lhs: &dyn Array, rhs: &dyn Array, operator: Operator) -> Result<B
         DataType::Float64 => {
             let lhs = lhs.as_any().downcast_ref::<Float64Array>().unwrap();
             let rhs = rhs.as_any().downcast_ref::<Float64Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
-        }
-        DataType::Interval(IntervalUnit::DayTime) => {
-            let lhs = lhs
-                .as_any()
-                .downcast_ref::<PrimitiveArray<days_ms>>()
-                .unwrap();
-            let rhs = rhs
-                .as_any()
-                .downcast_ref::<PrimitiveArray<days_ms>>()
-                .unwrap();
             primitive::compare(lhs, rhs, operator)
         }
         DataType::Utf8 => {

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -6,7 +6,7 @@ use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::{
     array::*,
-    types::{days_ms, Index, NativeType},
+    types::{Index, NativeType},
 };
 
 use crate::buffer::MutableBuffer;
@@ -63,9 +63,6 @@ pub fn sort(
         DataType::UInt64 => dyn_sort!(u64, values, ord::total_cmp, options, limit),
         DataType::Float32 => dyn_sort!(f32, values, ord::total_cmp_f32, options, limit),
         DataType::Float64 => dyn_sort!(f64, values, ord::total_cmp_f64, options, limit),
-        DataType::Interval(IntervalUnit::DayTime) => {
-            dyn_sort!(days_ms, values, ord::total_cmp, options, limit)
-        }
         _ => {
             let indices = sort_to_indices::<u64>(values, options, limit)?;
             take::take(values, &indices)
@@ -134,9 +131,6 @@ pub fn sort_to_indices<I: Index>(
         DataType::UInt64 => dyn_sort_indices!(I, u64, values, ord::total_cmp, options, limit),
         DataType::Float32 => dyn_sort_indices!(I, f32, values, ord::total_cmp_f32, options, limit),
         DataType::Float64 => dyn_sort_indices!(I, f64, values, ord::total_cmp_f64, options, limit),
-        DataType::Interval(IntervalUnit::DayTime) => {
-            dyn_sort_indices!(I, days_ms, values, ord::total_cmp, options, limit)
-        }
         DataType::Utf8 => Ok(utf8::indices_sorted_unstable_by::<I, i32>(
             values.as_any().downcast_ref().unwrap(),
             options,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,10 +7,7 @@
 //! represent chunks of bits (e.g. `u8`, `u16`), and [`BitChunkIter`], that can be used to
 //! iterate over bitmaps in [`BitChunk`]s.
 //! Finally, this module also contains traits used to compile code optimized for SIMD instructions at [`simd`].
-use std::{
-    cmp::{Ord, Ordering},
-    convert::TryFrom,
-};
+use std::convert::TryFrom;
 
 mod bit_chunk;
 pub use bit_chunk::{BitChunk, BitChunkIter};
@@ -229,20 +226,5 @@ impl days_ms {
     #[inline]
     pub fn milliseconds(&self) -> i32 {
         self.0[1]
-    }
-}
-
-impl Ord for days_ms {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match self.days().cmp(&other.days()) {
-            Ordering::Equal => self.milliseconds().cmp(&other.milliseconds()),
-            other => other,
-        }
-    }
-}
-
-impl PartialOrd for days_ms {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
     }
 }


### PR DESCRIPTION
The `days_ms` type cannot be ordered as there is a number of ms `m` over which `(1,m) > (2,0)`, and thus ordering by days and then by milliseconds is not a valid order. In general such intervals have no order relation.

Thanks a lot to @emkornfield [for pointing this here](https://github.com/jorgecarleitao/arrow2/pull/268#discussion_r687968328).

All operations relying on order are no longer supported for the logical type `Interval(DayTime)` (ord, comparison, sort).