### PR TITLE
Added support for compute to `BinaryArray`

### DIFF
--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -1,11 +1,12 @@
 use std::{iter::FromIterator, sync::Arc};
 
 use crate::{
-    array::{Array, MutableArray, Offset, TryExtend, TryPush},
+    array::{specification::check_offsets, Array, MutableArray, Offset, TryExtend, TryPush},
     bitmap::MutableBitmap,
     buffer::MutableBuffer,
     datatypes::DataType,
     error::{ArrowError, Result},
+    trusted_len::TrustedLen,
 };
 
 use super::BinaryArray;
@@ -45,6 +46,36 @@ impl<O: Offset> MutableBinaryArray<O> {
     /// This allocates a [`MutableBuffer`] of one element
     pub fn new() -> Self {
         Self::with_capacity(0)
+    }
+
+    /// The canonical method to create a [`MutableBinaryArray`] out of low-end APIs.
+    /// # Panics
+    /// This function panics iff:
+    /// * The `offsets` and `values` are inconsistent
+    /// * The validity is not `None` and its length is different from `offsets`'s length minus one.
+    pub fn from_data(
+        data_type: DataType,
+        offsets: MutableBuffer<O>,
+        values: MutableBuffer<u8>,
+        validity: Option<MutableBitmap>,
+    ) -> Self {
+        check_offsets(&offsets, values.len());
+        if let Some(ref validity) = validity {
+            assert_eq!(offsets.len() - 1, validity.len());
+        }
+        if data_type.to_physical_type() != Self::default_data_type().to_physical_type() {
+            panic!("MutableBinaryArray can only be initialized with DataType::Binary or DataType::LargeBinary")
+        }
+        Self {
+            data_type,
+            offsets,
+            values,
+            validity,
+        }
+    }
+
+    fn default_data_type() -> DataType {
+        BinaryArray::<O>::default_data_type()
     }
 
     /// Creates a new [`MutableBinaryArray`] with capacity for `capacity` values.
@@ -148,6 +179,90 @@ impl<O: Offset, P: AsRef<[u8]>> FromIterator<Option<P>> for MutableBinaryArray<O
     }
 }
 
+impl<O: Offset> MutableBinaryArray<O> {
+    /// Creates a [`MutableBinaryArray`] from an iterator of trusted length.
+    /// # Safety
+    /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
+    /// I.e. that `size_hint().1` correctly reports its length.
+    #[inline]
+    pub unsafe fn from_trusted_len_iter_unchecked<I, P>(iterator: I) -> Self
+    where
+        P: AsRef<[u8]>,
+        I: Iterator<Item = Option<P>>,
+    {
+        let (validity, offsets, values) = trusted_len_unzip(iterator);
+
+        // soundness: P is `str`
+        Self::from_data(Self::default_data_type(), offsets, values, validity)
+    }
+
+    /// Creates a [`MutableBinaryArray`] from an iterator of trusted length.
+    #[inline]
+    pub fn from_trusted_len_iter<I, P>(iterator: I) -> Self
+    where
+        P: AsRef<[u8]>,
+        I: TrustedLen<Item = Option<P>>,
+    {
+        // soundness: I is `TrustedLen`
+        unsafe { Self::from_trusted_len_iter_unchecked(iterator) }
+    }
+
+    /// Creates a new [`BinaryArray`] from a [`TrustedLen`] of `&str`.
+    #[inline]
+    pub fn from_trusted_len_values_iter<T: AsRef<[u8]>, I: TrustedLen<Item = T>>(
+        iterator: I,
+    ) -> Self {
+        // soundness: I is `TrustedLen`
+        let (offsets, values) = unsafe { trusted_len_values_iter(iterator) };
+        // soundness: T is AsRef<[u8]>
+        Self::from_data(Self::default_data_type(), offsets, values, None)
+    }
+
+    /// Creates a [`MutableBinaryArray`] from an falible iterator of trusted length.
+    /// # Safety
+    /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
+    /// I.e. that `size_hint().1` correctly reports its length.
+    #[inline]
+    pub unsafe fn try_from_trusted_len_iter_unchecked<E, I, P>(
+        iterator: I,
+    ) -> std::result::Result<Self, E>
+    where
+        P: AsRef<[u8]>,
+        I: IntoIterator<Item = std::result::Result<Option<P>, E>>,
+    {
+        let iterator = iterator.into_iter();
+
+        // soundness: assumed trusted len
+        let (validity, offsets, values) = try_trusted_len_unzip(iterator)?;
+
+        // soundness: P is `str`
+        Ok(Self::from_data(
+            Self::default_data_type(),
+            offsets,
+            values,
+            validity,
+        ))
+    }
+
+    /// Creates a [`MutableBinaryArray`] from an falible iterator of trusted length.
+    #[inline]
+    pub fn try_from_trusted_len_iter<E, I, P>(iterator: I) -> std::result::Result<Self, E>
+    where
+        P: AsRef<[u8]>,
+        I: TrustedLen<Item = std::result::Result<Option<P>, E>>,
+    {
+        // soundness: I: TrustedLen
+        unsafe { Self::try_from_trusted_len_iter_unchecked(iterator) }
+    }
+
+    /// Creates a new [`MutableBinaryArray`] from a [`Iterator`] of `&[u8]`.
+    pub fn from_iter_values<T: AsRef<[u8]>, I: Iterator<Item = T>>(iterator: I) -> Self {
+        let (offsets, values) = values_iter(iterator);
+        // soundness: T: AsRef<[u8]>
+        Self::from_data(Self::default_data_type(), offsets, values, None)
+    }
+}
+
 impl<O: Offset, T: AsRef<[u8]>> Extend<Option<T>> for MutableBinaryArray<O> {
     fn extend<I: IntoIterator<Item = Option<T>>>(&mut self, iter: I) {
         self.try_extend(iter).unwrap();
@@ -190,4 +305,167 @@ impl<O: Offset, T: AsRef<[u8]>> TryPush<Option<T>> for MutableBinaryArray<O> {
         }
         Ok(())
     }
+}
+
+/// Creates [`MutableBitmap`] and two [`MutableBuffer`]s from an iterator of `Option`.
+/// The first buffer corresponds to a offset buffer, the second one
+/// corresponds to a values buffer.
+/// # Safety
+/// The caller must ensure that `iterator` is `TrustedLen`.
+#[inline]
+unsafe fn trusted_len_unzip<O, I, P>(
+    iterator: I,
+) -> (Option<MutableBitmap>, MutableBuffer<O>, MutableBuffer<u8>)
+where
+    O: Offset,
+    P: AsRef<[u8]>,
+    I: Iterator<Item = Option<P>>,
+{
+    let (_, upper) = iterator.size_hint();
+    let len = upper.expect("trusted_len_unzip requires an upper limit");
+
+    let mut null = MutableBitmap::with_capacity(len);
+    let mut offsets = MutableBuffer::<O>::with_capacity(len + 1);
+    let mut values = MutableBuffer::<u8>::new();
+
+    let mut length = O::default();
+    let mut dst = offsets.as_mut_ptr();
+    std::ptr::write(dst, length);
+    dst = dst.add(1);
+    for item in iterator {
+        if let Some(item) = item {
+            null.push(true);
+            let s = item.as_ref();
+            length += O::from_usize(s.len()).unwrap();
+            values.extend_from_slice(s);
+        } else {
+            null.push(false);
+            values.extend_from_slice(b"");
+        };
+
+        std::ptr::write(dst, length);
+        dst = dst.add(1);
+    }
+    assert_eq!(
+        dst.offset_from(offsets.as_ptr()) as usize,
+        len + 1,
+        "Trusted iterator length was not accurately reported"
+    );
+    offsets.set_len(len + 1);
+
+    (null.into(), offsets, values)
+}
+
+/// # Safety
+/// The caller must ensure that `iterator` is `TrustedLen`.
+#[inline]
+#[allow(clippy::type_complexity)]
+pub(crate) unsafe fn try_trusted_len_unzip<E, I, P, O>(
+    iterator: I,
+) -> std::result::Result<(Option<MutableBitmap>, MutableBuffer<O>, MutableBuffer<u8>), E>
+where
+    O: Offset,
+    P: AsRef<[u8]>,
+    I: Iterator<Item = std::result::Result<Option<P>, E>>,
+{
+    let (_, upper) = iterator.size_hint();
+    let len = upper.expect("trusted_len_unzip requires an upper limit");
+
+    let mut null = MutableBitmap::with_capacity(len);
+    let mut offsets = MutableBuffer::<O>::with_capacity(len + 1);
+    let mut values = MutableBuffer::<u8>::new();
+
+    let mut length = O::default();
+    let mut dst = offsets.as_mut_ptr();
+    std::ptr::write(dst, length);
+    dst = dst.add(1);
+    for item in iterator {
+        if let Some(item) = item? {
+            null.push(true);
+            let s = item.as_ref();
+            length += O::from_usize(s.len()).unwrap();
+            values.extend_from_slice(s);
+        } else {
+            null.push(false);
+        };
+
+        std::ptr::write(dst, length);
+        dst = dst.add(1);
+    }
+    assert_eq!(
+        dst.offset_from(offsets.as_ptr()) as usize,
+        len + 1,
+        "Trusted iterator length was not accurately reported"
+    );
+    offsets.set_len(len + 1);
+
+    Ok((null.into(), offsets, values))
+}
+
+/// Creates two [`Buffer`]s from an iterator of `&[u8]`.
+/// The first buffer corresponds to a offset buffer, the second to a values buffer.
+/// # Safety
+/// The caller must ensure that `iterator` is [`TrustedLen`].
+#[inline]
+pub(crate) unsafe fn trusted_len_values_iter<O, I, P>(
+    iterator: I,
+) -> (MutableBuffer<O>, MutableBuffer<u8>)
+where
+    O: Offset,
+    P: AsRef<[u8]>,
+    I: Iterator<Item = P>,
+{
+    let (_, upper) = iterator.size_hint();
+    let len = upper.expect("trusted_len_unzip requires an upper limit");
+
+    let mut offsets = MutableBuffer::<O>::with_capacity(len + 1);
+    let mut values = MutableBuffer::<u8>::new();
+
+    let mut length = O::default();
+    let mut dst = offsets.as_mut_ptr();
+    std::ptr::write(dst, length);
+    dst = dst.add(1);
+    for item in iterator {
+        let s = item.as_ref();
+        length += O::from_usize(s.len()).unwrap();
+        values.extend_from_slice(s);
+
+        std::ptr::write(dst, length);
+        dst = dst.add(1);
+    }
+    assert_eq!(
+        dst.offset_from(offsets.as_ptr()) as usize,
+        len + 1,
+        "Trusted iterator length was not accurately reported"
+    );
+    offsets.set_len(len + 1);
+
+    (offsets, values)
+}
+
+/// Creates two [`MutableBuffer`]s from an iterator of `&[u8]`.
+/// The first buffer corresponds to a offset buffer, the second to a values buffer.
+#[inline]
+fn values_iter<O, I, P>(iterator: I) -> (MutableBuffer<O>, MutableBuffer<u8>)
+where
+    O: Offset,
+    P: AsRef<[u8]>,
+    I: Iterator<Item = P>,
+{
+    let (lower, _) = iterator.size_hint();
+
+    let mut offsets = MutableBuffer::<O>::with_capacity(lower + 1);
+    let mut values = MutableBuffer::<u8>::new();
+
+    let mut length = O::default();
+    offsets.push(length);
+
+    for item in iterator {
+        let s = item.as_ref();
+        length += O::from_usize(s.len()).unwrap();
+        values.extend_from_slice(s);
+
+        offsets.push(length)
+    }
+    (offsets, values)
 }

