### PR TITLE
Fixed error in computing existing bitsize in `extend_constant`

### DIFF
--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -148,7 +148,7 @@ impl MutableBitmap {
         additional = additional.saturating_sub(added);
         if additional > 0 {
             debug_assert_eq!(self.length % 8, 0);
-            let existing = self.buffer.len();
+            let existing = self.length.saturating_add(7) / 8;
             let required = (self.length + additional).saturating_add(7) / 8;
             // add remaining as full bytes
             self.buffer.extend_from_trusted_len_iter(


### PR DESCRIPTION
This fixes #309 by computing required from the same source of truth, the length of the buffer. I cannot really think of a way how to test this properly. Have you got an idea?

Closes #309.