### PR TITLE
Add support to extension types in FFI

### DIFF
--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -23,6 +23,14 @@ import pyarrow
 import arrow_pyarrow_integration_testing
 
 
+class UuidType(pyarrow.PyExtensionType):
+    def __init__(self):
+        super().__init__(pyarrow.binary(16))
+
+    def __reduce__(self):
+        return UuidType, ()
+
+
 class TestCase(unittest.TestCase):
     def setUp(self):
         self.old_allocated_rust = (
@@ -176,6 +184,13 @@ class TestCase(unittest.TestCase):
 
     def test_field_metadata(self):
         field = pyarrow.field("aa", pyarrow.bool_(), {"a": "b"})
+        result = arrow_pyarrow_integration_testing.round_trip_field(field)
+        assert field == result
+        assert field.metadata == result.metadata
+
+    # see https://issues.apache.org/jira/browse/ARROW-13855
+    def _test_field_extension(self):
+        field = pyarrow.field("aa", UuidType())
         result = arrow_pyarrow_integration_testing.round_trip_field(field)
         assert field == result
         assert field.metadata == result.metadata

--- a/src/datatypes/field.rs
+++ b/src/datatypes/field.rs
@@ -277,3 +277,19 @@ impl std::fmt::Display for Field {
         write!(f, "{:?}", self)
     }
 }
+
+pub(crate) type Metadata = Option<BTreeMap<String, String>>;
+pub(crate) type Extension = Option<(String, Option<String>)>;
+
+pub(crate) fn get_extension(metadata: &Option<BTreeMap<String, String>>) -> Extension {
+    if let Some(metadata) = metadata {
+        if let Some(name) = metadata.get("ARROW:extension:name") {
+            let metadata = metadata.get("ARROW:extension:metadata").cloned();
+            Some((name.clone(), metadata))
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -7,6 +7,8 @@ pub use field::Field;
 pub use physical_type::*;
 pub use schema::Schema;
 
+pub(crate) use field::{get_extension, Extension, Metadata};
+
 /// The set of datatypes that are supported by this implementation of Apache Arrow.
 ///
 /// The Arrow specification on data types includes some more types.

--- a/src/io/ipc/convert.rs
+++ b/src/io/ipc/convert.rs
@@ -17,7 +17,9 @@
 
 //! Utilities for converting between IPC types and native Arrow types
 
-use crate::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit};
+use crate::datatypes::{
+    get_extension, DataType, Extension, Field, IntervalUnit, Metadata, Schema, TimeUnit,
+};
 use crate::endianess::is_native_little_endian;
 use crate::io::ipc::convert::ipc::UnionMode;
 
@@ -31,9 +33,6 @@ use flatbuffers::{FlatBufferBuilder, ForwardsUOffset, UnionWIPOffset, Vector, WI
 use std::collections::{BTreeMap, HashMap};
 
 use DataType::*;
-
-type Metadata = Option<BTreeMap<String, String>>;
-type Extension = Option<(String, Option<String>)>;
 
 pub fn schema_to_fb_offset<'a>(
     fbb: &mut FlatBufferBuilder<'a>,
@@ -79,19 +78,6 @@ fn read_metadata(field: &ipc::Field) -> Metadata {
             }
         }
         Some(metadata_map)
-    } else {
-        None
-    }
-}
-
-pub(crate) fn get_extension(metadata: &Metadata) -> Extension {
-    if let Some(metadata) = metadata {
-        if let Some(name) = metadata.get("ARROW:extension:name") {
-            let metadata = metadata.get("ARROW:extension:metadata").cloned();
-            Some((name.clone(), metadata))
-        } else {
-            None
-        }
     } else {
         None
     }

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -13,7 +13,6 @@ mod compression;
 mod convert;
 
 pub use convert::fb_to_schema;
-pub(crate) use convert::get_extension;
 pub use gen::Message::root_as_message;
 pub mod read;
 pub mod write;

--- a/src/io/json_integration/schema.rs
+++ b/src/io/json_integration/schema.rs
@@ -25,8 +25,7 @@ use serde_json::{json, Value};
 
 use crate::error::{ArrowError, Result};
 
-use crate::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit};
-use crate::io::ipc::get_extension;
+use crate::datatypes::{get_extension, DataType, Field, IntervalUnit, Schema, TimeUnit};
 
 pub trait ToJson {
     /// Generate a JSON representation

--- a/tests/it/ffi.rs
+++ b/tests/it/ffi.rs
@@ -172,3 +172,13 @@ fn schema() -> Result<()> {
     let field = field.with_metadata(metadata);
     test_round_trip_schema(field)
 }
+
+#[test]
+fn extension() -> Result<()> {
+    let field = Field::new(
+        "a",
+        DataType::Extension("a".to_string(), Box::new(DataType::Int32), None),
+        true,
+    );
+    test_round_trip_schema(field)
+}


### PR DESCRIPTION
With this PR, exporting and import the extension datatype roundtrips.

Pyarrow equivalent being worked at https://github.com/apache/arrow/pull/11071