### PR TITLE
Changed validity from `&Option<Bitmap>` to `Option<&Bitmap>`.

### DIFF
--- a/guide/src/high_level.md
+++ b/guide/src/high_level.md
@@ -209,7 +209,7 @@ Like `FromIterator`, this crate contains two sets of APIs to iterate over data. 
 an array `array: &PrimitiveArray<T>`, the following applies:
 
 1. If you need to iterate over `Option<&T>`, use `array.iter()`
-2. If you can operate over the values and validity independently, use `array.values() -> &Buffer<T>` and `array.validity() -> &Option<Bitmap>`
+2. If you can operate over the values and validity independently, use `array.values() -> &Buffer<T>` and `array.validity() -> Option<&Bitmap>`
 
 Note that case 1 is useful when e.g. you want to perform an operation that depends on both validity and values, while the latter is suitable for SIMD and copies, as they return contiguous memory regions (buffers and bitmaps). We will see below how to leverage these APIs.
 
@@ -241,7 +241,7 @@ where
     let values = array.values().iter().map(|v| op(*v));
     let values = Buffer::from_trusted_len_iter(values);
 
-    PrimitiveArray::<O>::from_data(data_type.clone(), values, array.validity().clone())
+    PrimitiveArray::<O>::from_data(data_type.clone(), values, array.validity().cloned())
 }
 ```
 

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -168,8 +168,8 @@ impl<O: Offset> Array for BinaryArray<O> {
         &self.data_type
     }
 
-    fn validity(&self) -> &Option<Bitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
     }
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {

--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -142,8 +142,8 @@ impl<O: Offset> MutableArray for MutableBinaryArray<O> {
         self.offsets.len() - 1
     }
 
-    fn validity(&self) -> &Option<MutableBitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&MutableBitmap> {
+        self.validity.as_ref()
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -122,8 +122,8 @@ impl Array for BooleanArray {
     }
 
     #[inline]
-    fn validity(&self) -> &Option<Bitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
     }
 
     #[inline]

--- a/src/array/boolean/mutable.rs
+++ b/src/array/boolean/mutable.rs
@@ -334,8 +334,8 @@ impl MutableArray for MutableBooleanArray {
         self.values.len()
     }
 
-    fn validity(&self) -> &Option<MutableBitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&MutableBitmap> {
+        self.validity.as_ref()
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -142,7 +142,7 @@ impl<K: DictionaryKey> Array for DictionaryArray<K> {
         &self.data_type
     }
 
-    fn validity(&self) -> &Option<Bitmap> {
+    fn validity(&self) -> Option<&Bitmap> {
         self.keys.validity()
     }
 

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -111,7 +111,7 @@ impl<K: DictionaryKey, M: 'static + MutableArray> MutableArray for MutableDictio
         self.keys.len()
     }
 
-    fn validity(&self) -> &Option<MutableBitmap> {
+    fn validity(&self) -> Option<&MutableBitmap> {
         self.keys.validity()
     }
 

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -132,8 +132,8 @@ impl Array for FixedSizeBinaryArray {
         &self.data_type
     }
 
-    fn validity(&self) -> &Option<Bitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
     }
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {

--- a/src/array/fixed_size_binary/mutable.rs
+++ b/src/array/fixed_size_binary/mutable.rs
@@ -169,8 +169,8 @@ impl MutableArray for MutableFixedSizeBinaryArray {
         self.values.len() / self.size
     }
 
-    fn validity(&self) -> &Option<MutableBitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&MutableBitmap> {
+        self.validity.as_ref()
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -136,8 +136,8 @@ impl Array for FixedSizeListArray {
         &self.data_type
     }
 
-    fn validity(&self) -> &Option<Bitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
     }
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -65,8 +65,8 @@ impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
         self.values.len() / self.size
     }
 
-    fn validity(&self) -> &Option<MutableBitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&MutableBitmap> {
+        self.validity.as_ref()
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -179,8 +179,8 @@ impl<O: Offset> Array for ListArray<O> {
     }
 
     #[inline]
-    fn validity(&self) -> &Option<Bitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
     }
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -173,8 +173,8 @@ impl<O: Offset, M: MutableArray + 'static> MutableArray for MutableListArray<O, 
         self.offsets.len() - 1
     }
 
-    fn validity(&self) -> &Option<MutableBitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&MutableBitmap> {
+        self.validity.as_ref()
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -45,7 +45,7 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     /// The validity of the [`Array`]: every array has an optional [`Bitmap`] that, when available
     /// specifies whether the array slot is valid or not (null).
     /// When the validity is [`None`], all slots are valid.
-    fn validity(&self) -> &Option<Bitmap>;
+    fn validity(&self) -> Option<&Bitmap>;
 
     /// The number of null slots on this [`Array`].
     /// # Implementation
@@ -111,7 +111,7 @@ pub trait MutableArray: std::fmt::Debug {
     }
 
     /// The optional validity of the array.
-    fn validity(&self) -> &Option<MutableBitmap>;
+    fn validity(&self) -> Option<&MutableBitmap>;
 
     /// Convert itself to an (immutable) [`Array`].
     fn as_arc(&mut self) -> Arc<dyn Array>;

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -56,8 +56,8 @@ impl Array for NullArray {
         &DataType::Null
     }
 
-    fn validity(&self) -> &Option<Bitmap> {
-        &None
+    fn validity(&self) -> Option<&Bitmap> {
+        None
     }
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -27,7 +27,7 @@ pub use mutable::*;
 /// # fn main() {
 /// let array = PrimitiveArray::from([Some(1), None, Some(10)]);
 /// assert_eq!(array.values().as_slice(), &[1, 0, 10]);
-/// assert_eq!(array.validity(), &Some(Bitmap::from([true, false, true])));
+/// assert_eq!(array.validity(), Some(&Bitmap::from([true, false, true])));
 /// # }
 /// ```
 #[derive(Debug, Clone)]
