### PR TITLE
Implement `BitXor` trait for `Bitmap`

### DIFF
--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitAnd, BitOr, Not};
+use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 use crate::buffer::MutableBuffer;
 
@@ -132,12 +132,19 @@ where
     }
 }
 
+#[inline]
 fn and(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
     binary(lhs, rhs, |x, y| x & y)
 }
 
+#[inline]
 fn or(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
     binary(lhs, rhs, |x, y| x | y)
+}
+
+#[inline]
+fn xor(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
+    binary(lhs, rhs, |x, y| x ^ y)
 }
 
 fn eq(lhs: &Bitmap, rhs: &Bitmap) -> bool {
@@ -180,6 +187,14 @@ impl<'a, 'b> BitAnd<&'b Bitmap> for &'a Bitmap {
 
     fn bitand(self, rhs: &'b Bitmap) -> Bitmap {
         and(self, rhs)
+    }
+}
+
+impl<'a, 'b> BitXor<&'b Bitmap> for &'a Bitmap {
+    type Output = Bitmap;
+
+    fn bitxor(self, rhs: &'b Bitmap) -> Bitmap {
+        xor(self, rhs)
     }
 }
 


### PR DESCRIPTION
For https://github.com/jorgecarleitao/arrow2/issues/457. To calculate cast error bitmap, we need to run `array_validity ^ cast_validity`.