### PR TITLE
Added `extend_*values` to `MutablePrimitiveArray`

### DIFF
--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -98,10 +98,8 @@ impl MutableBitmap {
         if self.length % 8 == 0 {
             self.buffer.push_unchecked(0);
         }
-        if value {
-            let byte = self.buffer.as_mut_slice().last_mut().unwrap();
-            *byte = set(*byte, self.length % 8, true);
-        };
+        let byte = self.buffer.as_mut_slice().last_mut().unwrap();
+        *byte = set(*byte, self.length % 8, value);
         self.length += 1;
     }
 

--- a/src/compute/like.rs
+++ b/src/compute/like.rs
@@ -232,7 +232,10 @@ fn a_like_binary_scalar<O: Offset, F: Fn(bool) -> bool>(
 ) -> Result<BooleanArray> {
     let validity = lhs.validity();
     let pattern = std::str::from_utf8(rhs).map_err(|e| {
-        ArrowError::InvalidArgumentError(format!("Unable to convert the LIKE pattern to string: {}", e))
+        ArrowError::InvalidArgumentError(format!(
+            "Unable to convert the LIKE pattern to string: {}",
+            e
+        ))
     })?;
 
     let values = if !pattern.contains(is_like_pattern) {

--- a/tests/it/array/primitive/mutable.rs
+++ b/tests/it/array/primitive/mutable.rs
@@ -127,6 +127,38 @@ fn extend_trusted_len() {
 }
 
 #[test]
+fn extend_trusted_len_values() {
+    let mut a = MutablePrimitiveArray::<i32>::new();
+    a.extend_trusted_len_values(vec![1, 2, 3].into_iter());
+    assert_eq!(a.validity(), &None);
+    assert_eq!(a.values(), &MutableBuffer::<i32>::from([1, 2, 3]));
+
+    let mut a = MutablePrimitiveArray::<i32>::new();
+    a.push(None);
+    a.extend_trusted_len_values(vec![1, 2].into_iter());
+    assert_eq!(
+        a.validity(),
+        &Some(MutableBitmap::from([false, true, true]))
+    );
+}
+
+#[test]
+fn extend_from_slice() {
+    let mut a = MutablePrimitiveArray::<i32>::new();
+    a.extend_from_slice(&[1, 2, 3]);
+    assert_eq!(a.validity(), &None);
+    assert_eq!(a.values(), &MutableBuffer::<i32>::from([1, 2, 3]));
+
+    let mut a = MutablePrimitiveArray::<i32>::new();
+    a.push(None);
+    a.extend_from_slice(&[1, 2]);
+    assert_eq!(
+        a.validity(),
+        &Some(MutableBitmap::from([false, true, true]))
+    );
+}
+
+#[test]
 fn set_validity() {
     let mut a = MutablePrimitiveArray::<i32>::new();
     a.extend_trusted_len(vec![Some(1), Some(2)].into_iter());


### PR DESCRIPTION
adds

* extend_trusted_len_values
* extend_trusted_len_values_unchecked
* extend_from_slice