### PR TITLE
Added support for `Extension`

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ venv/bin/python parquet_integration/write_parquet.py
 * `MutableArray` API to work in-memory in-place.
 * faster IPC reader (different design that avoids an extra copy of all data)
 * IPC supports 2.0 (compression)
+* Extension type supported
 * All implemented arrow types pass FFI integration tests against pyarrow / C++
 * All implemented arrow types pass IPC integration tests against other implementations
 
@@ -83,7 +84,7 @@ venv/bin/python parquet_integration/write_parquet.py
 ## Features in the original not available in this crate
 
 * Parquet read and write of struct and nested lists.
-* Map types
+* Map type
 
 ## Features in this crate not in pyarrow
 

--- a/examples/extension.rs
+++ b/examples/extension.rs
@@ -1,0 +1,51 @@
+use std::io::{Cursor, Seek, Write};
+use std::sync::Arc;
+
+use arrow2::array::*;
+use arrow2::datatypes::*;
+use arrow2::error::Result;
+use arrow2::io::ipc::read;
+use arrow2::io::ipc::write;
+use arrow2::record_batch::RecordBatch;
+
+fn write_ipc<W: Write + Seek>(writer: &mut W, array: impl Array + 'static) -> Result<()> {
+    // create a batch
+    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), false)]);
+
+    let mut writer = write::FileWriter::try_new(writer, &schema)?;
+
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)])?;
+
+    writer.write(&batch)
+}
+
+fn read_ipc(reader: &[u8]) -> Result<RecordBatch> {
+    let mut reader = Cursor::new(reader);
+    let metadata = read::read_file_metadata(&mut reader)?;
+    let mut reader = read::FileReader::new(&mut reader, metadata, None);
+    reader.next().unwrap()
+}
+
+fn main() -> Result<()> {
+    let array = UInt16Array::from_slice([1, 2]);
+    let extension_type =
+        DataType::Extension("date16".to_string(), Box::new(DataType::UInt16), None);
+    let extension_array = ExtensionArray::from_data(extension_type.clone(), Arc::new(array));
+
+    // from here on, it is as usual
+    let mut buffer = Cursor::new(vec![]);
+
+    // write to IPC
+    write_ipc(&mut buffer, extension_array)?;
+
+    // read it back
+    let batch = read_ipc(&buffer.into_inner())?;
+
+    // and verify that the datatype is preserved.
+    let array = &batch.columns()[0];
+    assert_eq!(array.data_type(), &extension_type);
+
+    // see https://arrow.apache.org/docs/format/Columnar.html#extension-types
+    // for consuming by other consumers.
+    Ok(())
+}

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Compute](./compute.md)
 - [Metadata](./metadata.md)
 - [Foreign interfaces](./ffi.md)
+- [Extension](./extension.md)
 - [IO](./io/README.md)
     - [Read CSV](./io/csv_reader.md)
     - [Write CSV](./io/csv_write.md)

--- a/guide/src/extension.md
+++ b/guide/src/extension.md
@@ -1,0 +1,9 @@
+# Extension types
+
+This crate supports Arrows' ["extension type"](https://arrow.apache.org/docs/format/Columnar.html#extension-types),
+to declare, use, and share custom logical types. The follow example shows how
+to declare one:
+
+```rust
+{{#include ../../../examples/extension.rs}}
+```

--- a/src/array/display.rs
+++ b/src/array/display.rs
@@ -234,6 +234,10 @@ pub fn get_value_display<'a>(array: &'a dyn Array) -> Box<dyn Fn(usize) -> Strin
                 displays[field](index)
             })
         }
+        Extension(_, _, _) => {
+            let array = array.as_any().downcast_ref::<ExtensionArray>().unwrap();
+            get_value_display(array.inner())
+        }
     }
 }
 

--- a/src/array/equal/extension.rs
+++ b/src/array/equal/extension.rs
@@ -1,0 +1,7 @@
+use crate::array::ExtensionArray;
+
+use super::equal as main_equal;
+
+pub(super) fn equal(lhs: &ExtensionArray, rhs: &ExtensionArray) -> bool {
+    main_equal(lhs.inner(), rhs.inner())
+}

--- a/src/array/equal/mod.rs
+++ b/src/array/equal/mod.rs
@@ -8,6 +8,7 @@ use super::*;
 mod binary;
 mod boolean;
 mod dictionary;
+mod extension;
 mod fixed_size_binary;
 mod fixed_size_list;
 mod list;