--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -192,7 +192,6 @@ impl<O: Offset> MutableBinaryArray<O> {
     {
         let (validity, offsets, values) = trusted_len_unzip(iterator);
 
-        // soundness: P is `str`
         Self::from_data(Self::default_data_type(), offsets, values, validity)
     }
 
@@ -207,14 +206,13 @@ impl<O: Offset> MutableBinaryArray<O> {
         unsafe { Self::from_trusted_len_iter_unchecked(iterator) }
     }
 
-    /// Creates a new [`BinaryArray`] from a [`TrustedLen`] of `&str`.
+    /// Creates a new [`BinaryArray`] from a [`TrustedLen`] of `&[u8]`.
     #[inline]
     pub fn from_trusted_len_values_iter<T: AsRef<[u8]>, I: TrustedLen<Item = T>>(
         iterator: I,
     ) -> Self {
         // soundness: I is `TrustedLen`
         let (offsets, values) = unsafe { trusted_len_values_iter(iterator) };
-        // soundness: T is AsRef<[u8]>
         Self::from_data(Self::default_data_type(), offsets, values, None)
     }
 
@@ -235,7 +233,6 @@ impl<O: Offset> MutableBinaryArray<O> {
         // soundness: assumed trusted len
         let (validity, offsets, values) = try_trusted_len_unzip(iterator)?;
 
-        // soundness: P is `str`
         Ok(Self::from_data(
             Self::default_data_type(),
             offsets,
@@ -258,7 +255,6 @@ impl<O: Offset> MutableBinaryArray<O> {
     /// Creates a new [`MutableBinaryArray`] from a [`Iterator`] of `&[u8]`.
     pub fn from_iter_values<T: AsRef<[u8]>, I: Iterator<Item = T>>(iterator: I) -> Self {
         let (offsets, values) = values_iter(iterator);
-        // soundness: T: AsRef<[u8]>
         Self::from_data(Self::default_data_type(), offsets, values, None)
     }
 }

--- a/src/array/growable/binary.rs
+++ b/src/array/growable/binary.rs
@@ -100,6 +100,11 @@ impl<'a, O: Offset> Growable<'a> for GrowableBinary<'a, O> {
 
 impl<'a, O: Offset> From<GrowableBinary<'a, O>> for BinaryArray<O> {
     fn from(val: GrowableBinary<'a, O>) -> Self {
-        BinaryArray::<O>::from_data(val.data_type, val.offsets.into(), val.values.into(), val.validity.into())
+        BinaryArray::<O>::from_data(
+            val.data_type,
+            val.offsets.into(),
+            val.values.into(),
+            val.validity.into(),
+        )
     }
 }

--- a/src/array/ord.rs
+++ b/src/array/ord.rs
@@ -92,6 +92,12 @@ fn compare_string<'a, O: Offset>(left: &'a dyn Array, right: &'a dyn Array) -> D
     Box::new(move |i, j| left.value(i).cmp(right.value(j)))
 }
 
+fn compare_binary<'a, O: Offset>(left: &'a dyn Array, right: &'a dyn Array) -> DynComparator<'a> {
+    let left = left.as_any().downcast_ref::<BinaryArray<O>>().unwrap();
+    let right = right.as_any().downcast_ref::<BinaryArray<O>>().unwrap();
+    Box::new(move |i, j| left.value(i).cmp(right.value(j)))
+}
+
 fn compare_dict<'a, K>(
     left: &'a DictionaryArray<K>,
     right: &'a DictionaryArray<K>,
@@ -178,6 +184,8 @@ pub fn build_compare<'a>(left: &'a dyn Array, right: &'a dyn Array) -> Result<Dy
         (Float64, Float64) => compare_f64(left, right),
         (Utf8, Utf8) => compare_string::<i32>(left, right),
         (LargeUtf8, LargeUtf8) => compare_string::<i64>(left, right),
+        (Binary, Binary) => compare_binary::<i32>(left, right),
+        (LargeBinary, LargeBinary) => compare_binary::<i64>(left, right),
         (Dictionary(key_type_lhs, _), Dictionary(key_type_rhs, _)) => {
             match (key_type_lhs.as_ref(), key_type_rhs.as_ref()) {
                 (UInt8, UInt8) => dyn_dict!(u8, left, right),

--- a/src/compute/arithmetics/decimal/sub.rs
+++ b/src/compute/arithmetics/decimal/sub.rs
@@ -314,30 +314,16 @@ mod tests {
 
     #[test]
     fn test_subtract_normal() {
-        let a = PrimitiveArray::from([
-            Some(11111i128),
-            Some(22200i128),
-            None,
-            Some(40000i128),
-        ])
-        .to(DataType::Decimal(5, 2));
+        let a = PrimitiveArray::from([Some(11111i128), Some(22200i128), None, Some(40000i128)])
+            .to(DataType::Decimal(5, 2));
 
-        let b = PrimitiveArray::from([
-            Some(22222i128),
-            Some(11100i128),
-            None,
-            Some(11100i128),
-        ])
-        .to(DataType::Decimal(5, 2));
+        let b = PrimitiveArray::from([Some(22222i128), Some(11100i128), None, Some(11100i128)])
+            .to(DataType::Decimal(5, 2));
 
         let result = sub(&a, &b).unwrap();
-        let expected = PrimitiveArray::from([
-            Some(-11111i128),
-            Some(11100i128),
-            None,
-            Some(28900i128),
-        ])
-        .to(DataType::Decimal(5, 2));
+        let expected =
+            PrimitiveArray::from([Some(-11111i128), Some(11100i128), None, Some(28900i128)])
+                .to(DataType::Decimal(5, 2));
 
         assert_eq!(result, expected);
 
@@ -367,30 +353,16 @@ mod tests {
 
     #[test]
     fn test_subtract_saturating() {
-        let a = PrimitiveArray::from([
-            Some(11111i128),
-            Some(22200i128),
-            None,
-            Some(40000i128),
-        ])
-        .to(DataType::Decimal(5, 2));
+        let a = PrimitiveArray::from([Some(11111i128), Some(22200i128), None, Some(40000i128)])
+            .to(DataType::Decimal(5, 2));
 
-        let b = PrimitiveArray::from([
-            Some(22222i128),
-            Some(11100i128),
-            None,
-            Some(11100i128),
-        ])
-        .to(DataType::Decimal(5, 2));
+        let b = PrimitiveArray::from([Some(22222i128), Some(11100i128), None, Some(11100i128)])
+            .to(DataType::Decimal(5, 2));
 
         let result = saturating_sub(&a, &b).unwrap();
-        let expected = PrimitiveArray::from([
-            Some(-11111i128),
-            Some(11100i128),
-            None,
-            Some(28900i128),
-        ])
-        .to(DataType::Decimal(5, 2));
+        let expected =
+            PrimitiveArray::from([Some(-11111i128), Some(11100i128), None, Some(28900i128)])
+                .to(DataType::Decimal(5, 2));
 
         assert_eq!(result, expected);
 
@@ -435,30 +407,16 @@ mod tests {
 
     #[test]
     fn test_subtract_checked() {
-        let a = PrimitiveArray::from([
-            Some(11111i128),
-            Some(22200i128),
-            None,
-            Some(40000i128),
-        ])
-        .to(DataType::Decimal(5, 2));
+        let a = PrimitiveArray::from([Some(11111i128), Some(22200i128), None, Some(40000i128)])
+            .to(DataType::Decimal(5, 2));
 
-        let b = PrimitiveArray::from([
-            Some(22222i128),
-            Some(11100i128),
-            None,
-            Some(11100i128),
-        ])
-        .to(DataType::Decimal(5, 2));
+        let b = PrimitiveArray::from([Some(22222i128), Some(11100i128), None, Some(11100i128)])
+            .to(DataType::Decimal(5, 2));
 
         let result = checked_sub(&a, &b).unwrap();
-        let expected = PrimitiveArray::from([
-            Some(-11111i128),
-            Some(11100i128),
-            None,
-            Some(28900i128),
-        ])
-        .to(DataType::Decimal(5, 2));
+        let expected =
+            PrimitiveArray::from([Some(-11111i128), Some(11100i128), None, Some(28900i128)])
+                .to(DataType::Decimal(5, 2));
 
         assert_eq!(result, expected);
 
@@ -469,8 +427,7 @@ mod tests {
 
     #[test]
     fn test_subtract_checked_overflow() {
-        let a =
-            PrimitiveArray::from([Some(4i128), Some(-99999i128)]).to(DataType::Decimal(5, 2));
+        let a = PrimitiveArray::from([Some(4i128), Some(-99999i128)]).to(DataType::Decimal(5, 2));
         let b = PrimitiveArray::from([Some(2i128), Some(1i128)]).to(DataType::Decimal(5, 2));
         let result = checked_sub(&a, &b).unwrap();
         let expected = PrimitiveArray::from([Some(2i128), None]).to(DataType::Decimal(5, 2));
@@ -487,8 +444,7 @@ mod tests {
         let b = PrimitiveArray::from([Some(11111_11i128)]).to(DataType::Decimal(7, 2));
         let result = adaptive_sub(&a, &b).unwrap();
 
-        let expected =
-            PrimitiveArray::from([Some(-11099_9989i128)]).to(DataType::Decimal(9, 4));
+        let expected = PrimitiveArray::from([Some(-11099_9989i128)]).to(DataType::Decimal(9, 4));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(9, 4));
@@ -501,8 +457,7 @@ mod tests {
         let b = PrimitiveArray::from([Some(1111i128)]).to(DataType::Decimal(5, 4));
         let result = adaptive_sub(&a, &b).unwrap();
 
-        let expected =
-            PrimitiveArray::from([Some(11110_8889i128)]).to(DataType::Decimal(9, 4));
+        let expected = PrimitiveArray::from([Some(11110_8889i128)]).to(DataType::Decimal(9, 4));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(9, 4));
@@ -515,8 +470,7 @@ mod tests {
         let b = PrimitiveArray::from([Some(11111_111i128)]).to(DataType::Decimal(8, 3));
         let result = adaptive_sub(&a, &b).unwrap();
 
-        let expected =
-            PrimitiveArray::from([Some(-00000_001i128)]).to(DataType::Decimal(8, 3));
+        let expected = PrimitiveArray::from([Some(-00000_001i128)]).to(DataType::Decimal(8, 3));
 
         assert_eq!(result, expected);
         assert_eq!(result.data_type(), &DataType::Decimal(8, 3));

--- a/src/compute/cast/binary_to.rs
+++ b/src/compute/cast/binary_to.rs
@@ -1,8 +1,7 @@
 use std::convert::TryFrom;
 
-use crate::datatypes::DataType;
 use crate::error::{ArrowError, Result};
-use crate::{array::*, buffer::Buffer};
+use crate::{array::*, buffer::Buffer, datatypes::DataType, types::NativeType};
 
 pub fn binary_to_large_binary(from: &BinaryArray<i32>, to_data_type: DataType) -> BinaryArray<i64> {
     let values = from.values().clone();
@@ -27,4 +26,47 @@ pub fn binary_large_to_binary(
         values,
         from.validity().clone(),
     ))
+}
+
+/// Casts a [`BinaryArray`] to a [`PrimitiveArray`], making any uncastable value a Null.
+pub fn binary_to_primitive<O: Offset, T>(from: &BinaryArray<O>, to: &DataType) -> PrimitiveArray<T>
+where
+    T: NativeType + lexical_core::FromLexical,
+{
+    let iter = from
+        .iter()
+        .map(|x| x.and_then::<T, _>(|x| lexical_core::parse(x).ok()));
+
+    PrimitiveArray::<T>::from_trusted_len_iter(iter).to(to.clone())
+}
+
+pub(super) fn binary_to_primitive_dyn<O: Offset, T>(
+    from: &dyn Array,
+    to: &DataType,
+) -> Result<Box<dyn Array>>
+where
+    T: NativeType + lexical_core::FromLexical,
+{
+    let from = from.as_any().downcast_ref().unwrap();
+    Ok(Box::new(binary_to_primitive::<O, T>(from, to)))
+}
+
+/// Cast [`BinaryArray`] to [`DictionaryArray`], also known as packing.
+/// # Errors
+/// This function errors if the maximum key is smaller than the number of distinct elements
+/// in the array.
+pub fn binary_to_dictionary<O: Offset, K: DictionaryKey>(
+    from: &BinaryArray<O>,
+) -> Result<DictionaryArray<K>> {
+    let mut array = MutableDictionaryArray::<K, MutableBinaryArray<O>>::new();
+    array.try_extend(from.iter())?;
+
+    Ok(array.into())
+}
+
+pub(super) fn binary_to_dictionary_dyn<O: Offset, K: DictionaryKey>(
+    from: &dyn Array,
+) -> Result<Box<dyn Array>> {
+    let values = from.as_any().downcast_ref().unwrap();
+    binary_to_dictionary::<O, K>(values).map(|x| Box::new(x) as Box<dyn Array>)
 }

--- a/src/compute/cast/boolean_to.rs
+++ b/src/compute/cast/boolean_to.rs
@@ -4,7 +4,7 @@ use crate::{
     types::{NativeType, NaturalDataType},
 };
 use crate::{
-    array::{Offset, Utf8Array},
+    array::{BinaryArray, Offset, Utf8Array},
     error::Result,
 };
 
@@ -39,4 +39,15 @@ pub fn boolean_to_utf8<O: Offset>(from: &BooleanArray) -> Utf8Array<O> {
 pub(super) fn boolean_to_utf8_dyn<O: Offset>(array: &dyn Array) -> Result<Box<dyn Array>> {
     let array = array.as_any().downcast_ref().unwrap();
     Ok(Box::new(boolean_to_utf8::<O>(array)))
+}
+
+/// Casts the [`BooleanArray`] to a [`BinaryArray`], casting trues to `"1"` and falses to `"0"`
+pub fn boolean_to_binary<O: Offset>(from: &BooleanArray) -> BinaryArray<O> {
+    let iter = from.values().iter().map(|x| if x { b"1" } else { b"0" });
+    BinaryArray::from_trusted_len_values_iter(iter)
+}
+
+pub(super) fn boolean_to_binary_dyn<O: Offset>(array: &dyn Array) -> Result<Box<dyn Array>> {
+    let array = array.as_any().downcast_ref().unwrap();
+    Ok(Box::new(boolean_to_binary::<O>(array)))
 }

--- a/src/compute/comparison/binary.rs
+++ b/src/compute/comparison/binary.rs
@@ -1,0 +1,251 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::datatypes::DataType;
+use crate::error::{ArrowError, Result};
+use crate::scalar::{BinaryScalar, Scalar};
+use crate::{array::*, bitmap::Bitmap};
+
+use super::{super::utils::combine_validities, Operator};
+
+/// Evaluate `op(lhs, rhs)` for [`BinaryArray`]s using a specified
+/// comparison function.
+fn compare_op<O, F>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>, op: F) -> Result<BooleanArray>
+where
+    O: Offset,
+    F: Fn(&[u8], &[u8]) -> bool,
+{
+    if lhs.len() != rhs.len() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Cannot perform comparison operation on arrays of different length".to_string(),
+        ));
+    }
+
+    let validity = combine_validities(lhs.validity(), rhs.validity());
+
+    let values = lhs
+        .values_iter()
+        .zip(rhs.values_iter())
+        .map(|(lhs, rhs)| op(lhs, rhs));
+    let values = Bitmap::from_trusted_len_iter(values);
+
+    Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
+}
+
+/// Evaluate `op(lhs, rhs)` for [`BinaryArray`] and scalar using
+/// a specified comparison function.
+fn compare_op_scalar<O, F>(lhs: &BinaryArray<O>, rhs: &[u8], op: F) -> BooleanArray
+where
+    O: Offset,
+    F: Fn(&[u8], &[u8]) -> bool,
+{
+    let validity = lhs.validity().clone();
+
+    let values = lhs.values_iter().map(|lhs| op(lhs, rhs));
+    let values = Bitmap::from_trusted_len_iter(values);
+
+    BooleanArray::from_data(DataType::Boolean, values, validity)
+}
+
+/// Perform `lhs == rhs` operation on [`BinaryArray`].
+fn eq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+    compare_op(lhs, rhs, |a, b| a == b)
+}
+
+/// Perform `lhs == rhs` operation on [`BinaryArray`] and a scalar.
+fn eq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+    compare_op_scalar(lhs, rhs, |a, b| a == b)
+}
+
+/// Perform `lhs != rhs` operation on [`BinaryArray`].
+fn neq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+    compare_op(lhs, rhs, |a, b| a != b)
+}
+
+/// Perform `lhs != rhs` operation on [`BinaryArray`] and a scalar.
+fn neq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+    compare_op_scalar(lhs, rhs, |a, b| a != b)
+}
+
+/// Perform `lhs < rhs` operation on [`BinaryArray`].
+fn lt<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+    compare_op(lhs, rhs, |a, b| a < b)
+}
+
+/// Perform `lhs < rhs` operation on [`BinaryArray`] and a scalar.
+fn lt_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+    compare_op_scalar(lhs, rhs, |a, b| a < b)
+}
+
+/// Perform `lhs <= rhs` operation on [`BinaryArray`].
+fn lt_eq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+    compare_op(lhs, rhs, |a, b| a <= b)
+}
+
+/// Perform `lhs <= rhs` operation on [`BinaryArray`] and a scalar.
+fn lt_eq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+    compare_op_scalar(lhs, rhs, |a, b| a <= b)
+}
+
+/// Perform `lhs > rhs` operation on [`BinaryArray`].
+fn gt<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+    compare_op(lhs, rhs, |a, b| a > b)
+}
+
+/// Perform `lhs > rhs` operation on [`BinaryArray`] and a scalar.
+fn gt_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+    compare_op_scalar(lhs, rhs, |a, b| a > b)
+}
+
+/// Perform `lhs >= rhs` operation on [`BinaryArray`].
+fn gt_eq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+    compare_op(lhs, rhs, |a, b| a >= b)
+}
+
+/// Perform `lhs >= rhs` operation on [`BinaryArray`] and a scalar.
+fn gt_eq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+    compare_op_scalar(lhs, rhs, |a, b| a >= b)
+}
+
+pub fn compare<O: Offset>(
+    lhs: &BinaryArray<O>,
+    rhs: &BinaryArray<O>,
+    op: Operator,
+) -> Result<BooleanArray> {
+    match op {
+        Operator::Eq => eq(lhs, rhs),
+        Operator::Neq => neq(lhs, rhs),
+        Operator::Gt => gt(lhs, rhs),
+        Operator::GtEq => gt_eq(lhs, rhs),
+        Operator::Lt => lt(lhs, rhs),
+        Operator::LtEq => lt_eq(lhs, rhs),
+    }
+}
+
+pub fn compare_scalar<O: Offset>(
+    lhs: &BinaryArray<O>,
+    rhs: &BinaryScalar<O>,
+    op: Operator,
+) -> BooleanArray {
+    if !rhs.is_valid() {
+        return BooleanArray::new_null(DataType::Boolean, lhs.len());
+    }
+    compare_scalar_non_null(lhs, rhs.value(), op)
+}
+
+pub fn compare_scalar_non_null<O: Offset>(
+    lhs: &BinaryArray<O>,
+    rhs: &[u8],
+    op: Operator,
+) -> BooleanArray {
+    match op {
+        Operator::Eq => eq_scalar(lhs, rhs),
+        Operator::Neq => neq_scalar(lhs, rhs),
+        Operator::Gt => gt_scalar(lhs, rhs),
+        Operator::GtEq => gt_eq_scalar(lhs, rhs),
+        Operator::Lt => lt_scalar(lhs, rhs),
+        Operator::LtEq => lt_eq_scalar(lhs, rhs),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_generic<O: Offset, F: Fn(&BinaryArray<O>, &BinaryArray<O>) -> Result<BooleanArray>>(
+        lhs: Vec<&[u8]>,
+        rhs: Vec<&[u8]>,
+        op: F,
+        expected: Vec<bool>,
+    ) {
+        let lhs = BinaryArray::<O>::from_slice(lhs);
+        let rhs = BinaryArray::<O>::from_slice(rhs);
+        let expected = BooleanArray::from_slice(expected);
+        assert_eq!(op(&lhs, &rhs).unwrap(), expected);
+    }
+
+    fn test_generic_scalar<O: Offset, F: Fn(&BinaryArray<O>, &[u8]) -> BooleanArray>(
+        lhs: Vec<&[u8]>,
+        rhs: &[u8],
+        op: F,
+        expected: Vec<bool>,
+    ) {
+        let lhs = BinaryArray::<O>::from_slice(lhs);
+        let expected = BooleanArray::from_slice(expected);
+        assert_eq!(op(&lhs, rhs), expected);
+    }
+
+    #[test]
+    fn test_gt_eq() {
+        test_generic::<i32, _>(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet"],
+            vec![b"flight", b"flight", b"flight", b"flight"],
+            gt_eq,
+            vec![false, false, true, true],
+        )
+    }
+
+    #[test]
+    fn test_gt_eq_scalar() {
+        test_generic_scalar::<i32, _>(
+            vec![b"arrow", b"datafusion", b"flight", b"parquet"],
+            b"flight",
+            gt_eq_scalar,
+            vec![false, false, true, true],
+        )
+    }
+
+    #[test]
+    fn test_eq() {
+        test_generic::<i32, _>(
+            vec![b"arrow", b"arrow", b"arrow", b"arrow"],
+            vec![b"arrow", b"parquet", b"datafusion", b"flight"],
+            eq,
+            vec![true, false, false, false],
+        )
+    }
+
+    #[test]
+    fn test_eq_scalar() {
+        test_generic_scalar::<i32, _>(
+            vec![b"arrow", b"parquet", b"datafusion", b"flight"],
+            b"arrow",
+            eq_scalar,
+            vec![true, false, false, false],
+        )
+    }
+
+    #[test]
+    fn test_neq() {
+        test_generic::<i32, _>(
+            vec![b"arrow", b"arrow", b"arrow", b"arrow"],
+            vec![b"arrow", b"parquet", b"datafusion", b"flight"],
+            neq,
+            vec![false, true, true, true],
+        )
+    }
+
+    #[test]
+    fn test_neq_scalar() {
+        test_generic_scalar::<i32, _>(
+            vec![b"arrow", b"parquet", b"datafusion", b"flight"],
+            b"arrow",
+            neq_scalar,
+            vec![false, true, true, true],
+        )
+    }
+}

--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -22,6 +22,7 @@ use crate::datatypes::{DataType, IntervalUnit};
 use crate::error::{ArrowError, Result};
 use crate::scalar::Scalar;
 
+mod binary;
 mod boolean;
 mod primitive;
 mod utf8;
@@ -131,6 +132,16 @@ pub fn compare(lhs: &dyn Array, rhs: &dyn Array, operator: Operator) -> Result<B
             let rhs = rhs.as_any().downcast_ref().unwrap();
             primitive::compare::<i128>(lhs, rhs, operator)
         }
