### PR TITLE
Improve `comparison` docs and re-export the array-comparing function

### DIFF
--- a/src/compute/comparison/binary.rs
+++ b/src/compute/comparison/binary.rs
@@ -121,6 +121,13 @@ fn gt_eq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a >= b)
 }
 
+/// Compare two [`BinaryArray`]s using the given [`Operator`].
+///
+/// # Errors
+/// When the two arrays have different lengths.
+///
+/// Check the [crate::compute::comparison](module documentation) for usage
+/// examples.
 pub fn compare<O: Offset>(
     lhs: &BinaryArray<O>,
     rhs: &BinaryArray<O>,
@@ -136,6 +143,11 @@ pub fn compare<O: Offset>(
     }
 }
 
+/// Compare a [`BinaryArray`] and a scalar value using the given
+/// [`Operator`].
+///
+/// Check the [crate::compute::comparison](module documentation) for usage
+/// examples.
 pub fn compare_scalar<O: Offset>(
     lhs: &BinaryArray<O>,
     rhs: &BinaryScalar<O>,

--- a/src/compute/comparison/boolean.rs
+++ b/src/compute/comparison/boolean.rs
@@ -140,6 +140,13 @@ pub fn gt_eq_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a | !b)
 }
 
+/// Compare two [`BooleanArray`]s using the given [`Operator`].
+///
+/// # Errors
+/// When the two arrays have different lengths.
+///
+/// Check the [crate::compute::comparison](module documentation) for usage
+/// examples.
 pub fn compare(lhs: &BooleanArray, rhs: &BooleanArray, op: Operator) -> Result<BooleanArray> {
     match op {
         Operator::Eq => eq(lhs, rhs),
@@ -151,6 +158,11 @@ pub fn compare(lhs: &BooleanArray, rhs: &BooleanArray, op: Operator) -> Result<B
     }
 }
 
+/// Compare a [`BooleanArray`] and a scalar value using the given
+/// [`Operator`].
+///
+/// Check the [crate::compute::comparison](module documentation) for usage
+/// examples.
 pub fn compare_scalar(lhs: &BooleanArray, rhs: &BooleanScalar, op: Operator) -> BooleanArray {
     if !rhs.is_valid() {
         return BooleanArray::new_null(DataType::Boolean, lhs.len());

--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -67,11 +67,12 @@
 //! ```
 //! use arrow2::compute::comparison::{utf8_compare_scalar, Operator};
 //! # use arrow2::array::{Array, BooleanArray, Utf8Array};
+//! # use arrow2::scalar::Utf8Scalar;
 //! # use arrow2::error::{ArrowError, Result};
 //!
 //! let array = Utf8Array::<i32>::from([Some("compute"), None, Some("compare")]);
-//! let word = "compare";
-//! let result = utf8_compare_scalar(&array, word, Operator::Neq);
+//! let word = Utf8Scalar::new(Some("compare"));
+//! let result = utf8_compare_scalar(&array, &word, Operator::Neq);
 //! assert_eq!(result, BooleanArray::from([Some(true), None, Some(false)]));
 //! # Ok::<(), ArrowError>(())
 //! ```

--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -90,14 +90,14 @@ mod simd;
 pub use simd::{Simd8, Simd8Lanes};
 
 pub use binary::compare as binary_compare;
-pub use binary::compare_scalar_non_null as binary_compare_scalar;
+pub use binary::compare_scalar as binary_compare_scalar;
 pub use boolean::compare as boolean_compare;
-pub use boolean::compare_scalar_non_null as boolean_compare_scalar;
+pub use boolean::compare_scalar as boolean_compare_scalar;
 pub use primitive::compare as primitive_compare;
-pub use primitive::compare_scalar_non_null as primitive_compare_scalar;
+pub use primitive::compare_scalar as primitive_compare_scalar;
 pub(crate) use primitive::compare_values_op as primitive_compare_values_op;
 pub use utf8::compare as utf8_compare;
-pub use utf8::compare_scalar_non_null as utf8_compare_scalar;
+pub use utf8::compare_scalar as utf8_compare_scalar;
 
 /// Comparison operators, such as `>` ([`Operator::Gt`])
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/compute/comparison/primitive.rs
+++ b/src/compute/comparison/primitive.rs
@@ -213,6 +213,13 @@ where
     compare_op_scalar(lhs, rhs, |a, b| a.gt_eq(b))
 }
 
+/// Compare two [`PrimitiveArray`]s using the given [`Operator`].
+///
+/// # Errors
+/// When the two arrays have different lengths.
+///
+/// Check the [crate::compute::comparison](module documentation) for usage
+/// examples.
 pub fn compare<T: NativeType + Simd8>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<T>,
@@ -228,6 +235,11 @@ pub fn compare<T: NativeType + Simd8>(
     }
 }
 
+/// Compare a [`PrimitiveArray`] and a scalar value using the given
+/// [`Operator`].
+///
+/// Check the [crate::compute::comparison](module documentation) for usage
+/// examples.
 pub fn compare_scalar<T: NativeType + Simd8>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveScalar<T>,

--- a/src/compute/comparison/utf8.rs
+++ b/src/compute/comparison/utf8.rs
@@ -121,6 +121,13 @@ fn gt_eq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a >= b)
 }
 
+/// Compare two [`Utf8Array`]s using the given [`Operator`].
+///
+/// # Errors
+/// When the two arrays have different lengths.
+///
+/// Check the [crate::compute::comparison](module documentation) for usage
+/// examples.
 pub fn compare<O: Offset>(
     lhs: &Utf8Array<O>,
     rhs: &Utf8Array<O>,
@@ -136,6 +143,11 @@ pub fn compare<O: Offset>(
     }
 }
 
+/// Compare a [`Utf8Array`] and a scalar value using the given
+/// [`Operator`].
+///
+/// Check the [crate::compute::comparison](module documentation) for usage
+/// examples.
 pub fn compare_scalar<O: Offset>(
     lhs: &Utf8Array<O>,
     rhs: &Utf8Scalar<O>,


### PR DESCRIPTION
Closes #349.

This PR slightly improves the `compute::comparison` module:

1. It adds extensive top-level documentation with examples and doc-tests.
2. It adds or expands the documentation of the main comparison functions.
3. It re-exports the array-comparing functions in the statically-typed case.

One *breaking* change which I kept in a separate commit and I'm not quite sure about is to change the scalar-oriented comparison functions from using the `_non_null` variants to the standard variants, the ones which check whether the `rhs` is valid first. If this is unwanted for some reason I'll happily revert it back.