### PR TITLE
Added property testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ lexical-core = { version = "0.8", optional = true }
 # We need to Hash values before sending them to an hasher. This
 # crate provides HashMap that assumes pre-hashed values.
 hash_hasher = "^2.0.3"
+# For SIMD utf8 validation
+simdutf8 = "0.1.3"
 
 csv = { version = "^1.1", optional = true }
 regex = { version = "^1.3", optional = true }
@@ -68,15 +70,13 @@ strength_reduce = { version = "0.2", optional = true }
 # For instruction multiversioning
 multiversion = { version = "0.6.1", optional = true }
 
-# For SIMD utf8 validation
-simdutf8 = "0.1.3"
-
 [dev-dependencies]
-rand = "0.8"
 criterion = "0.3"
 flate2 = "1"
 doc-comment = "0.3"
 crossbeam-channel = "0.5.1"
+# used to run formal property testing
+proptest = { version = "1", default_features = false, features = ["std"] }
 
 [package.metadata.docs.rs]
 features = ["full"]

--- a/tests/it/array/binary/mutable.rs
+++ b/tests/it/array/binary/mutable.rs
@@ -1,4 +1,4 @@
-use arrow2::array::{Array, BinaryArray, MutableBinaryArray};
+use arrow2::array::{BinaryArray, MutableBinaryArray};
 use arrow2::bitmap::Bitmap;
 
 #[test]

--- a/tests/it/array/utf8/mutable.rs
+++ b/tests/it/array/utf8/mutable.rs
@@ -1,4 +1,4 @@
-use arrow2::array::{Array, MutableUtf8Array, Utf8Array};
+use arrow2::array::{MutableUtf8Array, Utf8Array};
 use arrow2::bitmap::Bitmap;
 use arrow2::buffer::MutableBuffer;
 use arrow2::datatypes::DataType;

--- a/tests/it/bitmap/bitmap_ops.rs
+++ b/tests/it/bitmap/bitmap_ops.rs
@@ -1,12 +1,16 @@
+use proptest::prelude::*;
+
 use arrow2::bitmap::Bitmap;
 
-#[test]
-fn not_random() {
-    let iter = (0..100).map(|x| x % 7 == 0);
-    let iter_not = iter.clone().map(|x| !x);
+use crate::bitmap::bitmap_strategy;
 
-    let bitmap: Bitmap = iter.collect();
-    let expected: Bitmap = iter_not.collect();
+proptest! {
+    /// Asserts that !bitmap equals all bits flipped
+    #[test]
+    #[cfg_attr(miri, ignore)] // miri and proptest do not work well :(
+    fn not(bitmap in bitmap_strategy()) {
+        let not_bitmap: Bitmap = bitmap.iter().map(|x| !x).collect();
 
-    assert_eq!(!&bitmap, expected);
+        assert_eq!(!&bitmap, not_bitmap);
+    }
 }


### PR DESCRIPTION
This PR adds a couple of tests using [`proptest`](https://github.com/altsysrq/proptest), a testing framework to test code invariants. See [here](https://github.com/altsysrq/proptest) or [here](https://hypothesis.works/) for an introduction to the subject.

This framework is [being used](https://github.com/rust-lang/portable-simd/blob/master/crates/core_simd/Cargo.toml#L22) by the portable SIMD group, and in my opinion it makes a lot of sense here also, since we can rigorously declare and test the properties of our operations.
