### PR TITLE
Add Array::with_validity

### DIFF
--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -97,9 +97,9 @@ impl<O: Offset> BinaryArray<O> {
 
     /// Sets the validity bitmap on this [`BinaryArray`].
     /// # Panic
-    /// This function panics iff `validity.len() < self.len()`.
+    /// This function panics iff `validity.len() != self.len()`.
     pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
             panic!("validity should be as least as large as the array")
         }
         let mut arr = self.clone();

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -1,9 +1,4 @@
-use crate::{
-    bitmap::Bitmap,
-    buffer::Buffer,
-    datatypes::DataType,
-    error::{ArrowError, Result},
-};
+use crate::{bitmap::Bitmap, buffer::Buffer, datatypes::DataType};
 
 use super::{
     display_fmt, display_helper, specification::check_offsets, specification::Offset, Array,
@@ -99,6 +94,18 @@ impl<O: Offset> BinaryArray<O> {
             offset: self.offset + offset,
         }
     }
+
+    /// Sets the validity bitmap on this [`BinaryArray`].
+    /// # Panic
+    /// This function panics iff `validity.len() < self.len()`.
+    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            panic!("validity should be as least as large as the array")
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        arr
+    }
 }
 
 // accessors
@@ -164,15 +171,8 @@ impl<O: Offset> Array for BinaryArray<O> {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
-    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
-            return Err(ArrowError::InvalidArgumentError(
-                "validity should be as least as large as the array".into(),
-            ));
-        }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        Ok(Box::new(arr))
+    fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
+        Box::new(self.with_validity(validity))
     }
 }
 

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -94,9 +94,9 @@ impl BooleanArray {
 
     /// Sets the validity bitmap on this [`BooleanArray`].
     /// # Panic
-    /// This function panics iff `validity.len() < self.len()`.
+    /// This function panics iff `validity.len() != self.len()`.
     pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
             panic!("validity should be as least as large as the array")
         }
         let mut arr = self.clone();

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, PhysicalType},
+    error::{ArrowError, Result},
 };
 
 use super::{display_fmt, Array};
@@ -117,6 +118,16 @@ impl Array for BooleanArray {
     #[inline]
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            return Err(ArrowError::InvalidArgumentError(
+                "validity should be as least as large as the array".into(),
+            ));
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        Ok(Box::new(arr))
     }
 }
 

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, PhysicalType},
-    error::{ArrowError, Result},
 };
 
 use super::{display_fmt, Array};
@@ -92,6 +91,18 @@ impl BooleanArray {
     pub fn values(&self) -> &Bitmap {
         &self.values
     }
+
+    /// Sets the validity bitmap on this [`BooleanArray`].
+    /// # Panic
+    /// This function panics iff `validity.len() < self.len()`.
+    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            panic!("validity should be as least as large as the array")
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        arr
+    }
 }
 
 impl Array for BooleanArray {
@@ -119,15 +130,8 @@ impl Array for BooleanArray {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
-    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
-            return Err(ArrowError::InvalidArgumentError(
-                "validity should be as least as large as the array".into(),
-            ));
-        }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        Ok(Box::new(arr))
+    fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
+        Box::new(self.with_validity(validity))
     }
 }
 

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -85,9 +85,9 @@ impl<K: DictionaryKey> DictionaryArray<K> {
 
     /// Sets the validity bitmap on this [`Array`].
     /// # Panic
-    /// This function panics iff `validity.len() < self.len()`.
+    /// This function panics iff `validity.len() != self.len()`.
     pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
             panic!("validity should be as least as large as the array")
         }
         let mut arr = self.clone();

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::{
     bitmap::Bitmap,
     datatypes::DataType,
+    error::Result,
     scalar::{new_scalar, Scalar},
     types::{NativeType, NaturalDataType},
 };
@@ -136,6 +137,9 @@ impl<K: DictionaryKey> Array for DictionaryArray<K> {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
+        self.values.with_validity(validity)
     }
 }
 

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use crate::{
     bitmap::Bitmap,
     datatypes::DataType,
-    error::Result,
     scalar::{new_scalar, Scalar},
     types::{NativeType, NaturalDataType},
 };
@@ -84,6 +83,18 @@ impl<K: DictionaryKey> DictionaryArray<K> {
         }
     }
 
