### PR TITLE
Use itertools to process the `min_value` and `max_value` in statistics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ io_print = ["comfy-table"]
 # the compute kernels. Disabling this significantly reduces compile time.
 compute = ["strength_reduce", "multiversion", "lexical-core", "ahash"]
 # base64 + io_ipc because arrow schemas are stored as base64-encoded ipc format.
-io_parquet = ["parquet2", "io_ipc", "base64", "futures"]
+io_parquet = ["parquet2", "io_ipc", "base64", "futures", "itertools"]
 benchmarks = ["rand"]
 simd = ["packed_simd"]
 # uses a custom allocator whose pointers are aligned along cache lines.


### PR DESCRIPTION
Hello!

Currently, when processing the statistics, the array is scanned twice to get the `min` and `max` value.

The [Itertools::minmax_by](https://docs.rs/itertools/0.10.1/itertools/trait.Itertools.html#method.minmax_by) can do the same and faster, needing to go through `1.5 * n` elements, rather than `2 * n` elements, for an array of `n` elements.