### PR TITLE
Improved performance of iterator of `Utf8Array` and `BinaryArray` (3-4x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,3 +226,7 @@ harness = false
 [[bench]]
 name = "hash_kernel"
 harness = false
+
+[[bench]]
+name = "iter_utf8"
+harness = false

--- a/benches/iter_utf8.rs
+++ b/benches/iter_utf8.rs
@@ -1,0 +1,34 @@
+use arrow2::array::Utf8Array;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+
+        let array = Utf8Array::<i32>::from_trusted_len_values_iter(
+            std::iter::repeat("aaa")
+                .take(size / 2)
+                .chain(std::iter::repeat("bbb").take(size / 2)),
+        );
+
+        c.bench_function(&format!("iter_values 2^{}", log2_size), |b| {
+            b.iter(|| {
+                for x in array.values_iter() {
+                    assert_eq!(x.len(), 3);
+                }
+            })
+        });
+
+        c.bench_function(&format!("iter 2^{}", log2_size), |b| {
+            b.iter(|| {
+                for x in array.iter() {
+                    assert_eq!(x.unwrap().len(), 3);
+                }
+            })
+        });
+    })
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -53,8 +53,7 @@ unsafe impl Offset for i64 {
     }
 }
 
-#[inline]
-pub fn check_offsets<O: Offset>(offsets: &[O], values_len: usize) -> usize {
+pub fn check_offsets_minimal<O: Offset>(offsets: &[O], values_len: usize) -> usize {
     assert!(
         !offsets.is_empty(),
         "The length of the offset buffer must be larger than 1"
@@ -71,15 +70,33 @@ pub fn check_offsets<O: Offset>(offsets: &[O], values_len: usize) -> usize {
     len
 }
 
-#[inline]
-pub fn check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) -> usize {
-    let len = check_offsets(offsets, values.len());
+/// # Panics iff:
+/// * the `offsets` is not monotonically increasing, or
+/// * any slice of `values` between two consecutive pairs from `offsets` is invalid `utf8`, or
+/// * any offset is larger or equal to `values_len`.
+pub fn check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) {
     offsets.windows(2).for_each(|window| {
         let start = window[0].to_usize();
         let end = window[1].to_usize();
-        assert!(end <= values.len());
-        let slice = unsafe { std::slice::from_raw_parts(values.as_ptr().add(start), end - start) };
+        // assert monotonicity
+        assert!(start <= end);
+        // assert bounds
+        let slice = &values[start..end];
+        // assert utf8
         simdutf8::basic::from_utf8(slice).expect("A non-utf8 string was passed.");
     });
-    len
+}
+
+/// # Panics iff:
+/// * the `offsets` is not monotonically increasing, or
+/// * any offset is larger or equal to `values_len`.
+pub fn check_offsets<O: Offset>(offsets: &[O], values_len: usize) {
+    offsets.windows(2).for_each(|window| {
+        let start = window[0].to_usize();
+        let end = window[1].to_usize();
+        // assert monotonicity
+        assert!(start <= end);
+        // assert bound
+        assert!(end <= values_len);
+    });
 }

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -2,7 +2,7 @@ use std::{iter::FromIterator, sync::Arc};
 
 use crate::{
     array::{
-        specification::{check_offsets, check_offsets_and_utf8},
+        specification::{check_offsets_and_utf8, check_offsets_minimal},
         Array, MutableArray, Offset, TryExtend, TryPush,
     },
     bitmap::MutableBitmap,
@@ -93,7 +93,7 @@ impl<O: Offset> MutableUtf8Array<O> {
         values: MutableBuffer<u8>,
         validity: Option<MutableBitmap>,
     ) -> Self {
-        check_offsets(&offsets, values.len());
+        check_offsets_minimal(&offsets, values.len());
         if let Some(ref validity) = validity {
             assert_eq!(offsets.len() - 1, validity.len());
         }
@@ -267,7 +267,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// Extends [`MutableUtf8Array`] from an iterator of trusted len.
-    /// #Safety
+    /// # Safety
     /// The iterator must be trusted len.
     #[inline]
     pub unsafe fn extend_trusted_len_unchecked<I, P>(&mut self, iterator: I)


### PR DESCRIPTION
```
iter_values 2^20        time:   [1.6717 ms 1.6744 ms 1.6774 ms]                              
                        change: [-75.148% -75.071% -74.997%] (p = 0.00 < 0.05)
iter 2^20               time:   [2.2270 ms 2.2301 ms 2.2336 ms]                       
                        change: [-66.754% -66.678% -66.604%] (p = 0.00 < 0.05)
```

This has implications on almost every kernel over these arrays, as well as users of the iterator.