### PR TITLE
Generalized ZipIterator to accept a `BitmapIter`

### DIFF
--- a/src/array/binary/iterator.rs
+++ b/src/array/binary/iterator.rs
@@ -52,7 +52,10 @@ impl<'a, O: Offset> IntoIterator for &'a BinaryArray<O> {
 impl<'a, O: Offset> BinaryArray<O> {
     /// Returns an iterator of `Option<&[u8]>`
     pub fn iter(&'a self) -> ZipValidity<'a, &'a [u8], BinaryValueIter<'a, O>> {
-        zip_validity(BinaryValueIter::new(self), &self.validity)
+        zip_validity(
+            BinaryValueIter::new(self),
+            self.validity.as_ref().map(|x| x.iter()),
+        )
     }
 
     /// Returns an iterator of `&[u8]`

--- a/src/array/boolean/iterator.rs
+++ b/src/array/boolean/iterator.rs
@@ -16,7 +16,10 @@ impl<'a> BooleanArray {
     /// constructs a new iterator
     #[inline]
     pub fn iter(&'a self) -> ZipValidity<'a, bool, BitmapIter<'a>> {
-        zip_validity(self.values().iter(), &self.validity)
+        zip_validity(
+            self.values().iter(),
+            self.validity.as_ref().map(|x| x.iter()),
+        )
     }
 
     /// Returns an iterator of `bool`

--- a/src/array/dictionary/iterator.rs
+++ b/src/array/dictionary/iterator.rs
@@ -70,7 +70,10 @@ impl<'a, K: DictionaryKey> IntoIterator for &'a DictionaryArray<K> {
 impl<'a, K: DictionaryKey> DictionaryArray<K> {
     /// Returns an iterator of `Option<Box<dyn Array>>`
     pub fn iter(&'a self) -> ZipIter<'a, K> {
-        zip_validity(DictionaryValuesIter::new(self), self.keys.validity())
+        zip_validity(
+            DictionaryValuesIter::new(self),
+            self.keys.validity().as_ref().map(|x| x.iter()),
+        )
     }
 
     /// Returns an iterator of `Box<dyn Array>`

--- a/src/array/fixed_size_binary/iterator.rs
+++ b/src/array/fixed_size_binary/iterator.rs
@@ -50,6 +50,9 @@ impl<'a> IntoIterator for &'a FixedSizeBinaryArray {
 impl<'a> FixedSizeBinaryArray {
     /// constructs a new iterator
     pub fn iter(&'a self) -> ZipValidity<'a, &'a [u8], FixedSizeBinaryValuesIter<'a>> {
-        zip_validity(FixedSizeBinaryValuesIter::new(self), &self.validity)
+        zip_validity(
+            FixedSizeBinaryValuesIter::new(self),
+            self.validity.as_ref().map(|x| x.iter()),
+        )
     }
 }

--- a/src/array/fixed_size_list/iterator.rs
+++ b/src/array/fixed_size_list/iterator.rs
@@ -26,7 +26,10 @@ impl<'a> IntoIterator for &'a FixedSizeListArray {
 impl<'a> FixedSizeListArray {
     /// Returns an iterator of `Option<Box<dyn Array>>`
     pub fn iter(&'a self) -> ZipIter<'a> {
-        zip_validity(ListValuesIter::new(self), &self.validity)
+        zip_validity(
+            ListValuesIter::new(self),
+            self.validity.as_ref().map(|x| x.iter()),
+        )
     }
 
     /// Returns an iterator of `Box<dyn Array>`

--- a/src/array/list/iterator.rs
+++ b/src/array/list/iterator.rs
@@ -76,7 +76,10 @@ impl<'a, O: Offset> IntoIterator for &'a ListArray<O> {
 impl<'a, O: Offset> ListArray<O> {
     /// Returns an iterator of `Option<Box<dyn Array>>`
     pub fn iter(&'a self) -> ZipIter<'a, O> {
-        zip_validity(ListValuesIter::new(self), &self.validity)
+        zip_validity(
+            ListValuesIter::new(self),
+            self.validity.as_ref().map(|x| x.iter()),
+        )
     }
 
     /// Returns an iterator of `Box<dyn Array>`

--- a/src/array/primitive/iterator.rs
+++ b/src/array/primitive/iterator.rs
@@ -19,6 +19,9 @@ impl<'a, T: NativeType> PrimitiveArray<T> {
     /// constructs a new iterator
     #[inline]
     pub fn iter(&'a self) -> ZipValidity<'a, &'a T, std::slice::Iter<'a, T>> {
-        zip_validity(self.values().iter(), &self.validity)
+        zip_validity(
+            self.values().iter(),
+            self.validity.as_ref().map(|x| x.iter()),
+        )
     }
 }

--- a/src/array/utf8/iterator.rs
+++ b/src/array/utf8/iterator.rs
@@ -68,7 +68,10 @@ impl<'a, O: Offset> IntoIterator for &'a Utf8Array<O> {
 impl<'a, O: Offset> Utf8Array<O> {
     /// Returns an iterator of `Option<&str>`
     pub fn iter(&'a self) -> ZipValidity<'a, &'a str, Utf8ValuesIter<'a, O>> {
-        zip_validity(Utf8ValuesIter::new(self), &self.validity)
+        zip_validity(
+            Utf8ValuesIter::new(self),
+            self.validity.as_ref().map(|x| x.iter()),
+        )
     }
 
     /// Returns an iterator of `&str`

--- a/tests/it/bitmap/utils/zip_validity.rs
+++ b/tests/it/bitmap/utils/zip_validity.rs
@@ -2,9 +2,10 @@ use arrow2::bitmap::{utils::zip_validity, Bitmap};
 
 #[test]
 fn basic() {
-    let a = Some(Bitmap::from([true, false]));
+    let a = Bitmap::from([true, false]);
+    let a = Some(a.iter());
     let values = vec![0, 1];
-    let zip = zip_validity(values.into_iter(), &a);
+    let zip = zip_validity(values.into_iter(), a);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(a, vec![Some(0), None]);
@@ -12,11 +13,10 @@ fn basic() {
 
 #[test]
 fn complete() {
-    let a = Some(Bitmap::from([
-        true, false, true, false, true, false, true, false,
-    ]));
+    let a = Bitmap::from([true, false, true, false, true, false, true, false]);
+    let a = Some(a.iter());
     let values = vec![0, 1, 2, 3, 4, 5, 6, 7];
-    let zip = zip_validity(values.into_iter(), &a);
+    let zip = zip_validity(values.into_iter(), a);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(
@@ -27,7 +27,8 @@ fn complete() {
 
 #[test]
 fn slices() {
-    let a = Some(Bitmap::from([true, false]));
+    let a = Bitmap::from([true, false]);
+    let a = Some(a.iter());
     let offsets = vec![0, 2, 3];
     let values = vec![1, 2, 3];
     let iter = offsets.windows(2).map(|x| {
@@ -35,7 +36,7 @@ fn slices() {
         let end = x[1];
         &values[start..end]
     });
-    let zip = zip_validity(iter, &a);
+    let zip = zip_validity(iter, a);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(a, vec![Some([1, 2].as_ref()), None]);
@@ -43,11 +44,10 @@ fn slices() {
 
 #[test]
 fn byte() {
-    let a = Some(Bitmap::from([
-        true, false, true, false, false, true, true, false, true,
-    ]));
+    let a = Bitmap::from([true, false, true, false, false, true, true, false, true]);
+    let a = Some(a.iter());
     let values = vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
-    let zip = zip_validity(values.into_iter(), &a);
+    let zip = zip_validity(values.into_iter(), a);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(
@@ -68,10 +68,10 @@ fn byte() {
 
 #[test]
 fn offset() {
-    let a = Bitmap::from([true, false, true, false, false, true, true, false, true]);
-    let a = Some(a.slice(1, 8));
+    let a = Bitmap::from([true, false, true, false, false, true, true, false, true]).slice(1, 8);
+    let a = Some(a.iter());
     let values = vec![0, 1, 2, 3, 4, 5, 6, 7];
-    let zip = zip_validity(values.into_iter(), &a);
+    let zip = zip_validity(values.into_iter(), a);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(
@@ -83,7 +83,7 @@ fn offset() {
 #[test]
 fn none() {
     let values = vec![0, 1, 2];
-    let zip = zip_validity(values.into_iter(), &None);
+    let zip = zip_validity(values.into_iter(), None);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(a, vec![Some(0), Some(1), Some(2)]);
@@ -91,10 +91,10 @@ fn none() {
 
 #[test]
 fn rev() {
-    let a = Bitmap::from([true, false, true, false, false, true, true, false, true]);
-    let a = Some(a.slice(1, 8));
+    let a = Bitmap::from([true, false, true, false, false, true, true, false, true]).slice(1, 8);
+    let a = Some(a.iter());
     let values = vec![0, 1, 2, 3, 4, 5, 6, 7];
-    let zip = zip_validity(values.into_iter(), &a);
+    let zip = zip_validity(values.into_iter(), a);
 
     let result = zip.rev().collect::<Vec<_>>();
     let expected = vec![None, Some(1), None, None, Some(4), Some(5), None, Some(7)]


### PR DESCRIPTION
# Rational

It allows to re-use the `ZipValidity` on `MutableArrays`.

# backwards incompatible

`bitmap::utils::zip_validity` and `bitmap::utils::ZipValidity::new` now expect a `BitmapIter` in their arguments.


