### PR TITLE
elide partial bounds check in list iterator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -230,3 +230,7 @@ harness = false
 [[bench]]
 name = "iter_utf8"
 harness = false
+
+[[bench]]
+name = "iter_list"
+harness = false

--- a/benches/iter_list.rs
+++ b/benches/iter_list.rs
@@ -1,0 +1,54 @@
+use arrow2::{
+    array::{ListArray, PrimitiveArray},
+    buffer::Buffer,
+    datatypes::DataType,
+};
+
+use arrow2::bitmap::Bitmap;
+use arrow2::buffer::MutableBuffer;
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::iter::FromIterator;
+use std::sync::Arc;
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+
+        let values = Buffer::from_iter(0..size as i32);
+        let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+
+        let mut offsets = MutableBuffer::from_iter((0..size as i32).step_by(2));
+        offsets.push(size as i32);
+
+        let validity = (0..(offsets.len() - 1))
+            .map(|i| i % 4 == 0)
+            .collect::<Bitmap>();
+
+        let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
+        let array = ListArray::<i32>::from_data(
+            data_type,
+            offsets.into(),
+            Arc::new(values),
+            Some(validity),
+        );
+
+        c.bench_function(&format!("list: iter_values 2^{}", log2_size), |b| {
+            b.iter(|| {
+                for x in array.values_iter() {
+                    assert_eq!(x.len(), 2);
+                }
+            })
+        });
+
+        c.bench_function(&format!("list: iter 2^{}", log2_size), |b| {
+            b.iter(|| {
+                for x in array.iter() {
+                    assert_eq!(x.unwrap().len(), 2);
+                }
+            })
+        });
+    })
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -101,7 +101,7 @@ impl<O: Offset> BinaryArray<O> {
     /// # Implementation
     /// This function is `O(1)`: all data will be shared between both arrays.
     /// # Safety
-    /// The caller must ensure that `offset + length < self.len()`.
+    /// The caller must ensure that `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         let validity = self
             .validity

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -90,8 +90,24 @@ impl<O: Offset> BinaryArray<O> {
     /// # Panics
     /// iff `offset + length > self.len()`.
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        let validity = self.validity.clone().map(|x| x.slice(offset, length));
-        let offsets = self.offsets.clone().slice(offset, length + 1);
+        assert!(
+            offset + length <= self.len(),
+            "the offset of the new Buffer cannot exceed the existing length"
+        );
+        unsafe { self.slice_unchecked(offset, length) }
+    }
+
+    /// Creates a new [`BinaryArray`] by slicing this [`BinaryArray`].
+    /// # Implementation
+    /// This function is `O(1)`: all data will be shared between both arrays.
+    /// # Safety
+    /// The caller must ensure that `offset + length < self.len()`.
+    pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
+        let validity = self
+            .validity
+            .clone()
+            .map(|x| x.slice_unchecked(offset, length));
+        let offsets = self.offsets.clone().slice_unchecked(offset, length + 1);
         Self {
             data_type: self.data_type.clone(),
             offsets,
@@ -174,6 +190,9 @@ impl<O: Offset> Array for BinaryArray<O> {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
+        Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -72,7 +72,7 @@ impl BooleanArray {
     /// # Implementation
     /// This operation is `O(1)` as it amounts to increase two ref counts.
     /// # Safety
-    /// The caller must ensure that `offset + length < self.len()`.
+    /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
     pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         let validity = self

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -61,10 +61,27 @@ impl BooleanArray {
     /// This function panics iff `offset + length >= self.len()`.
     #[inline]
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        let validity = self.validity.clone().map(|x| x.slice(offset, length));
+        assert!(
+            offset + length <= self.len(),
+            "the offset of the new Buffer cannot exceed the existing length"
+        );
+        unsafe { self.slice_unchecked(offset, length) }
+    }
+
+    /// Returns a slice of this [`BooleanArray`].
+    /// # Implementation
+    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// # Safety
+    /// The caller must ensure that `offset + length < self.len()`.
+    #[inline]
+    pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
+        let validity = self
+            .validity
+            .clone()
+            .map(|x| x.slice_unchecked(offset, length));
         Self {
             data_type: self.data_type.clone(),
-            values: self.values.clone().slice(offset, length),
+            values: self.values.clone().slice_unchecked(offset, length),
             validity,
             offset: self.offset + offset,
         }
@@ -129,6 +146,10 @@ impl Array for BooleanArray {
     #[inline]
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    #[inline]
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
+        Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -86,6 +86,8 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     }
 
     /// Creates a new [`DictionaryArray`] by slicing the existing [`DictionaryArray`].
+    /// # Safety
+    /// Safe iff `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         Self {
             data_type: self.data_type.clone(),
@@ -162,7 +164,7 @@ impl<K: DictionaryKey> Array for DictionaryArray<K> {
         Box::new(self.slice(offset, length))
     }
     unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
-        Box::new(self.slice(offset, length))
+        Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -74,10 +74,22 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     }
 
     /// Creates a new [`DictionaryArray`] by slicing the existing [`DictionaryArray`].
+    /// # Panics
+    /// iff `offset + length > self.len()`.
     pub fn slice(&self, offset: usize, length: usize) -> Self {
         Self {
             data_type: self.data_type.clone(),
             keys: self.keys.clone().slice(offset, length),
+            values: self.values.clone(),
+            offset: self.offset + offset,
+        }
+    }
+
+    /// Creates a new [`DictionaryArray`] by slicing the existing [`DictionaryArray`].
+    pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
+        Self {
+            data_type: self.data_type.clone(),
+            keys: self.keys.clone().slice_unchecked(offset, length),
             values: self.values.clone(),
             offset: self.offset + offset,
         }
@@ -147,6 +159,9 @@ impl<K: DictionaryKey> Array for DictionaryArray<K> {
     }
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
+        Box::new(self.slice(offset, length))
+    }
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -50,12 +50,30 @@ impl FixedSizeBinaryArray {
     /// Returns a slice of this [`FixedSizeBinaryArray`].
     /// # Implementation
     /// This operation is `O(1)` as it amounts to increase 3 ref counts.
+    /// # Panics
+    /// panics iff `offset + length >= self.len()`
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        let validity = self.validity.clone().map(|x| x.slice(offset, length));
+        assert!(
+            offset + length <= self.len(),
+            "the offset of the new Buffer cannot exceed the existing length"
+        );
+        unsafe { self.slice_unchecked(offset, length) }
+    }
+
+    /// Returns a slice of this [`FixedSizeBinaryArray`].
+    /// # Implementation
+    /// This operation is `O(1)` as it amounts to increase 3 ref counts.
+    /// # Safety
+    /// The caller must ensure that `offset + length < self.len()`.
+    pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
+        let validity = self
+            .validity
+            .clone()
+            .map(|x| x.slice_unchecked(offset, length));
         let values = self
             .values
             .clone()
-            .slice(offset * self.size as usize, length * self.size as usize);
+            .slice_unchecked(offset * self.size as usize, length * self.size as usize);
         Self {
             data_type: self.data_type.clone(),
             size: self.size,
@@ -138,6 +156,9 @@ impl Array for FixedSizeBinaryArray {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
+        Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -51,7 +51,7 @@ impl FixedSizeBinaryArray {
     /// # Implementation
     /// This operation is `O(1)` as it amounts to increase 3 ref counts.
     /// # Panics
-    /// panics iff `offset + length >= self.len()`
+    /// panics iff `offset + length > self.len()`
     pub fn slice(&self, offset: usize, length: usize) -> Self {
         assert!(
             offset + length <= self.len(),
@@ -64,7 +64,7 @@ impl FixedSizeBinaryArray {
     /// # Implementation
     /// This operation is `O(1)` as it amounts to increase 3 ref counts.
     /// # Safety
-    /// The caller must ensure that `offset + length < self.len()`.
+    /// The caller must ensure that `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         let validity = self
             .validity

--- a/src/array/fixed_size_list/iterator.rs
+++ b/src/array/fixed_size_list/iterator.rs
@@ -6,8 +6,8 @@ use crate::{
 use super::FixedSizeListArray;
 
 impl IterableListArray for FixedSizeListArray {
-    fn value(&self, i: usize) -> Box<dyn Array> {
-        FixedSizeListArray::value(self, i)
+    unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array> {
+        FixedSizeListArray::value_unchecked(self, i)
     }
 }
 

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -64,7 +64,7 @@ impl FixedSizeListArray {
     /// # Implementation
     /// This operation is `O(1)`.
     /// # Panics
-    /// panics iff `offset + length >= self.len()`
+    /// panics iff `offset + length > self.len()`
     pub fn slice(&self, offset: usize, length: usize) -> Self {
         assert!(
             offset + length <= self.len(),
@@ -77,7 +77,7 @@ impl FixedSizeListArray {
     /// # Implementation
     /// This operation is `O(1)`.
     /// # Safety
-    /// The caller must ensure that `offset + length < self.len()`.
+    /// The caller must ensure that `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         let validity = self
             .validity

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -63,12 +63,30 @@ impl FixedSizeListArray {
     /// Returns a slice of this [`FixedSizeListArray`].
     /// # Implementation
     /// This operation is `O(1)`.
+    /// # Panics
+    /// panics iff `offset + length >= self.len()`
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        let validity = self.validity.clone().map(|x| x.slice(offset, length));
+        assert!(
+            offset + length <= self.len(),
+            "the offset of the new Buffer cannot exceed the existing length"
+        );
+        unsafe { self.slice_unchecked(offset, length) }
+    }
+
+    /// Returns a slice of this [`FixedSizeListArray`].
+    /// # Implementation
+    /// This operation is `O(1)`.
+    /// # Safety
+    /// The caller must ensure that `offset + length < self.len()`.
+    pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
+        let validity = self
+            .validity
+            .clone()
+            .map(|x| x.slice_unchecked(offset, length));
         let values = self
             .values
             .clone()
-            .slice(offset * self.size as usize, length * self.size as usize)
+            .slice_unchecked(offset * self.size as usize, length * self.size as usize)
             .into();
         Self {
             data_type: self.data_type.clone(),
@@ -85,10 +103,21 @@ impl FixedSizeListArray {
     }
 
     /// Returns the `Vec<T>` at position `i`.
+    /// # Panic:
+    /// panics iff `i >= self.len()`
     #[inline]
     pub fn value(&self, i: usize) -> Box<dyn Array> {
         self.values
             .slice(i * self.size as usize, self.size as usize)
+    }
+
+    /// Returns the `Vec<T>` at position `i`.
+    /// # Safety:
+    /// Caller must ensure that `i < self.len()`
+    #[inline]
+    pub unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array> {
+        self.values
+            .slice_unchecked(i * self.size as usize, self.size as usize)
     }
 
     /// Sets the validity bitmap on this [`FixedSizeListArray`].
@@ -142,6 +171,9 @@ impl Array for FixedSizeListArray {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
+        Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))

--- a/src/array/list/iterator.rs
+++ b/src/array/list/iterator.rs
@@ -32,7 +32,9 @@ impl<'a, A: IterableListArray> Iterator for ListValuesIter<'a, A> {
         }
         let old = self.index;
         self.index += 1;
-        Some(self.array.value(old))
+        // Safety:
+        // self.end is maximized by the length of the array
+        Some(unsafe { self.array.value_unchecked(old) })
     }
 
     #[inline]
@@ -50,14 +52,16 @@ impl<'a, A: IterableListArray> DoubleEndedIterator for ListValuesIter<'a, A> {
             None
         } else {
             self.end -= 1;
-            Some(self.array.value(self.end))
+            // Safety:
+            // self.end is maximized by the length of the array
+            Some(unsafe { self.array.value_unchecked(self.end) })
         }
     }
 }
 
 impl<O: Offset> IterableListArray for ListArray<O> {
-    fn value(&self, i: usize) -> Box<dyn Array> {
-        ListArray::<O>::value(self, i)
+    unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array> {
+        ListArray::<O>::value_unchecked(self, i)
     }
 }
 

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -93,7 +93,7 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     /// This operation is `O(1)` over `len`, as it amounts to increase two ref counts
     /// and moving the struct to the heap.
     /// # Safety
-    /// The caller must ensure that `offset + length < self.len()`
+    /// The caller must ensure that `offset + length <=| self.len()`
     unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array>;
 
     /// Sets the validity bitmap on this [`Array`].
@@ -434,8 +434,8 @@ fn display_fmt<T: std::fmt::Display, I: IntoIterator<Item = Option<T>>>(
 
 /// Trait that list arrays implement for the purposes of DRY.
 pub trait IterableListArray: Array {
-    // # Safety:
-    // The caller must ensure that `i < self.len()`
+    /// # Safety:
+    /// The caller must ensure that `i < self.len()`
     unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array>;
 }
 

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -88,6 +88,14 @@ pub trait Array: std::fmt::Debug + Send + Sync {
     /// This function panics iff `offset + length >= self.len()`.
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array>;
 
+    /// Slices the [`Array`], returning a new `Box<dyn Array>`.
+    /// # Implementation
+    /// This operation is `O(1)` over `len`, as it amounts to increase two ref counts
+    /// and moving the struct to the heap.
+    /// # Safety
+    /// The caller must ensure that `offset + length < self.len()`
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array>;
+
     /// Sets the validity bitmap on this [`Array`].
     /// # Panic
     /// This function panics iff `validity.len() < self.len()`.
@@ -426,7 +434,9 @@ fn display_fmt<T: std::fmt::Display, I: IntoIterator<Item = Option<T>>>(
 
 /// Trait that list arrays implement for the purposes of DRY.
 pub trait IterableListArray: Array {
-    fn value(&self, i: usize) -> Box<dyn Array>;
+    // # Safety:
+    // The caller must ensure that `i < self.len()`
+    unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array>;
 }
 
 /// Trait that [`BinaryArray`] and [`Utf8Array`] implement for the purposes of DRY.

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -63,6 +63,9 @@ impl Array for NullArray {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
+        Box::new(self.slice(offset, length))
+    }
     fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {
         panic!("cannot set validity of a null array")
     }

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -97,7 +97,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// # Implementation
     /// This operation is `O(1)` as it amounts to increase two ref counts.
     /// # Safety
-    /// The caller must ensure that `offset + length < self.len()`.
+    /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
     pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         let validity = self

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -86,10 +86,27 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// This function panics iff `offset + length >= self.len()`.
     #[inline]
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        let validity = self.validity.clone().map(|x| x.slice(offset, length));
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
+        unsafe { self.slice_unchecked(offset, length) }
+    }
+
+    /// Returns a slice of this [`PrimitiveArray`].
+    /// # Implementation
+    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// # Safety
+    /// The caller must ensure that `offset + length < self.len()`.
+    #[inline]
+    pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
+        let validity = self
+            .validity
+            .clone()
+            .map(|x| x.slice_unchecked(offset, length));
         Self {
             data_type: self.data_type.clone(),
-            values: self.values.clone().slice(offset, length),
+            values: self.values.clone().slice_unchecked(offset, length),
             validity,
             offset: self.offset + offset,
         }
@@ -175,6 +192,9 @@ impl<T: NativeType> Array for PrimitiveArray<T> {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
+        Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -116,7 +116,7 @@ impl StructArray {
     /// # Implementation
     /// This operation is `O(F)` where `F` is the number of fields.
     /// # Safety
-    /// The caller must ensure that `offset + length < self.len()`.
+    /// The caller must ensure that `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         let validity = self
             .validity

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -105,13 +105,29 @@ impl StructArray {
     /// # Implementation
     /// This operation is `O(F)` where `F` is the number of fields.
     pub fn slice(&self, offset: usize, length: usize) -> Self {
-        let validity = self.validity.clone().map(|x| x.slice(offset, length));
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
+        unsafe { self.slice_unchecked(offset, length) }
+    }
+
+    /// Creates a new [`StructArray`] that is a slice of `self`.
+    /// # Implementation
+    /// This operation is `O(F)` where `F` is the number of fields.
+    /// # Safety
+    /// The caller must ensure that `offset + length < self.len()`.
+    pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
+        let validity = self
+            .validity
+            .clone()
+            .map(|x| x.slice_unchecked(offset, length));
         Self {
             data_type: self.data_type.clone(),
             values: self
                 .values
                 .iter()
-                .map(|x| x.slice(offset, length).into())
+                .map(|x| x.slice_unchecked(offset, length).into())
                 .collect(),
             validity,
         }
@@ -174,6 +190,9 @@ impl Array for StructArray {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
+        Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -190,6 +190,23 @@ impl UnionArray {
             offset: self.offset + offset,
         }
     }
+
+    /// Returns a slice of this [`UnionArray`].
+    /// # Implementation
+    /// This operation is `O(F)` where `F` is the number of fields.
+    /// # Safety
+    /// The caller must ensure that `offset + length < self.len()`.
+    #[inline]
+    pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
+        Self {
+            data_type: self.data_type.clone(),
+            fields: self.fields.clone(),
+            fields_hash: self.fields_hash.clone(),
+            types: self.types.clone().slice_unchecked(offset, length),
+            offsets: self.offsets.clone(),
+            offset: self.offset + offset,
+        }
+    }
 }
 
 impl Array for UnionArray {
@@ -211,6 +228,9 @@ impl Array for UnionArray {
 
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
+    }
+    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
+        Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {
         panic!("cannot set validity of a union array")

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -195,7 +195,7 @@ impl UnionArray {
     /// # Implementation
     /// This operation is `O(F)` where `F` is the number of fields.
     /// # Safety
-    /// The caller must ensure that `offset + length < self.len()`.
+    /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
     pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         Self {

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -175,7 +175,7 @@ impl<O: Offset> Utf8Array<O> {
     /// # Implementation
     /// This operation is `O(1)` as it amounts to essentially increase two ref counts.
     /// # Safety
-    /// The caller must ensure that `offset + length < self.len()`.
+    /// The caller must ensure that `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         let validity = self
             .validity

--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -118,7 +118,7 @@ impl Bitmap {
 
     /// Slices `self`, offseting by `offset` and truncating up to `length` bits.
     /// # Safety
-    /// The caller must ensure that `self.offset + offset + length <= self.bytes.len() * 8`
+    /// The caller must ensure that `self.offset + offset + length <= self.len()`
     #[inline]
     pub unsafe fn slice_unchecked(mut self, offset: usize, length: usize) -> Self {
         self.offset += offset;

--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -108,11 +108,19 @@ impl Bitmap {
 
     /// Slices `self`, offseting by `offset` and truncating up to `length` bits.
     /// # Panic
-    /// Panics iff `self.offset + offset + length <= self.bytes.len() * 8`, i.e. if the offset and `length`
+    /// Panics iff `self.offset + offset + length >= self.bytes.len() * 8`, i.e. if the offset and `length`
     /// exceeds the allocated capacity of `self`.
     #[inline]
-    pub fn slice(mut self, offset: usize, length: usize) -> Self {
+    pub fn slice(self, offset: usize, length: usize) -> Self {
         assert!(offset + length <= self.length);
+        unsafe { self.slice_unchecked(offset, length) }
+    }
+
+    /// Slices `self`, offseting by `offset` and truncating up to `length` bits.
+    /// # Safety
+    /// The caller must ensure that `self.offset + offset + length <= self.bytes.len() * 8`
+    #[inline]
+    pub unsafe fn slice_unchecked(mut self, offset: usize, length: usize) -> Self {
         self.offset += offset;
         self.length = length;
         self.null_count = count_zeros(&self.bytes, self.offset, self.length);

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -86,11 +86,22 @@ impl<T: NativeType> Buffer<T> {
     /// # Panics
     /// Panics iff `offset` is larger than `len`.
     #[inline]
-    pub fn slice(mut self, offset: usize, length: usize) -> Self {
+    pub fn slice(self, offset: usize, length: usize) -> Self {
         assert!(
             offset + length <= self.len(),
             "the offset of the new Buffer cannot exceed the existing length"
         );
+        // Safety:
+        // we just check bounds
+        unsafe { self.slice_unchecked(offset, length) }
+    }
+
+    /// Returns a new [Buffer] that is a slice of this buffer starting at `offset`.
+    /// Doing so allows the same memory region to be shared between buffers.
+    /// # Safety
+    /// The caller must ensure `offset + length < self.len()`
+    #[inline]
+    pub unsafe fn slice_unchecked(mut self, offset: usize, length: usize) -> Self {
         self.offset += offset;
         self.length = length;
         self

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -91,15 +91,14 @@ impl<T: NativeType> Buffer<T> {
             offset + length <= self.len(),
             "the offset of the new Buffer cannot exceed the existing length"
         );
-        // Safety:
-        // we just check bounds
+        // Safety: we just checked bounds
         unsafe { self.slice_unchecked(offset, length) }
     }
 
     /// Returns a new [Buffer] that is a slice of this buffer starting at `offset`.
     /// Doing so allows the same memory region to be shared between buffers.
     /// # Safety
-    /// The caller must ensure `offset + length < self.len()`
+    /// The caller must ensure `offset + length <= self.len()`
     #[inline]
     pub unsafe fn slice_unchecked(mut self, offset: usize, length: usize) -> Self {
         self.offset += offset;


### PR DESCRIPTION
This PR elides some of the bounds checks done while iteration list values. The slicing still does bound checks and IMO should be one of the invariants of the offsets (being in bounds). I want to propose a `slice_unchecked` on the `Array` trait. Let me know what you think.

This optimization might also work for `FixedSizeList` if we add a `value_unchecked` to the array.

```
Gnuplot not found, using plotters backend
list: iter_values 2^10  time:   [15.214 us 15.217 us 15.220 us]                                    
                        change: [-12.125% -12.063% -11.995%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  2 (2.00%) high mild
  8 (8.00%) high severe

list: iter 2^10         time:   [15.274 us 15.277 us 15.280 us]                             
                        change: [-12.382% -12.065% -11.801%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

list: iter_values 2^12  time:   [60.861 us 60.869 us 60.878 us]                                   
                        change: [-11.760% -9.6523% -7.8631%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  7 (7.00%) high mild
  3 (3.00%) high severe

list: iter 2^12         time:   [61.928 us 61.995 us 62.076 us]                            
                        change: [-5.0382% -4.4427% -3.8211%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

list: iter_values 2^14  time:   [244.38 us 244.41 us 244.44 us]                                   
                        change: [-8.0274% -7.9989% -7.9730%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  1 (1.00%) high mild
  5 (5.00%) high severe

list: iter 2^14         time:   [245.20 us 245.23 us 245.26 us]                            
                        change: [-21.663% -18.963% -16.142%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

Benchmarking list: iter_values 2^16: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.4s, enable flat sampling, or reduce sample count to 60.
list: iter_values 2^16  time:   [1.0023 ms 1.0034 ms 1.0051 ms]                                    
                        change: [-3.7442% -3.3126% -2.7332%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  5 (5.00%) high mild
  9 (9.00%) high severe

Benchmarking list: iter 2^16: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 5.2s, enable flat sampling, or reduce sample count to 60.
list: iter 2^16         time:   [1.0243 ms 1.0254 ms 1.0266 ms]                             
                        change: [-0.3685% -0.1351% +0.1820%] (p = 0.35 > 0.05)
                        No change in performance detected.
Found 19 outliers among 100 measurements (19.00%)
  8 (8.00%) low mild
  8 (8.00%) high mild
  3 (3.00%) high severe

list: iter_values 2^18  time:   [3.9003 ms 3.9005 ms 3.9008 ms]                                    
                        change: [-11.058% -10.852% -10.638%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe

list: iter 2^18         time:   [3.9241 ms 3.9244 ms 3.9248 ms]                             
                        change: [-6.2696% -6.1584% -6.0561%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

list: iter_values 2^20  time:   [15.604 ms 15.606 ms 15.607 ms]                                   
                        change: [-7.4029% -7.2619% -7.1323%] (p = 0.00 < 0.05)
                        Performance has improved.

list: iter 2^20         time:   [15.923 ms 16.046 ms 16.204 ms]                            
                        change: [-4.1817% -3.4015% -2.4924%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
```