### PR TITLE
Added support for `Extension` (logical) type

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ venv/bin/python parquet_integration/write_parquet.py
 * `MutableArray` API to work in-memory in-place.
 * faster IPC reader (different design that avoids an extra copy of all data)
 * IPC supports 2.0 (compression)
+* Extension type supported
 * All implemented arrow types pass FFI integration tests against pyarrow / C++
 * All implemented arrow types pass IPC integration tests against other implementations
 
@@ -83,7 +84,7 @@ venv/bin/python parquet_integration/write_parquet.py
 ## Features in the original not available in this crate
 
 * Parquet read and write of struct and nested lists.
-* Map types
+* Map type
 
 ## Features in this crate not in pyarrow
 

--- a/examples/extension.rs
+++ b/examples/extension.rs
@@ -1,0 +1,52 @@
+use std::io::{Cursor, Seek, Write};
+use std::sync::Arc;
+
+use arrow2::array::*;
+use arrow2::datatypes::*;
+use arrow2::error::Result;
+use arrow2::io::ipc::read;
+use arrow2::io::ipc::write;
+use arrow2::record_batch::RecordBatch;
+
+fn main() -> Result<()> {
+    // declare an extension.
+    let extension_type =
+        DataType::Extension("date16".to_string(), Box::new(DataType::UInt16), None);
+
+    // initialize an array with it.
+    let array = UInt16Array::from_slice([1, 2]).to(extension_type.clone());
+
+    // from here on, it works as usual
+    let mut buffer = Cursor::new(vec![]);
+
+    // write to IPC
+    write_ipc(&mut buffer, array)?;
+
+    // read it back
+    let batch = read_ipc(&buffer.into_inner())?;
+
+    // and verify that the datatype is preserved.
+    let array = &batch.columns()[0];
+    assert_eq!(array.data_type(), &extension_type);
+
+    // see https://arrow.apache.org/docs/format/Columnar.html#extension-types
+    // for consuming by other consumers.
+    Ok(())
+}
+
+fn write_ipc<W: Write + Seek>(writer: &mut W, array: impl Array + 'static) -> Result<()> {
+    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), false)]);
+
+    let mut writer = write::FileWriter::try_new(writer, &schema)?;
+
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)])?;
+
+    writer.write(&batch)
+}
+
+fn read_ipc(reader: &[u8]) -> Result<RecordBatch> {
+    let mut reader = Cursor::new(reader);
+    let metadata = read::read_file_metadata(&mut reader)?;
+    let mut reader = read::FileReader::new(&mut reader, metadata, None);
+    reader.next().unwrap()
+}

--- a/guide/src/SUMMARY.md
+++ b/guide/src/SUMMARY.md
@@ -7,6 +7,7 @@
 - [Compute](./compute.md)
 - [Metadata](./metadata.md)
 - [Foreign interfaces](./ffi.md)
+- [Extension](./extension.md)
 - [IO](./io/README.md)
     - [Read CSV](./io/csv_reader.md)
     - [Write CSV](./io/csv_write.md)

