### PR TITLE
Investigate parallelism of parquet writing

### DIFF
--- a/benches/write_parquet.rs
+++ b/benches/write_parquet.rs
@@ -1,4 +1,8 @@
 use std::io::Cursor;
+use std::sync::mpsc;
+use std::sync::mpsc::{Receiver, Sender};
+use std::sync::Arc;
+use std::thread;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
@@ -6,6 +10,7 @@ use arrow2::array::*;
 use arrow2::datatypes::{DataType, Field, Schema};
 use arrow2::error::Result;
 use arrow2::io::parquet::write::*;
+use arrow2::record_batch::RecordBatch;
 use arrow2::util::bench_util::{create_boolean_array, create_primitive_array, create_string_array};
 
 fn write(array: &dyn Array, encoding: Encoding) -> Result<()> {
@@ -41,6 +46,75 @@ fn write(array: &dyn Array, encoding: Encoding) -> Result<()> {
     Ok(())
 }
 
+fn prepare(schema: &Schema) -> Result<(WriteOptions, Encoding, SchemaDescriptor)> {
+    let options = WriteOptions {
+        write_statistics: true,
+        compression: Compression::Uncompressed,
+        version: Version::V2,
+    };
+    let encoding = Encoding::Plain;
+
+    // map arrow fields to parquet fields
+    let parquet_schema = to_parquet_schema(&schema)?;
+    Ok((options, encoding, parquet_schema))
+}
+
+fn write_parallel(array: &dyn Array, encoding: Encoding) -> Result<()> {
+    let array: Arc<dyn Array> = clone(array).into();
+    let field = Field::new("c1", array.data_type().clone(), true);
+    let schema = Schema::new(vec![field.clone(), field.clone()]);
+    let batch = RecordBatch::try_new(Arc::new(schema), vec![array.clone(), array])?;
+
+    // prepare a channel to send serialized records from threads
+    let (tx, rx) = mpsc::sync_channel(2);
+    let mut children = Vec::new();
+
+    let (options, encoding, parquet_schema) = prepare(batch.schema())?;
+
+    batch
+        .columns()
+        .iter()
+        .zip(parquet_schema.columns().to_vec().into_iter())
+        .for_each(|(array, descriptor)| {
+            let array = array.clone(); // note: this is cheap
+
+            // The sender endpoint can be cloned
+            let thread_tx = tx.clone();
+
+            let options = options.clone();
+            let child = thread::spawn(move || {
+                // create compressed pages
+                let pages = array_to_pages(array, descriptor, options, encoding)
+                    .unwrap()
+                    .collect::<Vec<_>>();
+                thread_tx.send(pages).unwrap();
+            });
+
+            children.push(child);
+        });
+
+    let row_groups = std::iter::once(Result::Ok(DynIter::new(
+        (0..batch.num_columns()).map(|_| Ok(DynIter::new(rx.recv().unwrap().into_iter()))),
+    )));
+
+    let mut writer = Cursor::new(vec![]);
+
+    // Write the file. Note that, at present, any error results in a corrupted file.
+    let _ = write_file(
+        &mut writer,
+        row_groups,
+        batch.schema(),
+        parquet_schema,
+        options,
+        None,
+    )?;
+
+    for child in children {
+        child.join().expect("child thread panicked");
+    }
+    Ok(())
+}
+
 fn add_benchmark(c: &mut Criterion) {
     (0..=10).step_by(2).for_each(|i| {
         let array = &create_primitive_array::<i64>(1024 * 2usize.pow(i), DataType::Int64, 0.1);
@@ -66,6 +140,12 @@ fn add_benchmark(c: &mut Criterion) {
         c.bench_function(&a, |b| {
             b.iter(|| write(array, Encoding::DeltaLengthByteArray).unwrap())
         });
+    });
+
+    (0..=10).step_by(2).for_each(|i| {
+        let array = &create_primitive_array::<i64>(1024 * 2usize.pow(i), DataType::Int64, 0.1);
+        let a = format!("write parallel i64 2^{}", 10 + i);
+        c.bench_function(&a, |b| b.iter(|| write(array, Encoding::Plain).unwrap()));
     });
 }
 

--- a/examples/parquet_write_parallel/.gitignore
+++ b/examples/parquet_write_parallel/.gitignore
@@ -1,0 +1,1 @@
+*.parquet

--- a/examples/parquet_write_parallel/Cargo.toml
+++ b/examples/parquet_write_parallel/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "parquet_write_parallel"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+arrow2 = { path = "../../", default-features = false, features = ["io_parquet", "io_parquet_compression"] }
+rayon = { version = "1", default-features = false }

--- a/examples/parquet_write_parallel/src/main.rs
+++ b/examples/parquet_write_parallel/src/main.rs
@@ -1,0 +1,93 @@
+/// Example demonstrating how to write to parquet in parallel.
+use std::sync::Arc;
+
+use rayon::prelude::*;
+
+use arrow2::{
+    array::*, datatypes::PhysicalType, error::Result, io::parquet::write::*,
+    record_batch::RecordBatch,
+};
+
+fn parallel_write(path: &str, batch: &RecordBatch) -> Result<()> {
+    let options = WriteOptions {
+        write_statistics: true,
+        compression: Compression::Uncompressed,
+        version: Version::V2,
+    };
+    let encodings = batch
+        .schema()
+        .fields()
+        .iter()
+        .map(|field| match field.data_type().to_physical_type() {
+            // let's be fancy and use delta-encoding for binary fields
+            PhysicalType::Binary
+            | PhysicalType::LargeBinary
+            | PhysicalType::Utf8
+            | PhysicalType::LargeUtf8 => Encoding::DeltaLengthByteArray,
+            // dictionaries are kept dict-encoded
+            PhysicalType::Dictionary(_) => Encoding::RleDictionary,
+            // remaining is plain
+            _ => Encoding::Plain,
+        })
+        .collect::<Vec<_>>();
+
+    let parquet_schema = to_parquet_schema(batch.schema())?;
+
+    // write batch to pages; parallelize with rayon
+    let columns = batch
+        .columns()
+        .par_iter()
+        .zip(parquet_schema.columns().to_vec().into_par_iter())
+        .zip(encodings.into_par_iter())
+        .map(|((array, descriptor), encoding)| {
+            let array = array.clone();
+
+            // create encoded and compressed pages this column
+            array_to_pages(array, descriptor, options, encoding)
+                .unwrap()
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    // create the iterator over groups (one in this case)
+    // (for more batches, create the iterator from them here)
+    let row_groups = std::iter::once(Result::Ok(DynIter::new(
+        columns
+            .into_iter()
+            .map(|column| Ok(DynIter::new(column.into_iter()))),
+    )));
+
+    // Create a new empty file
+    let mut file = std::fs::File::create(path)?;
+
+    // Write the file.
+    let _file_size = write_file(
+        &mut file,
+        row_groups,
+        batch.schema(),
+        parquet_schema,
+        options,
+        None,
+    )?;
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let c1 = Int32Array::from(&[Some(0), None, None, Some(2), Some(3)]);
+    let c2 = Utf8Array::<i32>::from(&[Some("1"), None, None, Some("2"), Some("3")]);
+
+    // and a dict array
+    let data = [Some("hello"), Some("bye"), None, Some("hello"), Some("bye")];
+    let mut a = MutableDictionaryArray::<i32, MutableUtf8Array<i32>>::new();
+    a.try_extend(data)?;
+    let c3: DictionaryArray<i32> = a.into();
+
+    let batch = RecordBatch::try_from_iter([
+        ("c1", Arc::new(c1) as Arc<dyn Array>),
+        ("c2", Arc::new(c2) as Arc<dyn Array>),
+        ("c3", Arc::new(c3) as Arc<dyn Array>),
+    ])?;
+
+    parallel_write("example.parquet", &batch)
+}


### PR DESCRIPTION
This PR adds a new case to the `write_parquet` bench used to investigate how to parallelize the CPU-bounded part of writing to parquet. On my computer the bench writes 2 columns in parallel with the same performance as 1 column.

Specifically, `write parallel` writes 2 columns in parallel, `write` writes 1 column, and they take the same time to complete:

```
write i64 2^20          time:   [12.111 ms 12.176 ms 12.243 ms]
write parallel i64 2^20 time:   [12.176 ms 12.255 ms 12.337 ms]
```

I need to check how the order of the columns behave, as I think we need to ensure that the order is preserved (which this bench does not do).