@@ -126,6 +127,18 @@ impl PartialEq<StructArray> for StructArray {
 }
 
 impl PartialEq<&dyn Array> for StructArray {
+    fn eq(&self, other: &&dyn Array) -> bool {
+        equal(self, *other)
+    }
+}
+
+impl PartialEq<ExtensionArray> for ExtensionArray {
+    fn eq(&self, other: &Self) -> bool {
+        equal(self, other)
+    }
+}
+
+impl PartialEq<&dyn Array> for ExtensionArray {
     fn eq(&self, other: &&dyn Array) -> bool {
         equal(self, *other)
     }
@@ -299,6 +312,11 @@ pub fn equal(lhs: &dyn Array, rhs: &dyn Array) -> bool {
             let lhs = lhs.as_any().downcast_ref().unwrap();
             let rhs = rhs.as_any().downcast_ref().unwrap();
             union::equal(lhs, rhs)
+        }
+        DataType::Extension(_, _, _) => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            extension::equal(lhs, rhs)
         }
     }
 }

--- a/src/array/extension/ffi.rs
+++ b/src/array/extension/ffi.rs
@@ -1,0 +1,27 @@
+use crate::{
+    array::{ffi as array_ffi, FromFfi, ToFfi},
+    datatypes::DataType,
+    error::Result,
+    ffi,
+};
+
+use super::ExtensionArray;
+
+unsafe impl ToFfi for ExtensionArray {
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
+        array_ffi::buffers(self.inner.as_ref())
+    }
+
+    #[inline]
+    fn offset(&self) -> usize {
+        array_ffi::offset(self.inner.as_ref())
+    }
+}
+
+unsafe impl<A: ffi::ArrowArrayRef> FromFfi<A> for ExtensionArray {
+    fn try_from_ffi(array: A) -> Result<Self> {
+        let inner = ffi::try_from(array)?.into();
+        let data_type: DataType = todo!(); // todo: DataType from fields' metadata
+        Ok(Self::from_data(data_type, inner))
+    }
+}

--- a/src/array/extension/mod.rs
+++ b/src/array/extension/mod.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use crate::{
+    array::{new_empty_array, new_null_array, Array},
+    bitmap::Bitmap,
+    datatypes::DataType,
+};
+
+mod ffi;
+
+#[derive(Debug, Clone)]
+pub struct ExtensionArray {
+    data_type: DataType,
+    inner: Arc<dyn Array>,
+}
+
+impl ExtensionArray {
+    pub fn from_data(data_type: DataType, inner: Arc<dyn Array>) -> Self {
+        if let DataType::Extension(_, inner_data_type, _) = &data_type {
+            assert_eq!(inner_data_type.as_ref(), inner.data_type())
+        } else {
+            panic!("Extension array requires DataType::Extension")
+        }
+        Self { data_type, inner }
+    }
+
+    pub fn new_empty(data_type: DataType) -> Self {
+        if let DataType::Extension(_, inner_data_type, _) = &data_type {
+            let inner = new_empty_array(inner_data_type.as_ref().clone()).into();
+            Self::from_data(data_type, inner)
+        } else {
+            panic!("Extension array requires DataType::Extension")
+        }
+    }
+
+    pub fn new_null(data_type: DataType, length: usize) -> Self {
+        if let DataType::Extension(_, inner_data_type, _) = &data_type {
+            let inner = new_null_array(inner_data_type.as_ref().clone(), length).into();
+            Self::from_data(data_type, inner)
+        } else {
+            panic!("Extension array requires DataType::Extension")
+        }
+    }
+
+    pub fn inner(&self) -> &dyn Array {
+        self.inner.as_ref()
+    }
+}
+
+impl Array for ExtensionArray {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn validity(&self) -> &Option<Bitmap> {
+        self.inner.validity()
+    }
+
+    fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
+        Array::slice(self.inner.as_ref(), offset, length)
+    }
+}

--- a/src/array/ffi.rs
+++ b/src/array/ffi.rs
@@ -26,10 +26,24 @@ pub unsafe trait FromFfi<T: ffi::ArrowArrayRef>: Sized {
     fn try_from_ffi(array: T) -> Result<Self>;
 }
 