@@ -169,8 +169,8 @@ impl<T: NativeType> Array for PrimitiveArray<T> {
         &self.data_type
     }
 
-    fn validity(&self) -> &Option<Bitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
     }
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -322,8 +322,8 @@ impl<T: NativeType> MutableArray for MutablePrimitiveArray<T> {
         self.values.len()
     }
 
-    fn validity(&self) -> &Option<MutableBitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&MutableBitmap> {
+        self.validity.as_ref()
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -168,8 +168,8 @@ impl Array for StructArray {
     }
 
     #[inline]
-    fn validity(&self) -> &Option<Bitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
     }
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -205,8 +205,8 @@ impl Array for UnionArray {
         &self.data_type
     }
 
-    fn validity(&self) -> &Option<Bitmap> {
-        &None
+    fn validity(&self) -> Option<&Bitmap> {
+        None
     }
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -218,8 +218,8 @@ impl<O: Offset> Array for Utf8Array<O> {
         &self.data_type
     }
 
-    fn validity(&self) -> &Option<Bitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
     }
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -183,8 +183,8 @@ impl<O: Offset> MutableArray for MutableUtf8Array<O> {
         self.offsets.len() - 1
     }
 
-    fn validity(&self) -> &Option<MutableBitmap> {
-        &self.validity
+    fn validity(&self) -> Option<&MutableBitmap> {
+        self.validity.as_ref()
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {

--- a/src/compute/aggregate/memory.rs
+++ b/src/compute/aggregate/memory.rs
@@ -2,7 +2,7 @@ use crate::array::*;
 use crate::bitmap::Bitmap;
 use crate::datatypes::PhysicalType;
 
-fn validity_size(validity: &Option<Bitmap>) -> usize {
+fn validity_size(validity: Option<&Bitmap>) -> usize {
     validity.as_ref().map(|b| b.as_slice().0.len()).unwrap_or(0)
 }
 

--- a/src/compute/arity.rs
+++ b/src/compute/arity.rs
@@ -29,7 +29,7 @@ where
     let values = array.values().iter().map(|v| op(*v));
     let values = Buffer::from_trusted_len_iter(values);
 
-    PrimitiveArray::<O>::from_data(data_type, values, array.validity().clone())
+    PrimitiveArray::<O>::from_data(data_type, values, array.validity().cloned())
 }
 
 /// Version of unary that checks for errors in the closure used to create the
@@ -50,7 +50,7 @@ where
     Ok(PrimitiveArray::<O>::from_data(
         data_type,
         values,
-        array.validity().clone(),
+        array.validity().cloned(),
     ))
 }
 
@@ -77,7 +77,7 @@ where
     let values = Buffer::from_trusted_len_iter(values);
 
     (
-        PrimitiveArray::<O>::from_data(data_type, values, array.validity().clone()),
+        PrimitiveArray::<O>::from_data(data_type, values, array.validity().cloned()),
         mut_bitmap.into(),
     )
 }
@@ -115,7 +115,7 @@ where
     // the iteration, then the validity is changed to None to mark the value
     // as Null
     let bitmap: Bitmap = mut_bitmap.into();
-    let validity = combine_validities(array.validity(), &Some(bitmap));
+    let validity = combine_validities(array.validity(), Some(&bitmap));
 
     PrimitiveArray::<O>::from_data(data_type, values, validity)
 }
@@ -278,7 +278,7 @@ where
     // creation of the values with the iterator. If an error was found during
     // the iteration, then the validity is changed to None to mark the value
     // as Null
-    let validity = combine_validities(&validity, &Some(bitmap));
+    let validity = combine_validities(validity.as_ref(), Some(&bitmap));
 
     Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
 }

--- a/src/compute/boolean.rs
+++ b/src/compute/boolean.rs
@@ -99,7 +99,7 @@ pub fn or(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
 /// ```
 pub fn not(array: &BooleanArray) -> BooleanArray {
     let values = !array.values();
-    let validity = array.validity().clone();
+    let validity = array.validity().cloned();
     BooleanArray::from_data(DataType::Boolean, values, validity)
 }
 

--- a/src/compute/cast/binary_to.rs
+++ b/src/compute/cast/binary_to.rs
@@ -7,7 +7,7 @@ pub fn binary_to_large_binary(from: &BinaryArray<i32>, to_data_type: DataType) -
     let values = from.values().clone();
     let offsets = from.offsets().iter().map(|x| *x as i64);
     let offsets = Buffer::from_trusted_len_iter(offsets);
-    BinaryArray::<i64>::from_data(to_data_type, offsets, values, from.validity().clone())
+    BinaryArray::<i64>::from_data(to_data_type, offsets, values, from.validity().cloned())
 }
 
 pub fn binary_large_to_binary(
@@ -24,7 +24,7 @@ pub fn binary_large_to_binary(
         to_data_type,
         offsets,
         values,
-        from.validity().clone(),
+        from.validity().cloned(),
     ))
 }
 

--- a/src/compute/cast/boolean_to.rs
+++ b/src/compute/cast/boolean_to.rs
@@ -27,7 +27,7 @@ where
         .map(|x| if x { T::one() } else { T::default() });
     let values = Buffer::<T>::from_trusted_len_iter(iter);
 
