### PR TITLE
Added support to add an interval to a timestamp

### DIFF
--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -5,7 +5,6 @@ use crate::{
     bitmap::Bitmap,
     compute::arity::unary,
     datatypes::{DataType, TimeUnit},
-    error::ArrowError,
     temporal_conversions::*,
     types::NativeType,
 };
@@ -329,17 +328,10 @@ fn chrono_tz_timestamp_to_utf8<O: Offset>(
     time_unit: TimeUnit,
     timezone_str: &str,
 ) -> Result<Utf8Array<O>> {
-    let timezone = parse_offset_tz(timezone_str);
-    if let Some(timezone) = timezone {
-        Ok(timestamp_to_utf8_impl::<O, chrono_tz::Tz>(
-            from, time_unit, timezone,
-        ))
-    } else {
-        Err(ArrowError::InvalidArgumentError(format!(
-            "timezone \"{}\" cannot be parsed",
-            timezone_str
-        )))
-    }
+    let timezone = parse_offset_tz(timezone_str)?;
+    Ok(timestamp_to_utf8_impl::<O, chrono_tz::Tz>(
+        from, time_unit, timezone,
+    ))
 }
 
 #[cfg(not(feature = "chrono-tz"))]
@@ -348,6 +340,7 @@ fn chrono_tz_timestamp_to_utf8<O: Offset>(
     _: TimeUnit,
     timezone_str: &str,
 ) -> Result<Utf8Array<O>> {
+    use crate::error::ArrowError;
     Err(ArrowError::InvalidArgumentError(format!(
         "timezone \"{}\" cannot be parsed (feature chrono-tz is not active)",
         timezone_str

--- a/src/compute/temporal.rs
+++ b/src/compute/temporal.rs
@@ -82,15 +82,8 @@ fn chrono_tz_hour(
     time_unit: TimeUnit,
     timezone_str: &str,
 ) -> Result<PrimitiveArray<u32>> {
-    let timezone = parse_offset_tz(timezone_str);
-    if let Some(timezone) = timezone {
-        Ok(extract_impl(array, time_unit, timezone, |x| x.hour()))
-    } else {
-        Err(ArrowError::InvalidArgumentError(format!(
-            "timezone \"{}\" cannot be parsed",
-            timezone_str
-        )))
-    }
+    let timezone = parse_offset_tz(timezone_str)?;
+    Ok(extract_impl(array, time_unit, timezone, |x| x.hour()))
 }
 
 #[cfg(not(feature = "chrono-tz"))]
@@ -112,15 +105,8 @@ fn chrono_tz_year(
     time_unit: TimeUnit,
     timezone_str: &str,
 ) -> Result<PrimitiveArray<i32>> {
-    let timezone = parse_offset_tz(timezone_str);
-    if let Some(timezone) = timezone {
-        Ok(extract_impl(array, time_unit, timezone, |x| x.year()))
-    } else {
-        Err(ArrowError::InvalidArgumentError(format!(
-            "timezone \"{}\" cannot be parsed",
-            timezone_str
-        )))
-    }
+    let timezone = parse_offset_tz(timezone_str)?;
+    Ok(extract_impl(array, time_unit, timezone, |x| x.year()))
 }
 
 #[cfg(not(feature = "chrono-tz"))]


### PR DESCRIPTION
This adds support for adding an interval to a timestamp with timezone, thus taking leap days (Feb 29th) and leap hours (daylight saving) into account.

This brings the last missing piece to fully support timestamps with timezones: we can now convert them from and to strings, and perform basic interval arithmetic taking the timezone into account.

3 examples:

* adding 1 hour to `2020-03-29 00:00:00 WET` results in `2020-03-29 02:00:00 WEST`
* adding 7 months and 1 hour to `2020-03-29 00:00:00 WET` results in `2020-10-29 01:00:00 WET`

the former crosses one summer time shift (and thus adds an extra hour), the latter crosses both (and thus adds no extra hour).

* adding 1d,1h,1m to `1972-02-28 01:00:00 +01:00` results in `1972-02-29 02:01:00 +01:00`

because 1972 has a leap year.

When the timestamp has no timezone information, days are `24 * 60 * 60`.

Closes #23