### PR TITLE
Un-nested `compute::arithemtics::basic`

### DIFF
--- a/benches/arithmetic_kernels.rs
+++ b/benches/arithmetic_kernels.rs
@@ -5,8 +5,8 @@ use criterion::Criterion;
 use arrow2::array::*;
 use arrow2::util::bench_util::*;
 use arrow2::{
-    compute::arithmetics::basic::add::add, compute::arithmetics::basic::div::div_scalar,
-    datatypes::DataType, types::NativeType,
+    compute::arithmetics::basic::add, compute::arithmetics::basic::div_scalar, datatypes::DataType,
+    types::NativeType,
 };
 use num_traits::NumCast;
 use std::ops::{Add, Div};

--- a/src/compute/arithmetics/basic/add.rs
+++ b/src/compute/arithmetics/basic/add.rs
@@ -23,7 +23,7 @@ use crate::{
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::add::add;
+/// use arrow2::compute::arithmetics::basic::add;
 /// use arrow2::array::PrimitiveArray;
 ///
 /// let a = PrimitiveArray::from([None, Some(6), None, Some(6)]);
@@ -50,7 +50,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::add::checked_add;
+/// use arrow2::compute::arithmetics::basic::checked_add;
 /// use arrow2::array::PrimitiveArray;
 ///
 /// let a = PrimitiveArray::from([Some(100i8), Some(100i8), Some(100i8)]);
@@ -80,7 +80,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::add::saturating_add;
+/// use arrow2::compute::arithmetics::basic::saturating_add;
 /// use arrow2::array::PrimitiveArray;
 ///
 /// let a = PrimitiveArray::from([Some(100i8)]);
@@ -114,7 +114,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::add::overflowing_add;
+/// use arrow2::compute::arithmetics::basic::overflowing_add;
 /// use arrow2::array::PrimitiveArray;
 ///
 /// let a = PrimitiveArray::from([Some(1i8), Some(100i8)]);
@@ -194,7 +194,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::add::add_scalar;
+/// use arrow2::compute::arithmetics::basic::add_scalar;
 /// use arrow2::array::PrimitiveArray;
 ///
 /// let a = PrimitiveArray::from([None, Some(6), None, Some(6)]);
@@ -216,7 +216,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::add::checked_add_scalar;
+/// use arrow2::compute::arithmetics::basic::checked_add_scalar;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[None, Some(100), None, Some(100)]);
@@ -240,7 +240,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::add::saturating_add_scalar;
+/// use arrow2::compute::arithmetics::basic::saturating_add_scalar;
 /// use arrow2::array::PrimitiveArray;
 ///
 /// let a = PrimitiveArray::from([Some(100i8)]);
@@ -265,7 +265,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::add::overflowing_add_scalar;
+/// use arrow2::compute::arithmetics::basic::overflowing_add_scalar;
 /// use arrow2::array::PrimitiveArray;
 ///
 /// let a = PrimitiveArray::from([Some(1i8), Some(100i8)]);

--- a/src/compute/arithmetics/basic/div.rs
+++ b/src/compute/arithmetics/basic/div.rs
@@ -22,7 +22,7 @@ use strength_reduce::{
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::div::div;
+/// use arrow2::compute::arithmetics::basic::div;
 /// use arrow2::array::Int32Array;
 ///
 /// let a = Int32Array::from(&[Some(10), Some(1), Some(6)]);
@@ -64,7 +64,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::div::checked_div;
+/// use arrow2::compute::arithmetics::basic::checked_div;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(-100i8), Some(10i8)]);
@@ -117,7 +117,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::div::div_scalar;
+/// use arrow2::compute::arithmetics::basic::div_scalar;
 /// use arrow2::array::Int32Array;
 ///
 /// let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
@@ -200,7 +200,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::div::checked_div_scalar;
+/// use arrow2::compute::arithmetics::basic::checked_div_scalar;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(-100i8)]);

--- a/src/compute/arithmetics/basic/mod.rs
+++ b/src/compute/arithmetics/basic/mod.rs
@@ -1,7 +1,19 @@
-//! Defines the arithmetic kernels for `PrimitiveArrays`.
-pub mod add;
-pub mod div;
-pub mod mul;
-pub mod pow;
-pub mod rem;
-pub mod sub;
+//! Contains arithemtic functions for [`PrimitiveArray`](crate::array::PrimitiveArray)s.
+//!
+//! Each operation has four variants, like the rest of Rust's ecosystem:
+//! * usual, that [`panic!`]s on overflow
+//! * `checked_*` that turns overflowings to `None`
+//! * `overflowing_*` returning a [`Bitmap`](crate::bitmap::Bitmap) with items that overflow.
+//! * `saturating_*` that saturates the result.
+mod add;
+pub use add::*;
+mod div;
+pub use div::*;
+mod mul;
+pub use mul::*;
+mod pow;
+pub use pow::*;
+mod rem;
+pub use rem::*;
+mod sub;
+pub use sub::*;

--- a/src/compute/arithmetics/basic/mul.rs
+++ b/src/compute/arithmetics/basic/mul.rs
@@ -23,7 +23,7 @@ use crate::{
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::mul::mul;
+/// use arrow2::compute::arithmetics::basic::mul;
 /// use arrow2::array::Int32Array;
 ///
 /// let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
@@ -51,7 +51,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::mul::checked_mul;
+/// use arrow2::compute::arithmetics::basic::checked_mul;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(100i8), Some(100i8), Some(100i8)]);
@@ -81,7 +81,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::mul::saturating_mul;
+/// use arrow2::compute::arithmetics::basic::saturating_mul;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(-100i8)]);
@@ -115,7 +115,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::mul::overflowing_mul;
+/// use arrow2::compute::arithmetics::basic::overflowing_mul;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(1i8), Some(-100i8)]);
@@ -194,7 +194,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::mul::mul_scalar;
+/// use arrow2::compute::arithmetics::basic::mul_scalar;
 /// use arrow2::array::Int32Array;
 ///
 /// let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
@@ -216,7 +216,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::mul::checked_mul_scalar;
+/// use arrow2::compute::arithmetics::basic::checked_mul_scalar;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[None, Some(100), None, Some(100)]);
@@ -240,7 +240,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::mul::saturating_mul_scalar;
+/// use arrow2::compute::arithmetics::basic::saturating_mul_scalar;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(-100i8)]);
@@ -265,7 +265,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::mul::overflowing_mul_scalar;
+/// use arrow2::compute::arithmetics::basic::overflowing_mul_scalar;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(1i8), Some(100i8)]);

--- a/src/compute/arithmetics/basic/pow.rs
+++ b/src/compute/arithmetics/basic/pow.rs
@@ -12,7 +12,7 @@ use crate::{
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::pow::powf_scalar;
+/// use arrow2::compute::arithmetics::basic::powf_scalar;
 /// use arrow2::array::Float32Array;
 ///
 /// let a = Float32Array::from(&[Some(2f32), None]);
@@ -33,7 +33,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::pow::checked_powf_scalar;
+/// use arrow2::compute::arithmetics::basic::checked_powf_scalar;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(1i8), None, Some(7i8)]);

--- a/src/compute/arithmetics/basic/rem.rs
+++ b/src/compute/arithmetics/basic/rem.rs
@@ -21,7 +21,7 @@ use strength_reduce::{
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::rem::rem;
+/// use arrow2::compute::arithmetics::basic::rem;
 /// use arrow2::array::Int32Array;
 ///
 /// let a = Int32Array::from(&[Some(10), Some(7)]);
@@ -49,7 +49,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::rem::checked_rem;
+/// use arrow2::compute::arithmetics::basic::checked_rem;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(-100i8), Some(10i8)]);
@@ -100,7 +100,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::rem::rem_scalar;
+/// use arrow2::compute::arithmetics::basic::rem_scalar;
 /// use arrow2::array::Int32Array;
 ///
 /// let a = Int32Array::from(&[None, Some(6), None, Some(7)]);
@@ -184,7 +184,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::rem::checked_rem_scalar;
+/// use arrow2::compute::arithmetics::basic::checked_rem_scalar;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(-100i8)]);

--- a/src/compute/arithmetics/basic/sub.rs
+++ b/src/compute/arithmetics/basic/sub.rs
@@ -23,7 +23,7 @@ use crate::{
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::sub::sub;
+/// use arrow2::compute::arithmetics::basic::sub;
 /// use arrow2::array::Int32Array;
 ///
 /// let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
@@ -50,7 +50,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::sub::checked_sub;
+/// use arrow2::compute::arithmetics::basic::checked_sub;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(100i8), Some(-100i8), Some(100i8)]);
@@ -80,7 +80,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::sub::saturating_sub;
+/// use arrow2::compute::arithmetics::basic::saturating_sub;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(-100i8)]);
@@ -114,7 +114,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::sub::overflowing_sub;
+/// use arrow2::compute::arithmetics::basic::overflowing_sub;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(1i8), Some(-100i8)]);
@@ -194,7 +194,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::sub::sub_scalar;
+/// use arrow2::compute::arithmetics::basic::sub_scalar;
 /// use arrow2::array::Int32Array;
 ///
 /// let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
@@ -216,7 +216,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::sub::checked_sub_scalar;
+/// use arrow2::compute::arithmetics::basic::checked_sub_scalar;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[None, Some(-100), None, Some(-100)]);
@@ -240,7 +240,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::sub::saturating_sub_scalar;
+/// use arrow2::compute::arithmetics::basic::saturating_sub_scalar;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(-100i8)]);
@@ -265,7 +265,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::basic::sub::overflowing_sub_scalar;
+/// use arrow2::compute::arithmetics::basic::overflowing_sub_scalar;
 /// use arrow2::array::Int8Array;
 ///
 /// let a = Int8Array::from(&[Some(1i8), Some(-100i8)]);

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -250,11 +250,11 @@ where
         + Rem<Output = T>,
 {
     match op {
-        Operator::Add => basic::add::add(lhs, rhs),
-        Operator::Subtract => basic::sub::sub(lhs, rhs),
-        Operator::Multiply => basic::mul::mul(lhs, rhs),
-        Operator::Divide => basic::div::div(lhs, rhs),
-        Operator::Remainder => basic::rem::rem(lhs, rhs),
+        Operator::Add => basic::add(lhs, rhs),
+        Operator::Subtract => basic::sub(lhs, rhs),
+        Operator::Multiply => basic::mul(lhs, rhs),
+        Operator::Divide => basic::div(lhs, rhs),
+        Operator::Remainder => basic::rem(lhs, rhs),
     }
 }
 
@@ -275,11 +275,11 @@ where
         + NumCast,
 {
     match op {
-        Operator::Add => Ok(basic::add::add_scalar(lhs, rhs)),
-        Operator::Subtract => Ok(basic::sub::sub_scalar(lhs, rhs)),
-        Operator::Multiply => Ok(basic::mul::mul_scalar(lhs, rhs)),
-        Operator::Divide => Ok(basic::div::div_scalar(lhs, rhs)),
-        Operator::Remainder => Ok(basic::rem::rem_scalar(lhs, rhs)),
+        Operator::Add => Ok(basic::add_scalar(lhs, rhs)),
+        Operator::Subtract => Ok(basic::sub_scalar(lhs, rhs)),
+        Operator::Multiply => Ok(basic::mul_scalar(lhs, rhs)),
+        Operator::Divide => Ok(basic::div_scalar(lhs, rhs)),
+        Operator::Remainder => Ok(basic::rem_scalar(lhs, rhs)),
     }
 }
 

--- a/tests/it/compute/aggregate/sum.rs
+++ b/tests/it/compute/aggregate/sum.rs
@@ -46,7 +46,7 @@ fn test_primitive_array_sum_large_64() {
         .map(|i| if i % 3 == 0 { Some(0) } else { Some(i) })
         .collect();
     // create an array that actually has non-zero values at the invalid indices
-    let c = arithmetics::basic::add::add(&a, &b).unwrap();
+    let c = arithmetics::basic::add(&a, &b).unwrap();
     assert_eq!(
         Some((1..=100).filter(|i| i % 3 == 0).sum()),
         sum_primitive(&c)

--- a/tests/it/compute/arithmetics/basic/add.rs
+++ b/tests/it/compute/arithmetics/basic/add.rs
@@ -1,6 +1,6 @@
 use arrow2::array::*;
 use arrow2::bitmap::Bitmap;
-use arrow2::compute::arithmetics::basic::add::*;
+use arrow2::compute::arithmetics::basic::*;
 use arrow2::compute::arithmetics::{
     ArrayAdd, ArrayCheckedAdd, ArrayOverflowingAdd, ArraySaturatingAdd,
 };

--- a/tests/it/compute/arithmetics/basic/div.rs
+++ b/tests/it/compute/arithmetics/basic/div.rs
@@ -1,5 +1,5 @@
 use arrow2::array::*;
-use arrow2::compute::arithmetics::basic::div::*;
+use arrow2::compute::arithmetics::basic::*;
 use arrow2::compute::arithmetics::{ArrayCheckedDiv, ArrayDiv};
 
 #[test]

--- a/tests/it/compute/arithmetics/basic/mul.rs
+++ b/tests/it/compute/arithmetics/basic/mul.rs
@@ -1,6 +1,6 @@
 use arrow2::array::*;
 use arrow2::bitmap::Bitmap;
-use arrow2::compute::arithmetics::basic::mul::*;
+use arrow2::compute::arithmetics::basic::*;
 use arrow2::compute::arithmetics::{
     ArrayCheckedMul, ArrayMul, ArrayOverflowingMul, ArraySaturatingMul,
 };

--- a/tests/it/compute/arithmetics/basic/pow.rs
+++ b/tests/it/compute/arithmetics/basic/pow.rs
@@ -1,5 +1,5 @@
 use arrow2::array::*;
-use arrow2::compute::arithmetics::basic::pow::*;
+use arrow2::compute::arithmetics::basic::*;
 
 #[test]
 fn test_raise_power_scalar() {

--- a/tests/it/compute/arithmetics/basic/rem.rs
+++ b/tests/it/compute/arithmetics/basic/rem.rs
@@ -1,5 +1,5 @@
 use arrow2::array::*;
-use arrow2::compute::arithmetics::basic::rem::*;
+use arrow2::compute::arithmetics::basic::*;
 use arrow2::compute::arithmetics::{ArrayCheckedRem, ArrayRem};
 
 #[test]

--- a/tests/it/compute/arithmetics/basic/sub.rs
+++ b/tests/it/compute/arithmetics/basic/sub.rs
@@ -1,6 +1,6 @@
 use arrow2::array::*;
 use arrow2::bitmap::Bitmap;
-use arrow2::compute::arithmetics::basic::sub::*;
+use arrow2::compute::arithmetics::basic::*;
 use arrow2::compute::arithmetics::{
     ArrayCheckedSub, ArrayOverflowingSub, ArraySaturatingSub, ArraySub,
 };


### PR DESCRIPTION
This PR removes the modules `compute::arithmetics::basic::*` from the public API, instead re-exporting all functions on them to `compute::arithmetics::basic`, making them a bit easier to find and use.

To migrate, replace `compute::arithmetics::basic::add`, `compute::arithmetics::basic::sub`, etc. by `compute::arithmetics::basic`.