### PR TITLE
Simplified enums in `datatypes`

### DIFF
--- a/src/compute/arithmetics/time.rs
+++ b/src/compute/arithmetics/time.rs
@@ -36,20 +36,20 @@ fn create_scale(lhs: &DataType, rhs: &DataType) -> Result<f64> {
         | (DataType::Time32(timeunit_a), DataType::Duration(timeunit_b))
         | (DataType::Time64(timeunit_a), DataType::Duration(timeunit_b)) => {
             // The scale is based on the TimeUnit that each of the numbers have.
-            timeunit_scale(timeunit_a, timeunit_b)
+            timeunit_scale(*timeunit_a, *timeunit_b)
         }
         (DataType::Date32, DataType::Duration(timeunit)) => {
             // Date32 represents the time elapsed time since UNIX epoch
             // (1970-01-01) in days (32 bits). The duration value has to be
             // scaled to days to be able to add the value to the Date.
-            timeunit_scale(&TimeUnit::Second, timeunit) / SECONDS_IN_DAY as f64
+            timeunit_scale(TimeUnit::Second, *timeunit) / SECONDS_IN_DAY as f64
         }
         (DataType::Date64, DataType::Duration(timeunit)) => {
             // Date64 represents the time elapsed time since UNIX epoch
             // (1970-01-01) in milliseconds (64 bits). The duration value has
             // to be scaled to milliseconds to be able to add the value to the
             // Date.
-            timeunit_scale(&TimeUnit::Millisecond, timeunit)
+            timeunit_scale(TimeUnit::Millisecond, *timeunit)
         }
         _ => {
             return Err(ArrowError::InvalidArgumentError(
@@ -216,10 +216,10 @@ pub fn subtract_timestamps(
         (DataType::Timestamp(timeunit_a, None), DataType::Timestamp(timeunit_b, None)) => {
             // Closure for the binary operation. The closure contains the scale
             // required to calculate the difference between the timestamps.
-            let scale = timeunit_scale(timeunit_a, timeunit_b);
+            let scale = timeunit_scale(*timeunit_a, *timeunit_b);
             let op = move |a, b| a - (b as f64 * scale) as i64;
 
-            binary(lhs, rhs, DataType::Duration(timeunit_a.clone()), op)
+            binary(lhs, rhs, DataType::Duration(*timeunit_a), op)
         }
         _ => Err(ArrowError::InvalidArgumentError(
             "Incorrect data type for the arguments".to_string(),

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -780,7 +780,7 @@ fn cast_with_options(
             primitive_dyn!(array, time32ms_to_time32s)
         }
         (Time32(from_unit), Time64(to_unit)) => {
-            primitive_dyn!(array, time32_to_time64, from_unit, to_unit)
+            primitive_dyn!(array, time32_to_time64, *from_unit, *to_unit)
         }
         (Time64(TimeUnit::Microsecond), Time64(TimeUnit::Nanosecond)) => {
             primitive_dyn!(array, time64us_to_time64ns)
@@ -789,15 +789,15 @@ fn cast_with_options(
             primitive_dyn!(array, time64ns_to_time64us)
         }
         (Time64(from_unit), Time32(to_unit)) => {
-            primitive_dyn!(array, time64_to_time32, from_unit, to_unit)
+            primitive_dyn!(array, time64_to_time32, *from_unit, *to_unit)
         }
         (Timestamp(_, _), Int64) => primitive_to_same_primitive_dyn::<i64>(array, to_type),
         (Int64, Timestamp(_, _)) => primitive_to_same_primitive_dyn::<i64>(array, to_type),
         (Timestamp(from_unit, tz1), Timestamp(to_unit, tz2)) if tz1 == tz2 => {
-            primitive_dyn!(array, timestamp_to_timestamp, from_unit, to_unit, tz2)
+            primitive_dyn!(array, timestamp_to_timestamp, *from_unit, *to_unit, tz2)
         }
-        (Timestamp(from_unit, _), Date32) => primitive_dyn!(array, timestamp_to_date32, from_unit),
-        (Timestamp(from_unit, _), Date64) => primitive_dyn!(array, timestamp_to_date64, from_unit),
+        (Timestamp(from_unit, _), Date32) => primitive_dyn!(array, timestamp_to_date32, *from_unit),
+        (Timestamp(from_unit, _), Date64) => primitive_dyn!(array, timestamp_to_date64, *from_unit),
 
         (Int64, Duration(_)) => primitive_to_same_primitive_dyn::<i64>(array, to_type),
         (Duration(_), Int64) => primitive_to_same_primitive_dyn::<i64>(array, to_type),

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -128,8 +128,8 @@ impl std::fmt::Display for DataType {
     }
 }
 
-/// An absolute length of time in seconds, milliseconds, microseconds or nanoseconds.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+/// Time units defined in Arrow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TimeUnit {
     /// Time in seconds.
     Second,
@@ -141,8 +141,8 @@ pub enum TimeUnit {
     Nanosecond,
 }
 
-/// YEAR_MONTH or DAY_TIME interval in SQL style.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+/// Interval units defined in Arrow
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum IntervalUnit {
     /// Indicates the number of elapsed whole months, stored as 4-byte integers.
     YearMonth,

--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -129,7 +129,7 @@ pub fn timestamp_ns_to_datetime(v: i64) -> NaiveDateTime {
 /// Calculates the scale factor between two TimeUnits. The function returns the
 /// scale that should multiply the TimeUnit "b" to have the same time scale as
 /// the TimeUnit "a".
-pub fn timeunit_scale(a: &TimeUnit, b: &TimeUnit) -> f64 {
+pub fn timeunit_scale(a: TimeUnit, b: TimeUnit) -> f64 {
     match (a, b) {
         (TimeUnit::Second, TimeUnit::Second) => 1.0,
         (TimeUnit::Second, TimeUnit::Millisecond) => 0.001,


### PR DESCRIPTION
* Removed `PartialOrd` nor `Ord`, since there is no natural order on them.
* Made `IntervalUnit` and `TimeUnit` `Copy`, since they are simple enums.