### PR TITLE
improve take kernel performance

### DIFF
--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -77,6 +77,30 @@ impl Bitmap {
         }
     }
 
+    /// Creates a new [`Bitmap`] from [`Bytes`], a length and a known null_count.
+    /// # Panic
+    /// Panics iff `length <= bytes.len() * 8`
+    ///
+    /// # Safety
+    ///
+    /// The caller is responsible for correctly passing the null_count
+    #[inline]
+    pub unsafe fn from_bytes_and_null_count(
+        bytes: MutableBitmap,
+        length: usize,
+        null_count: usize,
+    ) -> Self {
+        assert!(length <= bytes.len() * 8);
+        let buffer: Bytes<u8> = bytes.into();
+        debug_assert_eq!(null_count, count_zeros(&buffer, 0, length));
+        Self {
+            length,
+            offset: 0,
+            bytes: Arc::new(buffer),
+            null_count,
+        }
+    }
+
     /// Creates a new [`Bitmap`] from [`MutableBuffer`] and a length.
     /// # Panic
     /// Panics iff `length <= buffer.len() * 8`

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -5,6 +5,7 @@ use crate::{buffer::MutableBuffer, trusted_len::TrustedLen};
 
 use super::utils::{count_zeros, fmt, get_bit, set, set_bit, BitmapIter};
 use super::Bitmap;
+use crate::buffer::bytes::Bytes;
 
 /// A container to store booleans. [`MutableBitmap`] is semantically equivalent
 /// to [`Vec<bool>`], but each value is stored as a single bit, thereby achieving a compression of 8x.
@@ -219,6 +220,12 @@ impl MutableBitmap {
     pub fn from_buffer(buffer: MutableBuffer<u8>, length: usize) -> Self {
         assert!(length <= buffer.len() * 8);
         Self { buffer, length }
+    }
+}
+
+impl From<MutableBitmap> for Bytes<u8> {
+    fn from(buffer: MutableBitmap) -> Self {
+        buffer.buffer.into()
     }
 }
 


### PR DESCRIPTION
This is a proposal for improving the take kernel performance. I can also apply the same principle for the other kernels. 

I made `from_bytes_and_null_count` public, because I'd like create a `Bitmap` from known `null_count` in polars.

The benchmark on the primitive kernel with 20% null values is:

```
Gnuplot not found, using plotters backend
take i32 512            time:   [2.0383 us 2.0412 us 2.0443 us]                          
                        change: [-4.3796% -4.2624% -4.1443%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

take i32 1024           time:   [3.8100 us 3.8120 us 3.8141 us]                           
                        change: [-10.955% -10.275% -9.6184%] (p = 0.00 < 0.05)
                        Performance has improved.
```

*this is including the performance gains from 87aa617a0301070f1ecc3fa56e2ff846f7d4c504*