### PR TITLE
Improved performance of unary _not_ for aligned bitmaps (3x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,3 +183,7 @@ harness = false
 [[bench]]
 name = "concat"
 harness = false
+
+[[bench]]
+name = "bitmap_ops"
+harness = false

--- a/benches/bitmap_ops.rs
+++ b/benches/bitmap_ops.rs
@@ -1,0 +1,37 @@
+use arrow2::bitmap::Bitmap;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_arrow2(lhs: &Bitmap, rhs: &Bitmap) {
+    let r = lhs | rhs;
+    assert!(r.null_count() > 0);
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+
+        let bitmap: Bitmap = (0..size).into_iter().map(|x| x % 3 == 0).collect();
+        c.bench_function(&format!("bitmap aligned not 2^{}", log2_size), |b| {
+            b.iter(|| {
+                let r = !&bitmap;
+                assert!(r.null_count() > 0);
+            })
+        });
+        let bitmap1 = bitmap.clone().slice(1, size - 1);
+        c.bench_function(&format!("bitmap not 2^{}", log2_size), |b| {
+            b.iter(|| {
+                let r = !&bitmap1;
+                assert!(r.null_count() > 0);
+            })
+        });
+
+        let bitmap1: Bitmap = (0..size).into_iter().map(|x| x % 4 == 0).collect();
+        c.bench_function(&format!("bitmap aligned or 2^{}", log2_size), |b| {
+            b.iter(|| bench_arrow2(&bitmap, &bitmap1))
+        });
+    });
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/src/bitmap/utils/chunk_iterator/chunks_exact.rs
+++ b/src/bitmap/utils/chunk_iterator/chunks_exact.rs
@@ -1,5 +1,7 @@
 use std::{convert::TryInto, slice::ChunksExact};
 
+use crate::trusted_len::TrustedLen;
+
 use super::{BitChunk, BitChunkIterExact};
 
 /// An iterator over a slice of bytes in [`BitChunk`]s.
@@ -83,6 +85,8 @@ impl<T: BitChunk> Iterator for BitChunksExact<'_, T> {
         self.iter.size_hint()
     }
 }
+
+unsafe impl<T: BitChunk> TrustedLen for BitChunksExact<'_, T> {}
 
 impl<T: BitChunk> BitChunkIterExact<T> for BitChunksExact<'_, T> {
     #[inline]

--- a/src/bitmap/utils/chunk_iterator/mod.rs
+++ b/src/bitmap/utils/chunk_iterator/mod.rs
@@ -10,7 +10,7 @@ use crate::{trusted_len::TrustedLen, types::BitChunkIter};
 pub(crate) use merge::merge_reversed;
 
 /// Trait representing an exact iterator over bytes in [`BitChunk`].
-pub trait BitChunkIterExact<B: BitChunk>: Iterator<Item = B> {
+pub trait BitChunkIterExact<B: BitChunk>: TrustedLen<Item = B> {
     /// The remainder of the iterator.
     fn remainder(&self) -> B;
 }


### PR DESCRIPTION
```
bitmap aligned not 2^20 time:   [32.273 us 32.387 us 32.524 us]                                     
                        change: [-60.815% -60.557% -60.274%] (p = 0.00 < 0.05)
bitmap not 2^20         time:   [76.473 us 76.545 us 76.630 us]                            
                        change: [-8.2910% -8.1104% -7.9196%] (p = 0.00 < 0.05)
```