### PR TITLE
Added API to FFI `Field`

### DIFF
--- a/.github/workflows/integration-ffi.yml
+++ b/.github/workflows/integration-ffi.yml
@@ -38,6 +38,6 @@ jobs:
           python -m venv venv
           source venv/bin/activate
 
-          pip install maturin==0.10.2 toml==0.10.1 pyarrow==4.0.0
+          pip install maturin==0.10.2 toml==0.10.1 pyarrow==5.0.0
           maturin develop
           python -m unittest discover tests

--- a/arrow-pyarrow-integration-testing/Cargo.toml
+++ b/arrow-pyarrow-integration-testing/Cargo.toml
@@ -17,13 +17,9 @@
 
 [package]
 name = "arrow-pyarrow-integration-testing"
-description = ""
-version = "4.0.0-SNAPSHOT"
-homepage = "https://github.com/apache/arrow-rs"
-repository = "https://github.com/apache/arrow-rs"
-authors = ["Apache Arrow <dev@arrow.apache.org>"]
+version = "0.0.0"
+authors = ["Jorge C. Leitao <jorgecarleitao@gmail.com>", "Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
-keywords = [ "arrow" ]
 edition = "2018"
 
 [lib]
@@ -31,8 +27,8 @@ name = "arrow_pyarrow_integration_testing"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow2 = { path = "../", default-features = false, features = ["compute"] }
-pyo3 = { version = "0.12.1", features = ["extension-module"] }
+arrow2 = { path = "../", default-features = false }
+pyo3 = { version = "0.14", features = ["extension-module"] }
 
 [package.metadata.maturin]
 requires-dist = ["pyarrow>=1"]

--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -40,60 +40,12 @@ class TestCase(unittest.TestCase):
         # No leak of C++ memory
         self.assertEqual(self.old_allocated_cpp, pyarrow.total_allocated_bytes())
 
-    def test_primitive_python(self):
-        """
-        Python -> Rust -> Python
-        """
-        a = pyarrow.array([1, 2, 3])
-        b = arrow_pyarrow_integration_testing.double(a)
-        self.assertEqual(b, pyarrow.array([2, 4, 6]))
-
-    def test_primitive_rust(self):
-        """
-        Rust -> Python -> Rust
-        """
-
-        def double(array):
-            array = array.to_pylist()
-            return pyarrow.array([x * 2 if x is not None else None for x in array])
-
-        is_correct = arrow_pyarrow_integration_testing.double_py(double)
-        self.assertTrue(is_correct)
-
-    def test_import_primitive(self):
-        """
-        Python -> Rust
-        """
-        old_allocated = pyarrow.total_allocated_bytes()
-
-        a = pyarrow.array([2, None, 6])
-
-        is_correct = arrow_pyarrow_integration_testing.import_primitive(a)
-        self.assertTrue(is_correct)
-        # No leak of C++ memory
-        del a
-        self.assertEqual(old_allocated, pyarrow.total_allocated_bytes())
-
-    def test_export_primitive(self):
-        """
-        Python -> Rust
-        """
-        old_allocated = pyarrow.total_allocated_bytes()
-
-        expected = pyarrow.array([2, None, 6])
-
-        result = arrow_pyarrow_integration_testing.export_primitive()
-        self.assertEqual(expected, result)
-        # No leak of C++ memory
-        del expected
-        self.assertEqual(old_allocated, pyarrow.total_allocated_bytes())
-
     def test_string_roundtrip(self):
         """
         Python -> Rust -> Python
         """
         a = pyarrow.array(["a", None, "ccc"])
-        b = arrow_pyarrow_integration_testing.round_trip(a)
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
         c = pyarrow.array(["a", None, "ccc"])
         self.assertEqual(b, c)
 
@@ -107,25 +59,8 @@ class TestCase(unittest.TestCase):
             None,
         ]
         a = pyarrow.array(data, pyarrow.decimal128(5, 2))
