### PR TITLE
Added reading of parquet required dictionary-encoded binary.

### DIFF
--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -143,6 +143,16 @@ fn v1_utf8_nullable_dict() -> Result<()> {
 }
 
 #[test]
+fn v2_utf8_required_dict() -> Result<()> {
+    test_pyarrow_integration(2, 2, "basic", true, true)
+}
+
+#[test]
+fn v1_utf8_required_dict() -> Result<()> {
+    test_pyarrow_integration(2, 1, "basic", true, true)
+}
+
+#[test]
 fn v2_boolean_nullable() -> Result<()> {
     test_pyarrow_integration(3, 2, "basic", false, false)
 }


### PR DESCRIPTION
Closes #418.

Thanks @Dandandan for flagging this!