### PR TITLE
Added `io_csv_read` and `io_csv_write` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,9 @@ full = [
     "chrono-tz",
 ]
 merge_sort = ["itertools"]
-io_csv = ["csv", "lazy_static", "regex", "lexical-core", "streaming-iterator"]
+io_csv = ["io_csv_read", "io_csv_write"]
+io_csv_read = ["csv", "lazy_static", "regex", "lexical-core"]
+io_csv_write = ["csv", "streaming-iterator", "lexical-core"]
 io_json = ["serde", "serde_json", "indexmap"]
 io_ipc = ["flatbuffers"]
 io_ipc_compression = ["lz4", "zstd"]

--- a/src/io/csv/mod.rs
+++ b/src/io/csv/mod.rs
@@ -17,6 +17,7 @@ impl From<chrono::ParseError> for ArrowError {
 }
 
 #[cfg(feature = "io_csv_read")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io_csv_read")))]
 pub mod read;
 #[cfg(feature = "io_csv_write")]
 #[cfg_attr(docsrs, doc(cfg(feature = "io_csv_write")))]

--- a/src/io/csv/mod.rs
+++ b/src/io/csv/mod.rs
@@ -16,5 +16,7 @@ impl From<chrono::ParseError> for ArrowError {
     }
 }
 
+#[cfg(feature = "io_csv_read")]
 pub mod read;
+#[cfg(feature = "io_csv_write")]
 pub mod write;

--- a/src/io/csv/mod.rs
+++ b/src/io/csv/mod.rs
@@ -19,4 +19,5 @@ impl From<chrono::ParseError> for ArrowError {
 #[cfg(feature = "io_csv_read")]
 pub mod read;
 #[cfg(feature = "io_csv_write")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io_csv_write")))]
 pub mod write;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,5 +1,5 @@
 //! Interact with different formats such as Arrow, CSV, parquet, etc.
-#[cfg(feature = "io_csv")]
+#[cfg(any(feature = "io_csv_read", feature = "io_csv_write"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "io_csv")))]
 pub mod csv;
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,8 +1,8 @@
 //! Misc utilities used in different places in the crate.
 
-#[cfg(any(feature = "compute", feature = "io_csv"))]
+#[cfg(any(feature = "compute", feature = "io_csv_write", feature = "io_csv_read"))]
 mod lexical;
-#[cfg(any(feature = "compute", feature = "io_csv"))]
+#[cfg(any(feature = "compute", feature = "io_csv_write", feature = "io_csv_read"))]
 pub use lexical::*;
 
 #[cfg(feature = "benchmarks")]


### PR DESCRIPTION
This feature gates `io_csv` into `io_csv_read` and `io_csv_write` in a backwards compatible manner.

`io_csv = ["io_csv_read", "io_csv_write"]`

closes #407 