### PR TITLE
Split `io_csv` feature into `read_csv` and `write_csv`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = []
 full = [
-    "io_csv",
+    "read_csv",
+    "write_csv",
     "io_json",
     "io_ipc",
     "io_ipc_compression",
@@ -94,7 +95,8 @@ full = [
     "chrono-tz",
 ]
 merge_sort = ["itertools"]
-io_csv = ["csv", "lazy_static", "regex", "lexical-core", "streaming-iterator"]
+read_csv = ["csv", "lexical-core", "regex", "lazy_static"]
+write_csv = ["csv", "lexical-core", "streaming-iterator"]
 io_json = ["serde", "serde_json", "indexmap"]
 io_ipc = ["flatbuffers"]
 io_ipc_compression = ["lz4", "zstd"]

--- a/guide/src/README.md
+++ b/guide/src/README.md
@@ -19,7 +19,8 @@ functionality, such as:
 
 * `io_ipc`: to interact with the IPC format
 * `io_ipc_compression`: to read and write compressed IPC (v2)
-* `io_csv` to read and write CSV
+* `read_csv` to read CSV
+* `write_csv` to write CSV
 * `io_json` to read and write JSON
 * `io_parquet` to read and write parquet
 * `io_parquet_compression` to read and write compressed parquet

--- a/guide/src/io/README.md
+++ b/guide/src/io/README.md
@@ -3,7 +3,7 @@
 This crate offers optional features that enable interoperability with different formats:
 
 * Arrow (`io_ipc`)
-* CSV (`io_csv`)
+* CSV (`read_csv` and `write_csv`)
 * Parquet (`io_parquet`)
 * Json (`io_json`)
 

--- a/guide/src/io/csv_reader.md
+++ b/guide/src/io/csv_reader.md
@@ -1,6 +1,6 @@
 # CSV reader
 
-When compiled with feature `io_csv`, you can use this crate to read CSV files.
+When compiled with feature `read_csv`, you can use this crate to read CSV files.
 This crate makes minimal assumptions on how you want to read a CSV, and offers a large degree of customization to it, along with a useful default.
 
 ## Background

--- a/guide/src/io/csv_write.md
+++ b/guide/src/io/csv_write.md
@@ -1,6 +1,6 @@
 # Write CSV
 
-When compiled with feature `io_csv`, you can use this crate to write CSV files.
+When compiled with feature `write_csv`, you can use this crate to write CSV files.
 
 This crate relies on [the crate csv](https://crates.io/crates/csv) to write well-formed CSV files, which your code should also depend on.
 

--- a/src/io/csv/mod.rs
+++ b/src/io/csv/mod.rs
@@ -16,5 +16,8 @@ impl From<chrono::ParseError> for ArrowError {
     }
 }
 
+#[cfg(feature = "read_csv")]
 pub mod read;
+
+#[cfg(feature = "write_csv")]
 pub mod write;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,6 +1,6 @@
 //! Interact with different formats such as Arrow, CSV, parquet, etc.
-#[cfg(feature = "io_csv")]
-#[cfg_attr(docsrs, doc(cfg(feature = "io_csv")))]
+#[cfg(any(feature = "read_csv", feature = "write_csv"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "read_csv", feature = "write_csv"))))]
 pub mod csv;
 
 #[cfg(feature = "io_json")]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,8 +1,8 @@
 //! Misc utilities used in different places in the crate.
 
-#[cfg(any(feature = "compute", feature = "io_csv"))]
+#[cfg(any(feature = "compute", feature = "read_csv", feature = "write_csv"))]
 mod lexical;
-#[cfg(any(feature = "compute", feature = "io_csv"))]
+#[cfg(any(feature = "compute", feature = "read_csv", feature = "write_csv"))]
 pub use lexical::*;
 
 #[cfg(feature = "benchmarks")]

--- a/tests/it/io/mod.rs
+++ b/tests/it/io/mod.rs
@@ -10,5 +10,5 @@ mod ipc;
 #[cfg(feature = "io_parquet")]
 mod parquet;
 
-#[cfg(feature = "io_csv")]
+#[cfg(any(feature = "read_csv", feature = "write_csv"))]
 mod csv;


### PR DESCRIPTION
Closes #405

I completely replaced `io_csv` with `read_csv` and `write_csv`, didn't know if we wanted an umbrella `io_csv` feature that encapsulates the other two.
