### PR TITLE
Bumped parquet2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ futures = { version = "0.3", optional = true }
 # for faster hashing
 ahash = { version = "0.7", optional = true }
 
-parquet2 = { version = "0.4", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { version = "0.5", optional = true, default_features = false, features = ["stream"] }
 
 avro-rs = { version = "0.13", optional = true, default_features = false }
 


### PR DESCRIPTION
Migration: rename `Compression::Zsld` to `Compression::Zstd`.