### PR TITLE
Improved performance of comparison with SIMD feature flag (2x-3.5x)

### DIFF
--- a/benches/comparison_kernels.rs
+++ b/benches/comparison_kernels.rs
@@ -32,7 +32,7 @@ where
 
 fn bench_op_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T, op: Operator)
 where
-    T: NativeType + std::cmp::PartialOrd,
+    T: NativeType + Simd8,
 {
     primitive_compare_scalar(
         criterion::black_box(arr_a),

--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -30,6 +30,9 @@ mod boolean;
 mod primitive;
 mod utf8;
 
+mod simd;
+pub use simd::{Simd8, Simd8Lanes};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Operator {
     Lt,

--- a/src/compute/comparison/simd/mod.rs
+++ b/src/compute/comparison/simd/mod.rs
@@ -1,6 +1,76 @@
-mod native;
+#[inline]
+pub(super) fn set<T: Copy, F: Fn(T, T) -> bool>(lhs: [T; 8], rhs: [T; 8], op: F) -> u8 {
+    let mut byte = 0u8;
+    lhs.iter()
+        .zip(rhs.iter())
+        .enumerate()
+        .for_each(|(i, (lhs, rhs))| {
+            byte |= if op(*lhs, *rhs) { 1 << i } else { 0 };
+        });
+    byte
+}
 
+macro_rules! simd8_native {
+    ($type:ty) => {
+        impl Simd8 for $type {
+            type Simd = [$type; 8];
+        }
+
+        impl Simd8Lanes<$type> for [$type; 8] {
+            #[inline]
+            fn from_chunk(v: &[$type]) -> Self {
+                v.try_into().unwrap()
+            }
+
+            #[inline]
+            fn from_incomplete_chunk(v: &[$type], remaining: $type) -> Self {
+                let mut a = [remaining; 8];
+                a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
+                a
+            }
+
+            #[inline]
+            fn eq(self, other: Self) -> u8 {
+                set(self, other, |x, y| x == y)
+            }
+
+            #[inline]
+            fn neq(self, other: Self) -> u8 {
+                #[allow(clippy::float_cmp)]
+                set(self, other, |x, y| x != y)
+            }
+
+            #[inline]
+            fn lt_eq(self, other: Self) -> u8 {
+                set(self, other, |x, y| x <= y)
+            }
+
+            #[inline]
+            fn lt(self, other: Self) -> u8 {
+                set(self, other, |x, y| x < y)
+            }
+
+            #[inline]
+            fn gt_eq(self, other: Self) -> u8 {
+                set(self, other, |x, y| x >= y)
+            }
+
+            #[inline]
+            fn gt(self, other: Self) -> u8 {
+                set(self, other, |x, y| x > y)
+            }
+        }
+    };
+}
+
+#[cfg(not(feature = "simd"))]
+mod native;
+#[cfg(not(feature = "simd"))]
 pub use native::*;
+#[cfg(feature = "simd")]
+mod packed;
+#[cfg(feature = "simd")]
+pub use packed::*;
 
 use crate::types::NativeType;
 

--- a/src/compute/comparison/simd/mod.rs
+++ b/src/compute/comparison/simd/mod.rs
@@ -1,3 +1,21 @@
+use crate::types::NativeType;
+
+/// [`NativeType`] that supports a representation of 8 lanes
+pub trait Simd8: NativeType {
+    type Simd: Simd8Lanes<Self>;
+}
+
+pub trait Simd8Lanes<T>: Copy {
+    fn from_chunk(v: &[T]) -> Self;
+    fn from_incomplete_chunk(v: &[T], remaining: T) -> Self;
+    fn eq(self, other: Self) -> u8;
+    fn neq(self, other: Self) -> u8;
+    fn lt_eq(self, other: Self) -> u8;
+    fn lt(self, other: Self) -> u8;
+    fn gt(self, other: Self) -> u8;
+    fn gt_eq(self, other: Self) -> u8;
+}
+
 #[inline]
 pub(super) fn set<T: Copy, F: Fn(T, T) -> bool>(lhs: [T; 8], rhs: [T; 8], op: F) -> u8 {
     let mut byte = 0u8;
@@ -71,21 +89,3 @@ pub use native::*;
 mod packed;
 #[cfg(feature = "simd")]
 pub use packed::*;
-
-use crate::types::NativeType;
-
-/// [`NativeType`] that supports a representation of 8 lanes
-pub trait Simd8: NativeType {
-    type Simd: Simd8Lanes<Self>;
-}
-
-pub trait Simd8Lanes<T> {
-    fn from_chunk(v: &[T]) -> Self;
-    fn from_incomplete_chunk(v: &[T], remaining: T) -> Self;
-    fn eq(self, other: Self) -> u8;
-    fn neq(self, other: Self) -> u8;
-    fn lt_eq(self, other: Self) -> u8;
-    fn lt(self, other: Self) -> u8;
-    fn gt(self, other: Self) -> u8;
-    fn gt_eq(self, other: Self) -> u8;
-}

--- a/src/compute/comparison/simd/mod.rs
+++ b/src/compute/comparison/simd/mod.rs
@@ -1,0 +1,21 @@
+mod native;
+
+pub use native::*;
+
+use crate::types::NativeType;
+
+/// [`NativeType`] that supports a representation of 8 lanes
+pub trait Simd8: NativeType {
+    type Simd: Simd8Lanes<Self>;
+}
+
+pub trait Simd8Lanes<T> {
+    fn from_chunk(v: &[T]) -> Self;
+    fn from_incomplete_chunk(v: &[T], remaining: T) -> Self;
+    fn eq(self, other: Self) -> u8;
+    fn neq(self, other: Self) -> u8;
+    fn lt_eq(self, other: Self) -> u8;
+    fn lt(self, other: Self) -> u8;
+    fn gt(self, other: Self) -> u8;
+    fn gt_eq(self, other: Self) -> u8;
+}

--- a/src/compute/comparison/simd/native.rs
+++ b/src/compute/comparison/simd/native.rs
@@ -1,0 +1,80 @@
+use std::convert::TryInto;
+
+use super::{Simd8, Simd8Lanes};
+
+#[inline]
+fn set<T: Copy, F: Fn(T, T) -> bool>(lhs: [T; 8], rhs: [T; 8], op: F) -> u8 {
+    let mut byte = 0u8;
+    lhs.iter()
+        .zip(rhs.iter())
+        .enumerate()
+        .for_each(|(i, (lhs, rhs))| {
+            byte |= if op(*lhs, *rhs) { 1 << i } else { 0 };
+        });
+    byte
+}
+
+macro_rules! simd8 {
+    ($type:ty) => {
+        impl Simd8 for $type {
+            type Simd = [$type; 8];
+        }
+
+        impl Simd8Lanes<$type> for [$type; 8] {
+            #[inline]
+            fn from_chunk(v: &[$type]) -> Self {
+                v.try_into().unwrap()
+            }
+
+            #[inline]
+            fn from_incomplete_chunk(v: &[$type], remaining: $type) -> Self {
+                let mut a = [remaining; 8];
+                a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
+                a
+            }
+
+            #[inline]
+            fn eq(self, other: Self) -> u8 {
+                set(self, other, |x, y| x == y)
+            }
+
+            #[inline]
+            fn neq(self, other: Self) -> u8 {
+                #[allow(clippy::float_cmp)]
+                set(self, other, |x, y| x != y)
+            }
+
+            #[inline]
+            fn lt_eq(self, other: Self) -> u8 {
+                set(self, other, |x, y| x <= y)
+            }
+
+            #[inline]
+            fn lt(self, other: Self) -> u8 {
+                set(self, other, |x, y| x < y)
+            }
+
+            #[inline]
+            fn gt_eq(self, other: Self) -> u8 {
+                set(self, other, |x, y| x >= y)
+            }
+
+            #[inline]
+            fn gt(self, other: Self) -> u8 {
+                set(self, other, |x, y| x > y)
+            }
+        }
+    };
+}
+
+simd8!(u8);
+simd8!(u16);
+simd8!(u32);
+simd8!(u64);
+simd8!(i8);
+simd8!(i16);
+simd8!(i32);
+simd8!(i128);
+simd8!(i64);
+simd8!(f32);
+simd8!(f64);

--- a/src/compute/comparison/simd/native.rs
+++ b/src/compute/comparison/simd/native.rs
@@ -1,80 +1,15 @@
 use std::convert::TryInto;
 
-use super::{Simd8, Simd8Lanes};
+use super::{set, Simd8, Simd8Lanes};
 
-#[inline]
-fn set<T: Copy, F: Fn(T, T) -> bool>(lhs: [T; 8], rhs: [T; 8], op: F) -> u8 {
-    let mut byte = 0u8;
-    lhs.iter()
-        .zip(rhs.iter())
-        .enumerate()
-        .for_each(|(i, (lhs, rhs))| {
-            byte |= if op(*lhs, *rhs) { 1 << i } else { 0 };
-        });
-    byte
-}
-
-macro_rules! simd8 {
-    ($type:ty) => {
-        impl Simd8 for $type {
-            type Simd = [$type; 8];
-        }
-
-        impl Simd8Lanes<$type> for [$type; 8] {
-            #[inline]
-            fn from_chunk(v: &[$type]) -> Self {
-                v.try_into().unwrap()
-            }
-
-            #[inline]
-            fn from_incomplete_chunk(v: &[$type], remaining: $type) -> Self {
-                let mut a = [remaining; 8];
-                a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
-                a
-            }
-
-            #[inline]
-            fn eq(self, other: Self) -> u8 {
-                set(self, other, |x, y| x == y)
-            }
-
-            #[inline]
-            fn neq(self, other: Self) -> u8 {
-                #[allow(clippy::float_cmp)]
-                set(self, other, |x, y| x != y)
-            }
-
-            #[inline]
-            fn lt_eq(self, other: Self) -> u8 {
-                set(self, other, |x, y| x <= y)
-            }
-
-            #[inline]
-            fn lt(self, other: Self) -> u8 {
-                set(self, other, |x, y| x < y)
-            }
-
-            #[inline]
-            fn gt_eq(self, other: Self) -> u8 {
-                set(self, other, |x, y| x >= y)
-            }
-
-            #[inline]
-            fn gt(self, other: Self) -> u8 {
-                set(self, other, |x, y| x > y)
-            }
-        }
-    };
-}
-
-simd8!(u8);
-simd8!(u16);
-simd8!(u32);
-simd8!(u64);
-simd8!(i8);
-simd8!(i16);
-simd8!(i32);
-simd8!(i128);
-simd8!(i64);
-simd8!(f32);
-simd8!(f64);
+simd8_native!(u8);
+simd8_native!(u16);
+simd8_native!(u32);
+simd8_native!(u64);
+simd8_native!(i8);
+simd8_native!(i16);
+simd8_native!(i32);
+simd8_native!(i128);
+simd8_native!(i64);
+simd8_native!(f32);
+simd8_native!(f64);

--- a/src/compute/comparison/simd/packed.rs
+++ b/src/compute/comparison/simd/packed.rs
@@ -1,0 +1,67 @@
+use super::{set, Simd8, Simd8Lanes};
+
+use packed_simd::*;
+
+macro_rules! simd8 {
+    ($type:ty, $md:ty) => {
+        impl Simd8 for $type {
+            type Simd = $md;
+        }
+
+        impl Simd8Lanes<$type> for $md {
+            #[inline]
+            fn from_chunk(v: &[$type]) -> Self {
+                <$md>::from_slice_aligned(v)
+            }
+
+            #[inline]
+            fn from_incomplete_chunk(v: &[$type], remaining: $type) -> Self {
+                let mut a = [remaining; 8];
+                a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
+                Self::from_chunk(a.as_ref())
+            }
+
+            #[inline]
+            fn eq(self, other: Self) -> u8 {
+                self.eq(other).bitmask()
+            }
+
+            #[inline]
+            fn neq(self, other: Self) -> u8 {
+                self.ne(other).bitmask()
+            }
+
+            #[inline]
+            fn lt_eq(self, other: Self) -> u8 {
+                self.le(other).bitmask()
+            }
+
+            #[inline]
+            fn lt(self, other: Self) -> u8 {
+                self.lt(other).bitmask()
+            }
+
+            #[inline]
+            fn gt_eq(self, other: Self) -> u8 {
+                self.ge(other).bitmask()
+            }
+
+            #[inline]
+            fn gt(self, other: Self) -> u8 {
+                self.gt(other).bitmask()
+            }
+        }
+    };
+}
+
+simd8!(u8, u8x8);
+simd8!(u16, u16x8);
+simd8!(u32, u32x8);
+simd8!(u64, u64x8);
+simd8!(i8, i8x8);
+simd8!(i16, i16x8);
+simd8!(i32, i32x8);
+simd8!(i64, i64x8);
+simd8_native!(i128);
+simd8!(f32, f32x8);
+simd8!(f64, f64x8);

--- a/src/compute/comparison/simd/packed.rs
+++ b/src/compute/comparison/simd/packed.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use super::{set, Simd8, Simd8Lanes};
 
 use packed_simd::*;

--- a/src/compute/nullif.rs
+++ b/src/compute/nullif.rs
@@ -1,5 +1,5 @@
 use crate::array::PrimitiveArray;
-use crate::compute::comparison::primitive_compare_values_op;
+use crate::compute::comparison::{primitive_compare_values_op, Simd8, Simd8Lanes};
 use crate::datatypes::DataType;
 use crate::error::{ArrowError, Result};
 use crate::{array::Array, types::NativeType};
@@ -29,7 +29,7 @@ use super::utils::combine_validities;
 /// This function errors iff
 /// * The arguments do not have the same logical type
 /// * The arguments do not have the same length
-pub fn nullif_primitive<T: NativeType>(
+pub fn nullif_primitive<T: NativeType + Simd8>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<T>,
 ) -> Result<PrimitiveArray<T>> {
@@ -39,7 +39,7 @@ pub fn nullif_primitive<T: NativeType>(
         ));
     }
 
-    let equal = primitive_compare_values_op(lhs.values(), rhs.values(), |lhs, rhs| lhs != rhs);
+    let equal = primitive_compare_values_op(lhs.values(), rhs.values(), |lhs, rhs| lhs.neq(rhs));
     let equal = equal.into();
 
     let validity = combine_validities(lhs.validity(), &equal);

--- a/src/trusted_len.rs
+++ b/src/trusted_len.rs
@@ -26,6 +26,8 @@ where
 {
 }
 
+unsafe impl<T> TrustedLen for std::slice::ChunksExact<'_, T> {}
+
 unsafe impl<T> TrustedLen for std::slice::Windows<'_, T> {}
 
 unsafe impl<A, B> TrustedLen for std::iter::Chain<A, B>


### PR DESCRIPTION
This PR adds explicit SIMD implementations to comparison compute.

By operating over groups of 8 and applying the relevant conversions with native packed_simd2 apis, we gain 2-3.5x in performance. There is no difference in performance over the non-simd implementation; it was just written in a more abstract fashion to allow the simd version to be plugged in.

```bash
cargo bench --no-default-features --features benchmarks,compute --bench comparison_kernels
cargo bench --no-default-features --features benchmarks,compute,simd --bench comparison_kernels
```

```bash
eq Float32              time:   [20.319 us 20.394 us 20.492 us]                        
                        change: [-70.496% -70.317% -70.165%] (p = 0.00 < 0.05)

eq scalar Float32       time:   [16.452 us 16.512 us 16.585 us]                               
                        change: [-54.292% -53.941% -53.602%] (p = 0.00 < 0.05)

lt Float32              time:   [19.904 us 19.972 us 20.063 us]                        
                        change: [-67.563% -67.329% -67.084%] (p = 0.00 < 0.05)

lt scalar Float32       time:   [16.410 us 16.467 us 16.541 us]                               
                        change: [-54.324% -54.088% -53.814%] (p = 0.00 < 0.05)
```