+        DataType::Binary => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            binary::compare::<i32>(lhs, rhs, operator)
+        }
+        DataType::LargeBinary => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            binary::compare::<i64>(lhs, rhs, operator)
+        }
         _ => Err(ArrowError::NotYetImplemented(format!(
             "Comparison between {:?} is not supported",
             data_type
@@ -233,6 +244,16 @@ pub fn compare_scalar(
             let rhs = rhs.as_any().downcast_ref().unwrap();
             utf8::compare_scalar::<i64>(lhs, rhs, operator)
         }
+        DataType::Binary => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            binary::compare_scalar::<i32>(lhs, rhs, operator)
+        }
+        DataType::LargeBinary => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            binary::compare_scalar::<i64>(lhs, rhs, operator)
+        }
         _ => {
             return Err(ArrowError::NotYetImplemented(format!(
                 "Comparison between {:?} is not supported",
@@ -242,6 +263,7 @@ pub fn compare_scalar(
     })
 }
 
+pub use binary::compare_scalar_non_null as binary_compare_scalar;
 pub use boolean::compare_scalar_non_null as boolean_compare_scalar;
 pub use primitive::compare_scalar_non_null as primitive_compare_scalar;
 pub(crate) use primitive::compare_values_op as primitive_compare_values_op;
@@ -259,7 +281,7 @@ pub use utf8::compare_scalar_non_null as utf8_compare_scalar;
 /// assert_eq!(can_compare(&data_type), true);
 ///
 /// let data_type = DataType::LargeBinary;
-/// assert_eq!(can_compare(&data_type), false)
+/// assert_eq!(can_compare(&data_type), true)
 /// ```
 pub fn can_compare(data_type: &DataType) -> bool {
     matches!(
@@ -285,6 +307,8 @@ pub fn can_compare(data_type: &DataType) -> bool {
             | DataType::Utf8
             | DataType::LargeUtf8
             | DataType::Decimal(_, _)
+            | DataType::Binary
+            | DataType::LargeBinary
     )
 }
 

--- a/src/compute/comparison/utf8.rs
+++ b/src/compute/comparison/utf8.rs
@@ -22,7 +22,7 @@ use crate::{array::*, bitmap::Bitmap};
 
 use super::{super::utils::combine_validities, Operator};
 
-/// Evaluate `op(lhs, rhs)` for [`PrimitiveArray`]s using a specified
+/// Evaluate `op(lhs, rhs)` for [`Utf8Array`]s using a specified
 /// comparison function.
 fn compare_op<O, F>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>, op: F) -> Result<BooleanArray>
 where
@@ -46,7 +46,7 @@ where
     Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
 }
 
-/// Evaluate `op(lhs, rhs)` for [`PrimitiveArray`] and scalar using
+/// Evaluate `op(lhs, rhs)` for [`Utf8Array`] and scalar using
 /// a specified comparison function.
 fn compare_op_scalar<O, F>(lhs: &Utf8Array<O>, rhs: &str, op: F) -> BooleanArray
 where
@@ -61,62 +61,62 @@ where
     BooleanArray::from_data(DataType::Boolean, values, validity)
 }
 
-/// Perform `lhs == rhs` operation on [`StringArray`] / [`LargeStringArray`].
+/// Perform `lhs == rhs` operation on [`Utf8Array`].
 fn eq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
     compare_op(lhs, rhs, |a, b| a == b)
 }
 
