### PR TITLE
More granular dtype serialization options for csv writer.

### DIFF
--- a/src/io/csv/write/serialize.rs
+++ b/src/io/csv/write/serialize.rs
@@ -13,8 +13,13 @@ use super::iterator::{BufStreamingIterator, StreamingIterator};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SerializeOptions {
+    // used for date32
     pub date_format: String,
+    /// used for dat64
+    pub datetime_format: String,
+    // used for time32/64
     pub time_format: String,
+    // used for timestamp
     pub timestamp_format: String,
 }
 
@@ -22,6 +27,7 @@ impl Default for SerializeOptions {
     fn default() -> Self {
         Self {
             date_format: "%F".to_string(),
+            datetime_format: "%FT%H:%M:%S.%9f".to_string(),
             time_format: "%T".to_string(),
             timestamp_format: "%FT%H:%M:%S.%9f".to_string(),
         }
@@ -150,7 +156,7 @@ pub fn new_serializer<'a>(
                 i64,
                 temporal_conversions::date64_to_datetime,
                 array,
-                &options.timestamp_format
+                &options.datetime_format
             )
         }
         DataType::Time64(TimeUnit::Microsecond) => {

--- a/src/io/csv/write/serialize.rs
+++ b/src/io/csv/write/serialize.rs
@@ -150,7 +150,7 @@ pub fn new_serializer<'a>(
                 i64,
                 temporal_conversions::date64_to_datetime,
                 array,
-                &options.date_format
+                &options.timestamp_format
             )
         }
         DataType::Time64(TimeUnit::Microsecond) => {

--- a/src/io/csv/write/serialize.rs
+++ b/src/io/csv/write/serialize.rs
@@ -13,22 +13,25 @@ use super::iterator::{BufStreamingIterator, StreamingIterator};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct SerializeOptions {
-    // used for date32
-    pub date_format: String,
-    /// used for dat64
-    pub datetime_format: String,
-    // used for time32/64
-    pub time_format: String,
-    // used for timestamp
+    /// used for date32
+    pub date32_format: String,
+    /// used for date64
+    pub date64_format: String,
+    /// used for time32
+    pub time32_format: String,
+    /// used for time64
+    pub time64_format: String,
+    /// used for timestamp
     pub timestamp_format: String,
 }
 
 impl Default for SerializeOptions {
     fn default() -> Self {
         Self {
-            date_format: "%F".to_string(),
-            datetime_format: "%FT%H:%M:%S.%9f".to_string(),
-            time_format: "%T".to_string(),
+            date32_format: "%F".to_string(),
+            date64_format: "%F".to_string(),
+            time32_format: "%T".to_string(),
+            time64_format: "%T".to_string(),
             timestamp_format: "%FT%H:%M:%S.%9f".to_string(),
         }
     }
@@ -129,7 +132,7 @@ pub fn new_serializer<'a>(
                 i32,
                 temporal_conversions::date32_to_datetime,
                 array,
-                &options.date_format
+                &options.date32_format
             )
         }
         DataType::Time32(TimeUnit::Second) => {
@@ -137,7 +140,7 @@ pub fn new_serializer<'a>(
                 i32,
                 temporal_conversions::time32s_to_time,
                 array,
-                &options.time_format
+                &options.time32_format
             )
         }
         DataType::Time32(TimeUnit::Millisecond) => {
@@ -145,7 +148,7 @@ pub fn new_serializer<'a>(
                 i32,
                 temporal_conversions::time32ms_to_time,
                 array,
-                &options.time_format
+                &options.time32_format
             )
         }
         DataType::Int64 => {
@@ -156,7 +159,7 @@ pub fn new_serializer<'a>(
                 i64,
                 temporal_conversions::date64_to_datetime,
                 array,
-                &options.datetime_format
+                &options.date64_format
             )
         }
         DataType::Time64(TimeUnit::Microsecond) => {
@@ -164,7 +167,7 @@ pub fn new_serializer<'a>(
                 i64,
                 temporal_conversions::time64us_to_time,
                 array,
-                &options.time_format
+                &options.time64_format
             )
         }
         DataType::Time64(TimeUnit::Nanosecond) => {
@@ -172,7 +175,7 @@ pub fn new_serializer<'a>(
                 i64,
                 temporal_conversions::time64ns_to_time,
                 array,
-                &options.time_format
+                &options.time64_format
             )
         }
         DataType::Timestamp(TimeUnit::Second, None) => {

--- a/tests/it/io/csv/write.rs
+++ b/tests/it/io/csv/write.rs
@@ -83,7 +83,8 @@ fn write_csv_custom_options() -> Result<()> {
     let mut writer = WriterBuilder::new().delimiter(b'|').from_writer(write);
 
     let options = SerializeOptions {
-        time_format: "%r".to_string(),
+        time32_format: "%r".to_string(),
+        time64_format: "%r".to_string(),
         ..Default::default()
     };
     write_batch(&mut writer, &batch, &options)?;


### PR DESCRIPTION
~This changes csv output for the `Date64` datatype to also include the time information. So that a round trip of `Date64 -> csv -> Date64` would not lose information.~