### PR TITLE
expose `shrink_to_fit` to mutable arrays

### DIFF
--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -138,6 +138,7 @@ impl<O: Offset> MutableBinaryArray<O> {
     /// Shrinks the capacity of the [`MutableBinaryArray`] to fit its current length.
     pub fn shrink_to_fit(&mut self) {
         self.values.shrink_to_fit();
+        self.offsets.shrink_to_fit();
         if let Some(validity) = &mut self.validity {
             validity.shrink_to_fit()
         }

--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -135,6 +135,10 @@ impl<O: Offset> MutableBinaryArray<O> {
         let a: BinaryArray<O> = self.into();
         Arc::new(a)
     }
+    /// Shrinks the capacity of the [`MutableBinaryArray`] to fit its current length.
+    pub fn shrink_to_fit(&mut self) {
+        self.values.shrink_to_fit();
+    }
 }
 
 impl<O: Offset> MutableArray for MutableBinaryArray<O> {
@@ -179,6 +183,10 @@ impl<O: Offset> MutableArray for MutableBinaryArray<O> {
     #[inline]
     fn push_null(&mut self) {
         self.push::<&[u8]>(None)
+    }
+
+    fn shrink_to_fit(&mut self) {
+        self.shrink_to_fit()
     }
 }
 

--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -138,6 +138,9 @@ impl<O: Offset> MutableBinaryArray<O> {
     /// Shrinks the capacity of the [`MutableBinaryArray`] to fit its current length.
     pub fn shrink_to_fit(&mut self) {
         self.values.shrink_to_fit();
+        if let Some(validity) = &mut self.validity {
+            validity.shrink_to_fit()
+        }
     }
 }
 

--- a/src/array/boolean/mutable.rs
+++ b/src/array/boolean/mutable.rs
@@ -461,6 +461,10 @@ impl MutableArray for MutableBooleanArray {
     fn push_null(&mut self) {
         self.push(None)
     }
+
+    fn shrink_to_fit(&mut self) {
+        // no-op still have to implement this for bitmaps
+    }
 }
 
 impl Extend<Option<bool>> for MutableBooleanArray {

--- a/src/array/boolean/mutable.rs
+++ b/src/array/boolean/mutable.rs
@@ -293,6 +293,14 @@ impl MutableBooleanArray {
         // Safety: `I` is `TrustedLen`
         unsafe { Self::try_from_trusted_len_iter_unchecked(iterator) }
     }
+
+    /// Shrinks the capacity of the [`MutableBooleanArray`] to fit its current length.
+    pub fn shrink_to_fit(&mut self) {
+        self.values.shrink_to_fit();
+        if let Some(validity) = &mut self.validity {
+            validity.shrink_to_fit()
+        }
+    }
 }
 
 /// Creates a Bitmap and an optional [`MutableBitmap`] from an iterator of `Option<bool>`.
@@ -463,7 +471,7 @@ impl MutableArray for MutableBooleanArray {
     }
 
     fn shrink_to_fit(&mut self) {
-        // no-op still have to implement this for bitmaps
+        self.shrink_to_fit()
     }
 }
 

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -104,6 +104,11 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
         let a: DictionaryArray<K> = self.into();
         Arc::new(a)
     }
+
+    /// Shrinks the capacity of the [`MutableDictionaryArray`] to fit its current length.
+    pub fn shrink_to_fit(&mut self) {
+        self.values.shrink_to_fit();
+    }
 }
 
 impl<K: DictionaryKey, M: 'static + MutableArray> MutableArray for MutableDictionaryArray<K, M> {
@@ -143,6 +148,9 @@ impl<K: DictionaryKey, M: 'static + MutableArray> MutableArray for MutableDictio
 
     fn push_null(&mut self) {
         self.keys.push(None)
+    }
+    fn shrink_to_fit(&mut self) {
+        self.shrink_to_fit()
     }
 }
 

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -108,6 +108,7 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
     /// Shrinks the capacity of the [`MutableDictionaryArray`] to fit its current length.
     pub fn shrink_to_fit(&mut self) {
         self.values.shrink_to_fit();
+        self.keys.shrink_to_fit();
     }
 }
 

--- a/src/array/fixed_size_binary/mutable.rs
+++ b/src/array/fixed_size_binary/mutable.rs
@@ -149,6 +149,11 @@ impl MutableFixedSizeBinaryArray {
     pub unsafe fn value_unchecked(&self, i: usize) -> &[u8] {
         std::slice::from_raw_parts(self.values.as_ptr().add(i * self.size), self.size)
     }
+
+    /// Shrinks the capacity of the [`MutablePrimitive`] to fit its current length.
+    pub fn shrink_to_fit(&mut self) {
+        self.values.shrink_to_fit();
+    }
 }
 
 /// Accessors
@@ -203,6 +208,10 @@ impl MutableArray for MutableFixedSizeBinaryArray {
 
     fn push_null(&mut self) {
         self.values.extend_constant(self.size, 0);
+    }
+
+    fn shrink_to_fit(&mut self) {
+        self.shrink_to_fit()
     }
 }
 

