### PR TITLE
Added support to read and write extension types to and from parquet

### DIFF
--- a/src/io/parquet/read/binary/dictionary.rs
+++ b/src/io/parquet/read/binary/dictionary.rs
@@ -32,7 +32,7 @@ fn read_dict_optional<K, O>(
 {
     let length = indices.len() + additional;
     values.extend_from_slice(dict.values());
-    offsets.extend(
+    offsets.extend_from_trusted_len_iter(
         dict.offsets()
             .iter()
             .map(|x| O::from_usize(*x as usize).unwrap()),
@@ -152,6 +152,10 @@ where
         )?
     }
 
+    if offsets.len() == 0 {
+        // the array is empty and thus we need to push the first offset ourselves.
+        offsets.push(O::zero());
+    };
     let keys = PrimitiveArray::from_data(K::DATA_TYPE, indices.into(), validity.into());
     let data_type = DictionaryArray::<K>::get_child(&data_type).clone();
     let values = Arc::new(Utf8Array::from_data(

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -136,7 +136,7 @@ where
     match encoding {
         Encoding::PlainDictionary | Encoding::RleDictionary => {
             // write DictPage
-            let dict_page = match array.values().data_type() {
+            let dict_page = match array.values().data_type().to_logical_type() {
                 DataType::Int8 => dyn_prim!(i8, i32, array),
                 DataType::Int16 => dyn_prim!(i16, i32, array),
                 DataType::Int32 | DataType::Date32 | DataType::Time32(_) => {

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -141,7 +141,7 @@ pub fn array_to_page(
         )));
     }
 
-    match data_type {
+    match data_type.to_logical_type() {
         DataType::Boolean => {
             boolean::array_to_page(array.as_any().downcast_ref().unwrap(), options, descriptor)
         }

--- a/src/io/parquet/write/schema.rs
+++ b/src/io/parquet/write/schema.rs
@@ -45,7 +45,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
         Repetition::Required
     };
     // create type from field
-    match field.data_type() {
+    match field.data_type().to_logical_type() {
         DataType::Null => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int32,

--- a/tests/it/io/ipc/write/file.rs
+++ b/tests/it/io/ipc/write/file.rs
@@ -163,6 +163,12 @@ fn write_100_decimal() -> Result<()> {
 }
 
 #[test]
+fn write_100_extension() -> Result<()> {
+    test_file("1.0.0-littleendian", "generated_extension")?;
+    test_file("1.0.0-bigendian", "generated_extension")
+}
+
+#[test]
 fn write_100_union() -> Result<()> {
     test_file("1.0.0-littleendian", "generated_union")?;
     test_file("1.0.0-bigendian", "generated_union")

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -458,6 +458,12 @@ fn roundtrip_100_dict() -> Result<()> {
     test_file("1.0.0-bigendian", "generated_dictionary")
 }
 
+#[test]
+fn roundtrip_100_extension() -> Result<()> {
+    test_file("1.0.0-littleendian", "generated_extension")?;
+    test_file("1.0.0-bigendian", "generated_extension")
+}
+
 /// Tests that when arrow-specific types (Duration and LargeUtf8) are written to parquet, we can rountrip its
 /// logical types.
 #[test]


### PR DESCRIPTION
Extensions can now be written and read to and from parquet (roundtrip), thereby allowing the extension to persist, just like IPC. This is achieved by using the extension available in the schema to derive the arrays' extension.

Closes #392 