-macro_rules! ffi_dyn {
+macro_rules! ffi_buffers_dyn {
     ($array:expr, $ty:ty) => {{
         let array = $array.as_any().downcast_ref::<$ty>().unwrap();
-        (array.buffers(), array.children(), None)
+        array.buffers()
+    }};
+}
+
+macro_rules! ffi_children_dyn {
+    ($array:expr, $ty:ty) => {{
+        let array = $array.as_any().downcast_ref::<$ty>().unwrap();
+        array.children()
+    }};
+}
+
+macro_rules! ffi_offset_dyn {
+    ($array:expr, $ty:ty) => {{
+        let array = $array.as_any().downcast_ref::<$ty>().unwrap();
+        array.offset()
     }};
 }
 
@@ -39,51 +53,166 @@ type BuffersChildren = (
     Option<Arc<dyn Array>>,
 );
 
-pub fn buffers_children_dictionary(array: &dyn Array) -> BuffersChildren {
+pub fn buffers(array: &dyn Array) -> Vec<Option<std::ptr::NonNull<u8>>> {
     match array.data_type() {
-        DataType::Null => ffi_dyn!(array, NullArray),
-        DataType::Boolean => ffi_dyn!(array, BooleanArray),
-        DataType::Int8 => ffi_dyn!(array, PrimitiveArray<i8>),
-        DataType::Int16 => ffi_dyn!(array, PrimitiveArray<i16>),
+        DataType::Null => ffi_buffers_dyn!(array, NullArray),
+        DataType::Boolean => ffi_buffers_dyn!(array, BooleanArray),
+        DataType::Int8 => ffi_buffers_dyn!(array, PrimitiveArray<i8>),
+        DataType::Int16 => ffi_buffers_dyn!(array, PrimitiveArray<i16>),
         DataType::Int32
         | DataType::Date32
         | DataType::Time32(_)
         | DataType::Interval(IntervalUnit::YearMonth) => {
-            ffi_dyn!(array, PrimitiveArray<i32>)
+            ffi_buffers_dyn!(array, PrimitiveArray<i32>)
         }
-        DataType::Interval(IntervalUnit::DayTime) => ffi_dyn!(array, PrimitiveArray<days_ms>),
+        DataType::Interval(IntervalUnit::DayTime) => {
+            ffi_buffers_dyn!(array, PrimitiveArray<days_ms>)
+        }
         DataType::Int64
         | DataType::Date64
         | DataType::Time64(_)
         | DataType::Timestamp(_, _)
-        | DataType::Duration(_) => ffi_dyn!(array, PrimitiveArray<i64>),
-        DataType::Decimal(_, _) => ffi_dyn!(array, PrimitiveArray<i128>),
-        DataType::UInt8 => ffi_dyn!(array, PrimitiveArray<u8>),
-        DataType::UInt16 => ffi_dyn!(array, PrimitiveArray<u16>),
-        DataType::UInt32 => ffi_dyn!(array, PrimitiveArray<u32>),
-        DataType::UInt64 => ffi_dyn!(array, PrimitiveArray<u64>),
+        | DataType::Duration(_) => ffi_buffers_dyn!(array, PrimitiveArray<i64>),
+        DataType::Decimal(_, _) => ffi_buffers_dyn!(array, PrimitiveArray<i128>),
+        DataType::UInt8 => ffi_buffers_dyn!(array, PrimitiveArray<u8>),
+        DataType::UInt16 => ffi_buffers_dyn!(array, PrimitiveArray<u16>),
+        DataType::UInt32 => ffi_buffers_dyn!(array, PrimitiveArray<u32>),
+        DataType::UInt64 => ffi_buffers_dyn!(array, PrimitiveArray<u64>),
         DataType::Float16 => unreachable!(),
-        DataType::Float32 => ffi_dyn!(array, PrimitiveArray<f32>),
-        DataType::Float64 => ffi_dyn!(array, PrimitiveArray<f64>),
-        DataType::Binary => ffi_dyn!(array, BinaryArray<i32>),
-        DataType::LargeBinary => ffi_dyn!(array, BinaryArray<i64>),
-        DataType::FixedSizeBinary(_) => ffi_dyn!(array, FixedSizeBinaryArray),
-        DataType::Utf8 => ffi_dyn!(array, Utf8Array::<i32>),
-        DataType::LargeUtf8 => ffi_dyn!(array, Utf8Array::<i64>),
-        DataType::List(_) => ffi_dyn!(array, ListArray::<i32>),
-        DataType::LargeList(_) => ffi_dyn!(array, ListArray::<i64>),
-        DataType::FixedSizeList(_, _) => ffi_dyn!(array, FixedSizeListArray),
-        DataType::Struct(_) => ffi_dyn!(array, StructArray),
-        DataType::Union(_, _, _) => ffi_dyn!(array, UnionArray),
+        DataType::Float32 => ffi_buffers_dyn!(array, PrimitiveArray<f32>),
+        DataType::Float64 => ffi_buffers_dyn!(array, PrimitiveArray<f64>),
+        DataType::Binary => ffi_buffers_dyn!(array, BinaryArray<i32>),
+        DataType::LargeBinary => ffi_buffers_dyn!(array, BinaryArray<i64>),
+        DataType::FixedSizeBinary(_) => ffi_buffers_dyn!(array, FixedSizeBinaryArray),
+        DataType::Utf8 => ffi_buffers_dyn!(array, Utf8Array::<i32>),
+        DataType::LargeUtf8 => ffi_buffers_dyn!(array, Utf8Array::<i64>),
+        DataType::List(_) => ffi_buffers_dyn!(array, ListArray::<i32>),
+        DataType::LargeList(_) => ffi_buffers_dyn!(array, ListArray::<i64>),
+        DataType::FixedSizeList(_, _) => ffi_buffers_dyn!(array, FixedSizeListArray),
+        DataType::Struct(_) => ffi_buffers_dyn!(array, StructArray),
+        DataType::Union(_, _, _) => ffi_buffers_dyn!(array, UnionArray),
         DataType::Dictionary(key_type, _) => {
             with_match_dictionary_key_type!(key_type.as_ref(), |$T| {
                 let array = array.as_any().downcast_ref::<DictionaryArray<$T>>().unwrap();
-                (
-                    array.buffers(),
-                    array.children(),
-                    Some(array.values().clone()),
-                )
+                array.buffers()
             })
         }
+        DataType::Extension(_, _, _) => ffi_buffers_dyn!(array, ExtensionArray),
     }
+}
+
+pub fn children(array: &dyn Array) -> Vec<Arc<dyn Array>> {
+    match array.data_type() {
+        DataType::Null => ffi_children_dyn!(array, NullArray),
+        DataType::Boolean => ffi_children_dyn!(array, BooleanArray),
+        DataType::Int8 => ffi_children_dyn!(array, PrimitiveArray<i8>),
+        DataType::Int16 => ffi_children_dyn!(array, PrimitiveArray<i16>),
+        DataType::Int32
+        | DataType::Date32
+        | DataType::Time32(_)
+        | DataType::Interval(IntervalUnit::YearMonth) => {
+            ffi_children_dyn!(array, PrimitiveArray<i32>)
+        }
+        DataType::Interval(IntervalUnit::DayTime) => {
+            ffi_children_dyn!(array, PrimitiveArray<days_ms>)
+        }
+        DataType::Int64
+        | DataType::Date64
+        | DataType::Time64(_)
+        | DataType::Timestamp(_, _)
+        | DataType::Duration(_) => ffi_children_dyn!(array, PrimitiveArray<i64>),
+        DataType::Decimal(_, _) => ffi_children_dyn!(array, PrimitiveArray<i128>),
+        DataType::UInt8 => ffi_children_dyn!(array, PrimitiveArray<u8>),
+        DataType::UInt16 => ffi_children_dyn!(array, PrimitiveArray<u16>),
+        DataType::UInt32 => ffi_children_dyn!(array, PrimitiveArray<u32>),
+        DataType::UInt64 => ffi_children_dyn!(array, PrimitiveArray<u64>),
+        DataType::Float16 => unreachable!(),
+        DataType::Float32 => ffi_children_dyn!(array, PrimitiveArray<f32>),
+        DataType::Float64 => ffi_children_dyn!(array, PrimitiveArray<f64>),
+        DataType::Binary => ffi_children_dyn!(array, BinaryArray<i32>),
+        DataType::LargeBinary => ffi_children_dyn!(array, BinaryArray<i64>),
+        DataType::FixedSizeBinary(_) => ffi_children_dyn!(array, FixedSizeBinaryArray),
+        DataType::Utf8 => ffi_children_dyn!(array, Utf8Array::<i32>),
+        DataType::LargeUtf8 => ffi_children_dyn!(array, Utf8Array::<i64>),
+        DataType::List(_) => ffi_children_dyn!(array, ListArray::<i32>),
+        DataType::LargeList(_) => ffi_children_dyn!(array, ListArray::<i64>),
+        DataType::FixedSizeList(_, _) => ffi_children_dyn!(array, FixedSizeListArray),
+        DataType::Struct(_) => ffi_children_dyn!(array, StructArray),
+        DataType::Union(_, _, _) => ffi_children_dyn!(array, UnionArray),
+        DataType::Dictionary(key_type, _) => {
+            with_match_dictionary_key_type!(key_type.as_ref(), |$T| {
+                let array = array.as_any().downcast_ref::<DictionaryArray<$T>>().unwrap();
+                    array.children()
+            })
+        }
+        DataType::Extension(_, _, _) => ffi_children_dyn!(array, ExtensionArray),
+    }
+}
+
+pub fn offset(array: &dyn Array) -> usize {
+    match array.data_type() {
+        DataType::Null => ffi_offset_dyn!(array, NullArray),
+        DataType::Boolean => ffi_offset_dyn!(array, BooleanArray),
+        DataType::Int8 => ffi_offset_dyn!(array, PrimitiveArray<i8>),
+        DataType::Int16 => ffi_offset_dyn!(array, PrimitiveArray<i16>),
+        DataType::Int32
+        | DataType::Date32
+        | DataType::Time32(_)
+        | DataType::Interval(IntervalUnit::YearMonth) => {
+            ffi_offset_dyn!(array, PrimitiveArray<i32>)
+        }
+        DataType::Interval(IntervalUnit::DayTime) => {
+            ffi_offset_dyn!(array, PrimitiveArray<days_ms>)
+        }
+        DataType::Int64
+        | DataType::Date64
+        | DataType::Time64(_)
+        | DataType::Timestamp(_, _)
+        | DataType::Duration(_) => ffi_offset_dyn!(array, PrimitiveArray<i64>),
+        DataType::Decimal(_, _) => ffi_offset_dyn!(array, PrimitiveArray<i128>),
+        DataType::UInt8 => ffi_offset_dyn!(array, PrimitiveArray<u8>),
+        DataType::UInt16 => ffi_offset_dyn!(array, PrimitiveArray<u16>),
+        DataType::UInt32 => ffi_offset_dyn!(array, PrimitiveArray<u32>),
+        DataType::UInt64 => ffi_offset_dyn!(array, PrimitiveArray<u64>),
+        DataType::Float16 => unreachable!(),
+        DataType::Float32 => ffi_offset_dyn!(array, PrimitiveArray<f32>),
+        DataType::Float64 => ffi_offset_dyn!(array, PrimitiveArray<f64>),
+        DataType::Binary => ffi_offset_dyn!(array, BinaryArray<i32>),
+        DataType::LargeBinary => ffi_offset_dyn!(array, BinaryArray<i64>),
+        DataType::FixedSizeBinary(_) => ffi_offset_dyn!(array, FixedSizeBinaryArray),
+        DataType::Utf8 => ffi_offset_dyn!(array, Utf8Array::<i32>),
+        DataType::LargeUtf8 => ffi_offset_dyn!(array, Utf8Array::<i64>),
+        DataType::List(_) => ffi_offset_dyn!(array, ListArray::<i32>),
+        DataType::LargeList(_) => ffi_offset_dyn!(array, ListArray::<i64>),
+        DataType::FixedSizeList(_, _) => ffi_offset_dyn!(array, FixedSizeListArray),
+        DataType::Struct(_) => ffi_offset_dyn!(array, StructArray),
+        DataType::Union(_, _, _) => ffi_offset_dyn!(array, UnionArray),
+        DataType::Dictionary(key_type, _) => {
+            with_match_dictionary_key_type!(key_type.as_ref(), |$T| {
+                let array = array.as_any().downcast_ref::<DictionaryArray<$T>>().unwrap();
+                    array.offset()
+            })
+        }
+        DataType::Extension(_, _, _) => ffi_offset_dyn!(array, ExtensionArray),
+    }
+}
+
+pub fn dictionary(array: &dyn Array) -> Option<Arc<dyn Array>> {
+    match array.data_type() {
+        DataType::Dictionary(key_type, _) => {
+            with_match_dictionary_key_type!(key_type.as_ref(), |$T| {
+                let array = array.as_any().downcast_ref::<DictionaryArray<$T>>().unwrap();
+                Some(array.values().clone())
+            })
+        }
+        DataType::Extension(_, _, _) => {
+            let array = array.as_any().downcast_ref::<ExtensionArray>().unwrap();
+            dictionary(array.inner())
+        }
+        _ => None,
+    }
+}
+
+pub fn buffers_children_dictionary(array: &dyn Array) -> BuffersChildren {
+    (buffers(array), children(array), dictionary(array))
 }

--- a/src/array/growable/mod.rs
+++ b/src/array/growable/mod.rs
@@ -231,5 +231,6 @@ pub fn make_growable<'a>(
                 dyn_dict_growable!($T, arrays, use_validity, capacity)
             })
         }