-/// Perform `lhs == rhs` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
+/// Perform `lhs == rhs` operation on [`Utf8Array`] and a scalar.
 fn eq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a == b)
 }
 
-/// Perform `lhs != rhs` operation on [`StringArray`] / [`LargeStringArray`].
+/// Perform `lhs != rhs` operation on [`Utf8Array`].
 fn neq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
     compare_op(lhs, rhs, |a, b| a != b)
 }
 
-/// Perform `lhs != rhs` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
+/// Perform `lhs != rhs` operation on [`Utf8Array`] and a scalar.
 fn neq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a != b)
 }
 
-/// Perform `lhs < rhs` operation on [`StringArray`] / [`LargeStringArray`].
+/// Perform `lhs < rhs` operation on [`Utf8Array`].
 fn lt<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
     compare_op(lhs, rhs, |a, b| a < b)
 }
 
-/// Perform `lhs < rhs` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
+/// Perform `lhs < rhs` operation on [`Utf8Array`] and a scalar.
 fn lt_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a < b)
 }
 
-/// Perform `lhs <= rhs` operation on [`StringArray`] / [`LargeStringArray`].
+/// Perform `lhs <= rhs` operation on [`Utf8Array`].
 fn lt_eq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
     compare_op(lhs, rhs, |a, b| a <= b)
 }
 