+    /// Sets the validity bitmap on this [`Array`].
+    /// # Panic
+    /// This function panics iff `validity.len() < self.len()`.
+    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            panic!("validity should be as least as large as the array")
+        }
+        let mut arr = self.clone();
+        arr.values = Arc::from(arr.values.with_validity(validity));
+        arr
+    }
+
     /// Returns the keys of the [`DictionaryArray`]. These keys can be used to fetch values
     /// from `values`.
     #[inline]
@@ -138,8 +149,8 @@ impl<K: DictionaryKey> Array for DictionaryArray<K> {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
-    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
-        self.values.with_validity(validity)
+    fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
+        Box::new(self.with_validity(validity))
     }
 }
 

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -1,9 +1,4 @@
-use crate::{
-    bitmap::Bitmap,
-    buffer::Buffer,
-    datatypes::DataType,
-    error::{ArrowError, Result},
-};
+use crate::{bitmap::Bitmap, buffer::Buffer, datatypes::DataType, error::Result};
 
 use super::{display_fmt, display_helper, ffi::ToFfi, Array};
 
@@ -98,6 +93,18 @@ impl FixedSizeBinaryArray {
     pub fn size(&self) -> usize {
         self.size as usize
     }
+
+    /// Sets the validity bitmap on this [`FixedSizeBinaryArray`].
+    /// # Panic
+    /// This function panics iff `validity.len() < self.len()`.
+    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            panic!("validity should be as least as large as the array")
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        arr
+    }
 }
 
 impl FixedSizeBinaryArray {
@@ -133,15 +140,8 @@ impl Array for FixedSizeBinaryArray {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
-    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
-            return Err(ArrowError::InvalidArgumentError(
-                "validity should be as least as large as the array".into(),
-            ));
-        }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        Ok(Box::new(arr))
+    fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
+        Box::new(self.with_validity(validity))
     }
 }
 

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -96,9 +96,9 @@ impl FixedSizeBinaryArray {
 
     /// Sets the validity bitmap on this [`FixedSizeBinaryArray`].
     /// # Panic
-    /// This function panics iff `validity.len() < self.len()`.
+    /// This function panics iff `validity.len() != self.len()`.
     pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
             panic!("validity should be as least as large as the array")
         }
         let mut arr = self.clone();

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -1,4 +1,9 @@
-use crate::{bitmap::Bitmap, buffer::Buffer, datatypes::DataType, error::Result};
+use crate::{
+    bitmap::Bitmap,
+    buffer::Buffer,
+    datatypes::DataType,
+    error::{ArrowError, Result},
+};
 
 use super::{display_fmt, display_helper, ffi::ToFfi, Array};
 
@@ -127,6 +132,16 @@ impl Array for FixedSizeBinaryArray {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            return Err(ArrowError::InvalidArgumentError(
+                "validity should be as least as large as the array".into(),
+            ));
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        Ok(Box::new(arr))
     }
 }
 

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -93,9 +93,9 @@ impl FixedSizeListArray {
 
     /// Sets the validity bitmap on this [`FixedSizeListArray`].
     /// # Panic
-    /// This function panics iff `validity.len() < self.len()`.
+    /// This function panics iff `validity.len() != self.len()`.
     pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
             panic!("validity should be as least as large as the array")
         }
         let mut arr = self.clone();

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -120,9 +120,9 @@ impl<O: Offset> ListArray<O> {
 
     /// Sets the validity bitmap on this [`ListArray`].
     /// # Panic
-    /// This function panics iff `validity.len() < self.len()`.
+    /// This function panics iff `validity.len() != self.len()`.
     pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
             panic!("validity should be as least as large as the array")
         }
         let mut arr = self.clone();

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     bitmap::Bitmap,
     buffer::Buffer,
     datatypes::{DataType, Field},
+    error::{ArrowError, Result},
 };
 
 use super::{
@@ -173,6 +174,16 @@ impl<O: Offset> Array for ListArray<O> {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            return Err(ArrowError::InvalidArgumentError(
+                "validity should be as least as large as the array".into(),
+            ));
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        Ok(Box::new(arr))
     }
 }
 

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -90,7 +90,9 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array>;
 
     /// Sets the validity bitmap on this [`Array`].