-    PrimitiveArray::<T>::from_data(T::DATA_TYPE, values, from.validity().clone())
+    PrimitiveArray::<T>::from_data(T::DATA_TYPE, values, from.validity().cloned())
 }
 
 /// Casts the [`BooleanArray`] to a [`Utf8Array`], casting trues to `"1"` and falses to `"0"`

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -294,7 +294,7 @@ fn cast_list<O: Offset>(
         to_type.clone(),
         array.offsets().clone(),
         new_values,
-        array.validity().clone(),
+        array.validity().cloned(),
     ))
 }
 
@@ -307,7 +307,7 @@ fn cast_list_to_large_list(array: &ListArray<i32>, to_type: &DataType) -> ListAr
         to_type.clone(),
         offets,
         array.values().clone(),
-        array.validity().clone(),
+        array.validity().cloned(),
     )
 }
 
@@ -320,7 +320,7 @@ fn cast_large_to_list(array: &ListArray<i64>, to_type: &DataType) -> ListArray<i
         to_type.clone(),
         offets,
         array.values().clone(),
-        array.validity().clone(),
+        array.validity().cloned(),
     )
 }
 

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -42,7 +42,7 @@ pub fn primitive_to_boolean<T: NativeType>(
     let iter = from.values().iter().map(|v| *v != T::default());
     let values = Bitmap::from_trusted_len_iter(iter);
 
-    BooleanArray::from_data(to_type, values, from.validity().clone())
+    BooleanArray::from_data(to_type, values, from.validity().cloned())
 }
 
 pub(super) fn primitive_to_boolean_dyn<T>(
@@ -131,7 +131,7 @@ where
     PrimitiveArray::<T>::from_data(
         to_type.clone(),
         from.values().clone(),
-        from.validity().clone(),
+        from.validity().cloned(),
     )
 }
 

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -126,7 +126,7 @@ pub fn utf8_to_large_utf8(from: &Utf8Array<i32>) -> Utf8Array<i64> {
     let offsets = from.offsets().iter().map(|x| *x as i64);
     let offsets = Buffer::from_trusted_len_iter(offsets);
     unsafe {
-        Utf8Array::<i64>::from_data_unchecked(data_type, offsets, values, from.validity().clone())
+        Utf8Array::<i64>::from_data_unchecked(data_type, offsets, values, from.validity().cloned())
     }
 }
 
@@ -139,6 +139,6 @@ pub fn utf8_large_to_utf8(from: &Utf8Array<i64>) -> Result<Utf8Array<i32>> {
     let offsets = from.offsets().iter().map(|x| *x as i32);
     let offsets = Buffer::from_trusted_len_iter(offsets);
     Ok(unsafe {
-        Utf8Array::<i32>::from_data_unchecked(data_type, offsets, values, from.validity().clone())
+        Utf8Array::<i32>::from_data_unchecked(data_type, offsets, values, from.validity().cloned())
     })
 }

--- a/src/compute/comparison/binary.rs
+++ b/src/compute/comparison/binary.rs
@@ -53,7 +53,7 @@ where
     O: Offset,
     F: Fn(&[u8], &[u8]) -> bool,
 {
-    let validity = lhs.validity().clone();
+    let validity = lhs.validity().cloned();
 
     let values = lhs.values_iter().map(|lhs| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);

--- a/src/compute/comparison/boolean.rs
+++ b/src/compute/comparison/boolean.rs
@@ -72,7 +72,7 @@ where
         values.push(op(lhs_remainder, rhs))
     };
     let values = MutableBitmap::from_buffer(values, lhs.len()).into();
-    BooleanArray::from_data(DataType::Boolean, values, lhs.validity().clone())
+    BooleanArray::from_data(DataType::Boolean, values, lhs.validity().cloned())
 }
 
 /// Perform `lhs == rhs` operation on two arrays.

--- a/src/compute/comparison/primitive.rs
+++ b/src/compute/comparison/primitive.rs
@@ -87,7 +87,7 @@ where
     T: NativeType + Simd8,
     F: Fn(T::Simd, T::Simd) -> u8,
 {
-    let validity = lhs.validity().clone();
+    let validity = lhs.validity().cloned();
     let rhs = T::Simd::from_chunk(&[rhs; 8]);
 
     let lhs_chunks_iter = lhs.values().chunks_exact(8);

--- a/src/compute/comparison/utf8.rs
+++ b/src/compute/comparison/utf8.rs
@@ -53,7 +53,7 @@ where
     O: Offset,
     F: Fn(&str, &str) -> bool,
 {
-    let validity = lhs.validity().clone();
+    let validity = lhs.validity().cloned();
 
     let values = lhs.values_iter().map(|lhs| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -35,7 +35,7 @@ pub fn hash_boolean(array: &BooleanArray) -> PrimitiveArray<u64> {
 
     let iter = array.values_iter().map(|x| u8::get_hash(&x, &state));
     let values = Buffer::from_trusted_len_iter(iter);
-    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().clone())
+    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().cloned())
 }
 
 #[multiversion]
@@ -48,7 +48,7 @@ pub fn hash_utf8<O: Offset>(array: &Utf8Array<O>) -> PrimitiveArray<u64> {
         .values_iter()
         .map(|x| <[u8]>::get_hash(&x.as_bytes(), &state));
     let values = Buffer::from_trusted_len_iter(iter);
-    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().clone())
+    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().cloned())
 }
 
 /// Element-wise hash of a [`BinaryArray`]. Validity is preserved.