-/// Perform `lhs <= rhs` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
+/// Perform `lhs <= rhs` operation on [`Utf8Array`] and a scalar.
 fn lt_eq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a <= b)
 }
 
-/// Perform `lhs > rhs` operation on [`StringArray`] / [`LargeStringArray`].
+/// Perform `lhs > rhs` operation on [`Utf8Array`].
 fn gt<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
     compare_op(lhs, rhs, |a, b| a > b)
 }
 
-/// Perform `lhs > rhs` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
+/// Perform `lhs > rhs` operation on [`Utf8Array`] and a scalar.
 fn gt_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a > b)
 }
 
-/// Perform `lhs >= rhs` operation on [`StringArray`] / [`LargeStringArray`].
+/// Perform `lhs >= rhs` operation on [`Utf8Array`].
 fn gt_eq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
     compare_op(lhs, rhs, |a, b| a >= b)
 }
 
-/// Perform `lhs >= rhs` operation on [`StringArray`] / [`LargeStringArray`] and a scalar.
+/// Perform `lhs >= rhs` operation on [`Utf8Array`] and a scalar.
 fn gt_eq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a >= b)
 }

--- a/src/compute/contains.rs
+++ b/src/compute/contains.rs
@@ -96,7 +96,7 @@ where
     Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
 }
 
