### PR TITLE
Made GroupFilter optional in  parquet's`RecordReader` and added method to set it.

### DIFF
--- a/benches/read_parquet.rs
+++ b/benches/read_parquet.rs
@@ -1,5 +1,4 @@
 use std::io::Read;
-use std::sync::Arc;
 use std::{fs, io::Cursor, path::PathBuf};
 
 use criterion::{criterion_group, criterion_main, Criterion};
@@ -20,8 +19,7 @@ fn to_buffer(size: usize) -> Vec<u8> {
 fn read_decompressed_pages(buffer: &[u8], size: usize, column: usize) -> Result<()> {
     let file = Cursor::new(buffer);
 
-    let reader =
-        read::RecordReader::try_new(file, Some(vec![column]), None, Arc::new(|_, _| true), None)?;
+    let reader = read::RecordReader::try_new(file, Some(vec![column]), None, None, None)?;
 
     for maybe_batch in reader {
         let batch = maybe_batch?;

--- a/examples/parquet_read_record.rs
+++ b/examples/parquet_read_record.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::sync::Arc;
 
 use arrow2::error::Result;
 use arrow2::io::parquet::read;
@@ -11,7 +10,7 @@ fn main() -> Result<()> {
     let file_path = &args[1];
 
     let reader = File::open(file_path)?;
-    let reader = read::RecordReader::try_new(reader, None, None, Arc::new(|_, _| true), None)?;
+    let reader = read::RecordReader::try_new(reader, None, None, None, None)?;
 
     for maybe_batch in reader {
         let batch = maybe_batch?;

--- a/src/io/parquet/read/record_batch.rs
+++ b/src/io/parquet/read/record_batch.rs
@@ -90,6 +90,10 @@ impl<R: Read + Seek> RecordReader<R> {
         &self.schema
     }
 
+    pub fn metadata(&self) -> &FileMetaData {
+        self.metadata.as_ref()
+    }
+
     pub fn set_groups_filter(&mut self, groups_filter: GroupFilter) {
         self.groups_filter = Some(groups_filter);
     }

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -21,13 +21,7 @@ pub fn read_column<R: Read + Seek>(
 ) -> Result<ArrayStats> {
     let metadata = read_metadata(&mut reader)?;
 
-    let mut reader = RecordReader::try_new(
-        reader,
-        Some(vec![column]),
-        None,
-        Arc::new(|_, _| true),
-        None,
-    )?;
+    let mut reader = RecordReader::try_new(reader, Some(vec![column]), None, None, None)?;
 
     let statistics = metadata.row_groups[row_group]
         .column(column)
@@ -432,7 +426,7 @@ fn integration_write(schema: &Schema, batches: &[RecordBatch]) -> Result<Vec<u8>
 
 fn integration_read(data: &[u8]) -> Result<(Arc<Schema>, Vec<RecordBatch>)> {
     let reader = Cursor::new(data);
-    let reader = RecordReader::try_new(reader, None, None, Arc::new(|_, _| true), None)?;
+    let reader = RecordReader::try_new(reader, None, None, None, None)?;
     let schema = reader.schema().clone();
     let batches = reader.collect::<Result<Vec<_>>>()?;
 

--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::sync::Arc;
 
 use arrow2::array::*;
 use arrow2::error::Result;
@@ -223,7 +222,7 @@ fn all_types() -> Result<()> {
     let path = "testing/parquet-testing/data/alltypes_plain.parquet";
     let reader = std::fs::File::open(path)?;
 
-    let reader = RecordReader::try_new(reader, None, None, Arc::new(|_, _| true), None)?;
+    let reader = RecordReader::try_new(reader, None, None, None, None)?;
 
     let batches = reader.collect::<Result<Vec<_>>>()?;
     assert_eq!(batches.len(), 1);


### PR DESCRIPTION
This is more expressive since filtering is optional.

# Backward incompatible changes

The function `RecordReader::try_new` now expects `Option<GroupFilter>` instead of `GroupFilter`. If you were not using filtering, migrate to this by passing `None`. If you were filtering, pass `Some(...)` instead.

