### PR TITLE
Improved performance of concatenating non-aligned validities (15x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,3 +176,11 @@ harness = false
 [[bench]]
 name = "arithmetic_kernels"
 harness = false
+
+[[bench]]
+name = "bitmap"
+harness = false
+
+[[bench]]
+name = "concat"
+harness = false

--- a/benches/bitmap.rs
+++ b/benches/bitmap.rs
@@ -1,0 +1,60 @@
+extern crate arrow2;
+
+use std::iter::FromIterator;
+
+use arrow2::bitmap::*;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+//
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+
+        let bitmap2 = Bitmap::from_iter((0..size).into_iter().map(|x| x % 3 == 0));
+
+        c.bench_function(&format!("bitmap extend aligned 2^{}", log2_size), |b| {
+            let mut bitmap1 = MutableBitmap::new();
+            b.iter(|| {
+                bitmap1.extend_from_bitmap(&bitmap2);
+                bitmap1.clear();
+            })
+        });
+
+        c.bench_function(&format!("bitmap extend unaligned 2^{}", log2_size), |b| {
+            let mut bitmap1 = MutableBitmap::with_capacity(1);
+            b.iter(|| {
+                bitmap1.push(true);
+                bitmap1.extend_from_bitmap(&bitmap2);
+                bitmap1.clear();
+            })
+        });
+
+        c.bench_function(
+            &format!("bitmap extend_constant aligned 2^{}", log2_size),
+            |b| {
+                let mut bitmap1 = MutableBitmap::new();
+                b.iter(|| {
+                    bitmap1.extend_constant(size, true);
+                    bitmap1.clear();
+                })
+            },
+        );
+
+        c.bench_function(
+            &format!("bitmap extend_constant unaligned 2^{}", log2_size),
+            |b| {
+                let mut bitmap1 = MutableBitmap::with_capacity(1);
+                b.iter(|| {
+                    bitmap1.push(true);
+                    bitmap1.extend_constant(size, true);
+                    bitmap1.clear();
+                })
+            },
+        );
+    });
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/benches/concat.rs
+++ b/benches/concat.rs
@@ -1,0 +1,52 @@
+extern crate arrow2;
+
+use arrow2::{
+    compute::concat,
+    datatypes::DataType,
+    util::bench_util::{create_boolean_array, create_primitive_array},
+};
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn add_benchmark(c: &mut Criterion) {
+    (20..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+
+        let array1 = create_primitive_array::<i32>(8, DataType::Int32, 0.5);
+        let array2 = create_primitive_array::<i32>(size + 1, DataType::Int32, 0.5);
+
+        c.bench_function(&format!("int32 concat aligned 2^{}", log2_size), |b| {
+            b.iter(|| {
+                let _ = concat::concatenate(&[&array1, &array2]);
+            })
+        });
+
+        let array1 = create_primitive_array::<i32>(9, DataType::Int32, 0.5);
+
+        c.bench_function(&format!("int32 concat unaligned 2^{}", log2_size), |b| {
+            b.iter(|| {
+                let _ = concat::concatenate(&[&array1, &array2]);
+            })
+        });
+
+        let array1 = create_boolean_array(8, 0.5, 0.5);
+        let array2 = create_boolean_array(size + 1, 0.5, 0.5);
+
+        c.bench_function(&format!("boolean concat aligned 2^{}", log2_size), |b| {
+            b.iter(|| {
+                let _ = concat::concatenate(&[&array1, &array2]);
+            })
+        });
+
+        let array1 = create_boolean_array(9, 0.5, 0.5);
+
+        c.bench_function(&format!("boolean concat unaligned 2^{}", log2_size), |b| {
+            b.iter(|| {
+                let _ = concat::concatenate(&[&array1, &array2]);
+            })
+        });
+    });
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/src/array/growable/boolean.rs
+++ b/src/array/growable/boolean.rs
@@ -55,8 +55,9 @@ impl<'a> Growable<'a> for GrowableBoolean<'a> {
 
         let array = self.arrays[index];
         let values = array.values();
-        let iter = (start..start + len).map(|i| values.get_bit(i));
-        unsafe { self.values.extend_from_trusted_len_iter_unchecked(iter) };
+
+        let (slice, offset, _) = values.as_slice();
+        self.values.extend_from_slice(slice, start + offset, len);
     }
 
     fn extend_validity(&mut self, additional: usize) {

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -39,6 +39,13 @@ impl MutableBitmap {
         }
     }
 
