### PR TITLE
Fixed reading multiple parquet pages.

### DIFF
--- a/src/io/parquet/read/binary/dictionary.rs
+++ b/src/io/parquet/read/binary/dictionary.rs
@@ -30,6 +30,7 @@ fn read_dict_optional<K, O>(
     K: DictionaryKey,
     O: Offset,
 {
+    let length = indices.len() + additional;
     values.extend_from_slice(dict.values());
     offsets.extend(
         dict.offsets()
@@ -50,7 +51,7 @@ fn read_dict_optional<K, O>(
     for run in validity_iterator {
         match run {
             hybrid_rle::HybridEncoded::Bitpacked(packed) => {
-                let remaining = additional - indices.len();
+                let remaining = length - indices.len();
                 let len = std::cmp::min(packed.len() * 8, remaining);
                 for is_valid in BitmapIter::new(packed, 0, len) {
                     let value = if is_valid {

--- a/src/io/parquet/read/primitive/basic.rs
+++ b/src/io/parquet/read/primitive/basic.rs
@@ -27,6 +27,7 @@ fn read_dict_buffer_optional<T, A, F>(
     A: ArrowNativeType,
     F: Fn(T) -> A,
 {
+    let length = additional + values.len();
     let dict_values = dict.values();
 
     // SPEC: Data page format: the bit width used to encode the entry ids stored as 1 byte (max bit width = 32),
@@ -42,7 +43,7 @@ fn read_dict_buffer_optional<T, A, F>(
     for run in validity_iterator {
         match run {
             hybrid_rle::HybridEncoded::Bitpacked(packed) => {
-                let remaining = additional - values.len();
+                let remaining = length - values.len();
                 let len = std::cmp::min(packed.len() * 8, remaining);
                 for is_valid in BitmapIter::new(packed, 0, len) {
                     let value = if is_valid {
@@ -83,6 +84,7 @@ fn read_nullable<T, A, F>(
     A: ArrowNativeType,
     F: Fn(T) -> A,
 {
+    let length = additional + values.len();
     let mut chunks = ExactChunksIter::<T>::new(values_buffer);
 
     let validity_iterator = hybrid_rle::Decoder::new(validity_buffer, 1);
@@ -91,7 +93,7 @@ fn read_nullable<T, A, F>(
         match run {
             hybrid_rle::HybridEncoded::Bitpacked(packed) => {
                 // the pack may contain more items than needed.
-                let remaining = additional - values.len();
+                let remaining = length - values.len();
                 let len = std::cmp::min(packed.len() * 8, remaining);
                 for is_valid in BitmapIter::new(packed, 0, len) {
                     let value = if is_valid {


### PR DESCRIPTION
There was a mistake from my part in computing the remaining number of elements when reading parquet pages that caused the skip of the last elements of the last page. :/

Thank you very much to @vincev for reporting this at #373 .

Closes #373 

PS. I will be working in creating random tests to make us a bit more resilient on large scale parquet files created by external sources.