### PR TITLE
Added `compare_scalar`

### DIFF
--- a/benches/comparison_kernels.rs
+++ b/benches/comparison_kernels.rs
@@ -38,8 +38,7 @@ where
         criterion::black_box(arr_a),
         criterion::black_box(value_b),
         op,
-    )
-    .unwrap();
+    );
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -15,16 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines basic comparison kernels for [`PrimitiveArray`]s.
-//!
-//! These kernels can leverage SIMD if available on your system.  Currently no runtime
-//! detection is provided, you should enable the specific SIMD intrinsics using
-//! `RUSTFLAGS="-C target-feature=+avx2"` for example.  See the documentation
-//! [here](https://doc.rust-lang.org/stable/core/arch/) for more information.
+//! Defines basic comparison kernels.
 
 use crate::array::*;
 use crate::datatypes::{DataType, IntervalUnit};
 use crate::error::{ArrowError, Result};
+use crate::scalar::Scalar;
 
 mod boolean;
 mod primitive;
@@ -43,10 +39,16 @@ pub enum Operator {
     Neq,
 }
 
+/// Compares each slot of `lhs` against each slot of `rhs`.
+/// # Error
+/// Errors iff:
+/// * `lhs.data_type() != rhs.data_type()` or
+/// * `lhs.len() != rhs.len()` or
+/// * the datatype is not supported (use [`can_compare`] to tell whether it is supported)
 pub fn compare(lhs: &dyn Array, rhs: &dyn Array, operator: Operator) -> Result<BooleanArray> {
     let data_type = lhs.data_type();
     if data_type != rhs.data_type() {
-        return Err(ArrowError::NotYetImplemented(
+        return Err(ArrowError::InvalidArgumentError(
             "Comparison is only supported for arrays of the same logical type".to_string(),
         ));
     }
@@ -136,10 +138,114 @@ pub fn compare(lhs: &dyn Array, rhs: &dyn Array, operator: Operator) -> Result<B
     }
 }
 
-pub use boolean::compare_scalar as boolean_compare_scalar;
-pub use primitive::compare_scalar as primitive_compare_scalar;
+/// Compares all slots of `lhs` against `rhs`.
+/// # Error
+/// Errors iff:
+/// * `lhs.data_type() != rhs.data_type()` or
+/// * the datatype is not supported (use [`can_compare`] to tell whether it is supported)
+pub fn compare_scalar(
+    lhs: &dyn Array,
+    rhs: &dyn Scalar,
+    operator: Operator,
+) -> Result<BooleanArray> {
+    let data_type = lhs.data_type();
+    if data_type != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Comparison is only supported for the same logical type".to_string(),
+        ));
+    }
+    Ok(match data_type {
+        DataType::Boolean => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            boolean::compare_scalar(lhs, rhs, operator)
+        }
+        DataType::Int8 => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare_scalar::<i8>(lhs, rhs, operator)
+        }
+        DataType::Int16 => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare_scalar::<i16>(lhs, rhs, operator)
+        }
+        DataType::Int32
+        | DataType::Date32
+        | DataType::Time32(_)
+        | DataType::Interval(IntervalUnit::YearMonth) => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare_scalar::<i32>(lhs, rhs, operator)
+        }
+        DataType::Int64
+        | DataType::Timestamp(_, None)
+        | DataType::Date64
+        | DataType::Time64(_)
+        | DataType::Duration(_) => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare_scalar::<i64>(lhs, rhs, operator)
+        }
+        DataType::UInt8 => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare_scalar::<u8>(lhs, rhs, operator)
+        }
+        DataType::UInt16 => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare_scalar::<u16>(lhs, rhs, operator)
+        }
+        DataType::UInt32 => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare_scalar::<u32>(lhs, rhs, operator)
+        }
+        DataType::UInt64 => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare_scalar::<u64>(lhs, rhs, operator)
+        }
+        DataType::Float16 => unreachable!(),
+        DataType::Float32 => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare_scalar::<f32>(lhs, rhs, operator)
+        }
+        DataType::Float64 => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare_scalar::<f64>(lhs, rhs, operator)
+        }
+        DataType::Decimal(_, _) => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare_scalar::<i128>(lhs, rhs, operator)
+        }
+        DataType::Utf8 => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            utf8::compare_scalar::<i32>(lhs, rhs, operator)
+        }
+        DataType::LargeUtf8 => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            utf8::compare_scalar::<i64>(lhs, rhs, operator)
+        }
+        _ => {
+            return Err(ArrowError::NotYetImplemented(format!(
+                "Comparison between {:?} is not supported",
+                data_type
+            )))
+        }
+    })
+}
+
+pub use boolean::compare_scalar_non_null as boolean_compare_scalar;
+pub use primitive::compare_scalar_non_null as primitive_compare_scalar;
 pub(crate) use primitive::compare_values_op as primitive_compare_values_op;
-pub use utf8::compare_scalar as utf8_compare_scalar;
+pub use utf8::compare_scalar_non_null as utf8_compare_scalar;
 
 /// Checks if an array of type `datatype` can be compared with another array of
 /// the same type.
@@ -184,6 +290,8 @@ pub fn can_compare(data_type: &DataType) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::scalar::new_scalar;
+
     use super::*;
 
     #[test]
@@ -225,13 +333,26 @@ mod tests {
             Duration(TimeUnit::Nanosecond),
         ];
 
