### PR TITLE
Fixed error in displaying dictionaries with nulls in values

### DIFF
--- a/src/array/display.rs
+++ b/src/array/display.rs
@@ -24,7 +24,7 @@ macro_rules! dyn_dict {
             .downcast_ref::<DictionaryArray<$ty>>()
             .unwrap();
         let keys = a.keys();
-        let display = get_value_display(a.values().as_ref());
+        let display = get_display(a.values().as_ref());
         Box::new(move |row: usize| display(keys.value(row) as usize))
     }};
 }

--- a/tests/it/io/print.rs
+++ b/tests/it/io/print.rs
@@ -116,6 +116,31 @@ fn write_dictionary() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn dictionary_validities() -> Result<()> {
+    // define a schema.
+    let field_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Int32));
+    let schema = Arc::new(Schema::new(vec![Field::new("d1", field_type, true)]));
+
+    let keys = PrimitiveArray::<i32>::from([Some(1), None, Some(0)]);
+    let values = PrimitiveArray::<i32>::from([None, Some(10)]);
+    let array = DictionaryArray::<i32>::from_data(keys, Arc::new(values));
+
+    let batch = RecordBatch::try_new(schema, vec![Arc::new(array)])?;
+
+    let table = write(&[batch]);
+
+    let expected = vec![
+        "+----+", "| d1 |", "+----+", "| 10 |", "|    |", "|    |", "+----+",
+    ];
+
+    let actual: Vec<&str> = table.lines().collect();
+
+    assert_eq!(expected, actual, "Actual result:\n{}", table);
+
+    Ok(())
+}
+
 /// Generate an array with type $ARRAYTYPE with a numeric value of
 /// $VALUE, and compare $EXPECTED_RESULT to the output of
 /// formatting that array with `write`


### PR DESCRIPTION
They were displayed as their values, even if they were null.