+    /// Empties the [`MutableBitmap`].
+    #[inline]
+    pub fn clear(&mut self) {
+        self.length = 0;
+        self.buffer.clear();
+    }
+
     /// Initializes a zeroed [`MutableBitmap`].
     #[inline]
     pub fn from_len_zeroed(length: usize) -> Self {

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -1,5 +1,6 @@
 use std::iter::FromIterator;
 
+use crate::bitmap::utils::merge_reversed;
 use crate::{buffer::MutableBuffer, trusted_len::TrustedLen};
 
 use super::utils::{fmt, get_bit, null_count, set, set_bit, BitmapIter};
@@ -130,16 +131,63 @@ impl MutableBitmap {
         self.length = len;
     }
 
+    fn extend_set(&mut self, mut additional: usize) {
+        let offset = self.length % 8;
+        let added = if offset != 0 {
+            // offset != 0 => at least one byte in the buffer
+            let last_index = self.buffer.len() - 1;
+            let last = &mut self.buffer[last_index];
+
+            let remaining = 0b11111111u8;
+            let remaining = remaining >> 8usize.saturating_sub(additional);
+            let remaining = remaining << offset;
+            *last |= remaining;
+            std::cmp::min(additional, 8 - offset)
+        } else {
+            0
+        };
+        self.length += added;
+        additional = additional.saturating_sub(added);
+        if additional > 0 {
+            debug_assert_eq!(self.length % 8, 0);
+            let existing = self.buffer.len();
+            let required = (self.length + additional).saturating_add(7) / 8;
+            // add remaining as full bytes
+            self.buffer.extend_from_trusted_len_iter(
+                std::iter::repeat(0b11111111u8).take(required - existing),
+            );
+            self.length += additional;
+        }
+    }
+
+    fn extend_unset(&mut self, mut additional: usize) {
+        let offset = self.length % 8;
+        let added = if offset != 0 {
+            // offset != 0 => at least one byte in the buffer
+            let last_index = self.buffer.len() - 1;
+            let last = &mut self.buffer[last_index];
+            *last &= 0b11111111u8 >> (8 - offset); // unset them
+            std::cmp::min(additional, 8 - offset)
+        } else {
+            0
+        };
+        self.length += added;
+        additional = additional.saturating_sub(added);
+        if additional > 0 {
+            debug_assert_eq!(self.length % 8, 0);
+            self.buffer
+                .resize((self.length + additional).saturating_add(7) / 8, 0);
+            self.length += additional;
+        }
+    }
+
     /// Extends [`MutableBitmap`] by `additional` values of constant `value`.
     #[inline]
     pub fn extend_constant(&mut self, additional: usize, value: bool) {
         if value {
-            let iter = std::iter::repeat(true).take(additional);
-            self.extend_from_trusted_len_iter(iter);
+            self.extend_set(additional)
         } else {
-            self.buffer
-                .resize((self.length + additional).saturating_add(7) / 8, 0);
-            self.length += additional;
+            self.extend_unset(additional)
         }
     }
 
@@ -420,6 +468,42 @@ impl MutableBitmap {
         Ok(Self { buffer, length })
     }
 
+    fn extend_unaligned(&mut self, slice: &[u8], offset: usize, length: usize) {
+        let own_offset = self.length % 8;
+        // e.g.
+        // [a, b, --101010]     <- to be extended
+        // [00111111, 11010101] <- to extend
+        // [a, b, 11101010, --001111] expected result
+        let aligned_offset = offset / 8;
+        let bytes_len = length.saturating_add(7) / 8;
+        let items = &slice[aligned_offset..aligned_offset + bytes_len];
+        // self has some offset => we need to shift all `items`, and merge the first
+        let buffer = self.buffer.as_mut_slice();
+        let last = &mut buffer[buffer.len() - 1];
+
+        // --101010 | 00111111 << 6 = 11101010
+        // erase previous
+        *last &= 0b11111111u8 >> (8 - own_offset); // unset before setting
+        *last |= items[0] << own_offset;
+
+        let remaining = [items[items.len() - 1], 0];
+        let bytes = items
+            .windows(2)
+            .chain(std::iter::once(remaining.as_ref()))
+            .map(|w| merge_reversed(w[0], w[1], 8 - own_offset));
+        self.buffer.extend_from_trusted_len_iter(bytes);
+
+        self.length += length;
+    }
+
+    fn extend_aligned(&mut self, slice: &[u8], offset: usize, length: usize) {
+        let aligned_offset = offset / 8;
+        let bytes_len = length.saturating_add(7) / 8;
+        let items = &slice[aligned_offset..aligned_offset + bytes_len];
+        self.buffer.extend_from_slice(items);
+        self.length += length;
+    }
+
     /// Extends the [`MutableBitmap`] from a slice of bytes with optional offset.
     /// This is the fastest way to extend a [`MutableBitmap`].
     /// # Implementation
@@ -428,16 +512,14 @@ impl MutableBitmap {
     #[inline]
     pub fn extend_from_slice(&mut self, slice: &[u8], offset: usize, length: usize) {
         assert!(offset + length <= slice.len() * 8);
+        if length == 0 {
+            return;
+        };
         let is_aligned = self.length % 8 == 0;
         let other_is_aligned = offset % 8 == 0;
         match (is_aligned, other_is_aligned) {
-            (true, true) => {
-                let aligned_offset = offset / 8;
-                let bytes_len = length.saturating_add(7) / 8;
-                let items = &slice[aligned_offset..aligned_offset + bytes_len];
-                self.buffer.extend_from_slice(items);
-                self.length += length;
-            }
+            (true, true) => self.extend_aligned(slice, offset, length),
+            (false, true) => self.extend_unaligned(slice, offset, length),
             // todo: further optimize the other branches.
             _ => self.extend_from_trusted_len_iter(BitmapIter::new(slice, offset, length)),
         }

--- a/src/bitmap/utils/chunk_iterator/mod.rs
+++ b/src/bitmap/utils/chunk_iterator/mod.rs
@@ -7,7 +7,7 @@ pub use crate::types::BitChunk;
 pub use chunks_exact::BitChunksExact;
 
 use crate::{trusted_len::TrustedLen, types::BitChunkIter};
-use merge::merge_reversed;
+pub(crate) use merge::merge_reversed;
 
 pub trait BitChunkIterExact<B: BitChunk>: Iterator<Item = B> {
     fn remainder(&self) -> B;

--- a/src/bitmap/utils/mod.rs
+++ b/src/bitmap/utils/mod.rs
@@ -4,6 +4,7 @@ mod iterator;
 mod slice_iterator;
 mod zip_validity;
 
+pub(crate) use chunk_iterator::merge_reversed;
 pub use chunk_iterator::{BitChunk, BitChunkIterExact, BitChunks, BitChunksExact};
 pub use fmt::fmt;
 pub use iterator::BitmapIter;


### PR DESCRIPTION
This PR significantly improves the performance of concatenating arrays whose lengths are not a multiple of 8 by improving the performance of concatenating bitmaps.

Before this PR, we concatenated bitmaps by iterating bit by bit and setting bit by bit. However, there is a more efficient way of doing this via byte operations. Specifically, given a mutable bitmap `[10101000, --101010]` (`length = 8+6=14`) a bitmap can be concatenated to by shifts. E.g. `[00000011, a, b, ..., c]` can be concatenated to it by something like

* `00000011 << 6` and OR it
* merge `a` with `00000011` with an offset of 2 and append
* merge `b` with `a` with an offset of 2 and append
* ...
*  append `c`

This results in a significantly less number of instructions, lookups, etc.

This improves performance of almost operations that in some way concatenate validities. It includes:

* Growable API (`concat`, `filter`, `merge-sort`)
* lower-level bitmap concatenation

```bash
git checkout afb05d2511d495075180436dcd16af2e4b6ed71a
cargo bench --no-default-features --features benchmarks,compute --bench bitmap --bench concat --bench filter_kernels -- "2\^20"
git checkout improve_perf
cargo bench --no-default-features --features benchmarks,compute --bench bitmap --bench concat --bench filter_kernels -- "2\^20"
```

```
bitmap extend aligned 2^20                                                                             
                        time:   [3.7567 us 3.7847 us 3.8217 us]
                        change: [-3.0540% +1.6941% +6.6158%] (p = 0.49 > 0.05)

bitmap extend unaligned 2^20                                                                            
                        time:   [247.46 us 248.23 us 249.13 us]
                        change: [-75.411% -75.289% -75.172%] (p = 0.00 < 0.05)

bitmap extend_constant aligned 2^20                                                                             
                        time:   [2.6766 us 2.6822 us 2.6883 us]
                        change: [-99.536% -99.534% -99.532%] (p = 0.00 < 0.05)

bitmap extend_constant unaligned 2^20                                                                             
                        time:   [2.6916 us 2.6970 us 2.7026 us]
                        change: [-99.531% -99.529% -99.527%] (p = 0.00 < 0.05)

int32 concat aligned 2^20                                                                            
                        time:   [487.53 us 488.09 us 488.75 us]
                        change: [-93.566% -93.548% -93.530%] (p = 0.00 < 0.05)

int32 concat unaligned 2^20                                                                            
                        time:   [758.76 us 759.91 us 761.29 us]
                        change: [-89.977% -89.951% -89.923%] (p = 0.00 < 0.05)

boolean concat aligned 2^20                                                                            
                        time:   [224.02 us 224.50 us 225.02 us]
                        change: [-98.193% -98.187% -98.181%] (p = 0.00 < 0.05)

boolean concat unaligned 2^20                                                                            
                        time:   [708.63 us 710.23 us 712.14 us]
                        change: [-94.305% -94.286% -94.268%] (p = 0.00 < 0.05)

filter 2^20 f32         time:   [2.5137 ms 2.5199 ms 2.5274 ms]                             
                        change: [-2.6963% -2.3576% -1.9729%] (p = 0.00 < 0.05)

filter null 2^20 f32    time:   [7.6607 ms 7.6773 ms 7.6954 ms]                                 
                        change: [-12.051% -11.757% -11.473%] (p = 0.00 < 0.05)
```
