### PR TITLE
Improved performance of sum aggregation via aligned loads (-10%)

### DIFF
--- a/src/compute/aggregate/sum.rs
+++ b/src/compute/aggregate/sum.rs
@@ -26,10 +26,7 @@ where
     T: NativeType + Simd + Add<Output = T> + std::iter::Sum<T>,
     T::Simd: Sum<T> + Add<Output = T::Simd>,
 {
-    // Safety:
-    // T::Simd is the vector type T and the alignment is similar to aligning to [T; alignment]
-    // the alignment of T::Simd ensures that it fits T.
-    let (head, simd_vals, tail) = unsafe { values.align_to::<T::Simd>() };
+    let (head, simd_vals, tail) = T::Simd::align(values);
 
     let mut reduced = T::Simd::from_incomplete_chunk(&[], T::default());
     for chunk in simd_vals {

--- a/src/compute/aggregate/sum.rs
+++ b/src/compute/aggregate/sum.rs
@@ -21,7 +21,7 @@ pub trait Sum<T> {
 
 #[multiversion]
 #[clone(target = "x86_64+avx")]
-fn nonnull_sum<'a, T>(values: &'a [T]) -> T
+fn nonnull_sum<T>(values: &[T]) -> T
 where
     T: NativeType + Simd + Add<Output = T> + std::iter::Sum<T>,
     T::Simd: Sum<T> + Add<Output = T::Simd>,
@@ -89,7 +89,7 @@ where
 /// Returns the sum of values in the array.
 ///
 /// Returns `None` if the array is empty or only contains null values.
-pub fn sum_primitive<'a, T>(array: &'a PrimitiveArray<T>) -> Option<T>
+pub fn sum_primitive<T>(array: &PrimitiveArray<T>) -> Option<T>
 where
     T: NativeType + Simd + Add<Output = T> + std::iter::Sum<T>,
     T::Simd: Add<Output = T::Simd> + Sum<T>,

--- a/src/compute/aggregate/sum.rs
+++ b/src/compute/aggregate/sum.rs
@@ -33,7 +33,7 @@ where
 
     let mut reduced = T::Simd::from_incomplete_chunk(&[], T::default());
     for chunk in simd_vals {
-        reduced = reduced + chunk.clone()
+        reduced = reduced + *chunk;
     }
 
     reduced.simd_sum() + head.iter().copied().sum() + tail.iter().copied().sum()

--- a/src/compute/aggregate/sum.rs
+++ b/src/compute/aggregate/sum.rs
@@ -19,23 +19,43 @@ pub trait Sum<T> {
     fn simd_sum(self) -> T;
 }
 
+fn split_by_alignment<U, T>(values: &[T]) -> (&[T], &[T]) {
+    let alignment = std::mem::align_of::<U>();
+
+    let vals_ptr = values.as_ptr();
+    let bytes_offset = vals_ptr.align_offset(alignment);
+    let type_offset = if bytes_offset > 0 {
+        std::mem::align_of::<T>() / bytes_offset
+    } else {
+        0
+    };
+
+    let head = &values[..type_offset];
+    let aligned_values = &values[type_offset..];
+    (head, aligned_values)
+}
+
 #[multiversion]
 #[clone(target = "x86_64+avx")]
 fn nonnull_sum<T>(values: &[T]) -> T
 where
-    T: NativeType + Simd,
+    T: NativeType + Simd + Add<Output = T> + std::iter::Sum<T>,
     T::Simd: Add<Output = T::Simd> + Sum<T>,
 {
-    let mut chunks = values.chunks_exact(T::Simd::LANES);
+    let (head, aligned_values) = split_by_alignment::<T::Simd, _>(values);
 
+    let mut chunks = aligned_values.chunks_exact(T::Simd::LANES);
+
+    // Safety:
+    // we just made sure that we work on a slice af data aligned to T::Simd
     let sum = chunks.by_ref().fold(T::Simd::default(), |acc, chunk| {
-        acc + T::Simd::from_chunk(chunk)
+        acc + unsafe { T::Simd::from_chunk_aligned_unchecked(chunk) }
     });
 
     let remainder = T::Simd::from_incomplete_chunk(chunks.remainder(), T::default());
     let reduced = sum + remainder;
 
-    reduced.simd_sum()
+    reduced.simd_sum() + head.iter().copied().sum()
 }
 
 /// # Panics
@@ -90,7 +110,7 @@ where
 /// Returns `None` if the array is empty or only contains null values.
 pub fn sum_primitive<T>(array: &PrimitiveArray<T>) -> Option<T>
 where
-    T: NativeType + Simd,
+    T: NativeType + Simd + Add<Output = T> + std::iter::Sum<T>,
     T::Simd: Add<Output = T::Simd> + Sum<T>,
 {
     let null_count = array.null_count();

--- a/src/types/simd/mod.rs
+++ b/src/types/simd/mod.rs
@@ -28,6 +28,13 @@ pub trait NativeSimd: Default {
     /// * iff `v.len()` != `T::LANES`
     fn from_chunk(v: &[Self::Native]) -> Self;
 
+    /// Convert itself from a slice.
+    /// # Safety:
+    /// Caller must ensure:
+    /// * `v.len() == T::LANES`
+    /// * slice is aligned to `Self`
+    unsafe fn from_chunk_aligned_unchecked(v: &[Self::Native]) -> Self;
+
     /// creates a new Self from `v` by populating items from `v` up to its length.
     /// Items from `v` at positions larger than the number of lanes are ignored;
     /// remaining items are populated with `remaining`.

--- a/src/types/simd/mod.rs
+++ b/src/types/simd/mod.rs
@@ -10,7 +10,10 @@ pub trait FromMaskChunk<T> {
 }
 
 /// A struct that lends itself well to be compiled leveraging SIMD
-pub trait NativeSimd: Default + Copy {
+/// # Safety
+/// The `NativeType` and the `NativeSimd` must have possible a matching alignment.
+/// e.g. slicing `&[NativeType]` by `align_of<NativeSimd>()` must be properly aligned/safe.
+pub unsafe trait NativeSimd: Default + Copy {
     /// Number of lanes
     const LANES: usize;
     /// The [`NativeType`] of this struct. E.g. `f32` for a `NativeSimd = f32x16`.
@@ -32,6 +35,8 @@ pub trait NativeSimd: Default + Copy {
     /// Items from `v` at positions larger than the number of lanes are ignored;
     /// remaining items are populated with `remaining`.
     fn from_incomplete_chunk(v: &[Self::Native], remaining: Self::Native) -> Self;
+
+    fn align(values: &[Self::Native]) -> (&[Self::Native], &[Self], &[Self::Native]);
 }
 
 /// Trait implemented by some [`NativeType`] that have a SIMD representation.

--- a/src/types/simd/mod.rs
+++ b/src/types/simd/mod.rs
@@ -28,17 +28,12 @@ pub trait NativeSimd: Default {
     /// * iff `v.len()` != `T::LANES`
     fn from_chunk(v: &[Self::Native]) -> Self;
 
-    /// Convert itself from a slice.
-    /// # Safety:
-    /// Caller must ensure:
-    /// * `v.len() == T::LANES`
-    /// * slice is aligned to `Self`
-    unsafe fn from_chunk_aligned_unchecked(v: &[Self::Native]) -> Self;
-
     /// creates a new Self from `v` by populating items from `v` up to its length.
     /// Items from `v` at positions larger than the number of lanes are ignored;
     /// remaining items are populated with `remaining`.
     fn from_incomplete_chunk(v: &[Self::Native], remaining: Self::Native) -> Self;
+
+    fn clone(&self) -> Self;
 }
 
 /// Trait implemented by some [`NativeType`] that have a SIMD representation.

--- a/src/types/simd/mod.rs
+++ b/src/types/simd/mod.rs
@@ -10,7 +10,7 @@ pub trait FromMaskChunk<T> {
 }
 
 /// A struct that lends itself well to be compiled leveraging SIMD
-pub trait NativeSimd: Default {
+pub trait NativeSimd: Default + Copy {
     /// Number of lanes
     const LANES: usize;
     /// The [`NativeType`] of this struct. E.g. `f32` for a `NativeSimd = f32x16`.
@@ -32,8 +32,6 @@ pub trait NativeSimd: Default {
     /// Items from `v` at positions larger than the number of lanes are ignored;
     /// remaining items are populated with `remaining`.
     fn from_incomplete_chunk(v: &[Self::Native], remaining: Self::Native) -> Self;
-
-    fn clone(&self) -> Self;
 }
 
 /// Trait implemented by some [`NativeType`] that have a SIMD representation.

--- a/src/types/simd/native.rs
+++ b/src/types/simd/native.rs
@@ -6,6 +6,7 @@ use super::*;
 macro_rules! simd {
     ($name:tt, $type:ty, $lanes:expr, $mask:ty) => {
         #[allow(non_camel_case_types)]
+        #[derive(Copy, Clone)]
         pub struct $name(pub [$type; $lanes]);
 
         impl NativeSimd for $name {
@@ -34,10 +35,6 @@ macro_rules! simd {
                 let mut a = [remaining; $lanes];
                 a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
                 Self(a)
-            }
-            #[inline]
-            fn clone(&self) -> Self {
-                ($name)(self.0).into()
             }
         }
 

--- a/src/types/simd/native.rs
+++ b/src/types/simd/native.rs
@@ -30,15 +30,14 @@ macro_rules! simd {
             }
 
             #[inline]
-            unsafe fn from_chunk_aligned_unchecked(v: &[$type]) -> Self {
-                ($name)(v.try_into().unwrap())
-            }
-
-            #[inline]
             fn from_incomplete_chunk(v: &[$type], remaining: $type) -> Self {
                 let mut a = [remaining; $lanes];
                 a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
                 Self(a)
+            }
+            #[inline]
+            fn clone(&self) -> Self {
+                self.clone()
             }
         }
 

--- a/src/types/simd/native.rs
+++ b/src/types/simd/native.rs
@@ -9,7 +9,7 @@ macro_rules! simd {
         #[derive(Copy, Clone)]
         pub struct $name(pub [$type; $lanes]);
 
-        impl NativeSimd for $name {
+        unsafe impl NativeSimd for $name {
             const LANES: usize = $lanes;
             type Native = $type;
             type Chunk = $mask;
@@ -35,6 +35,11 @@ macro_rules! simd {
                 let mut a = [remaining; $lanes];
                 a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
                 Self(a)
+            }
+
+            #[inline]
+            fn align(values: &[Self::Native]) -> (&[Self::Native], &[Self], &[Self::Native]) {
+                unsafe { values.align_to::<Self>() }
             }
         }
 

--- a/src/types/simd/native.rs
+++ b/src/types/simd/native.rs
@@ -30,6 +30,11 @@ macro_rules! simd {
             }
 
             #[inline]
+            unsafe fn from_chunk_aligned_unchecked(v: &[$type]) -> Self {
+                ($name)(v.try_into().unwrap())
+            }
+
+            #[inline]
             fn from_incomplete_chunk(v: &[$type], remaining: $type) -> Self {
                 let mut a = [remaining; $lanes];
                 a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);

--- a/src/types/simd/native.rs
+++ b/src/types/simd/native.rs
@@ -37,7 +37,7 @@ macro_rules! simd {
             }
             #[inline]
             fn clone(&self) -> Self {
-                self.clone()
+                ($name)(self.0).into()
             }
         }
 

--- a/src/types/simd/packed.rs
+++ b/src/types/simd/packed.rs
@@ -29,11 +29,6 @@ macro_rules! simd {
                 a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
                 <$name>::from_chunk(a.as_ref())
             }
-
-            #[inline]
-            fn clone(&self) -> Self {
-                *self
-            }
         }
     };
 }

--- a/src/types/simd/packed.rs
+++ b/src/types/simd/packed.rs
@@ -7,7 +7,7 @@ use super::*;
 
 macro_rules! simd {
     ($name:tt, $type:ty, $lanes:expr, $chunk:ty, $mask:tt) => {
-        impl NativeSimd for $name {
+        unsafe impl NativeSimd for $name {
             const LANES: usize = $lanes;
             type Native = $type;
             type Chunk = $chunk;
@@ -28,6 +28,11 @@ macro_rules! simd {
                 let mut a = [remaining; $lanes];
                 a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
                 <$name>::from_chunk(a.as_ref())
+            }
+
+            #[inline]
+            fn align(values: &[Self::Native]) -> (&[Self::Native], &[Self], &[Self::Native]) {
+                unsafe { values.align_to::<Self>() }
             }
         }
     };

--- a/src/types/simd/packed.rs
+++ b/src/types/simd/packed.rs
@@ -24,6 +24,11 @@ macro_rules! simd {
             }
 
             #[inline]
+            unsafe fn from_chunk_aligned_unchecked(v: &[$type]) -> Self {
+                <$name>::from_slice_aligned_unchecked(v)
+            }
+
+            #[inline]
             fn from_incomplete_chunk(v: &[$type], remaining: $type) -> Self {
                 let mut a = [remaining; $lanes];
                 a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);

--- a/src/types/simd/packed.rs
+++ b/src/types/simd/packed.rs
@@ -24,15 +24,15 @@ macro_rules! simd {
             }
 
             #[inline]
-            unsafe fn from_chunk_aligned_unchecked(v: &[$type]) -> Self {
-                <$name>::from_slice_aligned_unchecked(v)
-            }
-
-            #[inline]
             fn from_incomplete_chunk(v: &[$type], remaining: $type) -> Self {
                 let mut a = [remaining; $lanes];
                 a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
                 <$name>::from_chunk(a.as_ref())
+            }
+
+            #[inline]
+            fn clone(&self) -> Self {
+                *self
             }
         }
     };


### PR DESCRIPTION
This adds aligned load instruction to the SIMD aggregation of arrays without null values. This implementation works on any alignment, and does not require an aligned allocator, and also works on sliced arrays.

Benchmark is a bit mixed on small data sizes. It seems to improving with more data, I want to run one on more data later.

```
Gnuplot not found, using plotters backend
sum 2^10 f32            time:   [101.38 ns 101.41 ns 101.45 ns]                         
                        change: [+1.5061% +1.5401% +1.5774%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

sum 2^12 f32            time:   [284.72 ns 285.05 ns 285.44 ns]                         
                        change: [+0.4929% +0.6963% +0.9300%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

sum 2^14 f32            time:   [1.0246 us 1.0246 us 1.0247 us]                          
                        change: [-4.1159% -3.6418% -3.1975%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

sum 2^16 f32            time:   [4.0764 us 4.0773 us 4.0783 us]                          
                        change: [+1.4638% +1.6504% +1.7873%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) high mild
  6 (6.00%) high severe

sum 2^18 f32            time:   [19.596 us 19.600 us 19.606 us]                          
                        change: [+0.2075% +0.2434% +0.2801%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

sum 2^20 f32            time:   [67.890 us 67.909 us 67.931 us]                         
                        change: [-6.5180% -6.4803% -6.4365%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  11 (11.00%) high mild
  1 (1.00%) high severe


```