-    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>>;
+    /// # Panic
+    /// This function panics iff `validity.len() < self.len()`.
+    fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array>;
 }
 
 /// A trait describing a mutable array; i.e. an array whose values can be changed.

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -88,6 +88,9 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     /// # Panic
     /// This function panics iff `offset + length >= self.len()`.
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array>;
+
+    /// Sets the validity bitmap on this [`Array`].
+    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>>;
 }
 
 /// A trait describing a mutable array; i.e. an array whose values can be changed.

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -1,4 +1,8 @@
-use crate::{bitmap::Bitmap, datatypes::DataType};
+use crate::{
+    bitmap::Bitmap,
+    datatypes::DataType,
+    error::{ArrowError, Result},
+};
 
 use super::{ffi::ToFfi, Array};
 
@@ -62,6 +66,11 @@ impl Array for NullArray {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    fn with_validity(&self, _: Option<Bitmap>) -> Result<Box<dyn Array>> {
+        Err(ArrowError::Other(
+            "cannot set validity of a null array".into(),
+        ))
     }
 }
 

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -1,8 +1,4 @@
-use crate::{
-    bitmap::Bitmap,
-    datatypes::DataType,
-    error::{ArrowError, Result},
-};
+use crate::{bitmap::Bitmap, datatypes::DataType};
 
 use super::{ffi::ToFfi, Array};
 
@@ -67,10 +63,8 @@ impl Array for NullArray {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
-    fn with_validity(&self, _: Option<Bitmap>) -> Result<Box<dyn Array>> {
-        Err(ArrowError::Other(
-            "cannot set validity of a null array".into(),
-        ))
+    fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {
+        panic!("cannot set validity of a null array")
     }
 }
 

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -96,9 +96,9 @@ impl<T: NativeType> PrimitiveArray<T> {
 
     /// Sets the validity bitmap on this [`PrimitiveArray`].
     /// # Panic
-    /// This function panics iff `validity.len() < self.len()`.
+    /// This function panics iff `validity.len() != self.len()`.
     pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
             panic!("validity should be as least as large as the array")
         }
         let mut arr = self.clone();

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     bitmap::Bitmap,
     buffer::Buffer,
     datatypes::*,
-    error::ArrowError,
+    error::{ArrowError, Result},
     types::{days_ms, months_days_ns, NativeType},
 };
 
@@ -161,6 +161,16 @@ impl<T: NativeType> Array for PrimitiveArray<T> {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            return Err(ArrowError::InvalidArgumentError(
+                "validity should be as least as large as the array".into(),
+            ));
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        Ok(Box::new(arr))
     }
 }
 

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, Field},
-    error::Result,
+    error::{ArrowError, Result},
     ffi,
 };
 
@@ -162,6 +162,16 @@ impl Array for StructArray {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            return Err(ArrowError::InvalidArgumentError(
+                "validity should be as least as large as the array".into(),
+            ));
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        Ok(Box::new(arr))
     }
 }
 

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, Field},
-    error::{ArrowError, Result},
+    error::Result,
     ffi,
 };
 
@@ -117,6 +117,18 @@ impl StructArray {
         }
     }
 
+    /// Sets the validity bitmap on this [`StructArray`].
+    /// # Panic
+    /// This function panics iff `validity.len() < self.len()`.
+    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            panic!("validity should be as least as large as the array")
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        arr
+    }
+
     /// Returns the values of this [`StructArray`].
     pub fn values(&self) -> &[Arc<dyn Array>] {
         &self.values
@@ -163,15 +175,8 @@ impl Array for StructArray {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
-    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
-            return Err(ArrowError::InvalidArgumentError(
-                "validity should be as least as large as the array".into(),
-            ));
-        }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        Ok(Box::new(arr))
+    fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
+        Box::new(self.with_validity(validity))
     }
 }
 

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -119,9 +119,9 @@ impl StructArray {
 
     /// Sets the validity bitmap on this [`StructArray`].
     /// # Panic
-    /// This function panics iff `validity.len() < self.len()`.
+    /// This function panics iff `validity.len() != self.len()`.
     pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
             panic!("validity should be as least as large as the array")
         }
         let mut arr = self.clone();

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     bitmap::Bitmap,
     buffer::Buffer,
     datatypes::{DataType, Field},