--- a/guide/src/extension.md
+++ b/guide/src/extension.md
@@ -1,0 +1,8 @@
+# Extension types
+
+This crate supports Arrows' ["extension type"](https://arrow.apache.org/docs/format/Columnar.html#extension-types), to declare, use, and share custom logical types.
+The follow example shows how to declare one:
+
+```rust
+{{#include ../../../examples/extension.rs}}
+```

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -43,25 +43,19 @@ pub struct DictionaryArray<K: DictionaryKey> {
 impl<K: DictionaryKey> DictionaryArray<K> {
     /// Returns a new empty [`DictionaryArray`].
     pub fn new_empty(data_type: DataType) -> Self {
-        if let DataType::Dictionary(_, values) = data_type {
-            let values = new_empty_array(values.as_ref().clone()).into();
-            Self::from_data(PrimitiveArray::<K>::new_empty(K::DATA_TYPE), values)
-        } else {
-            panic!("DictionaryArray must be initialized with DataType::Dictionary");
-        }
+        let values = Self::get_child(&data_type);
+        let values = new_empty_array(values.clone()).into();
+        Self::from_data(PrimitiveArray::<K>::new_empty(K::DATA_TYPE), values)
     }
 
     /// Returns an [`DictionaryArray`] whose all elements are null
     #[inline]
     pub fn new_null(data_type: DataType, length: usize) -> Self {
-        if let DataType::Dictionary(_, values) = data_type {
-            Self::from_data(
-                PrimitiveArray::<K>::new_null(K::DATA_TYPE, length),
-                new_empty_array(values.as_ref().clone()).into(),
-            )
-        } else {
-            panic!("DictionaryArray must be initialized with DataType::Dictionary");
-        }
+        let values = Self::get_child(&data_type);
+        Self::from_data(
+            PrimitiveArray::<K>::new_null(K::DATA_TYPE, length),
+            new_empty_array(values.clone()).into(),
+        )
     }
 
     /// The canonical method to create a new [`DictionaryArray`].
@@ -112,10 +106,10 @@ impl<K: DictionaryKey> DictionaryArray<K> {
 
 impl<K: DictionaryKey> DictionaryArray<K> {
     pub(crate) fn get_child(data_type: &DataType) -> &DataType {
-        if let DataType::Dictionary(_, values) = data_type {
-            values.as_ref()
-        } else {
-            panic!("Wrong DataType")
+        match data_type {
+            DataType::Dictionary(_, values) => values.as_ref(),
+            DataType::Extension(_, inner, _) => Self::get_child(inner),
+            _ => panic!("DictionaryArray must be initialized with DataType::Dictionary"),
         }
     }
 }

--- a/src/array/display.rs
+++ b/src/array/display.rs
@@ -234,6 +234,7 @@ pub fn get_value_display<'a>(array: &'a dyn Array) -> Box<dyn Fn(usize) -> Strin
                 displays[field](index)
             })
         }