+        DataType::Extension(_, _, _) => todo!(),
     }
 }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -207,6 +207,7 @@ impl Display for dyn Array {
                     fmt_dyn!(self, DictionaryArray::<$T>, f)
                 })
             }
+            DataType::Extension(_, _, _) => todo!(),
         }
     }
 }
@@ -255,6 +256,7 @@ pub fn new_empty_array(data_type: DataType) -> Box<dyn Array> {
                 Box::new(DictionaryArray::<$T>::new_empty(*value_type))
             })
         }
+        DataType::Extension(_, _, _) => Box::new(ExtensionArray::new_empty(data_type)),
     }
 }
 
@@ -304,6 +306,7 @@ pub fn new_null_array(data_type: DataType, length: usize) -> Box<dyn Array> {
                 Box::new(DictionaryArray::<$T>::new_null(*value_type, length))
             })
         }
+        DataType::Extension(_, _, _) => Box::new(ExtensionArray::new_null(data_type, length)),
     }
 }
 
@@ -359,6 +362,7 @@ pub fn clone(array: &dyn Array) -> Box<dyn Array> {
                 clone_dyn!(array, DictionaryArray::<$T>)
             })
         }
+        DataType::Extension(_, _, _) => clone_dyn!(array, ExtensionArray),
     }
 }
 