-        datatypes.into_iter().for_each(|d1| {
+        // array <> array
+        datatypes.clone().into_iter().for_each(|d1| {
             let array = new_null_array(d1.clone(), 10);
             let op = Operator::Eq;
             if can_compare(&d1) {
                 assert!(compare(array.as_ref(), array.as_ref(), op).is_ok());
             } else {
                 assert!(compare(array.as_ref(), array.as_ref(), op).is_err());
+            }
+        });
+
+        // array <> scalar
+        datatypes.into_iter().for_each(|d1| {
+            let array = new_null_array(d1.clone(), 10);
+            let scalar = new_scalar(array.as_ref(), 0);
+            let op = Operator::Eq;
+            if can_compare(&d1) {
+                assert!(compare_scalar(array.as_ref(), scalar.as_ref(), op).is_ok());
+            } else {
+                assert!(compare_scalar(array.as_ref(), scalar.as_ref(), op).is_err());
             }
         });
     }

--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -57,77 +57,77 @@ pub fn compare(lhs: &dyn Array, rhs: &dyn Array, operator: Operator) -> Result<B
             boolean::compare(lhs, rhs, operator)
         }
         DataType::Int8 => {
-            let lhs = lhs.as_any().downcast_ref::<Int8Array>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<Int8Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare::<i8>(lhs, rhs, operator)
         }
         DataType::Int16 => {
-            let lhs = lhs.as_any().downcast_ref::<Int16Array>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<Int16Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare::<i16>(lhs, rhs, operator)
         }
         DataType::Int32
         | DataType::Date32
         | DataType::Time32(_)
         | DataType::Interval(IntervalUnit::YearMonth) => {
-            let lhs = lhs.as_any().downcast_ref::<Int32Array>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<Int32Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare::<i32>(lhs, rhs, operator)
         }
         DataType::Int64
         | DataType::Timestamp(_, None)
         | DataType::Date64
         | DataType::Time64(_)
         | DataType::Duration(_) => {
-            let lhs = lhs.as_any().downcast_ref::<Int64Array>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<Int64Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare::<i64>(lhs, rhs, operator)
         }
         DataType::UInt8 => {
-            let lhs = lhs.as_any().downcast_ref::<UInt8Array>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<UInt8Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare::<u8>(lhs, rhs, operator)
         }
         DataType::UInt16 => {
-            let lhs = lhs.as_any().downcast_ref::<UInt16Array>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<UInt16Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare::<u16>(lhs, rhs, operator)
         }
         DataType::UInt32 => {
-            let lhs = lhs.as_any().downcast_ref::<UInt32Array>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<UInt32Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare::<u32>(lhs, rhs, operator)
         }
         DataType::UInt64 => {
-            let lhs = lhs.as_any().downcast_ref::<UInt64Array>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<UInt64Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare::<u64>(lhs, rhs, operator)
         }
         DataType::Float16 => unreachable!(),
         DataType::Float32 => {
-            let lhs = lhs.as_any().downcast_ref::<Float32Array>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<Float32Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare::<f32>(lhs, rhs, operator)
         }
         DataType::Float64 => {
-            let lhs = lhs.as_any().downcast_ref::<Float64Array>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<Float64Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare::<f64>(lhs, rhs, operator)
         }
         DataType::Utf8 => {
-            let lhs = lhs.as_any().downcast_ref::<Utf8Array<i32>>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<Utf8Array<i32>>().unwrap();
-            utf8::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            utf8::compare::<i32>(lhs, rhs, operator)
         }
         DataType::LargeUtf8 => {
-            let lhs = lhs.as_any().downcast_ref::<Utf8Array<i64>>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<Utf8Array<i64>>().unwrap();
-            utf8::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            utf8::compare::<i64>(lhs, rhs, operator)
         }
         DataType::Decimal(_, _) => {
-            let lhs = lhs.as_any().downcast_ref::<Int128Array>().unwrap();
-            let rhs = rhs.as_any().downcast_ref::<Int128Array>().unwrap();
-            primitive::compare(lhs, rhs, operator)
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            primitive::compare::<i128>(lhs, rhs, operator)
         }
         _ => Err(ArrowError::NotYetImplemented(format!(
             "Comparison between {:?} is not supported",

--- a/src/compute/comparison/utf8.rs
+++ b/src/compute/comparison/utf8.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use crate::error::{ArrowError, Result};
+use crate::scalar::{Scalar, Utf8Scalar};
 use crate::{array::*, bitmap::Bitmap};
 
 use super::{super::utils::combine_validities, Operator};
@@ -140,7 +141,22 @@ pub fn compare<O: Offset>(
     }
 }
 
-pub fn compare_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str, op: Operator) -> BooleanArray {
+pub fn compare_scalar<O: Offset>(
+    lhs: &Utf8Array<O>,
+    rhs: &Utf8Scalar<O>,
+    op: Operator,
+) -> BooleanArray {
+    if !rhs.is_valid() {
+        return BooleanArray::new_null(lhs.len());
+    }
+    compare_scalar_non_null(lhs, rhs.value(), op)
+}
+
+pub fn compare_scalar_non_null<O: Offset>(
+    lhs: &Utf8Array<O>,
+    rhs: &str,
+    op: Operator,
+) -> BooleanArray {
     match op {
         Operator::Eq => eq_scalar(lhs, rhs),
         Operator::Neq => neq_scalar(lhs, rhs),


### PR DESCRIPTION
This PR adds a new function, `arrow2::compute::comparison::compare_scalar` with signature

```rust
compare_scalar(lhs: &dyn Array, rhs: &dyn Scalar, operator: Operator) -> Result<BooleanArray>
```

that compares a `&dyn array` with a `&dyn scalar` (error if not of the same `datatype`). This allows implementations to not have to select the right implementation based on the `data_type`.

All implementations of `*_scalar` were also stripped from the `Result<>`, since they were infallible (backward-incompatible).

Closes #316