### PR TITLE
Made most features not default

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          cargo test
+          cargo test --features full
 
   windows-and-macos:
     name: ${{ matrix.os }}
@@ -99,7 +99,7 @@ jobs:
       - name: Run
         shell: bash
         # no need to run the whole thing. Rust guarantees interoperability
-        run: ARROW2_IGNORE_PARQUET= cargo test --lib
+        run: ARROW2_IGNORE_PARQUET= cargo test --features full
 
   clippy:
     name: Clippy
@@ -134,7 +134,7 @@ jobs:
         run: |
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
-          cargo clippy
+          cargo clippy --features full
 
   miri-checks:
     name: Miri
@@ -163,7 +163,7 @@ jobs:
         run: |
           cargo miri setup
           cargo clean
-          cargo miri test -- --skip io::parquet --skip io::ipc
+          cargo miri test --features full -- --skip io::parquet --skip io::ipc
 
   coverage:
     name: Coverage
@@ -199,7 +199,7 @@ jobs:
           # 2020-11-15: There is a cargo-tarpaulin regression in 0.17.0
           # see https://github.com/xd009642/tarpaulin/issues/618
           cargo install --version 0.16.0 cargo-tarpaulin
-          cargo tarpaulin --out Xml
+          cargo tarpaulin --features full --out Xml
       - name: Report coverage
         continue-on-error: true
         run: bash <(curl -s https://codecov.io/bash)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,8 @@ doc-comment = "0.3"
 crossbeam-channel = "0.5.1"
 
 [features]
-default = [
+default = []
+full = [
     "io_csv",
     "io_json",
     "io_ipc",
@@ -82,7 +83,6 @@ default = [
     "regex",
     "merge_sort",
     "ahash",
-    "benchmarks",
     "compute",
 ]
 merge_sort = ["itertools"]

--- a/guide/src/README.md
+++ b/guide/src/README.md
@@ -13,5 +13,19 @@ Arrow2 is divided into three main parts:
 
 ## Cargo features
 
-This crate has a significant number of cargo features to reduce compilation times and dependencies blowup.
-There is also a feature `simd`, that requires the nightly channel, that produces more explicit SIMD instructions via [`packed_simd`](https://github.com/rust-lang/packed_simd).
+This crate has a significant number of cargo features to reduce compilation
+time and number of dependencies. The feature `"full"` activates most
+functionality, such as:
+
+* `io_ipc`: to interact with the IPC format
+* `io_ipc_compression`: to read and write compressed IPC (v2)
+* `io_csv` to read and write CSV
+* `io_json` to read and write JSON
+* `io_parquet` to read and write parquet
+* `io_parquet_compression` to read and write compressed parquet
+* `io_print` to write batches to formatted ASCII tables
+* `compute` to operate on arrays (addition, sum, sort, etc.)
+
+The feature `simd` (not part of `full`) produces more explicit SIMD instructions
+via [`packed_simd`](https://github.com/rust-lang/packed_simd), but requires the 
+nightly channel.


### PR DESCRIPTION
This is a request for feedback: basically, it makes most features non-default and introduced a new feature, "full", containing most features.

This follows the same pattern of Tokio-rs (which has many features and a "full"). This makes it easier to start without being overwhelmed by all the dependencies we can potentially bring.

To migrate, pass `--features full,benchmarks` (or select the features accordingly ^_^)