@@ -56,7 +56,7 @@ pub fn hash_binary<O: Offset>(array: &BinaryArray<O>) -> PrimitiveArray<u64> {
     let state = new_state!();
     let iter = array.values_iter().map(|x| <[u8]>::get_hash(&x, &state));
     let values = Buffer::from_trusted_len_iter(iter);
-    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().clone())
+    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().cloned())
 }
 
 macro_rules! hash_dyn {

--- a/src/compute/length.rs
+++ b/src/compute/length.rs
@@ -42,7 +42,7 @@ where
         DataType::Int32
     };
 
-    PrimitiveArray::<O>::from_data(data_type, values, array.validity().clone())
+    PrimitiveArray::<O>::from_data(data_type, values, array.validity().cloned())
 }
 
 /// Returns an array of integers with the number of bytes on each string of the array.

--- a/src/compute/like.rs
+++ b/src/compute/like.rs
@@ -117,7 +117,7 @@ fn a_like_utf8_scalar<O: Offset, F: Fn(bool) -> bool>(
     Ok(BooleanArray::from_data(
         DataType::Boolean,
         values,
-        validity.clone(),
+        validity.cloned(),
     ))
 }
 
@@ -261,7 +261,7 @@ fn a_like_binary_scalar<O: Offset, F: Fn(bool) -> bool>(
     Ok(BooleanArray::from_data(
         DataType::Boolean,
         values,
-        validity.clone(),
+        validity.cloned(),
     ))
 }
 

--- a/src/compute/nullif.rs
+++ b/src/compute/nullif.rs
@@ -1,4 +1,5 @@
 use crate::array::PrimitiveArray;
+use crate::bitmap::Bitmap;
 use crate::compute::comparison::{primitive_compare_values_op, Simd8, Simd8Lanes};
 use crate::datatypes::DataType;
 use crate::error::{ArrowError, Result};
@@ -40,9 +41,9 @@ pub fn nullif_primitive<T: NativeType + Simd8>(
     }
 
     let equal = primitive_compare_values_op(lhs.values(), rhs.values(), |lhs, rhs| lhs.neq(rhs));
-    let equal = equal.into();
+    let equal: Option<Bitmap> = equal.into();
 