+    error::{ArrowError, Result},
     scalar::{new_scalar, Scalar},
 };
 
@@ -211,6 +212,11 @@ impl Array for UnionArray {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    fn with_validity(&self, _: Option<Bitmap>) -> Result<Box<dyn Array>> {
+        Err(ArrowError::Other(
+            "cannot set validity of a union array".into(),
+        ))
     }
 }
 

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -5,7 +5,6 @@ use crate::{
     bitmap::Bitmap,
     buffer::Buffer,
     datatypes::{DataType, Field},
-    error::{ArrowError, Result},
     scalar::{new_scalar, Scalar},
 };
 
@@ -213,10 +212,8 @@ impl Array for UnionArray {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
-    fn with_validity(&self, _: Option<Bitmap>) -> Result<Box<dyn Array>> {
-        Err(ArrowError::Other(
-            "cannot set validity of a union array".into(),
-        ))
+    fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {
+        panic!("cannot set validity of a union array")
     }
 }
 

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -152,9 +152,9 @@ impl<O: Offset> Utf8Array<O> {
 
     /// Sets the validity bitmap on this [`Utf8Array`].
     /// # Panic
-    /// This function panics iff `validity.len() < self.len()`.
+    /// This function panics iff `validity.len() != self.len()`.
     pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
             panic!("validity should be as least as large as the array")
         }
         let mut arr = self.clone();

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -1,4 +1,9 @@
-use crate::{bitmap::Bitmap, buffer::Buffer, datatypes::DataType};
+use crate::{
+    bitmap::Bitmap,
+    buffer::Buffer,
+    datatypes::DataType,
+    error::{ArrowError, Result},
+};
 
 use super::{
     display_fmt,
@@ -198,6 +203,16 @@ impl<O: Offset> Array for Utf8Array<O> {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            return Err(ArrowError::InvalidArgumentError(
+                "validity should be as least as large as the array".into(),
+            ));
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        Ok(Box::new(arr))
     }
 }
 

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -1,9 +1,4 @@
-use crate::{
-    bitmap::Bitmap,
-    buffer::Buffer,
-    datatypes::DataType,
-    error::{ArrowError, Result},
-};
+use crate::{bitmap::Bitmap, buffer::Buffer, datatypes::DataType};
 
 use super::{
     display_fmt,
@@ -155,6 +150,18 @@ impl<O: Offset> Utf8Array<O> {
         }
     }
 
+    /// Sets the validity bitmap on this [`Utf8Array`].
+    /// # Panic
+    /// This function panics iff `validity.len() < self.len()`.
+    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
+            panic!("validity should be as least as large as the array")
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        arr
+    }
+
     /// Returns the element at index `i` as &str
     pub fn value(&self, i: usize) -> &str {
         let offsets = self.offsets.as_slice();
@@ -204,15 +211,8 @@ impl<O: Offset> Array for Utf8Array<O> {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
-    fn with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>> {
-        if matches!(&validity, Some(bitmap) if bitmap.len() < self.len()) {
-            return Err(ArrowError::InvalidArgumentError(
-                "validity should be as least as large as the array".into(),
-            ));
-        }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        Ok(Box::new(arr))
+    fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
+        Box::new(self.with_validity(validity))
     }
 }
 

--- a/tests/it/array/mod.rs
+++ b/tests/it/array/mod.rs
@@ -75,7 +75,7 @@ fn test_clone() {
 fn test_with_validity() {
     let arr = PrimitiveArray::from_slice(&[1i32, 2, 3]);
     let validity = Bitmap::from(&[true, false, true]);
-    let arr = arr.with_validity(Some(validity)).unwrap();
+    let arr = arr.with_validity(Some(validity));
     let arr_ref = arr.as_any().downcast_ref::<PrimitiveArray<i32>>().unwrap();
 
     let expected = PrimitiveArray::from(&[Some(1i32), None, Some(3)]);


### PR DESCRIPTION
This adds `with_validity(&self, validity: Option<Bitmap>) -> Result<Box<dyn Array>>` to the `dyn Array` trait. This allows creating a new array with the new validity without downcasting. 