### PR TITLE
Improved performance of `PrimitiveGrowable` for nulls (-10%)

### DIFF
--- a/src/array/growable/binary.rs
+++ b/src/array/growable/binary.rs
@@ -20,12 +20,11 @@ pub struct GrowableBinary<'a, O: Offset> {
     values: MutableBuffer<u8>,
     offsets: MutableBuffer<O>,
     length: O, // always equal to the last offset at `offsets`.
-    // function used to extend nulls from arrays. This function's lifetime is bound to the array
-    // because it reads nulls from it.
     extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a, O: Offset> GrowableBinary<'a, O> {
+    /// Creates a new [`GrowableBinary`] bound to `arrays` with a pre-allocated `capacity`.
     /// # Panics
     /// If `arrays` is empty.
     pub fn new(arrays: Vec<&'a BinaryArray<O>>, mut use_validity: bool, capacity: usize) -> Self {

--- a/src/array/growable/boolean.rs
+++ b/src/array/growable/boolean.rs
@@ -17,12 +17,13 @@ pub struct GrowableBoolean<'a> {
     data_type: DataType,
     validity: MutableBitmap,
     values: MutableBitmap,
-    // function used to extend nulls from arrays. This function's lifetime is bound to the array
-    // because it reads nulls from it.
     extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a> GrowableBoolean<'a> {
+    /// Creates a new [`GrowableBoolean`] bound to `arrays` with a pre-allocated `capacity`.
+    /// # Panics
+    /// If `arrays` is empty.
     pub fn new(arrays: Vec<&'a BooleanArray>, mut use_validity: bool, capacity: usize) -> Self {
         let data_type = arrays[0].data_type().clone();
 

--- a/src/array/growable/fixed_binary.rs
+++ b/src/array/growable/fixed_binary.rs
@@ -16,13 +16,14 @@ pub struct GrowableFixedSizeBinary<'a> {
     arrays: Vec<&'a FixedSizeBinaryArray>,
     validity: MutableBitmap,
     values: MutableBuffer<u8>,
-    // function used to extend nulls from arrays. This function's lifetime is bound to the array
-    // because it reads nulls from it.
     extend_null_bits: Vec<ExtendNullBits<'a>>,
     size: usize, // just a cache
 }
 
 impl<'a> GrowableFixedSizeBinary<'a> {
+    /// Creates a new [`GrowableFixedSizeBinary`] bound to `arrays` with a pre-allocated `capacity`.
+    /// # Panics
+    /// If `arrays` is empty.
     pub fn new(
         arrays: Vec<&'a FixedSizeBinaryArray>,
         mut use_validity: bool,

--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -61,12 +61,13 @@ pub struct GrowableList<'a, O: Offset> {
     values: Box<dyn Growable<'a> + 'a>,
     offsets: MutableBuffer<O>,
     last_offset: O, // always equal to the last offset at `offsets`.
-    // function used to extend nulls from arrays. This function's lifetime is bound to the array
-    // because it reads nulls from it.
     extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a, O: Offset> GrowableList<'a, O> {
+    /// Creates a new [`GrowableFixedSizeBinary`] bound to `arrays` with a pre-allocated `capacity`.
+    /// # Panics
+    /// If `arrays` is empty.
     pub fn new(arrays: Vec<&'a ListArray<O>>, mut use_validity: bool, capacity: usize) -> Self {
         // if any of the arrays has nulls, insertions from any array requires setting bits
         // as there is at least one array with nulls.

--- a/src/array/growable/mod.rs
+++ b/src/array/growable/mod.rs
@@ -25,9 +25,9 @@ pub use dictionary::GrowableDictionary;
 
 mod utils;
 
-/// A trait describing a struct that can be extended from slices of pre-existing [`Array`]s.
-/// This is used in operations where a new array is built out of other arrays such,
-/// as filtering and concatenation.
+/// Describes a struct that can be extended from slices of other pre-existing [`Array`]s.
+/// This is used in operations where a new array is built out of other arrays such
+/// as filter and concatenation.
 pub trait Growable<'a> {
     /// Extends this [`Growable`] with elements from the bounded [`Array`] at index `index` from
     /// a slice starting at `start` and length `len`.
@@ -38,13 +38,13 @@ pub trait Growable<'a> {
     /// Extends this [`Growable`] with null elements, disregarding the bound arrays
     fn extend_validity(&mut self, additional: usize);
 
-    /// Converts itself to an `Arc<dyn Array>`, thereby finishing the mutation.
-    /// Self will be empty after such operation
+    /// Converts this [`Growable`] to an [`Arc<dyn Array>`], thereby finishing the mutation.
+    /// Self will be empty after such operation.
     fn as_arc(&mut self) -> std::sync::Arc<dyn Array> {
         self.as_box().into()
     }
 
-    /// Converts itself to an `Box<dyn Array>`, thereby finishing the mutation.
+    /// Converts this [`Growable`] to an [`Box<dyn Array>`], thereby finishing the mutation.
     /// Self will be empty after such operation
     fn as_box(&mut self) -> Box<dyn Array>;
 }
@@ -82,11 +82,11 @@ macro_rules! dyn_dict_growable {
     }};
 }
 
-/// Creates a new [`Growable`] from an arbitrary number of dynamic [`Array`]s.
+/// Creates a new [`Growable`] from an arbitrary number of [`Array`]s.
 /// # Panics
 /// This function panics iff
 /// * the arrays do not have the same [`DataType`].
-/// * `arrays.is_empty`.
+/// * `arrays.is_empty()`.
 pub fn make_growable<'a>(
     arrays: &[&'a dyn Array],
     use_validity: bool,

--- a/src/array/growable/null.rs
+++ b/src/array/growable/null.rs
@@ -20,6 +20,7 @@ impl Default for GrowableNull {
 }
 
 impl GrowableNull {
+    /// Creates a new [`GrowableNull`].
     pub fn new(data_type: DataType) -> Self {
         Self {
             data_type,

--- a/src/array/growable/structure.rs
+++ b/src/array/growable/structure.rs
@@ -17,14 +17,13 @@ pub struct GrowableStruct<'a> {
     arrays: Vec<&'a StructArray>,
     validity: MutableBitmap,
     values: Vec<Box<dyn Growable<'a> + 'a>>,
-    // function used to extend nulls from arrays. This function's lifetime is bound to the array
-    // because it reads nulls from it.
     extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a> GrowableStruct<'a> {
+    /// Creates a new [`GrowableStruct`] bound to `arrays` with a pre-allocated `capacity`.
     /// # Panics
-    /// This function panics if any of the `arrays` is not downcastable to `PrimitiveArray<T>`.
+    /// If `arrays` is empty.
     pub fn new(arrays: Vec<&'a StructArray>, mut use_validity: bool, capacity: usize) -> Self {
         // if any of the arrays has nulls, insertions from any array requires setting bits
         // as there is at least one array with nulls.

--- a/src/array/growable/utf8.rs
+++ b/src/array/growable/utf8.rs
@@ -18,12 +18,13 @@ pub struct GrowableUtf8<'a, O: Offset> {
     values: MutableBuffer<u8>,
     offsets: MutableBuffer<O>,
     length: O, // always equal to the last offset at `offsets`.
-    // function used to extend nulls from arrays. This function's lifetime is bound to the array
-    // because it reads nulls from it.
     extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a, O: Offset> GrowableUtf8<'a, O> {
+    /// Creates a new [`GrowableUtf8`] bound to `arrays` with a pre-allocated `capacity`.
+    /// # Panics
+    /// If `arrays` is empty.
     pub fn new(arrays: Vec<&'a Utf8Array<O>>, mut use_validity: bool, capacity: usize) -> Self {
         // if any of the arrays has nulls, insertions from any array requires setting bits
         // as there is at least one array with nulls.

--- a/src/array/growable/utils.rs
+++ b/src/array/growable/utils.rs
@@ -1,6 +1,6 @@
 use crate::{
     array::{Array, Offset},
-    bitmap::{Bitmap, MutableBitmap},
+    bitmap::MutableBitmap,
     buffer::MutableBuffer,
 };
 
@@ -18,6 +18,8 @@ pub(super) fn extend_offsets<T: Offset>(
     });
 }
 
+// function used to extend nulls from arrays. This function's lifetime is bound to the array
+// because it reads nulls from it.
 pub(super) type ExtendNullBits<'a> = Box<dyn Fn(&mut MutableBitmap, usize, usize) + 'a>;
 
 pub(super) fn build_extend_null_bits(array: &dyn Array, use_validity: bool) -> ExtendNullBits {
@@ -34,23 +36,6 @@ pub(super) fn build_extend_null_bits(array: &dyn Array, use_validity: bool) -> E
     } else {
         Box::new(|_, _, _| {})
     }
-}
-
-#[inline]
-pub(super) fn extend_validity(
-    mutable_validity: &mut MutableBitmap,
-    validity: &Option<Bitmap>,
-    start: usize,
-    len: usize,
-    use_validity: bool,
-) {
-    if let Some(bitmap) = validity {
-        assert!(start + len <= bitmap.len());
-        let (slice, offset, _) = bitmap.as_slice();
-        mutable_validity.extend_from_slice(slice, start + offset, len);
-    } else if use_validity {
-        mutable_validity.extend_constant(len, true);
-    };
 }
 
 #[inline]


### PR DESCRIPTION
* Added docs
* standardized design on extending nulls (-10% for primitive arrays)