--- a/src/array/fixed_size_binary/mutable.rs
+++ b/src/array/fixed_size_binary/mutable.rs
@@ -153,6 +153,9 @@ impl MutableFixedSizeBinaryArray {
     /// Shrinks the capacity of the [`MutablePrimitive`] to fit its current length.
     pub fn shrink_to_fit(&mut self) {
         self.values.shrink_to_fit();
+        if let Some(validity) = &mut self.validity {
+            validity.shrink_to_fit()
+        }
     }
 }
 

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -76,7 +76,10 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
     }
     /// Shrinks the capacity of the [`MutableFixedSizeList`] to fit its current length.
     pub fn shrink_to_fit(&mut self) {
-        self.values.shrink_to_fit()
+        self.values.shrink_to_fit();
+        if let Some(validity) = &mut self.validity {
+            validity.shrink_to_fit()
+        }
     }
 }
 

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -74,6 +74,10 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
             None => self.init_validity(),
         }
     }
+    /// Shrinks the capacity of the [`MutableFixedSizeList`] to fit its current length.
+    pub fn shrink_to_fit(&mut self) {
+        self.values.shrink_to_fit()
+    }
 }
 
 impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
@@ -123,6 +127,10 @@ impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
         } else {
             self.init_validity()
         }
+    }
+
+    fn shrink_to_fit(&mut self) {
+        self.shrink_to_fit()
     }
 }
 

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -42,6 +42,12 @@ impl<O: Offset, M: MutableArray + Default> MutableListArray<O, M> {
             validity: None,
         }
     }
+
+    /// Shrinks the capacity of the [`MutableList`] to fit its current length.
+    pub fn shrink_to_fit(&mut self) {
+        self.values.shrink_to_fit();
+        self.offsets.shrink_to_fit();
+    }
 }
 
 impl<O: Offset, M: MutableArray + Default> Default for MutableListArray<O, M> {
@@ -221,5 +227,8 @@ impl<O: Offset, M: MutableArray + 'static> MutableArray for MutableListArray<O, 
     #[inline]
     fn push_null(&mut self) {
         self.push_null()
+    }
+    fn shrink_to_fit(&mut self) {
+        self.shrink_to_fit();
     }
 }

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -47,6 +47,9 @@ impl<O: Offset, M: MutableArray + Default> MutableListArray<O, M> {
     pub fn shrink_to_fit(&mut self) {
         self.values.shrink_to_fit();
         self.offsets.shrink_to_fit();
+        if let Some(validity) = &mut self.validity {
+            validity.shrink_to_fit()
+        }
     }
 }
 
@@ -185,7 +188,7 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
     }
 }
 
-impl<O: Offset, M: MutableArray + 'static> MutableArray for MutableListArray<O, M> {
+impl<O: Offset, M: MutableArray + Default + 'static> MutableArray for MutableListArray<O, M> {
     fn len(&self) -> usize {
         self.offsets.len() - 1
     }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -155,6 +155,9 @@ pub trait MutableArray: std::fmt::Debug {
             .map(|x| x.get(index))
             .unwrap_or(true)
     }
+
+    /// Shrink the array to fit its length.
+    fn shrink_to_fit(&mut self);
 }
 
 macro_rules! general_dyn {

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -241,6 +241,9 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     /// Shrinks the capacity of the [`MutablePrimitive`] to fit its current length.
     pub fn shrink_to_fit(&mut self) {
         self.values.shrink_to_fit();
+        if let Some(validity) = &mut self.validity {
+            validity.shrink_to_fit()
+        }
     }
 }
 

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -237,6 +237,11 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
         let a: PrimitiveArray<T> = self.into();
         Arc::new(a)
     }
+
+    /// Shrinks the capacity of the [`MutablePrimitive`] to fit its current length.
+    pub fn shrink_to_fit(&mut self) {
+        self.values.shrink_to_fit();
+    }
 }
 
 /// Accessors
@@ -356,6 +361,10 @@ impl<T: NativeType> MutableArray for MutablePrimitiveArray<T> {
 
     fn push_null(&mut self) {
         self.push(None)
+    }
+
+    fn shrink_to_fit(&mut self) {
+        self.shrink_to_fit()
     }
 }
 

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -164,6 +164,12 @@ impl<O: Offset> MutableUtf8Array<O> {
         let a: Utf8Array<O> = self.into();
         Arc::new(a)
     }
+
+    /// Shrinks the capacity of the [`MutableUtf8`] to fit its current length.
+    pub fn shrink_to_fit(&mut self) {
+        self.values.shrink_to_fit();
+        self.offsets.shrink_to_fit();
+    }
 }
 
 impl<O: Offset> MutableUtf8Array<O> {
@@ -223,6 +229,10 @@ impl<O: Offset> MutableArray for MutableUtf8Array<O> {
 
     fn push_null(&mut self) {
         self.push::<&str>(None)
+    }
+
+    fn shrink_to_fit(&mut self) {
+        self.shrink_to_fit()
     }
 }
 

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -169,6 +169,9 @@ impl<O: Offset> MutableUtf8Array<O> {
     pub fn shrink_to_fit(&mut self) {
         self.values.shrink_to_fit();
         self.offsets.shrink_to_fit();
+        if let Some(validity) = &mut self.validity {
+            validity.shrink_to_fit()
+        }
     }
 }
 


### PR DESCRIPTION
This PR proposes to expose `shrink_to_fit` on the mutable arrays. The `MutableBuffer` already implements this, but its impossible to call with mutable array API as the internal buffers are private.

The same could be done for `MutableBitmap`.