-    let validity = combine_validities(lhs.validity(), &equal);
+    let validity = combine_validities(lhs.validity(), equal.as_ref());
 
     Ok(PrimitiveArray::<T>::from_data(
         lhs.data_type().clone(),

--- a/src/compute/sort/common.rs
+++ b/src/compute/sort/common.rs
@@ -77,7 +77,7 @@ fn sort_unstable_by<I, T, G, F>(
 /// * `cmp` is only called from the co-domain of `get`.
 #[inline]
 pub(super) fn indices_sorted_unstable_by<I, T, G, F>(
-    validity: &Option<Bitmap>,
+    validity: Option<&Bitmap>,
     get: G,
     cmp: F,
     length: usize,

--- a/src/compute/substring.rs
+++ b/src/compute/substring.rs
@@ -64,7 +64,7 @@ fn utf8_substring<O: Offset>(array: &Utf8Array<O>, start: O, length: &Option<O>)
         array.data_type().clone(),
         new_offsets.into(),
         new_values.into(),
-        validity.clone(),
+        validity.cloned(),
     )
 }
 
@@ -113,7 +113,7 @@ fn binary_substring<O: Offset>(
         array.data_type().clone(),
         new_offsets.into(),
         new_values.into(),
-        validity.clone(),
+        validity.cloned(),
     )
 }
 

--- a/src/compute/take/boolean.rs
+++ b/src/compute/take/boolean.rs
@@ -37,7 +37,7 @@ fn take_values_validity<I: Index>(
 ) -> (Bitmap, Option<Bitmap>) {
     let mut validity = MutableBitmap::with_capacity(indices.len());
 
-    let validity_values = values.validity().as_ref().unwrap();
+    let validity_values = values.validity().unwrap();
 
     let values_values = values.values();
 
@@ -60,7 +60,7 @@ fn take_indices_validity<I: Index>(
     values: &Bitmap,
     indices: &PrimitiveArray<I>,
 ) -> (Bitmap, Option<Bitmap>) {
-    let validity = indices.validity().as_ref().unwrap();
+    let validity = indices.validity().unwrap();
 
     let values = indices.values().iter().enumerate().map(|(i, index)| {
         let index = index.to_usize();
@@ -78,7 +78,7 @@ fn take_indices_validity<I: Index>(
 
     let buffer = Bitmap::from_trusted_len_iter(values);
 
-    (buffer, indices.validity().clone())
+    (buffer, indices.validity().cloned())
 }
 
 // take implementation when both values and indices contain nulls
@@ -88,7 +88,7 @@ fn take_values_indices_validity<I: Index>(
 ) -> (Bitmap, Option<Bitmap>) {
     let mut validity = MutableBitmap::with_capacity(indices.len());
 
-    let values_validity = values.validity().as_ref().unwrap();
+    let values_validity = values.validity().unwrap();
 
     let values_values = values.values();
     let values = indices.iter().map(|index| match index {

--- a/src/compute/take/generic_binary.rs
+++ b/src/compute/take/generic_binary.rs
@@ -69,7 +69,7 @@ pub fn take_values_validity<O: Offset, I: Index, A: GenericBinaryArray<O>>(
     let mut length = O::default();
     let mut validity = MutableBitmap::with_capacity(indices.len());
 
-    let null_values = values.validity().as_ref().unwrap();
+    let null_values = values.validity().unwrap();
     let offsets = values.offsets();
     let values_values = values.values();
 
@@ -122,7 +122,7 @@ pub fn take_indices_validity<O: Offset, I: Index>(
 
     let buffer = take_values(length, starts.as_slice(), offsets.as_slice(), values);
 
-    (offsets, buffer, indices.validity().clone())
+    (offsets, buffer, indices.validity().cloned())
 }
 
 // take implementation when both indices and values contain nulls
@@ -133,7 +133,7 @@ pub fn take_values_indices_validity<O: Offset, I: Index, A: GenericBinaryArray<O
     let mut length = O::default();
     let mut validity = MutableBitmap::with_capacity(indices.len());
 
-    let values_validity = values.validity().as_ref().unwrap();
+    let values_validity = values.validity().unwrap();
     let offsets = values.offsets();
     let values_values = values.values();
 

--- a/src/compute/take/primitive.rs
+++ b/src/compute/take/primitive.rs
@@ -41,7 +41,7 @@ fn take_values_validity<T: NativeType, I: Index>(
 ) -> (Buffer<T>, Option<Bitmap>) {
     let mut null = MutableBitmap::with_capacity(indices.len());
 
-    let null_values = values.validity().as_ref().unwrap();
+    let null_values = values.validity().unwrap();
 
     let values_values = values.values();
 
@@ -64,7 +64,7 @@ fn take_indices_validity<T: NativeType, I: Index>(
     values: &[T],
     indices: &PrimitiveArray<I>,
 ) -> (Buffer<T>, Option<Bitmap>) {
-    let validity = indices.validity().as_ref().unwrap();
+    let validity = indices.validity().unwrap();
     let values = indices.values().iter().enumerate().map(|(i, index)| {
         let index = index.to_usize();
         match values.get(index) {
@@ -81,7 +81,7 @@ fn take_indices_validity<T: NativeType, I: Index>(
 
     let buffer = MutableBuffer::from_trusted_len_iter(values);
 
-    (buffer.into(), indices.validity().clone())
+    (buffer.into(), indices.validity().cloned())
 }
 
 // take implementation when both values and indices contain nulls
@@ -91,7 +91,7 @@ fn take_values_indices_validity<T: NativeType, I: Index>(
 ) -> (Buffer<T>, Option<Bitmap>) {
     let mut bitmap = MutableBitmap::with_capacity(indices.len());
 
-    let values_validity = values.validity().as_ref().unwrap();
+    let values_validity = values.validity().unwrap();
 
     let values_values = values.values();
     let values = indices.iter().map(|index| match index {

--- a/src/compute/take/structure.rs
+++ b/src/compute/take/structure.rs
@@ -27,12 +27,12 @@ use super::Index;
 
 #[inline]
 fn take_validity<I: Index>(
-    validity: &Option<Bitmap>,
+    validity: Option<&Bitmap>,
     indices: &PrimitiveArray<I>,
 ) -> Result<Option<Bitmap>> {
     let indices_validity = indices.validity();
     match (validity, indices_validity) {
-        (None, _) => Ok(indices_validity.clone()),
+        (None, _) => Ok(indices_validity.cloned()),
         (Some(validity), None) => {
             let iter = indices.values().iter().map(|index| {
                 let index = index.to_usize();

--- a/src/compute/utils.rs
+++ b/src/compute/utils.rs
@@ -21,7 +21,7 @@ use crate::{
     datatypes::DataType,
 };
 
-pub fn combine_validities(lhs: &Option<Bitmap>, rhs: &Option<Bitmap>) -> Option<Bitmap> {
+pub fn combine_validities(lhs: Option<&Bitmap>, rhs: Option<&Bitmap>) -> Option<Bitmap> {
     match (lhs, rhs) {
         (Some(lhs), None) => Some(lhs.clone()),
         (None, Some(rhs)) => Some(rhs.clone()),
@@ -34,7 +34,7 @@ pub fn unary_utf8_boolean<O: Offset, F: Fn(&str) -> bool>(
     values: &Utf8Array<O>,
     op: F,
 ) -> BooleanArray {
-    let validity = values.validity().clone();
+    let validity = values.validity().cloned();
 
     let iterator = values.iter().map(|value| {
         if value.is_none() {

--- a/src/io/ipc/write/serialize.rs
+++ b/src/io/ipc/write/serialize.rs
@@ -69,7 +69,7 @@ fn write_boolean(
 
     write_bitmap(array.validity(), array.len(), buffers, arrow_data, offset);
     write_bitmap(
-        &Some(array.values().clone()),
+        Some(&array.values().clone()),
         array.len(),
         buffers,
         arrow_data,
@@ -78,7 +78,7 @@ fn write_boolean(
 }
 
 fn write_generic_binary<O: Offset>(
-    validity: &Option<Bitmap>,
+    validity: Option<&Bitmap>,
     offsets: &[O],
     values: &[u8],
     buffers: &mut Vec<Schema::Buffer>,
@@ -419,7 +419,7 @@ fn write_bytes_from_iter<I: TrustedLen<Item = u8>>(
 }
 
 fn write_bitmap(
-    bitmap: &Option<Bitmap>,
+    bitmap: Option<&Bitmap>,
     length: usize,
     buffers: &mut Vec<Schema::Buffer>,
     arrow_data: &mut Vec<u8>,

--- a/src/io/parquet/write/binary/basic.rs
+++ b/src/io/parquet/write/binary/basic.rs
@@ -126,7 +126,7 @@ pub(super) fn build_statistics<O: Offset>(
 pub(crate) fn encode_delta<O: Offset>(
     values: &[u8],
     offsets: &[O],
-    validity: &Option<Bitmap>,
+    validity: Option<&Bitmap>,
     is_optional: bool,
     buffer: &mut Vec<u8>,
 ) {

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -18,7 +18,7 @@ use crate::io::parquet::write::utils;
 fn encode_keys<K: DictionaryKey>(
     array: &PrimitiveArray<K>,
     // todo: merge this to not discard values' validity
-    validity: &Option<Bitmap>,
+    validity: Option<&Bitmap>,
     descriptor: ColumnDescriptor,
     options: WriteOptions,
 ) -> Result<CompressedPage> {
@@ -38,7 +38,7 @@ fn encode_keys<K: DictionaryKey>(
         utils::write_def_levels(
             &mut buffer,
             is_optional,
-            &Some(projected_val),
+            Some(&projected_val),
             array.len(),
             options.version,
         )?;

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -244,7 +244,7 @@ pub fn array_to_page(
             let array = FixedSizeBinaryArray::from_data(
                 DataType::FixedSizeBinary(12),
                 values.into(),
-                array.validity().clone(),
+                array.validity().cloned(),
             );
             fixed_len_bytes::array_to_page(&array, options, descriptor)
         }
@@ -262,7 +262,7 @@ pub fn array_to_page(
             let array = FixedSizeBinaryArray::from_data(
                 DataType::FixedSizeBinary(12),
                 values.into(),
-                array.validity().clone(),
+                array.validity().cloned(),
             );
             fixed_len_bytes::array_to_page(&array, options, descriptor)
         }
@@ -283,7 +283,7 @@ pub fn array_to_page(
                 let array = PrimitiveArray::<i32>::from_data(
                     DataType::Int32,
                     values,
-                    array.validity().clone(),
+                    array.validity().cloned(),
                 );
                 primitive::array_to_page::<i32, i32>(&array, options, descriptor)
             } else if precision <= 18 {
@@ -292,7 +292,7 @@ pub fn array_to_page(
                 let array = PrimitiveArray::<i64>::from_data(
                     DataType::Int64,
                     values,
-                    array.validity().clone(),
+                    array.validity().cloned(),
                 );
                 primitive::array_to_page::<i64, i64>(&array, options, descriptor)
             } else {
@@ -307,7 +307,7 @@ pub fn array_to_page(
                 let array = FixedSizeBinaryArray::from_data(
                     DataType::FixedSizeBinary(size as i32),
                     values.into(),
-                    array.validity().clone(),
+                    array.validity().cloned(),
                 );
                 fixed_len_bytes::array_to_page(&array, options, descriptor)
             }
@@ -338,7 +338,7 @@ macro_rules! dyn_nested_prim {
 
 fn list_array_to_page<O: Offset>(
     offsets: &[O],
-    validity: &Option<Bitmap>,
+    validity: Option<&Bitmap>,
     values: &dyn Array,
     descriptor: ColumnDescriptor,
     options: WriteOptions,

--- a/src/io/parquet/write/utils.rs
+++ b/src/io/parquet/write/utils.rs
@@ -45,7 +45,7 @@ fn encode_iter<I: Iterator<Item = bool>>(
 pub fn write_def_levels(
     writer: &mut Vec<u8>,
     is_optional: bool,
-    validity: &Option<Bitmap>,
+    validity: Option<&Bitmap>,
     len: usize,
     version: Version,
 ) -> Result<()> {

--- a/tests/it/array/binary/mod.rs
+++ b/tests/it/array/binary/mod.rs
@@ -21,7 +21,7 @@ fn basics() {
     assert_eq!(array.offsets().as_slice(), &[0, 5, 5, 11]);
     assert_eq!(
         array.validity(),
-        &Some(Bitmap::from_u8_slice(&[0b00000101], 3))
+        Some(&Bitmap::from_u8_slice(&[0b00000101], 3))
     );
     assert!(array.is_valid(0));
     assert!(!array.is_valid(1));
@@ -31,7 +31,7 @@ fn basics() {
         DataType::Binary,
         array.offsets().clone(),
         array.values().clone(),
-        array.validity().clone(),
+        array.validity().cloned(),
     );
     assert_eq!(array, array2);
 
@@ -48,14 +48,14 @@ fn empty() {
     let array = BinaryArray::<i32>::new_empty(DataType::Binary);
     assert_eq!(array.values().as_slice(), b"");
     assert_eq!(array.offsets().as_slice(), &[0]);
-    assert_eq!(array.validity(), &None);
+    assert_eq!(array.validity(), None);
 }
 
 #[test]
 fn from() {
     let array = BinaryArray::<i32>::from(&[Some(b"hello".as_ref()), Some(b" ".as_ref()), None]);
 
-    let a = array.validity().as_ref().unwrap();
+    let a = array.validity().unwrap();
     assert_eq!(a, &Bitmap::from([true, true, false]));
 }
 
@@ -80,7 +80,7 @@ fn with_validity() {
     let array = array.with_validity(None);
 
     let a = array.validity();
-    assert_eq!(a, &None);
+    assert_eq!(a, None);
 }
 
 #[test]

--- a/tests/it/array/binary/mutable.rs
+++ b/tests/it/array/binary/mutable.rs
@@ -7,5 +7,5 @@ fn push_null() {
     array.push::<&str>(None);
 
     let array: BinaryArray<i32> = array.into();
-    assert_eq!(array.validity(), &Some(Bitmap::from([false])));
+    assert_eq!(array.validity(), Some(&Bitmap::from([false])));
 }

--- a/tests/it/array/boolean/mod.rs
+++ b/tests/it/array/boolean/mod.rs
@@ -18,7 +18,7 @@ fn basics() {
     assert_eq!(array.values(), &Bitmap::from_u8_slice(&[0b00000001], 3));
     assert_eq!(
         array.validity(),
-        &Some(Bitmap::from_u8_slice(&[0b00000101], 3))
+        Some(&Bitmap::from_u8_slice(&[0b00000101], 3))
     );
     assert!(array.is_valid(0));
     assert!(!array.is_valid(1));
@@ -27,7 +27,7 @@ fn basics() {
     let array2 = BooleanArray::from_data(
         DataType::Boolean,
         array.values().clone(),
-        array.validity().clone(),
+        array.validity().cloned(),
     );
     assert_eq!(array, array2);
 
@@ -40,7 +40,7 @@ fn basics() {
 fn empty() {
     let array = BooleanArray::new_empty(DataType::Boolean);
     assert_eq!(array.values().len(), 0);
-    assert_eq!(array.validity(), &None);
+    assert_eq!(array.validity(), None);
 }
 
 #[test]

--- a/tests/it/array/boolean/mutable.rs
+++ b/tests/it/array/boolean/mutable.rs
@@ -61,6 +61,6 @@ fn reserve() {
     );
 
     a.reserve(10);
-    assert!(a.validity().as_ref().unwrap().capacity() > 0);
+    assert!(a.validity().unwrap().capacity() > 0);
     assert!(a.values().capacity() > 0)
 }

--- a/tests/it/array/fixed_size_binary/mutable.rs
+++ b/tests/it/array/fixed_size_binary/mutable.rs
@@ -13,7 +13,7 @@ fn basic() {
     assert_eq!(a.len(), 2);
     assert_eq!(a.data_type(), &DataType::FixedSizeBinary(2));
     assert_eq!(a.values(), &MutableBuffer::from([1, 2, 3, 4]));
-    assert_eq!(a.validity(), &None);
+    assert_eq!(a.validity(), None);
     assert_eq!(a.value(1), &[3, 4]);
     assert_eq!(unsafe { a.value_unchecked(1) }, &[3, 4]);
 }
@@ -65,5 +65,5 @@ fn push_null() {
     array.push::<&[u8]>(None);
 
     let array: FixedSizeBinaryArray = array.into();
-    assert_eq!(array.validity(), &Some(Bitmap::from([false])));
+    assert_eq!(array.validity(), Some(&Bitmap::from([false])));
 }

--- a/tests/it/array/growable/utils.rs
+++ b/tests/it/array/growable/utils.rs
@@ -44,7 +44,7 @@ pub(super) fn build_extend_null_bits(array: &dyn Array, use_validity: bool) -> E
 #[inline]
 pub(super) fn extend_validity(
     mutable_validity: &mut MutableBitmap,
-    validity: &Option<Bitmap>,
+    validity: Option<&Bitmap>,
     start: usize,
     len: usize,
     use_validity: bool,

--- a/tests/it/array/primitive/mod.rs
+++ b/tests/it/array/primitive/mod.rs
@@ -22,7 +22,7 @@ fn basics() {
     assert_eq!(array.values().as_slice(), &[1, 0, 10]);
     assert_eq!(
         array.validity(),
-        &Some(Bitmap::from_u8_slice(&[0b00000101], 3))
+        Some(&Bitmap::from_u8_slice(&[0b00000101], 3))
     );
     assert!(array.is_valid(0));
     assert!(!array.is_valid(1));
@@ -31,7 +31,7 @@ fn basics() {
     let array2 = Int32Array::from_data(
         DataType::Int32,
         array.values().clone(),
-        array.validity().clone(),
+        array.validity().cloned(),
     );
     assert_eq!(array, array2);
 
@@ -50,7 +50,7 @@ fn basics() {
 fn empty() {
     let array = Int32Array::new_empty(DataType::Int32);
     assert_eq!(array.values().len(), 0);
-    assert_eq!(array.validity(), &None);
+    assert_eq!(array.validity(), None);
 }
 
 #[test]

--- a/tests/it/array/primitive/mutable.rs
+++ b/tests/it/array/primitive/mutable.rs
@@ -88,7 +88,7 @@ fn set() {
 fn from_iter() {
     let a = MutablePrimitiveArray::<i32>::from_iter((0..2).map(Some));
     assert_eq!(a.len(), 2);
-    assert_eq!(a.validity(), &None);
+    assert_eq!(a.validity(), None);
 }
 
 #[test]
@@ -103,25 +103,25 @@ fn only_nulls() {
     a.push(None);
     a.push(None);
     let a: PrimitiveArray<i32> = a.into();
-    assert_eq!(a.validity(), &Some(Bitmap::from([false, false])));
+    assert_eq!(a.validity(), Some(&Bitmap::from([false, false])));
 }
 
 #[test]
 fn from_trusted_len() {
     let a = MutablePrimitiveArray::<i32>::from_trusted_len_iter(vec![Some(1), None].into_iter());
     let a: PrimitiveArray<i32> = a.into();
-    assert_eq!(a.validity(), &Some(Bitmap::from([true, false])));
+    assert_eq!(a.validity(), Some(&Bitmap::from([true, false])));
 }
 
 #[test]
 fn extend_trusted_len() {
     let mut a = MutablePrimitiveArray::<i32>::new();
     a.extend_trusted_len(vec![Some(1), Some(2)].into_iter());
-    assert_eq!(a.validity(), &None);
+    assert_eq!(a.validity(), None);
     a.extend_trusted_len(vec![None, Some(4)].into_iter());
     assert_eq!(
         a.validity(),
-        &Some(MutableBitmap::from([true, true, false, true]))
+        Some(&MutableBitmap::from([true, true, false, true]))
     );
     assert_eq!(a.values(), &MutableBuffer::<i32>::from([1, 2, 0, 4]));
 }
@@ -130,7 +130,7 @@ fn extend_trusted_len() {
 fn extend_trusted_len_values() {
     let mut a = MutablePrimitiveArray::<i32>::new();
     a.extend_trusted_len_values(vec![1, 2, 3].into_iter());
-    assert_eq!(a.validity(), &None);
+    assert_eq!(a.validity(), None);
     assert_eq!(a.values(), &MutableBuffer::<i32>::from([1, 2, 3]));
 
     let mut a = MutablePrimitiveArray::<i32>::new();
@@ -138,7 +138,7 @@ fn extend_trusted_len_values() {
     a.extend_trusted_len_values(vec![1, 2].into_iter());
     assert_eq!(
         a.validity(),
-        &Some(MutableBitmap::from([false, true, true]))
+        Some(&MutableBitmap::from([false, true, true]))
     );
 }
 
@@ -146,7 +146,7 @@ fn extend_trusted_len_values() {
 fn extend_from_slice() {
     let mut a = MutablePrimitiveArray::<i32>::new();
     a.extend_from_slice(&[1, 2, 3]);
-    assert_eq!(a.validity(), &None);
+    assert_eq!(a.validity(), None);
     assert_eq!(a.values(), &MutableBuffer::<i32>::from([1, 2, 3]));
 
     let mut a = MutablePrimitiveArray::<i32>::new();
@@ -154,7 +154,7 @@ fn extend_from_slice() {
     a.extend_from_slice(&[1, 2]);
     assert_eq!(
         a.validity(),
-        &Some(MutableBitmap::from([false, true, true]))
+        Some(&MutableBitmap::from([false, true, true]))
     );
 }
 
@@ -162,9 +162,9 @@ fn extend_from_slice() {
 fn set_validity() {
     let mut a = MutablePrimitiveArray::<i32>::new();
     a.extend_trusted_len(vec![Some(1), Some(2)].into_iter());
-    assert_eq!(a.validity(), &None);
+    assert_eq!(a.validity(), None);
     a.set_validity(Some(MutableBitmap::from([false, true])));
-    assert_eq!(a.validity(), &Some(MutableBitmap::from([false, true])));
+    assert_eq!(a.validity(), Some(&MutableBitmap::from([false, true])));
 }
 
 #[test]

--- a/tests/it/array/utf8/mod.rs
+++ b/tests/it/array/utf8/mod.rs
@@ -16,7 +16,7 @@ fn basics() {
     assert_eq!(array.offsets().as_slice(), &[0, 5, 5, 11]);
     assert_eq!(
         array.validity(),
-        &Some(Bitmap::from_u8_slice(&[0b00000101], 3))
+        Some(&Bitmap::from_u8_slice(&[0b00000101], 3))
     );
     assert!(array.is_valid(0));
     assert!(!array.is_valid(1));
@@ -26,7 +26,7 @@ fn basics() {
         DataType::Utf8,
         array.offsets().clone(),
         array.values().clone(),
-        array.validity().clone(),
+        array.validity().cloned(),
     );
     assert_eq!(array, array2);
 
@@ -43,14 +43,14 @@ fn empty() {
     let array = Utf8Array::<i32>::new_empty(DataType::Utf8);
     assert_eq!(array.values().as_slice(), b"");
     assert_eq!(array.offsets().as_slice(), &[0]);
-    assert_eq!(array.validity(), &None);
+    assert_eq!(array.validity(), None);
 }
 
 #[test]
 fn from() {
     let array = Utf8Array::<i32>::from(&[Some("hello"), Some(" "), None]);
 
-    let a = array.validity().as_ref().unwrap();
+    let a = array.validity().unwrap();
     assert_eq!(a, &Bitmap::from([true, true, false]));
 }
 

--- a/tests/it/array/utf8/mutable.rs
+++ b/tests/it/array/utf8/mutable.rs
@@ -17,7 +17,7 @@ fn push_null() {
     array.push::<&str>(None);
 
     let array: Utf8Array<i32> = array.into();
-    assert_eq!(array.validity(), &Some(Bitmap::from([false])));
+    assert_eq!(array.validity(), Some(&Bitmap::from([false])));
 }
 
 /// Safety guarantee
@@ -60,7 +60,7 @@ fn test_extend_trusted_len_values() {
     assert_eq!(array.offsets().as_slice(), &[0, 2, 7, 12, 17, 17]);
     assert_eq!(
         array.validity(),
-        &Some(Bitmap::from_u8_slice(&[0b00001111], 5))
+        Some(&Bitmap::from_u8_slice(&[0b00001111], 5))
     );
 }
 
@@ -78,6 +78,6 @@ fn test_extend_trusted_len() {
     assert_eq!(array.offsets().as_slice(), &[0, 2, 7, 7, 12, 17]);
     assert_eq!(
         array.validity(),
-        &Some(Bitmap::from_u8_slice(&[0b00011011], 5))
+        Some(&Bitmap::from_u8_slice(&[0b00011011], 5))
     );
 }


### PR DESCRIPTION
Changed the signature of `Array::validity()` and `MutableArray::validity()`. IMO it makes the API a bit easier to use and aligned with other methods in `std`.

To migrate:

* Change `validity().as_ref().unwrap()` to `validity().unwrap()`
* Change `validity().as_ref().map(...)` to `validity().map(...)`
* Change `validity().clone()` to `validity().cloned()`
* Change `&Option<Bitmap>` to `Option<&Bitmap>`
* Change `assert_eq!(validity, &None)` to `assert_eq!(validity, None)`
* Change `assert_eq!(validity, &Some(Bitmap(...))` to `assert_eq!(validity, Some(&Bitmap(...)))`
