### PR TITLE
Improved inference and deserialization of CSV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ full = [
 ]
 merge_sort = ["itertools"]
 io_csv = ["io_csv_read", "io_csv_write"]
-io_csv_read = ["csv", "lazy_static", "regex", "lexical-core"]
+io_csv_read = ["csv", "lexical-core"]
 io_csv_write = ["csv", "streaming-iterator", "lexical-core"]
 io_json = ["serde", "serde_json", "indexmap"]
 io_ipc = ["flatbuffers"]

--- a/src/io/csv/read/deserialize.rs
+++ b/src/io/csv/read/deserialize.rs
@@ -8,9 +8,11 @@ use crate::{
     datatypes::*,
     error::{ArrowError, Result},
     record_batch::RecordBatch,
-    temporal_conversions::EPOCH_DAYS_FROM_CE,
+    temporal_conversions,
     types::{NativeType, NaturalDataType},
 };
+
+use super::infer_schema::RFC3339;
 
 fn deserialize_primitive<T, F>(
     rows: &[ByteRecord],
@@ -61,6 +63,22 @@ fn deserialize_utf8<O: Offset>(rows: &[ByteRecord], column: usize) -> Arc<dyn Ar
 fn deserialize_binary<O: Offset>(rows: &[ByteRecord], column: usize) -> Arc<dyn Array> {
     let iter = rows.iter().map(|row| row.get(column));
     Arc::new(BinaryArray::<O>::from_trusted_len_iter(iter))
+}
+
+#[inline]
+fn deserialize_datetime<T: chrono::TimeZone>(string: &str, tz: &T) -> Option<i64> {
+    let mut parsed = chrono::format::Parsed::new();
+    let fmt = chrono::format::StrftimeItems::new(RFC3339);
+    if chrono::format::parse(&mut parsed, string, fmt).is_ok() {
+        parsed
+            .to_datetime()
+            .map(|x| x.naive_utc())
+            .map(|x| tz.from_utc_datetime(&x))
+            .map(|x| x.timestamp_nanos())
+            .ok()
+    } else {
+        None
+    }
 }
 
 /// Deserializes `column` of `rows` into an [`Array`] of [`DataType`] `datatype`.
@@ -115,7 +133,7 @@ pub fn deserialize_column(
             simdutf8::basic::from_utf8(bytes)
                 .ok()
                 .and_then(|x| x.parse::<chrono::NaiveDate>().ok())
-                .map(|x| x.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
+                .map(|x| x.num_days_from_ce() - temporal_conversions::EPOCH_DAYS_FROM_CE)
         }),
         Date64 => deserialize_primitive(rows, column, datatype, |bytes| {
             simdutf8::basic::from_utf8(bytes)
@@ -139,20 +157,30 @@ pub fn deserialize_column(
                     .map(|x| x.timestamp_nanos() / 1000)
             })
         }
-        Timestamp(TimeUnit::Millisecond, None) => {
+        Timestamp(time_unit, None) => deserialize_primitive(rows, column, datatype, |bytes| {
+            simdutf8::basic::from_utf8(bytes)
+                .ok()
+                .and_then(|x| x.parse::<chrono::NaiveDateTime>().ok())
+                .map(|x| x.timestamp_nanos())
+                .map(|x| match time_unit {
+                    TimeUnit::Second => x / 1_000_000_000,
+                    TimeUnit::Millisecond => x / 1_000_000,
+                    TimeUnit::Microsecond => x / 1_000,
+                    TimeUnit::Nanosecond => x,
+                })
+        }),
+        Timestamp(time_unit, Some(ref tz)) => {
+            let tz = temporal_conversions::parse_offset(tz)?;
             deserialize_primitive(rows, column, datatype, |bytes| {
                 simdutf8::basic::from_utf8(bytes)
                     .ok()
-                    .and_then(|x| x.parse::<chrono::NaiveDateTime>().ok())
-                    .map(|x| x.timestamp_nanos() / 1_000_000)
-            })
-        }
-        Timestamp(TimeUnit::Second, None) => {
-            deserialize_primitive(rows, column, datatype, |bytes| {
-                simdutf8::basic::from_utf8(bytes)
-                    .ok()
-                    .and_then(|x| x.parse::<chrono::NaiveDateTime>().ok())
-                    .map(|x| x.timestamp_nanos() / 1_000_000_000)
+                    .and_then(|x| deserialize_datetime(x, &tz))
+                    .map(|x| match time_unit {
+                        TimeUnit::Second => x / 1_000_000_000,
+                        TimeUnit::Millisecond => x / 1_000_000,
+                        TimeUnit::Microsecond => x / 1_000,
+                        TimeUnit::Nanosecond => x,
+                    })
             })
         }
         Utf8 => deserialize_utf8::<i32>(rows, column),

--- a/src/io/csv/read/mod.rs
+++ b/src/io/csv/read/mod.rs
@@ -8,5 +8,5 @@ pub use csv::{ByteRecord, Reader, ReaderBuilder};
 mod infer_schema;
 
 pub use deserialize::{deserialize_batch, deserialize_column};
-pub use infer_schema::infer_schema;
+pub use infer_schema::{infer, infer_schema};
 pub use reader::*;

--- a/src/io/csv/read/reader.rs
+++ b/src/io/csv/read/reader.rs
@@ -1,8 +1,5 @@
 use std::io::Read;
 
-use lazy_static::lazy_static;
-use regex::{Regex, RegexBuilder};
-
 use super::{ByteRecord, Reader};
 
 use crate::{
@@ -51,38 +48,4 @@ pub fn read_rows<R: Read>(
         row_number += 1;
     }
     Ok(row_number)
-}
-
-lazy_static! {
-    static ref DECIMAL_RE: Regex = Regex::new(r"^-?(\d+\.\d+)$").unwrap();
-    static ref INTEGER_RE: Regex = Regex::new(r"^-?(\d+)$").unwrap();
-    static ref BOOLEAN_RE: Regex = RegexBuilder::new(r"^(true)$|^(false)$")
-        .case_insensitive(true)
-        .build()
-        .unwrap();
-    static ref DATE_RE: Regex = Regex::new(r"^\d{4}-\d\d-\d\d$").unwrap();
-    static ref DATETIME_RE: Regex = Regex::new(r"^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d$").unwrap();
-}
-
-/// Infer the data type of a record
-pub fn infer(string: &str) -> DataType {
-    // when quoting is enabled in the reader, these quotes aren't escaped, we default to
-    // Utf8 for them
-    if string.starts_with('"') {
-        return DataType::Utf8;
-    }
-    // match regex in a particular order
-    if BOOLEAN_RE.is_match(string) {
-        DataType::Boolean
-    } else if DECIMAL_RE.is_match(string) {
-        DataType::Float64
-    } else if INTEGER_RE.is_match(string) {
-        DataType::Int64
-    } else if DATETIME_RE.is_match(string) {
-        DataType::Date64
-    } else if DATE_RE.is_match(string) {
-        DataType::Date32
-    } else {
-        DataType::Utf8
-    }
 }

--- a/tests/it/io/csv/read.rs
+++ b/tests/it/io/csv/read.rs
@@ -1,3 +1,5 @@
+use proptest::prelude::*;
+
 use std::io::Cursor;
 use std::sync::Arc;
 
@@ -175,7 +177,7 @@ fn float32() -> Result<()> {
 }
 
 #[test]
-fn binary() -> Result<()> {
+fn deserialize_binary() -> Result<()> {
     let input = vec!["aa", "bb"];
     let input = input.join("\n");
 
@@ -184,4 +186,42 @@ fn binary() -> Result<()> {
     let result = test_deserialize(&input, DataType::Binary)?;
     assert_eq!(expected, result.as_ref());
     Ok(())
+}
+
+#[test]
+fn deserialize_timestamp() -> Result<()> {
+    let input = vec!["1996-12-19T16:34:57-02:00", "1996-12-19T16:34:58-02:00"];
+    let input = input.join("\n");
+
+    let data_type = DataType::Timestamp(TimeUnit::Millisecond, Some("-01:00".to_string()));
+
+    let expected = Int64Array::from([Some(851020497000), Some(851020498000)]).to(data_type.clone());
+
+    let result = test_deserialize(&input, data_type)?;
+    assert_eq!(expected, result.as_ref());
+    Ok(())
+}
+
+proptest! {
+    #[test]
+    #[cfg_attr(miri, ignore)] // miri and proptest do not work well :(
+    fn i64(v in any::<i64>()) {
+        assert_eq!(infer(v.to_string().as_bytes()), DataType::Int64);
+    }
+}
+
+proptest! {
+    #[test]
+    #[cfg_attr(miri, ignore)] // miri and proptest do not work well :(
+    fn utf8(v in "a.*") {
+        assert_eq!(infer(v.as_bytes()), DataType::Utf8);
+    }
+}
+
+proptest! {
+    #[test]
+    #[cfg_attr(miri, ignore)] // miri and proptest do not work well :(
+    fn dates(v in "1996-12-19T16:3[0-9]:57-02:00") {
+        assert_eq!(infer(v.as_bytes()), DataType::Timestamp(TimeUnit::Millisecond, Some("-02:00".to_string())));
+    }
 }


### PR DESCRIPTION
This PR:

* improves performance of inference by removing the `&[u8] -> utf8` for types that do not need such conversion (integer, boolean, float) 
* Added support to infer and deserialize timestamps with timezone
* Added support to deserialize all timestamp units
* Removed two dependencies to reading csv: `lazy_static` and `regex`, so that the inference is 100% consistent with deserialization

The deserialization and inference of timestamps with timezone assumes RFC3339. Users may extend the inferer and deserializer to handle other formats.

This also fixes a bug on which datetimes were being parsed as `Date64`, when `date64` is expected to be a multiple of 86400000 and not an arbitrary number. They are now inferer and parsed as a `Timestamp(Millisecond, None)`