### PR TITLE
Added support for reading binary from CSV

### DIFF
--- a/src/io/csv/read/deserialize.rs
+++ b/src/io/csv/read/deserialize.rs
@@ -58,6 +58,11 @@ fn deserialize_utf8<O: Offset>(rows: &[ByteRecord], column: usize) -> Arc<dyn Ar
     Arc::new(Utf8Array::<O>::from_trusted_len_iter(iter))
 }
 
+fn deserialize_binary<O: Offset>(rows: &[ByteRecord], column: usize) -> Arc<dyn Array> {
+    let iter = rows.iter().map(|row| row.get(column));
+    Arc::new(BinaryArray::<O>::from_trusted_len_iter(iter))
+}
+
 pub fn deserialize_column(
     rows: &[ByteRecord],
     column: usize,
@@ -151,6 +156,8 @@ pub fn deserialize_column(
         }
         Utf8 => deserialize_utf8::<i32>(rows, column),
         LargeUtf8 => deserialize_utf8::<i64>(rows, column),
+        Binary => deserialize_binary::<i32>(rows, column),
+        LargeBinary => deserialize_binary::<i64>(rows, column),
         other => {
             return Err(ArrowError::NotYetImplemented(format!(
                 "Deserializing type \"{:?}\" is not implemented",

--- a/tests/it/io/csv/read.rs
+++ b/tests/it/io/csv/read.rs
@@ -173,3 +173,15 @@ fn float32() -> Result<()> {
     assert_eq!(expected, result.as_ref());
     Ok(())
 }
+
+#[test]
+fn binary() -> Result<()> {
+    let input = vec!["aa", "bb"];
+    let input = input.join("\n");
+
+    let expected = BinaryArray::<i32>::from([Some(b"aa"), Some(b"bb")]);
+
+    let result = test_deserialize(&input, DataType::Binary)?;
+    assert_eq!(expected, result.as_ref());
+    Ok(())
+}


### PR DESCRIPTION
Useful when the CSV has fields with non-utf8 entries that are not to be discarded.