### PR TITLE
Allowed accessing validity without importing `Array`

### DIFF
--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -155,6 +155,12 @@ impl<O: Offset> BinaryArray<O> {
         self.values.get_unchecked(start..end)
     }
 
+    /// The optional validity.
+    #[inline]
+    pub fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
+    }
+
     /// Returns the offsets that slice `.values()` to return valid values.
     #[inline]
     pub fn offsets(&self) -> &Buffer<O> {

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -87,6 +87,21 @@ impl BooleanArray {
         }
     }
 
+    /// Sets the validity bitmap on this [`BooleanArray`].
+    /// # Panic
+    /// This function panics iff `validity.len() != self.len()`.
+    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
+            panic!("validity should be as least as large as the array")
+        }
+        let mut arr = self.clone();
+        arr.validity = validity;
+        arr
+    }
+}
+
+// accessors
+impl BooleanArray {
     /// Returns the value at index `i`
     /// # Panic
     /// This function panics iff `i >= self.len()`.
@@ -103,22 +118,16 @@ impl BooleanArray {
         self.values.get_bit_unchecked(i)
     }
 
+    /// The optional validity.
+    #[inline]
+    pub fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
+    }
+
     /// Returns the values of this [`BooleanArray`].
     #[inline]
     pub fn values(&self) -> &Bitmap {
         &self.values
-    }
-
-    /// Sets the validity bitmap on this [`BooleanArray`].
-    /// # Panic
-    /// This function panics iff `validity.len() != self.len()`.
-    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
-            panic!("validity should be as least as large as the array")
-        }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        arr
     }
 }
 

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -109,6 +109,12 @@ impl<K: DictionaryKey> DictionaryArray<K> {
         arr
     }
 
+    /// The optional validity. Equivalent to `self.keys().validity()`.
+    #[inline]
+    pub fn validity(&self) -> Option<&Bitmap> {
+        self.keys.validity()
+    }
+
     /// Returns the keys of the [`DictionaryArray`]. These keys can be used to fetch values
     /// from `values`.
     #[inline]

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -83,6 +83,12 @@ impl FixedSizeBinaryArray {
         }
     }
 
+    /// The optional validity.
+    #[inline]
+    pub fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
+    }
+
     /// Returns the values allocated on this [`FixedSizeBinaryArray`].
     pub fn values(&self) -> &Buffer<u8> {
         &self.values

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -97,6 +97,12 @@ impl FixedSizeListArray {
         }
     }
 
+    /// The optional validity.
+    #[inline]
+    pub fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
+    }
+
     /// Returns the inner array.
     pub fn values(&self) -> &Arc<dyn Array> {
         &self.values

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -124,7 +124,13 @@ impl<T: NativeType> PrimitiveArray<T> {
         arr
     }
 
-    /// The values.
+    /// The optional validity.
+    #[inline]
+    pub fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
+    }
+
+    /// The values [`Buffer`].
     /// Values on null slots are undetermined (they can be anything).
     #[inline]
     pub fn values(&self) -> &Buffer<T> {

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -144,6 +144,15 @@ impl StructArray {
         arr.validity = validity;
         arr
     }
+}
+
+// Accessors
+impl StructArray {
+    /// The optional validity.
+    #[inline]
+    pub fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
+    }
 
     /// Returns the values of this [`StructArray`].
     pub fn values(&self) -> &[Arc<dyn Array>] {

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -132,33 +132,6 @@ impl<O: Offset> Utf8Array<O> {
         }
     }
 
-    /// Returns the element at index `i` as &str
-    /// # Safety
-    /// This function is safe iff `i < self.len`.
-    pub unsafe fn value_unchecked(&self, i: usize) -> &str {
-        // soundness: the invariant of the function
-        let start = self.offsets.get_unchecked(i).to_usize();
-        let end = self.offsets.get_unchecked(i + 1).to_usize();
-
-        // soundness: the invariant of the struct
-        let slice = self.values.get_unchecked(start..end);
-
-        // soundness: the invariant of the struct
-        std::str::from_utf8_unchecked(slice)
-    }
-
-    /// Returns the element at index `i`
-    pub fn value(&self, i: usize) -> &str {
-        let start = self.offsets[i].to_usize();
-        let end = self.offsets[i + 1].to_usize();
-
-        // soundness: the invariant of the struct
-        let slice = unsafe { self.values.get_unchecked(start..end) };
-
-        // soundness: we always check for utf8 soundness on constructors.
-        unsafe { std::str::from_utf8_unchecked(slice) }
-    }
-
     /// Returns a slice of this [`Utf8Array`].
     /// # Implementation
     /// This operation is `O(1)` as it amounts to essentially increase two ref counts.
@@ -202,6 +175,42 @@ impl<O: Offset> Utf8Array<O> {
         let mut arr = self.clone();
         arr.validity = validity;
         arr
+    }
+}
+
+// Accessors
+impl<O: Offset> Utf8Array<O> {
+    /// Returns the element at index `i` as &str
+    /// # Safety
+    /// This function is safe iff `i < self.len`.
+    pub unsafe fn value_unchecked(&self, i: usize) -> &str {
+        // soundness: the invariant of the function
+        let start = self.offsets.get_unchecked(i).to_usize();
+        let end = self.offsets.get_unchecked(i + 1).to_usize();
+
+        // soundness: the invariant of the struct
+        let slice = self.values.get_unchecked(start..end);
+
+        // soundness: the invariant of the struct
+        std::str::from_utf8_unchecked(slice)
+    }
+
+    /// Returns the element at index `i`
+    pub fn value(&self, i: usize) -> &str {
+        let start = self.offsets[i].to_usize();
+        let end = self.offsets[i + 1].to_usize();
+
+        // soundness: the invariant of the struct
+        let slice = unsafe { self.values.get_unchecked(start..end) };
+
+        // soundness: we always check for utf8 soundness on constructors.
+        unsafe { std::str::from_utf8_unchecked(slice) }
+    }
+
+    /// The optional validity.
+    #[inline]
+    pub fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
     }
 
     /// Returns the offsets of this [`Utf8Array`].

--- a/src/compute/utils.rs
+++ b/src/compute/utils.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use crate::{
-    array::{Array, BooleanArray, Offset, Utf8Array},
+    array::{BooleanArray, Offset, Utf8Array},
     bitmap::Bitmap,
     datatypes::DataType,
 };


### PR DESCRIPTION
This avoids importing `Array` just to access the validity bitmap for structs implementing `Array`.