### PR TITLE
Made writing stream to parquet require a non-static lifetime

### DIFF
--- a/src/io/parquet/write/stream.rs
+++ b/src/io/parquet/write/stream.rs
@@ -24,7 +24,7 @@ pub async fn write_stream<'a, W, I>(
 ) -> Result<u64>
 where
     W: std::io::Write,
-    I: Stream<Item = Result<RowGroupIter<'static, ArrowError>>>,
+    I: Stream<Item = Result<RowGroupIter<'a, ArrowError>>>,
 {
     let key_value_metadata = key_value_metadata
         .map(|mut x| {
@@ -56,7 +56,7 @@ pub async fn write_stream_stream<'a, W, I>(
 ) -> Result<u64>
 where
     W: futures::io::AsyncWrite + Unpin + Send,
-    I: Stream<Item = Result<RowGroupIter<'static, ArrowError>>>,
+    I: Stream<Item = Result<RowGroupIter<'a, ArrowError>>>,
 {
     let key_value_metadata = key_value_metadata
         .map(|mut x| {


### PR DESCRIPTION
Hello !

Would it be possible to change the lifetime of the iterators to something a little less restrictive when writing to a `parquet` file ?

