### PR TITLE
Fixed error writing dictionary extension to IPC

### DIFF
--- a/tests/it/io/ipc/write/file.rs
+++ b/tests/it/io/ipc/write/file.rs
@@ -163,6 +163,12 @@ fn write_100_decimal() -> Result<()> {
 }
 
 #[test]
+fn write_100_extension() -> Result<()> {
+    test_file("1.0.0-littleendian", "generated_extension")?;
+    test_file("1.0.0-bigendian", "generated_extension")
+}
+
+#[test]
 fn write_100_union() -> Result<()> {
     test_file("1.0.0-littleendian", "generated_union")?;
     test_file("1.0.0-bigendian", "generated_union")


### PR DESCRIPTION
Dictionary extensions are tricky in that they are represented by a single `Field` in IPC, but are represented as `Dictionary(Extension())` as a `DataType`, which requires some custom code to handle correctly. This PR does this