-/// Checks if a [`GenericListArray`] contains a value in the [`BinaryArray`]
+/// Checks if a [`ListArray`] contains a value in the [`BinaryArray`]
 fn contains_binary<O, OO>(list: &ListArray<O>, values: &BinaryArray<OO>) -> Result<BooleanArray>
 where
     O: Offset,

--- a/src/compute/contains.rs
+++ b/src/compute/contains.rs
@@ -17,7 +17,7 @@
 
 use crate::types::NativeType;
 use crate::{
-    array::{Array, BooleanArray, ListArray, Offset, PrimitiveArray, Utf8Array},
+    array::{Array, BinaryArray, BooleanArray, ListArray, Offset, PrimitiveArray, Utf8Array},
     bitmap::Bitmap,
 };
 use crate::{
@@ -96,6 +96,40 @@ where
     Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
 }
 
+/// Checks if a [`GenericListArray`] contains a value in the [`BinaryArray`]
+fn contains_binary<O, OO>(list: &ListArray<O>, values: &BinaryArray<OO>) -> Result<BooleanArray>
+where
+    O: Offset,
+    OO: Offset,
+{
+    if list.len() != values.len() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Contains requires arrays of the same length".to_string(),
+        ));
+    }
+    if list.values().data_type() != values.data_type() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Contains requires the inner array to be of the same logical type".to_string(),
+        ));
+    }
+
+    let validity = combine_validities(list.validity(), values.validity());
+
+    let values = list.iter().zip(values.iter()).map(|(list, values)| {
+        if list.is_none() | values.is_none() {
+            // validity takes care of this
+            return false;
+        };
+        let list = list.unwrap();
+        let list = list.as_any().downcast_ref::<BinaryArray<OO>>().unwrap();
+        let values = values.unwrap();
+        list.iter().any(|x| x.map(|x| x == values).unwrap_or(false))
+    });
+    let values = Bitmap::from_trusted_len_iter(values);
+
+    Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
+}
+
 macro_rules! primitive {
     ($list:expr, $values:expr, $l_ty:ty, $r_ty:ty) => {{
         let list = $list.as_any().downcast_ref::<ListArray<$l_ty>>().unwrap();
@@ -131,6 +165,26 @@ pub fn contains(list: &dyn Array, values: &dyn Array) -> Result<BooleanArray> {
             let list = list.as_any().downcast_ref::<ListArray<i64>>().unwrap();
             let values = values.as_any().downcast_ref::<Utf8Array<i32>>().unwrap();
             contains_utf8(list, values)
+        }
+        (DataType::List(_), DataType::Binary) => {
+            let list = list.as_any().downcast_ref::<ListArray<i32>>().unwrap();
+            let values = values.as_any().downcast_ref::<BinaryArray<i32>>().unwrap();
+            contains_binary(list, values)
+        }
+        (DataType::List(_), DataType::LargeBinary) => {
+            let list = list.as_any().downcast_ref::<ListArray<i32>>().unwrap();
+            let values = values.as_any().downcast_ref::<BinaryArray<i64>>().unwrap();
+            contains_binary(list, values)
+        }
+        (DataType::LargeList(_), DataType::LargeBinary) => {
+            let list = list.as_any().downcast_ref::<ListArray<i64>>().unwrap();
+            let values = values.as_any().downcast_ref::<BinaryArray<i64>>().unwrap();
+            contains_binary(list, values)
+        }
+        (DataType::LargeList(_), DataType::Binary) => {
+            let list = list.as_any().downcast_ref::<ListArray<i64>>().unwrap();
+            let values = values.as_any().downcast_ref::<BinaryArray<i32>>().unwrap();
+            contains_binary(list, values)
         }
         (DataType::List(_), DataType::Int8) => primitive!(list, values, i32, i8),
         (DataType::List(_), DataType::Int16) => primitive!(list, values, i32, i16),
@@ -189,6 +243,31 @@ mod tests {
         ]);
 
         let mut a = MutableListArray::<i32, MutablePrimitiveArray<i32>>::new();
+        a.try_extend(data).unwrap();
+        let a: ListArray<i32> = a.into();
+
+        let result = contains(&a, &values).unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_contains_binary() {
+        let data = vec![
+            Some(vec![Some(b"a"), Some(b"b"), None]),
+            Some(vec![Some(b"a"), Some(b"b"), None]),
+            Some(vec![Some(b"a"), Some(b"b"), None]),
+            None,
+        ];
+        let values = BinaryArray::<i32>::from(&[Some(b"a"), Some(b"c"), None, Some(b"a")]);
+        let expected = BooleanArray::from(vec![
+            Some(true),
+            Some(false),
+            None,
+            None
+        ]);
+
+        let mut a = MutableListArray::<i32, MutableBinaryArray<i32>>::new();
         a.try_extend(data).unwrap();
         let a: ListArray<i32> = a.into();
 

--- a/src/compute/like.rs
+++ b/src/compute/like.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use regex::bytes::Regex as BytesRegex;
 use regex::Regex;
 
 use crate::datatypes::DataType;
@@ -147,4 +148,193 @@ pub fn like_utf8_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> Result<Bool
 
 pub fn nlike_utf8_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> Result<BooleanArray> {
     a_like_utf8_scalar(lhs, rhs, |x| !x)
+}
+
+#[inline]
+fn a_like_binary<O: Offset, F: Fn(bool) -> bool>(
+    lhs: &BinaryArray<O>,
+    rhs: &BinaryArray<O>,
+    op: F,
+) -> Result<BooleanArray> {
+    if lhs.len() != rhs.len() {
+        return Err(ArrowError::InvalidArgumentError(
+            "Cannot perform comparison operation on arrays of different length".to_string(),
+        ));
+    }
+
+    let validity = combine_validities(lhs.validity(), rhs.validity());
+
+    let mut map = HashMap::new();
+
+    let values =
+        Bitmap::try_from_trusted_len_iter(lhs.iter().zip(rhs.iter()).map(|(lhs, rhs)| {
+            match (lhs, rhs) {
+                (Some(lhs), Some(pattern)) => {
+                    let pattern = if let Some(pattern) = map.get(pattern) {
+                        pattern
+                    } else {
+                        let re_pattern = std::str::from_utf8(pattern)
+                            .unwrap()
+                            .replace("%", ".*")
+                            .replace("_", ".");
+                        let re = BytesRegex::new(&format!("^{}$", re_pattern)).map_err(|e| {
+                            ArrowError::InvalidArgumentError(format!(
+                                "Unable to build regex from LIKE pattern: {}",
+                                e
+                            ))
+                        })?;
+                        map.insert(pattern, re);
+                        map.get(pattern).unwrap()
+                    };
+                    Result::Ok(op(pattern.is_match(lhs)))
+                }
+                _ => Ok(false),
+            }
+        }))?;
+
+    Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
+}
+
+/// Returns `lhs LIKE rhs` operation on two [`BinaryArray`].
+///
+/// There are two wildcards supported:
+///
+/// * `%` - The percent sign represents zero, one, or multiple characters
+/// * `_` - The underscore represents a single character
+///
+/// # Error
+/// Errors iff:
+/// * the arrays have a different length
+/// * any of the patterns is not valid
+/// # Example
+/// ```
+/// use arrow2::array::{BinaryArray, BooleanArray};
+/// use arrow2::compute::like::like_binary;
+///
+/// let strings = BinaryArray::<i32>::from_slice(&["Arrow", "Arrow", "Arrow", "Arrow", "Ar"]);
+/// let patterns = BinaryArray::<i32>::from_slice(&["A%", "B%", "%r_ow", "A_", "A_"]);
+///
+/// let result = like_binary(&strings, &patterns).unwrap();
+/// assert_eq!(result, BooleanArray::from_slice(&[true, false, true, false, true]));
+/// ```
+pub fn like_binary<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+    a_like_binary(lhs, rhs, |x| x)
+}
+
+pub fn nlike_binary<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+    a_like_binary(lhs, rhs, |x| !x)
+}
+
+fn a_like_binary_scalar<O: Offset, F: Fn(bool) -> bool>(
+    lhs: &BinaryArray<O>,
+    rhs: &[u8],
+    op: F,
+) -> Result<BooleanArray> {
+    let validity = lhs.validity();
+    let pattern = std::str::from_utf8(rhs).map_err(|e| {
+        ArrowError::InvalidArgumentError(format!("Unable to convert the LIKE pattern to string: {}", e))
+    })?;
+
+    let values = if !pattern.contains(is_like_pattern) {
+        Bitmap::from_trusted_len_iter(lhs.values_iter().map(|x| x == rhs))
+    } else if pattern.ends_with('%') && !pattern[..pattern.len() - 1].contains(is_like_pattern) {
+        // fast path, can use starts_with
+        let starts_with = &rhs[..rhs.len() - 1];
+        Bitmap::from_trusted_len_iter(lhs.values_iter().map(|x| op(x.starts_with(starts_with))))
+    } else if pattern.starts_with('%') && !pattern[1..].contains(is_like_pattern) {
+        // fast path, can use ends_with
+        let ends_with = &rhs[1..];
+        Bitmap::from_trusted_len_iter(lhs.values_iter().map(|x| op(x.ends_with(ends_with))))
+    } else {
+        let re_pattern = pattern.replace("%", ".*").replace("_", ".");
+        let re = BytesRegex::new(&format!("^{}$", re_pattern)).map_err(|e| {
+            ArrowError::InvalidArgumentError(format!(
+                "Unable to build regex from LIKE pattern: {}",
+                e
+            ))
+        })?;
+        Bitmap::from_trusted_len_iter(lhs.values_iter().map(|x| op(re.is_match(x))))
+    };
+    Ok(BooleanArray::from_data(
+        DataType::Boolean,
+        values,
+        validity.clone(),
+    ))
+}
+
+/// Returns `lhs LIKE rhs` operation.
+///
+/// There are two wildcards supported:
+///
+/// * `%` - The percent sign represents zero, one, or multiple characters
+/// * `_` - The underscore represents a single character
+///
+/// # Error
+/// Errors iff:
+/// * the arrays have a different length
+/// * any of the patterns is not valid
+/// # Example
+/// ```
+/// use arrow2::array::{BinaryArray, BooleanArray};
+/// use arrow2::compute::like::like_binary_scalar;
+///
+/// let array = BinaryArray::<i32>::from_slice(&["Arrow", "Arrow", "Arrow", "BA"]);
+///
+/// let result = like_binary_scalar(&array, b"A%").unwrap();
+/// assert_eq!(result, BooleanArray::from_slice(&[true, true, true, false]));
+/// ```
+pub fn like_binary_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> Result<BooleanArray> {
+    a_like_binary_scalar(lhs, rhs, |x| x)
+}
+
+pub fn nlike_binary_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> Result<BooleanArray> {
+    a_like_binary_scalar(lhs, rhs, |x| !x)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_like_binary() -> Result<()> {
+        let strings = BinaryArray::<i32>::from_slice(&["Arrow", "Arrow", "Arrow", "Arrow", "Ar"]);
+        let patterns = BinaryArray::<i32>::from_slice(&["A%", "B%", "%r_ow", "A_", "A_"]);
+        let result = like_binary(&strings, &patterns).unwrap();
+        assert_eq!(
+            result,
+            BooleanArray::from_slice(&[true, false, true, false, true])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_nlike_binary() -> Result<()> {
+        let strings = BinaryArray::<i32>::from_slice(&["Arrow", "Arrow", "Arrow", "Arrow", "Ar"]);
+        let patterns = BinaryArray::<i32>::from_slice(&["A%", "B%", "%r_ow", "A_", "A_"]);
+        let result = nlike_binary(&strings, &patterns).unwrap();
+        assert_eq!(
+            result,
+            BooleanArray::from_slice(&[false, true, false, true, false])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_like_binary_scalar() -> Result<()> {
+        let array = BinaryArray::<i32>::from_slice(&["Arrow", "Arrow", "Arrow", "BA"]);
+        let result = like_binary_scalar(&array, b"A%").unwrap();
+        assert_eq!(result, BooleanArray::from_slice(&[true, true, true, false]));
+        Ok(())
+    }
+
+    #[test]
+    fn test_nlike_binary_scalar() -> Result<()> {
+        let array = BinaryArray::<i32>::from_slice(&["Arrow", "Arrow", "Arrow", "BA"]);
+        let result = nlike_binary_scalar(&array, "A%".as_bytes()).unwrap();
+        assert_eq!(
+            result,
+            BooleanArray::from_slice(&[false, false, false, true])
+        );
+        Ok(())
+    }
 }

--- a/src/compute/sort/binary.rs
+++ b/src/compute/sort/binary.rs
@@ -1,0 +1,15 @@
+use crate::array::{Array, BinaryArray, Offset, PrimitiveArray};
+use crate::types::Index;
+
+use super::common;
+use super::SortOptions;
+
+pub(super) fn indices_sorted_unstable_by<I: Index, O: Offset>(
+    array: &BinaryArray<O>,
+    options: &SortOptions,
+    limit: Option<usize>,
+) -> PrimitiveArray<I> {
+    let get = |idx| unsafe { array.value_unchecked(idx as usize) };
+    let cmp = |lhs: &&[u8], rhs: &&[u8]| lhs.cmp(rhs);
+    common::indices_sorted_unstable_by(array.validity(), get, cmp, array.len(), options, limit)
+}

--- a/src/io/parquet/read/binary/mod.rs
+++ b/src/io/parquet/read/binary/mod.rs
@@ -3,6 +3,6 @@ mod dictionary;
 mod nested;
 
 pub use basic::iter_to_array;
-pub use dictionary::iter_to_array as iter_to_dict_array;
 pub use basic::stream_to_array;
+pub use dictionary::iter_to_array as iter_to_dict_array;
 pub use nested::iter_to_array as iter_to_array_nested;

--- a/tests/it/array/binary/mod.rs
+++ b/tests/it/array/binary/mod.rs
@@ -4,6 +4,8 @@ use arrow2::{
     datatypes::DataType,
 };
 
+mod mutable;
+
 #[test]
 fn basics() {
     let data = vec![Some(b"hello".to_vec()), None, Some(b"hello2".to_vec())];
@@ -54,4 +56,18 @@ fn from() {
 
     let a = array.validity().as_ref().unwrap();
     assert_eq!(a, &Bitmap::from([true, true, false]));
+}
+
+#[test]
+fn from_trusted_len_iter() {
+    let iter = std::iter::repeat(b"hello").take(2).map(Some);
+    let a = BinaryArray::<i32>::from_trusted_len_iter(iter);
+    assert_eq!(a.len(), 2);
+}
+
+#[test]
+fn from_iter() {
+    let iter = std::iter::repeat(b"hello").take(2).map(Some);
+    let a: BinaryArray<i32> = iter.collect();
+    assert_eq!(a.len(), 2);
 }

--- a/tests/it/array/binary/mutable.rs
+++ b/tests/it/array/binary/mutable.rs
@@ -1,0 +1,11 @@
+use arrow2::array::{Array, BinaryArray, MutableBinaryArray};
+use arrow2::bitmap::Bitmap;
+
+#[test]
+fn push_null() {
+    let mut array = MutableBinaryArray::<i32>::new();
+    array.push::<&str>(None);
+
+    let array: BinaryArray<i32> = array.into();
+    assert_eq!(array.validity(), &Some(Bitmap::from([false])));
+}

--- a/tests/it/compute/cast.rs
+++ b/tests/it/compute/cast.rs
@@ -154,6 +154,26 @@ fn i32_to_list_f64_nullable_sliced() {
 }
 
 #[test]
+fn i32_to_binary() {
+    let array = Int32Array::from_slice(&[5, 6, 7]);
+    let b = cast(&array, &DataType::Binary).unwrap();
+    let expected = BinaryArray::<i32>::from(&[Some(b"5"), Some(b"6"), Some(b"7")]);
+    let c = b.as_any().downcast_ref::<BinaryArray<i32>>().unwrap();
+    assert_eq!(c, &expected);
+}
+
+#[test]
+fn binary_to_i32() {
+    let array = BinaryArray::<i32>::from_slice(&["5", "6", "seven", "8", "9.1"]);
+    let b = cast(&array, &DataType::Int32).unwrap();
+    let c = b.as_any().downcast_ref::<PrimitiveArray<i32>>().unwrap();
+
+    let expected = &[Some(5), Some(6), None, Some(8), None];
+    let expected = Int32Array::from(expected);
+    assert_eq!(c, &expected);
+}
+
+#[test]
 fn utf8_to_i32() {
     let array = Utf8Array::<i32>::from_slice(&["5", "6", "seven", "8", "9.1"]);
     let b = cast(&array, &DataType::Int32).unwrap();
@@ -183,6 +203,26 @@ fn bool_to_f64() {
 
     let expected = &[Some(1.0), Some(0.0), None];
     let expected = Float64Array::from(expected);
+    assert_eq!(c, &expected);
+}
+
+#[test]
+fn bool_to_utf8() {
+    let array = BooleanArray::from(vec![Some(true), Some(false), None]);
+    let b = cast(&array, &DataType::Utf8).unwrap();
+    let c = b.as_any().downcast_ref::<Utf8Array<i32>>().unwrap();
+
+    let expected = Utf8Array::<i32>::from(&[Some("1"), Some("0"), Some("0")]);
+    assert_eq!(c, &expected);
+}
+
+#[test]
+fn bool_to_binary() {
+    let array = BooleanArray::from(vec![Some(true), Some(false), None]);
+    let b = cast(&array, &DataType::Binary).unwrap();
+    let c = b.as_any().downcast_ref::<BinaryArray<i32>>().unwrap();
+
+    let expected = BinaryArray::<i32>::from(&[Some("1"), Some("0"), Some("0")]);
     assert_eq!(c, &expected);
 }
 

--- a/tests/it/io/json/write.rs
+++ b/tests/it/io/json/write.rs
@@ -196,7 +196,7 @@ fn write_list_of_struct() {
         vec![
             Arc::new(Int32Array::from(&[Some(1), None, Some(5)])),
             Arc::new(StructArray::from_data(
-               DataType::Struct(inner),
+                DataType::Struct(inner),
                 vec![Arc::new(Utf8Array::<i32>::from(&vec![
                     Some("e"),
                     Some("f"),


### PR DESCRIPTION
This PR improves the support of compute to `BinaryArray`. Main additions:
* comparison
* sort
* contains
* like
* cast
* substring
*  min_max

Closes #345