### PR TITLE
Improved performance of boolean comparison (5x-14x)

### DIFF
--- a/benches/comparison_kernels.rs
+++ b/benches/comparison_kernels.rs
@@ -1,64 +1,48 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-#[macro_use]
-extern crate criterion;
-use criterion::Criterion;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use arrow2::array::*;
+use arrow2::scalar::*;
 use arrow2::util::bench_util::*;
-use arrow2::{compute::comparison::*, datatypes::DataType, types::NativeType};
+use arrow2::{compute::comparison::*, datatypes::DataType};
 
-fn bench_op<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>, op: Operator)
-where
-    T: NativeType,
-{
-    compare(criterion::black_box(arr_a), criterion::black_box(arr_b), op).unwrap();
+fn bench_op(arr_a: &dyn Array, arr_b: &dyn Array, op: Operator) {
+    compare(black_box(arr_a), black_box(arr_b), op).unwrap();
 }
 
-fn bench_op_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T, op: Operator)
-where
-    T: NativeType + Simd8,
-{
-    primitive_compare_scalar(
-        criterion::black_box(arr_a),
-        criterion::black_box(value_b),
-        op,
-    );
+fn bench_op_scalar(arr_a: &dyn Array, value_b: &dyn Scalar, op: Operator) {
+    compare_scalar(black_box(arr_a), black_box(value_b), op).unwrap();
 }
 
 fn add_benchmark(c: &mut Criterion) {
-    let size = 65536;
-    let arr_a = create_primitive_array_with_seed::<f32>(size, DataType::Float32, 0.0, 42);
-    let arr_b = create_primitive_array_with_seed::<f32>(size, DataType::Float32, 0.0, 43);
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
 
-    c.bench_function("eq Float32", |b| {
-        b.iter(|| bench_op(&arr_a, &arr_b, Operator::Eq))
-    });
-    c.bench_function("eq scalar Float32", |b| {
-        b.iter(|| bench_op_scalar(&arr_a, 0.5, Operator::Eq))
-    });
+        let arr_a = create_primitive_array_with_seed::<f32>(size, DataType::Float32, 0.0, 42);
+        let arr_b = create_primitive_array_with_seed::<f32>(size, DataType::Float32, 0.0, 43);
 
-    c.bench_function("lt Float32", |b| {
-        b.iter(|| bench_op(&arr_a, &arr_b, Operator::Lt))
-    });
-    c.bench_function("lt scalar Float32", |b| {
-        b.iter(|| bench_op_scalar(&arr_a, 0.5, Operator::Lt))
-    });
+        c.bench_function(&format!("f32 2^{}", log2_size), |b| {
+            b.iter(|| bench_op(&arr_a, &arr_b, Operator::Eq))
+        });
+        c.bench_function(&format!("f32 scalar 2^{}", log2_size), |b| {
+            b.iter(|| {
+                bench_op_scalar(
+                    &arr_a,
+                    &PrimitiveScalar::<f32>::from(Some(0.5)),
+                    Operator::Eq,
+                )
+            })
+        });
+
+        let arr_a = create_boolean_array(size, 0.0, 0.1);
+        let arr_b = create_boolean_array(size, 0.0, 0.2);
+
+        c.bench_function(&format!("bool 2^{}", log2_size), |b| {
+            b.iter(|| bench_op(&arr_a, &arr_b, Operator::Eq))
+        });
+        c.bench_function(&format!("bool scalar 2^{}", log2_size), |b| {
+            b.iter(|| bench_op_scalar(&arr_a, &BooleanScalar::from(Some(true)), Operator::Eq))
+        });
+    })
 }
 
 criterion_group!(benches, add_benchmark);


### PR DESCRIPTION
The idea is that we can compare full bytes instead of iterating over individual bits, replacing `Fn(bool,bool) -> bool` by `Fn(u8,u8) -> u8` with corresponding bit operations (e.g. `a != b -> a ^ b`, `a < b -> !a & b`).

```
git checkout 0893100640f22dfc5fec4dede300f63fe095b170
cargo bench --no-default-features --features benchmarks,compute --bench comparison_kernels -- "bool.*2\^20"
git checkout cmp_boolean
cargo bench --no-default-features --features benchmarks,compute --bench comparison_kernels -- "bool.*2\^20"
```

```
bool 2^20               time:   [1.0651 ms 1.0719 ms 1.0817 ms]                       
                        change: [-78.884% -78.378% -77.783%] (p = 0.00 < 0.05)

bool scalar 2^20        time:   [212.37 us 213.76 us 215.72 us]                             
                        change: [-93.123% -93.040% -92.965%] (p = 0.00 < 0.05)
```