+        Extension(_, _, _) => todo!(),
     }
 }
 

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -99,6 +99,7 @@ impl FixedSizeBinaryArray {
     pub(crate) fn get_size(data_type: &DataType) -> &i32 {
         match data_type {
             DataType::FixedSizeBinary(size) => size,
+            DataType::Extension(_, child, _) => Self::get_size(child),
             _ => panic!("Wrong DataType"),
         }
     }

--- a/src/array/fixed_size_binary/mutable.rs
+++ b/src/array/fixed_size_binary/mutable.rs
@@ -35,10 +35,11 @@ impl From<MutableFixedSizeBinaryArray> for FixedSizeBinaryArray {
 impl MutableFixedSizeBinaryArray {
     /// Canonical method to create a new [`MutableFixedSizeBinaryArray`].
     pub fn from_data(
-        size: usize,
+        data_type: DataType,
         values: MutableBuffer<u8>,
         validity: Option<MutableBitmap>,
     ) -> Self {
+        let size = *FixedSizeBinaryArray::get_size(&data_type) as usize;
         assert_eq!(
             values.len() % size,
             0,
@@ -52,7 +53,7 @@ impl MutableFixedSizeBinaryArray {
             );
         }
         Self {
-            data_type: DataType::FixedSizeBinary(size as i32),
+            data_type,
             size,
             values,
             validity,
@@ -67,7 +68,7 @@ impl MutableFixedSizeBinaryArray {
     /// Creates a new [`MutableFixedSizeBinaryArray`] with capacity for `capacity` entries.
     pub fn with_capacity(size: usize, capacity: usize) -> Self {
         Self::from_data(
-            size,
+            DataType::FixedSizeBinary(size as i32),
             MutableBuffer::<u8>::with_capacity(capacity * size),
             None,
         )

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -96,12 +96,12 @@ impl FixedSizeListArray {
     pub(crate) fn get_child_and_size(data_type: &DataType) -> (&Field, &i32) {
         match data_type {
             DataType::FixedSizeList(child, size) => (child.as_ref(), size),
+            DataType::Extension(_, child, _) => Self::get_child_and_size(child),
             _ => panic!("Wrong DataType"),
         }
     }
 
     /// Returns a [`DataType`] consistent with this Array.
-    #[inline]
     pub fn default_datatype(data_type: DataType, size: usize) -> DataType {
         let field = Box::new(Field::new("item", data_type, true));
         DataType::FixedSizeList(field, size as i32)

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -120,7 +120,6 @@ impl<O: Offset> ListArray<O> {
 }
 
 impl<O: Offset> ListArray<O> {
-    #[inline]
     pub fn default_datatype(data_type: DataType) -> DataType {
         let field = Box::new(Field::new("item", data_type, true));
         if O::is_large() {
@@ -130,22 +129,22 @@ impl<O: Offset> ListArray<O> {
         }
     }
 
-    #[inline]
     pub fn get_child_field(data_type: &DataType) -> &Field {
         if O::is_large() {
             match data_type {
                 DataType::LargeList(child) => child.as_ref(),
+                DataType::Extension(_, child, _) => Self::get_child_field(child),
                 _ => panic!("Wrong DataType"),
             }
         } else {
             match data_type {
                 DataType::List(child) => child.as_ref(),
+                DataType::Extension(_, child, _) => Self::get_child_field(child),
                 _ => panic!("Wrong DataType"),
             }
         }
     }
 
-    #[inline]
     pub fn get_child_type(data_type: &DataType) -> &DataType {
         Self::get_child_field(data_type).data_type()
     }

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -70,20 +70,17 @@ impl StructArray {
         values: Vec<Arc<dyn Array>>,
         validity: Option<Bitmap>,
     ) -> Self {
-        if let DataType::Struct(fields) = &data_type {
-            assert!(!fields.is_empty());
-            assert_eq!(fields.len(), values.len());
-            assert!(values.iter().all(|x| x.len() == values[0].len()));
-            if let Some(ref validity) = validity {
-                assert_eq!(values[0].len(), validity.len());
-            }
-            Self {
-                data_type,
-                values,
-                validity,
-            }
-        } else {
-            panic!("StructArray must be initialized with DataType::Struct");
+        let fields = Self::get_fields(&data_type);
+        assert!(!fields.is_empty());
+        assert_eq!(fields.len(), values.len());
+        assert!(values.iter().all(|x| x.len() == values[0].len()));
+        if let Some(ref validity) = validity {
+            assert_eq!(values[0].len(), validity.len());
+        }
+        Self {
+            data_type,
+            values,
+            validity,
         }
     }
 
@@ -134,10 +131,10 @@ impl StructArray {
 impl StructArray {
     /// Returns the fields the `DataType::Struct`.
     pub fn get_fields(data_type: &DataType) -> &[Field] {
-        if let DataType::Struct(fields) = data_type {
-            fields
-        } else {
-            panic!("Wrong datatype passed to Struct.")
+        match data_type {
+            DataType::Struct(fields) => fields,
+            DataType::Extension(_, inner, _) => Self::get_fields(inner),
+            _ => panic!("Wrong datatype passed to Struct."),
         }
     }
 }

--- a/src/datatypes/field.rs
+++ b/src/datatypes/field.rs
@@ -23,7 +23,7 @@ use super::DataType;
 
 /// A logical [`DataType`] and its associated metadata per
 /// [Arrow specification](https://arrow.apache.org/docs/cpp/api/datatype.html)
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Field {
     /// Its name
     pub name: String,
@@ -255,6 +255,7 @@ impl Field {
             | DataType::FixedSizeBinary(_)
             | DataType::Utf8
             | DataType::LargeUtf8
+            | DataType::Extension(_, _, _)
             | DataType::Decimal(_, _) => {
                 if self.data_type != from.data_type {
                     return Err(ArrowError::Schema(

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -22,7 +22,7 @@ pub use schema::Schema;
 /// Nested types can themselves be nested within other arrays.
 /// For more information on these types please see
 /// [the physical memory layout of Apache Arrow](https://arrow.apache.org/docs/format/Columnar.html#physical-memory-layout).
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum DataType {
     /// Null type, representing an array without values or validity, only a length.
     Null,
@@ -116,6 +116,8 @@ pub enum DataType {
     /// scale is the number of decimal places.
     /// The number 999.99 has a precision of 5 and scale of 2.
     Decimal(usize, usize),
+    /// Extension type.
+    Extension(String, Box<DataType>, Option<String>),
 }
 
 impl std::fmt::Display for DataType {
@@ -206,6 +208,7 @@ impl DataType {
             Struct(_) => PhysicalType::Struct,
             Union(_, _, _) => PhysicalType::Union,
             Dictionary(key, _) => PhysicalType::Dictionary(to_dictionary_index_type(key.as_ref())),
+            Extension(_, key, _) => key.to_physical_type(),
         }
     }
 }

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -356,6 +356,7 @@ fn to_format(data_type: &DataType) -> String {
             r
         }
         DataType::Dictionary(index, _) => to_format(index.as_ref()),
+        DataType::Extension(_, inner, _) => to_format(inner.as_ref()),
     }
 }
 

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -13,6 +13,7 @@ mod compression;
 mod convert;
 
 pub use convert::fb_to_schema;
+pub(crate) use convert::get_extension;
 pub use gen::Message::root_as_message;
 pub mod read;
 pub mod write;

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -29,21 +29,6 @@ pub trait Scalar: std::fmt::Debug {
     fn data_type(&self) -> &DataType;
 }
 
-macro_rules! dyn_new {
-    ($array:expr, $index:expr, $type:ty) => {{
-        let array = $array
-            .as_any()
-            .downcast_ref::<PrimitiveArray<$type>>()
-            .unwrap();
-        let value = if array.is_valid($index) {
-            Some(array.value($index))
-        } else {
-            None
-        };
-        Box::new(PrimitiveScalar::new(array.data_type().clone(), value))
-    }};
-}
-
 macro_rules! dyn_new_utf8 {
     ($array:expr, $index:expr, $type:ty) => {{
         let array = $array.as_any().downcast_ref::<Utf8Array<$type>>().unwrap();
@@ -85,8 +70,8 @@ macro_rules! dyn_new_list {
 
 /// creates a new [`Scalar`] from an [`Array`].
 pub fn new_scalar(array: &dyn Array, index: usize) -> Box<dyn Scalar> {
-    use DataType::*;
-    match array.data_type() {
+    use PhysicalType::*;
+    match array.data_type().to_physical_type() {
         Null => Box::new(NullScalar::new()),
         Boolean => {
             let array = array.as_any().downcast_ref::<BooleanArray>().unwrap();
@@ -97,28 +82,25 @@ pub fn new_scalar(array: &dyn Array, index: usize) -> Box<dyn Scalar> {
             };
             Box::new(BooleanScalar::new(value))
         }
-        Int8 => dyn_new!(array, index, i8),
-        Int16 => dyn_new!(array, index, i16),
-        Int32 | Date32 | Time32(_) | Interval(IntervalUnit::YearMonth) => {
-            dyn_new!(array, index, i32)
-        }
-        Int64 | Date64 | Time64(_) | Duration(_) | Timestamp(_, _) => dyn_new!(array, index, i64),
-        Interval(IntervalUnit::DayTime) => dyn_new!(array, index, days_ms),
-        UInt8 => dyn_new!(array, index, u8),
-        UInt16 => dyn_new!(array, index, u16),
-        UInt32 => dyn_new!(array, index, u32),
-        UInt64 => dyn_new!(array, index, u64),
-        Decimal(_, _) => dyn_new!(array, index, i128),
-        Float16 => unreachable!(),
-        Float32 => dyn_new!(array, index, f32),
-        Float64 => dyn_new!(array, index, f64),
+        Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+            let array = array
+                .as_any()
+                .downcast_ref::<PrimitiveArray<$T>>()
+                .unwrap();
+            let value = if array.is_valid(index) {
+                Some(array.value(index))
+            } else {
+                None
+            };
+            Box::new(PrimitiveScalar::new(array.data_type().clone(), value))
+        }),
         Utf8 => dyn_new_utf8!(array, index, i32),
         LargeUtf8 => dyn_new_utf8!(array, index, i64),
         Binary => dyn_new_binary!(array, index, i32),
         LargeBinary => dyn_new_binary!(array, index, i64),
-        List(_) => dyn_new_list!(array, index, i32),
-        LargeList(_) => dyn_new_list!(array, index, i64),
-        Struct(_) => {
+        List => dyn_new_list!(array, index, i32),
+        LargeList => dyn_new_list!(array, index, i64),
+        Struct => {
             let array = array.as_any().downcast_ref::<StructArray>().unwrap();
             if array.is_valid(index) {
                 let values = array
@@ -131,9 +113,9 @@ pub fn new_scalar(array: &dyn Array, index: usize) -> Box<dyn Scalar> {
                 Box::new(StructScalar::new(array.data_type().clone(), None))
             }
         }
-        FixedSizeBinary(_) => todo!(),
-        FixedSizeList(_, _) => todo!(),
-        Union(_, _, _) => todo!(),
-        Dictionary(_, _) => todo!(),
+        FixedSizeBinary => todo!(),
+        FixedSizeList => todo!(),
+        Union => todo!(),
+        Dictionary(_) => todo!(),
     }
 }

--- a/tests/it/array/fixed_size_binary/mutable.rs
+++ b/tests/it/array/fixed_size_binary/mutable.rs
@@ -5,7 +5,11 @@ use arrow2::datatypes::DataType;
 
 #[test]
 fn basic() {
-    let a = MutableFixedSizeBinaryArray::from_data(2, MutableBuffer::from([1, 2, 3, 4]), None);
+    let a = MutableFixedSizeBinaryArray::from_data(
+        DataType::FixedSizeBinary(2),
+        MutableBuffer::from([1, 2, 3, 4]),
+        None,
+    );
     assert_eq!(a.len(), 2);
     assert_eq!(a.data_type(), &DataType::FixedSizeBinary(2));
     assert_eq!(a.values(), &MutableBuffer::from([1, 2, 3, 4]));
@@ -17,18 +21,26 @@ fn basic() {
 #[allow(clippy::eq_op)]
 #[test]
 fn equal() {
-    let a = MutableFixedSizeBinaryArray::from_data(2, MutableBuffer::from([1, 2, 3, 4]), None);
+    let a = MutableFixedSizeBinaryArray::from_data(
+        DataType::FixedSizeBinary(2),
+        MutableBuffer::from([1, 2, 3, 4]),
+        None,
+    );
     assert_eq!(a, a);
-    let b = MutableFixedSizeBinaryArray::from_data(2, MutableBuffer::from([1, 2]), None);
+    let b = MutableFixedSizeBinaryArray::from_data(
+        DataType::FixedSizeBinary(2),
+        MutableBuffer::from([1, 2]),
+        None,
+    );
     assert_eq!(b, b);
     assert!(a != b);
     let a = MutableFixedSizeBinaryArray::from_data(
-        2,
+        DataType::FixedSizeBinary(2),
         MutableBuffer::from([1, 2, 3, 4]),
         Some(MutableBitmap::from([true, false])),
     );
     let b = MutableFixedSizeBinaryArray::from_data(
-        2,
+        DataType::FixedSizeBinary(2),
         MutableBuffer::from([1, 2, 3, 4]),
         Some(MutableBitmap::from([false, true])),
     );

--- a/tests/it/io/ipc/read/file.rs
+++ b/tests/it/io/ipc/read/file.rs
@@ -16,7 +16,7 @@ fn test_file(version: &str, file_name: &str) -> Result<()> {
     let reader = FileReader::new(&mut file, metadata, None);
 
     // read expected JSON output
-    let (schema, batches) = read_gzip_json(version, file_name);
+    let (schema, batches) = read_gzip_json(version, file_name)?;
 
     assert_eq!(&schema, reader.schema().as_ref());
 
@@ -115,6 +115,11 @@ fn read_generated_100_interval() -> Result<()> {
 fn read_generated_100_union() -> Result<()> {
     test_file("1.0.0-littleendian", "generated_union")?;
     test_file("1.0.0-bigendian", "generated_union")
+}
+
+#[test]
+fn read_generated_100_extension() -> Result<()> {
+    test_file("1.0.0-littleendian", "generated_extension")
 }
 
 #[test]

--- a/tests/it/io/ipc/read/stream.rs
+++ b/tests/it/io/ipc/read/stream.rs
@@ -16,7 +16,7 @@ fn test_file(version: &str, file_name: &str) -> Result<()> {
     let reader = StreamReader::new(file, metadata);
 
     // read expected JSON output
-    let (schema, batches) = read_gzip_json(version, file_name);
+    let (schema, batches) = read_gzip_json(version, file_name)?;
 
     assert_eq!(&schema, reader.schema().as_ref());
 

--- a/tests/it/io/ipc/write/file.rs
+++ b/tests/it/io/ipc/write/file.rs
@@ -36,7 +36,7 @@ fn round_trip(batch: RecordBatch) -> Result<()> {
 }
 
 fn test_file(version: &str, file_name: &str) -> Result<()> {
-    let (schema, batches) = read_gzip_json(version, file_name);
+    let (schema, batches) = read_gzip_json(version, file_name)?;
 
     let mut result = Vec::<u8>::new();
 
@@ -56,7 +56,7 @@ fn test_file(version: &str, file_name: &str) -> Result<()> {
     let reader = FileReader::new(&mut reader, metadata, None);
 
     // read expected JSON output
-    let (expected_schema, expected_batches) = read_gzip_json(version, file_name);
+    let (expected_schema, expected_batches) = read_gzip_json(version, file_name)?;
 
     assert_eq!(schema.as_ref(), &expected_schema);
 

--- a/tests/it/io/ipc/write/stream.rs
+++ b/tests/it/io/ipc/write/stream.rs
@@ -30,7 +30,7 @@ fn test_file(version: &str, file_name: &str) {
     let schema = reader.schema().clone();
 
     // read expected JSON output
-    let (expected_schema, expected_batches) = read_gzip_json(version, file_name);
+    let (expected_schema, expected_batches) = read_gzip_json(version, file_name).unwrap();
 
     assert_eq!(schema.as_ref(), &expected_schema);
 

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -440,7 +440,7 @@ fn integration_read(data: &[u8]) -> Result<(Arc<Schema>, Vec<RecordBatch>)> {
 }
 
 fn test_file(version: &str, file_name: &str) -> Result<()> {
-    let (schema, batches) = read_gzip_json(version, file_name);
+    let (schema, batches) = read_gzip_json(version, file_name)?;
 
     let data = integration_write(&schema, &batches)?;
 


### PR DESCRIPTION
Adds support for Arrow's `Extension` "DataType", enabling users to define and use custom data types from Arrow's ecosystem.

Note that, from now on, array's `data_type` is not sufficient to downcast an array. I have updated the user guide with the new rules. The easiest way to think about them:

* `enum PhysicalType` has a one-to-one relationship to concrete arrays (e.g. `PhysicalType::Utf8 <-> Utf8Array<i32>`)
* `enum DataType` has a many-to-one relationship with a `PhysicalType`, which can be obtained via `.to_physical_type() -> PhysicalType`.

The corollary of this change is that, to correctly downcast arrays, users should now use `match array.data_type().to_physical_type()`. This is only relevant to the `ExtensionType`, which boxes a `DataType` which indicates its own logical type.

Thanks to @sundy-li for the initial implementation at #338 and follow-up discussions at #350.

Closes #361