@@ -366,6 +370,7 @@ mod binary;
 mod boolean;
 mod dictionary;
 mod display;
+mod extension;
 mod fixed_size_binary;
 mod fixed_size_list;
 mod list;
@@ -387,6 +392,7 @@ pub use equal::equal;
 pub use binary::{BinaryArray, MutableBinaryArray};
 pub use boolean::{BooleanArray, MutableBooleanArray};
 pub use dictionary::{DictionaryArray, DictionaryKey, MutableDictionaryArray};
+pub use extension::ExtensionArray;
 pub use fixed_size_binary::{FixedSizeBinaryArray, MutableFixedSizeBinaryArray};
 pub use fixed_size_list::{FixedSizeListArray, MutableFixedSizeListArray};
 pub use list::{ListArray, MutableListArray};

--- a/src/compute/aggregate/memory.rs
+++ b/src/compute/aggregate/memory.rs
@@ -136,6 +136,10 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
             UInt64 => dyn_dict!(array, u64),
             _ => unreachable!(),
         },
+        Extension(_, _, _) => {
+            let array = array.as_any().downcast_ref::<ExtensionArray>().unwrap();
+            estimated_bytes_size(array.inner())
+        }
     }
 }
 

--- a/src/datatypes/field.rs
+++ b/src/datatypes/field.rs
@@ -23,7 +23,7 @@ use super::DataType;
 
 /// A logical [`DataType`] and its associated metadata per
 /// [Arrow specification](https://arrow.apache.org/docs/cpp/api/datatype.html)
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Field {
     pub name: String,
     pub data_type: DataType,
@@ -250,6 +250,7 @@ impl Field {
             | DataType::FixedSizeBinary(_)
             | DataType::Utf8
             | DataType::LargeUtf8
+            | DataType::Extension(_, _, _)
             | DataType::Decimal(_, _) => {
                 if self.data_type != from.data_type {
                     return Err(ArrowError::Schema(

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -27,7 +27,7 @@ pub use schema::Schema;
 /// Nested types can themselves be nested within other arrays.
 /// For more information on these types please see
 /// [the physical memory layout of Apache Arrow](https://arrow.apache.org/docs/format/Columnar.html#physical-memory-layout).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum DataType {
     /// Null type, representing an array without values or validity, only a length.
     Null,
@@ -121,6 +121,8 @@ pub enum DataType {
     /// scale is the number of decimal places.
     /// The number 999.99 has a precision of 5 and scale of 2.
     Decimal(usize, usize),
+    /// Extension type.
+    Extension(String, Box<DataType>, Option<String>),
 }
 
 impl std::fmt::Display for DataType {

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -356,6 +356,7 @@ fn to_format(data_type: &DataType) -> String {
             r
         }
         DataType::Dictionary(index, _) => to_format(index.as_ref()),
+        DataType::Extension(_, inner, _) => to_format(inner.as_ref()),
     }
 }
 

--- a/src/io/ipc/convert.rs
+++ b/src/io/ipc/convert.rs
@@ -336,7 +336,7 @@ fn write_metadata<'a>(
     kv_vec: &mut Vec<WIPOffset<ipc::KeyValue<'a>>>,
 ) {
     for (k, v) in metadata {
-        if k != "ARROW:extension:name" || k != "ARROW:extension:metadata" {
+        if k != "ARROW:extension:name" && k != "ARROW:extension:metadata" {
             let kv_args = ipc::KeyValueArgs {
                 key: Some(fbb.create_string(k.as_str())),
                 value: Some(fbb.create_string(v.as_str())),
@@ -355,11 +355,8 @@ pub(crate) fn build_field<'a>(
     let mut kv_vec = vec![];
     if let DataType::Extension(name, _, metadata) = field.data_type() {
         // append extension information.
-        let kv_args = ipc::KeyValueArgs {
-            key: Some(fbb.create_string("ARROW:extension:name")),
-            value: Some(fbb.create_string(name.as_str())),
-        };
-        kv_vec.push(ipc::KeyValue::create(fbb, &kv_args));
+
+        // metadata
         if let Some(metadata) = metadata {
             let kv_args = ipc::KeyValueArgs {
                 key: Some(fbb.create_string("ARROW:extension:metadata")),
@@ -367,6 +364,13 @@ pub(crate) fn build_field<'a>(
             };
             kv_vec.push(ipc::KeyValue::create(fbb, &kv_args));
         }
+
+        // name
+        let kv_args = ipc::KeyValueArgs {
+            key: Some(fbb.create_string("ARROW:extension:name")),
+            value: Some(fbb.create_string(name.as_str())),
+        };
+        kv_vec.push(ipc::KeyValue::create(fbb, &kv_args));
     }
     if let Some(metadata) = field.metadata() {
         if !metadata.is_empty() {

--- a/src/io/ipc/convert.rs
+++ b/src/io/ipc/convert.rs
@@ -32,6 +32,9 @@ use std::collections::{BTreeMap, HashMap};
 
 use DataType::*;
 
+type Metadata = Option<BTreeMap<String, String>>;
+type Extension = Option<(String, Option<String>)>;
+
 pub fn schema_to_fb_offset<'a>(
     fbb: &mut FlatBufferBuilder<'a>,
     schema: &Schema,
@@ -67,35 +70,53 @@ pub fn schema_to_fb_offset<'a>(
     builder.finish()
 }
 
+fn read_metadata(field: &ipc::Field) -> Metadata {
+    if let Some(list) = field.custom_metadata() {
+        let mut metadata_map = BTreeMap::default();
+        for kv in list {
+            if let (Some(k), Some(v)) = (kv.key(), kv.value()) {
+                metadata_map.insert(k.to_string(), v.to_string());
+            }
+        }
+        Some(metadata_map)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn get_extension(metadata: &Metadata) -> Extension {
+    if let Some(metadata) = metadata {
+        if let Some(name) = metadata.get("ARROW:extension:name") {
+            let metadata = metadata.get("ARROW:extension:metadata").cloned();
+            Some((name.clone(), metadata))
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
 /// Convert an IPC Field to Arrow Field
 impl<'a> From<ipc::Field<'a>> for Field {
     fn from(field: ipc::Field) -> Field {
+        let metadata = read_metadata(&field);
+
+        let extension = get_extension(&metadata);
+
+        let data_type = get_data_type(field, extension, true);
+
         let mut arrow_field = if let Some(dictionary) = field.dictionary() {
             Field::new_dict(
                 field.name().unwrap(),
-                get_data_type(field, true),
+                data_type,
                 field.nullable(),
                 dictionary.id(),
                 dictionary.isOrdered(),
             )
         } else {
-            Field::new(
-                field.name().unwrap(),
-                get_data_type(field, true),
-                field.nullable(),
-            )
+            Field::new(field.name().unwrap(), data_type, field.nullable())
         };
-
-        let mut metadata = None;
-        if let Some(list) = field.custom_metadata() {
-            let mut metadata_map = BTreeMap::default();
-            for kv in list {
-                if let (Some(k), Some(v)) = (kv.key(), kv.value()) {
-                    metadata_map.insert(k.to_string(), v.to_string());
-                }
-            }
-            metadata = Some(metadata_map);
-        }
 
         arrow_field.set_metadata(metadata);
         arrow_field
@@ -132,7 +153,7 @@ pub fn fb_to_schema(fb: ipc::Schema) -> (Schema, bool) {
 }
 
 /// Get the Arrow data type from the flatbuffer Field table
-pub(crate) fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataType {
+fn get_data_type(field: ipc::Field, extension: Extension, may_be_dictionary: bool) -> DataType {
     if let Some(dictionary) = field.dictionary() {
         if may_be_dictionary {
             let int = dictionary.indexType().unwrap();
@@ -149,9 +170,15 @@ pub(crate) fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataT
             };
             return DataType::Dictionary(
                 Box::new(index_type),
-                Box::new(get_data_type(field, false)),
+                Box::new(get_data_type(field, extension, false)),
             );
         }
+    }
+
+    if let Some(extension) = extension {
+        let (name, metadata) = extension;
+        let data_type = get_data_type(field, None, false);
+        return DataType::Extension(name, Box::new(data_type), metadata);
     }
 
     match field.type_type() {
@@ -386,6 +413,7 @@ fn type_to_field_type(data_type: &DataType) -> ipc::Type {
         Union(_, _, _) => ipc::Type::Union,
         Struct(_) => ipc::Type::Struct_,
         Dictionary(_, v) => type_to_field_type(v),
+        Extension(_, v, _) => type_to_field_type(v),
     }
 }
 
@@ -625,6 +653,7 @@ pub(crate) fn get_fb_field_type<'a>(
             // type in the DictionaryEncoding metadata in the parent field
             get_fb_field_type(value_type, is_nullable, fbb)
         }
+        Extension(_, value_type, _) => get_fb_field_type(value_type, is_nullable, fbb),
         Decimal(precision, scale) => {
             let mut builder = ipc::DecimalBuilder::new(fbb);
             builder.add_precision(*precision as i32);

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -29,6 +29,7 @@ mod compression;
 mod convert;
 
 pub use convert::fb_to_schema;
+pub(crate) use convert::get_extension;
 pub use gen::Message::root_as_message;
 pub mod read;
 pub mod write;

--- a/src/io/json_integration/read.rs
+++ b/src/io/json_integration/read.rs
@@ -355,6 +355,20 @@ pub fn to_array(
             let array = UnionArray::from_data(data_type.clone(), types, fields, offsets);
             Ok(Arc::new(array))
         }
+        DataType::Extension(_, inner, _) => {
+            let field = Field::new_dict(
+                field.name(),
+                inner.as_ref().clone(),
+                field.is_nullable(),
+                field.dict_id().unwrap_or(0),
+                field.dict_is_ordered().unwrap_or(false),
+            );
+            let inner = to_array(&field, json_col, dictionaries)?;
+            Ok(Arc::new(ExtensionArray::from_data(
+                data_type.clone(),
+                inner,
+            )))
+        }
     }
 }
 

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -132,5 +132,9 @@ pub fn new_scalar(array: &dyn Array, index: usize) -> Box<dyn Scalar> {
         FixedSizeList(_, _) => todo!(),
         Union(_, _, _) => todo!(),
         Dictionary(_, _) => todo!(),
+        Extension(_, _, _) => {
+            let array = array.as_any().downcast_ref::<ExtensionArray>().unwrap();
+            new_scalar(array.inner(), index)
+        }
     }
 }

--- a/tests/it/io/ipc/read/file.rs
+++ b/tests/it/io/ipc/read/file.rs
@@ -16,7 +16,7 @@ fn test_file(version: &str, file_name: &str) -> Result<()> {
     let reader = FileReader::new(&mut file, metadata, None);
 
     // read expected JSON output
-    let (schema, batches) = read_gzip_json(version, file_name);
+    let (schema, batches) = read_gzip_json(version, file_name)?;
 
     assert_eq!(&schema, reader.schema().as_ref());
 
@@ -115,6 +115,11 @@ fn read_generated_100_interval() -> Result<()> {
 fn read_generated_100_union() -> Result<()> {
     test_file("1.0.0-littleendian", "generated_union")?;
     test_file("1.0.0-bigendian", "generated_union")
+}
+
+#[test]
+fn read_generated_100_extension() -> Result<()> {
+    test_file("1.0.0-littleendian", "generated_extension")
 }
 
 #[test]

--- a/tests/it/io/ipc/read/stream.rs
+++ b/tests/it/io/ipc/read/stream.rs
@@ -16,7 +16,7 @@ fn test_file(version: &str, file_name: &str) -> Result<()> {
     let reader = StreamReader::new(file, metadata);
 
     // read expected JSON output
-    let (schema, batches) = read_gzip_json(version, file_name);
+    let (schema, batches) = read_gzip_json(version, file_name)?;
 
     assert_eq!(&schema, reader.schema().as_ref());
 

--- a/tests/it/io/ipc/write/file.rs
+++ b/tests/it/io/ipc/write/file.rs
@@ -36,7 +36,7 @@ fn round_trip(batch: RecordBatch) -> Result<()> {
 }
 
 fn test_file(version: &str, file_name: &str) -> Result<()> {
-    let (schema, batches) = read_gzip_json(version, file_name);
+    let (schema, batches) = read_gzip_json(version, file_name)?;
 
     let mut result = Vec::<u8>::new();
 
@@ -56,7 +56,7 @@ fn test_file(version: &str, file_name: &str) -> Result<()> {
     let reader = FileReader::new(&mut reader, metadata, None);
 
     // read expected JSON output
-    let (expected_schema, expected_batches) = read_gzip_json(version, file_name);
+    let (expected_schema, expected_batches) = read_gzip_json(version, file_name)?;
 
     assert_eq!(schema.as_ref(), &expected_schema);
 

--- a/tests/it/io/ipc/write/stream.rs
+++ b/tests/it/io/ipc/write/stream.rs
@@ -30,7 +30,7 @@ fn test_file(version: &str, file_name: &str) {
     let schema = reader.schema().clone();
 
     // read expected JSON output
-    let (expected_schema, expected_batches) = read_gzip_json(version, file_name);
+    let (expected_schema, expected_batches) = read_gzip_json(version, file_name).unwrap();
 
     assert_eq!(schema.as_ref(), &expected_schema);
 

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -437,7 +437,7 @@ fn integration_read(data: &[u8]) -> Result<(Arc<Schema>, Vec<RecordBatch>)> {
 }
 
 fn test_file(version: &str, file_name: &str) -> Result<()> {
-    let (schema, batches) = read_gzip_json(version, file_name);
+    let (schema, batches) = read_gzip_json(version, file_name)?;
 
     let data = integration_write(&schema, &batches)?;
 


### PR DESCRIPTION
This PR adds support for Arrow's ["Extension type"](https://arrow.apache.org/docs/format/Columnar.html#extension-types).

This is represented by `DataType::Extension` and `ExtensionArray`, respectively.

For now, extension arrays are only supported to be shared via IPC (i.e. not FFI, since metadata is still not supported in FFI).

This PR adds an example demonstrating how to use it.

All of this is pending passing integration tests, as usual, as well as more tests covering the feature.