-        b = arrow_pyarrow_integration_testing.round_trip(a)
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
         self.assertEqual(a, b)
-
-    def test_string_python(self):
-        """
-        Python -> Rust -> Python
-        """
-        a = pyarrow.array(["a", None, "ccc"])
-        b = arrow_pyarrow_integration_testing.substring(a, 1)
-        self.assertEqual(b, pyarrow.array(["", None, "cc"]))
-
-    def test_time32_python(self):
-        """
-        Python -> Rust -> Python
-        """
-        a = pyarrow.array([None, 1, 2], pyarrow.time32("s"))
-        b = arrow_pyarrow_integration_testing.concatenate(a)
-        expected = pyarrow.array([None, 1, 2] + [None, 1, 2], pyarrow.time32("s"))
-        self.assertEqual(b, expected)
 
     def test_list_array(self):
         """
@@ -135,7 +70,7 @@ class TestCase(unittest.TestCase):
             a = pyarrow.array(
                 [[], None, [1, 2], [4, 5, 6]], pyarrow.list_(pyarrow.int64())
             )
-            b = arrow_pyarrow_integration_testing.round_trip(a)
+            b = arrow_pyarrow_integration_testing.round_trip_array(a)
 
             b.validate(full=True)
             assert a.to_pylist() == b.to_pylist()
@@ -159,7 +94,7 @@ class TestCase(unittest.TestCase):
             ],
             pyarrow.struct(fields),
         )
-        b = arrow_pyarrow_integration_testing.round_trip(a)
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
 
         b.validate(full=True)
         assert a.to_pylist() == b.to_pylist()
@@ -174,7 +109,7 @@ class TestCase(unittest.TestCase):
                 [[None], None, [[1], [2]], [[4, 5], [6]]],
                 pyarrow.list_(pyarrow.list_(pyarrow.int64())),
             )
-            b = arrow_pyarrow_integration_testing.round_trip(a)
+            b = arrow_pyarrow_integration_testing.round_trip_array(a)
 
             b.validate(full=True)
             assert a.to_pylist() == b.to_pylist()
@@ -188,7 +123,7 @@ class TestCase(unittest.TestCase):
             ["a", "a", "b", None, "c"],
             pyarrow.dictionary(pyarrow.int64(), pyarrow.utf8()),
         )
-        b = arrow_pyarrow_integration_testing.round_trip(a)
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
 
         b.validate(full=True)
         assert a.to_pylist() == b.to_pylist()
@@ -205,7 +140,7 @@ class TestCase(unittest.TestCase):
                 pyarrow.array([0, 1, 2, None, 0], pyarrow.int64()),
             ],
         )
-        b = arrow_pyarrow_integration_testing.round_trip(a)
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
 
         b.validate(full=True)
         assert a.to_pylist() == b.to_pylist()
@@ -223,8 +158,24 @@ class TestCase(unittest.TestCase):
                 pyarrow.array([0, 1, 2, None, 0], pyarrow.int64()),
             ],
         )
-        b = arrow_pyarrow_integration_testing.round_trip(a)
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
 
         b.validate(full=True)
         assert a.to_pylist() == b.to_pylist()
         assert a.type == b.type
+
+    def test_field(self):
+        field = pyarrow.field("aa", pyarrow.bool_())
+        result = arrow_pyarrow_integration_testing.round_trip_field(field)
+        assert field == result
+
+    def test_field_nested(self):
+        field = pyarrow.field("aa", pyarrow.list_(pyarrow.field("ab", pyarrow.bool_())))
+        result = arrow_pyarrow_integration_testing.round_trip_field(field)
+        assert field == result
+
+    def test_field_metadata(self):
+        field = pyarrow.field("aa", pyarrow.bool_(), {"a": "b"})
+        result = arrow_pyarrow_integration_testing.round_trip_field(field)
+        assert field == result
+        assert field.metadata == result.metadata

--- a/examples/ffi.rs
+++ b/examples/ffi.rs
@@ -1,0 +1,55 @@
+use arrow2::array::{Array, PrimitiveArray};
+use arrow2::datatypes::Field;
+use arrow2::error::Result;
+use arrow2::ffi;
+use std::sync::Arc;
+
+unsafe fn export(
+    array: Arc<dyn Array>,
+    array_ptr: *mut ffi::Ffi_ArrowArray,
+    schema_ptr: *mut ffi::Ffi_ArrowSchema,
+) {
+    let field = Field::new("a", array.data_type().clone(), true);
+    ffi::export_array_to_c(array, array_ptr);
+    ffi::export_field_to_c(&field, schema_ptr);
+}
+
+fn import(
+    array: Box<ffi::Ffi_ArrowArray>,
+    schema: &ffi::Ffi_ArrowSchema,
+) -> Result<Box<dyn Array>> {
+    let field = ffi::import_field_from_c(schema)?;
+    ffi::import_array_from_c(array, &field)
+}
+
+fn main() -> Result<()> {
+    // let's assume that we have an array:
+    let array = Arc::new(PrimitiveArray::<i32>::from([Some(1), None, Some(123)])) as Arc<dyn Array>;
+
+    // the goal is to export this array and import it back via FFI.
+    // to import, we initialize the structs that will receive the data
+    let array_ptr = Box::new(ffi::Ffi_ArrowArray::empty());
+    let schema_ptr = Box::new(ffi::Ffi_ArrowSchema::empty());
+
+    // since FFIs work in raw pointers, let's temporarily relinquish ownership so that producers
+    // can write into it in a thread-safe manner
+    let array_ptr = Box::into_raw(array_ptr);
+    let schema_ptr = Box::into_raw(schema_ptr);
+
+    // this is where a producer (in this case also us ^_^) writes to the pointers' location.
+    // `array` here could be anything or not even be available, if this was e.g. from Python.
+    // Safety: we just allocated the pointers correctly.
+    unsafe { export(array.clone(), array_ptr, schema_ptr) };
+
+    // we can now take ownership back, since we are responsible for deallocating this memory.
+    // Safety: we just into_raw them.
+    let array_ptr = unsafe { Box::from_raw(array_ptr) };
+    let schema_ptr = unsafe { Box::from_raw(schema_ptr) };
+
+    // and finally interpret the written memory into a new array.
+    let new_array = import(array_ptr, schema_ptr.as_ref())?;
+
+    // which is equal to the exported array
+    assert_eq!(array.as_ref(), new_array.as_ref());
+    Ok(())
+}

--- a/guide/src/ffi.md
+++ b/guide/src/ffi.md
@@ -5,58 +5,9 @@ has a specification, which allows languages to share data
 structures via foreign interfaces at zero cost (i.e. via pointers).
 This is known as the [C Data interface](https://arrow.apache.org/docs/format/CDataInterface.html).
 
-This crate supports importing from and exporting to most of `DataType`s.
-Types currently not supported:
-
-* `FixedSizeBinary`
-* `Union`
-* `Dictionary`
-* `FixedSizeList`
-* `Null`
-
-## Export
-
-The API to export an `Array` is as follows:
+This crate supports importing from and exporting to all `DataType`s. Follow the
+example below to learn how to import and export:
 
 ```rust
-use std::sync::Arc;
-use arrow2::array::{Array, PrimitiveArray};
-use arrow2::datatypes::DataType;
-use arrow2::ffi::ArrowArray;
-
-# fn main() {
-// Example of an array:
-let array = [Some(1), None, Some(123)]
-    .iter()
-    .collect::<PrimitiveArray<i32>>();
-
-// export the array.
-let ffi_array = ffi::export_to_c(Arc::new(array))?;
-
-// these are mutable pointers to `ArrowArray` and `ArrowSchema` of the C data interface
-let (array_ptr, schema_ptr) = ffi_array.references();
-# }
+{{#include ../../examples/ffi.rs}}
 ```
-
-## Import
-
-The API to import works similarly:
-
-```rust
-use arrow2::array::Array;
-use arrow2::ffi;
-
-let array = Arc::new(ffi::create_empty());
-
-// non-owned mutable pointers.
-let (array_ptr, schema_ptr) = array.references();
-
-// write to the pointers using any C data interface exporter
-
-// consume it to a `Box<dyn Array>`
-let array = ffi::try_from(array)?;
-```
-
-This assumes that the exporter writes to `array_ptr` and `schema_ptr` 
-according to the c data interface. This is an intrinsically `unsafe` operation.
-Failing to do so results in UB.

--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -25,7 +25,7 @@ unsafe impl<O: Offset> ToFfi for BinaryArray<O> {
 
 unsafe impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryArray<O> {
     fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field()?.data_type().clone();
+        let data_type = array.field().data_type().clone();
         let expected = if O::is_large() {
             DataType::LargeBinary
         } else {

--- a/src/array/boolean/ffi.rs
+++ b/src/array/boolean/ffi.rs
@@ -23,7 +23,7 @@ unsafe impl ToFfi for BooleanArray {
 
 unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for BooleanArray {
     fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field()?.data_type().clone();
+        let data_type = array.field().data_type().clone();
         assert_eq!(data_type, DataType::Boolean);
         let length = array.array().len();
         let offset = array.array().offset();

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -24,7 +24,7 @@ unsafe impl<O: Offset> ToFfi for ListArray<O> {
 
 unsafe impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for ListArray<O> {
     fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field()?.data_type().clone();
+        let data_type = array.field().data_type().clone();
         let length = array.array().len();
         let offset = array.array().offset();
         let mut validity = unsafe { array.validity() }?;

--- a/src/array/primitive/ffi.rs
+++ b/src/array/primitive/ffi.rs
@@ -24,7 +24,7 @@ unsafe impl<T: NativeType> ToFfi for PrimitiveArray<T> {
 
 unsafe impl<T: NativeType, A: ffi::ArrowArrayRef> FromFfi<A> for PrimitiveArray<T> {
     fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field()?.data_type().clone();
+        let data_type = array.field().data_type().clone();
         let length = array.array().len();
         let offset = array.array().offset();
         let mut validity = unsafe { array.validity() }?;

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -153,7 +153,7 @@ unsafe impl ToFfi for StructArray {
 
 unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for StructArray {
     fn try_from_ffi(array: A) -> Result<Self> {
-        let field = array.field()?;
+        let field = array.field();
         let fields = Self::get_fields(field.data_type()).to_vec();
 
         let length = array.array().len();

--- a/src/array/union/ffi.rs
+++ b/src/array/union/ffi.rs
@@ -29,7 +29,7 @@ unsafe impl ToFfi for UnionArray {
 
 unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for UnionArray {
     fn try_from_ffi(array: A) -> Result<Self> {
-        let field = array.field()?;
+        let field = array.field();
         let data_type = field.data_type().clone();
         let fields = Self::get_fields(field.data_type());
 

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -32,8 +32,7 @@ use crate::{
 /// * the data type is not supported
 /// * the interface is not valid (e.g. a null pointer)
 pub fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
-    let field = array.field()?;
-    let array: Box<dyn Array> = match field.data_type() {
+    let array: Box<dyn Array> = match array.field().data_type() {
         DataType::Boolean => Box::new(BooleanArray::try_from_ffi(array)?),
         DataType::Int8 => Box::new(PrimitiveArray::<i8>::try_from_ffi(array)?),
         DataType::Int16 => Box::new(PrimitiveArray::<i16>::try_from_ffi(array)?),

--- a/src/ffi/ffi.rs
+++ b/src/ffi/ffi.rs
@@ -95,8 +95,7 @@ impl Ffi_ArrowArray {
     /// # Safety
     /// This method releases `buffers`. Consumers of this struct *must* call `release` before
     /// releasing this struct, or contents in `buffers` leak.
-    pub fn new(array: Arc<dyn Array>) -> Self {
-        println!("{:?}", array);
+    pub(crate) fn new(array: Arc<dyn Array>) -> Self {
         let (buffers, children, dictionary) = buffers_children_dictionary(array.as_ref());
 
         let buffers_ptr = buffers
@@ -115,7 +114,6 @@ impl Ffi_ArrowArray {
             .collect::<Box<_>>();
         let n_children = children_ptr.len() as i64;
 
-        println!("{:?}", dictionary);
         let dictionary_ptr =
             dictionary.map(|array| Box::into_raw(Box::new(Ffi_ArrowArray::new(array))));
 
@@ -144,7 +142,7 @@ impl Ffi_ArrowArray {
     }
 
     // create an empty `Ffi_ArrowArray`, which can be used to import data into
-    fn empty() -> Self {
+    pub fn empty() -> Self {
         Self {
             length: 0,
             null_count: 0,
@@ -160,22 +158,17 @@ impl Ffi_ArrowArray {
     }
 
     /// the length of the array
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.length as usize
     }
 
-    /// whether the array is empty
-    pub fn is_empty(&self) -> bool {
-        self.length == 0
-    }
-
     /// the offset of the array
-    pub fn offset(&self) -> usize {
+    pub(crate) fn offset(&self) -> usize {
         self.offset as usize
     }
 
     /// the null count of the array
-    pub fn null_count(&self) -> usize {
+    pub(crate) fn null_count(&self) -> usize {
         self.null_count as usize
     }
 }
@@ -390,12 +383,12 @@ pub trait ArrowArrayRef {
 /// Furthermore, this struct assumes that the incoming data agrees with the C data interface.
 #[derive(Debug)]
 pub struct ArrowArray {
-    array: Arc<Ffi_ArrowArray>,
+    array: Box<Ffi_ArrowArray>,
     field: Field,
 }
 
 impl ArrowArray {
-    pub fn new(array: Arc<Ffi_ArrowArray>, field: Field) -> Self {
+    pub fn new(array: Box<Ffi_ArrowArray>, field: Field) -> Self {
         Self { array, field }
     }
 }

--- a/src/ffi/ffi.rs
+++ b/src/ffi/ffi.rs
@@ -452,13 +452,23 @@ impl<'a> ArrowArrayChild<'a> {
 }
 
 /// Exports an `Array` to the C data interface.
-pub fn export_to_c(array: Arc<dyn Array>) -> Result<ArrowArray> {
+pub fn export_array_to_c(array: Arc<dyn Array>) -> Result<ArrowArray> {
     let field = Field::new("", array.data_type().clone(), array.null_count() != 0);
 
     Ok(ArrowArray {
         array: Arc::new(Ffi_ArrowArray::new(array)),
-        schema: Arc::new(Ffi_ArrowSchema::try_new(field)?),
+        schema: Arc::new(Ffi_ArrowSchema::new(&field)),
     })
+}
+
+/// Exports a [`Field`] to the C data interface.
+pub fn export_field_to_c(field: &Field) -> Arc<Ffi_ArrowSchema> {
+    Arc::new(Ffi_ArrowSchema::new(field))
+}
+
+/// Imports a [`Field`] from the C data interface.
+pub fn import_field_from_c(field: &Ffi_ArrowSchema) -> Result<Field> {
+    to_field(field)
 }
 
 pub fn create_empty() -> ArrowArray {

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -6,7 +6,35 @@ mod ffi;
 mod schema;
 
 pub use array::try_from;
-pub use ffi::{
-    create_empty, export_array_to_c, export_field_to_c, import_field_from_c, ArrowArray,
-    ArrowArrayRef,
-};
+pub use ffi::{ArrowArray, ArrowArrayRef};
+
+use std::sync::Arc;
+
+use crate::array::Array;
+use crate::datatypes::Field;
+use crate::error::Result;
+
+use ffi::*;
+use schema::Ffi_ArrowSchema;
+
+use self::schema::to_field;
+
+/// Exports an `Array` to the C data interface.
+pub fn export_array_to_c(array: Arc<dyn Array>) -> Arc<Ffi_ArrowArray> {
+    Arc::new(Ffi_ArrowArray::new(array))
+}
+
+/// Exports a [`Field`] to the C data interface.
+pub fn export_field_to_c(field: &Field) -> Arc<Ffi_ArrowSchema> {
+    Arc::new(Ffi_ArrowSchema::new(field))
+}
+
+/// Imports a [`Field`] from the C data interface.
+pub fn import_field_from_c(field: &Ffi_ArrowSchema) -> Result<Field> {
+    to_field(field)
+}
+
+/// Imports a [`Field`] from the C data interface.
+pub fn import_array_from_c(array: Arc<Ffi_ArrowArray>, field: &Field) -> Result<Box<dyn Array>> {
+    try_from(Arc::new(ArrowArray::new(array, field.clone())))
+}

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -6,4 +6,7 @@ mod ffi;
 mod schema;
 
 pub use array::try_from;
-pub use ffi::{create_empty, export_to_c, ArrowArray, ArrowArrayRef};
+pub use ffi::{
+    create_empty, export_array_to_c, export_field_to_c, import_field_from_c, ArrowArray,
+    ArrowArrayRef,
+};

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -13,7 +13,7 @@ struct SchemaPrivateData {
 
 /// ABI-compatible struct for `ArrowSchema` from C Data Interface
 /// See <https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions>
-/// This was created by bindgen
+// This was created by bindgen
 #[repr(C)]
 #[derive(Debug)]
 pub struct Ffi_ArrowSchema {
@@ -52,7 +52,7 @@ unsafe extern "C" fn c_release_schema(schema: *mut Ffi_ArrowSchema) {
 
 impl Ffi_ArrowSchema {
     /// creates a new [Ffi_ArrowSchema]
-    pub fn new(field: &Field) -> Self {
+    pub(crate) fn new(field: &Field) -> Self {
         let format = to_format(field.data_type());
         let name = field.name().clone();
 
@@ -126,7 +126,7 @@ impl Ffi_ArrowSchema {
     }
 
     /// returns the format of this schema.
-    pub fn format(&self) -> &str {
+    pub(crate) fn format(&self) -> &str {
         assert!(!self.format.is_null());
         // safe because the lifetime of `self.format` equals `self`
         unsafe { CStr::from_ptr(self.format) }
@@ -135,26 +135,26 @@ impl Ffi_ArrowSchema {
     }
 
     /// returns the name of this schema.
-    pub fn name(&self) -> &str {
+    pub(crate) fn name(&self) -> &str {
         assert!(!self.name.is_null());
         // safe because the lifetime of `self.name` equals `self`
         unsafe { CStr::from_ptr(self.name) }.to_str().unwrap()
     }
 
-    pub fn child(&self, index: usize) -> &'static Self {
+    pub(crate) fn child(&self, index: usize) -> &'static Self {
         assert!(index < self.n_children as usize);
         assert!(!self.name.is_null());
         unsafe { self.children.add(index).as_ref().unwrap().as_ref().unwrap() }
     }
 
-    pub fn dictionary(&self) -> Option<&'static Self> {
+    pub(crate) fn dictionary(&self) -> Option<&'static Self> {
         if self.dictionary.is_null() {
             return None;
         };
         Some(unsafe { self.dictionary.as_ref().unwrap() })
     }
 
-    pub fn nullable(&self) -> bool {
+    pub(crate) fn nullable(&self) -> bool {
         (self.flags / 2) & 1 == 1
     }
 }


### PR DESCRIPTION
So that the fields can be imported and exported from the C data interface.

The public API is different since ownership rules changed (#328); see `examples/ffi.rs` with a complete example.

Closes #328.

