### PR TITLE
Added `extend`/`extend_unchecked` for `MutableBinaryArray`

### DIFF
--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -269,7 +269,7 @@ impl<O: Offset> MutableBinaryArray<O> {
         P: AsRef<[u8]>,
         I: TrustedLen<Item = P>,
     {
-        // Safety: The iterator must be `TrustedLen`
+        // Safety: The iterator is `TrustedLen`
         unsafe { self.extend_trusted_len_values_unchecked(iterator) }
     }
 
@@ -301,7 +301,7 @@ impl<O: Offset> MutableBinaryArray<O> {
         P: AsRef<[u8]>,
         I: TrustedLen<Item = Option<P>>,
     {
-        // Safety: The iterator must be `TrustedLen`
+        // Safety: The iterator is `TrustedLen`
         unsafe { self.extend_trusted_len_unchecked(iterator) }
     }
 

--- a/tests/it/array/binary/mutable.rs
+++ b/tests/it/array/binary/mutable.rs
@@ -9,3 +9,38 @@ fn push_null() {
     let array: BinaryArray<i32> = array.into();
     assert_eq!(array.validity(), Some(&Bitmap::from([false])));
 }
+
+#[test]
+fn extend_trusted_len_values() {
+    let mut array = MutableBinaryArray::<i32>::new();
+
+    array.extend_trusted_len_values(vec![b"first".to_vec(), b"second".to_vec()].into_iter());
+    array.extend_trusted_len_values(vec![b"third".to_vec()].into_iter());
+    array.extend_trusted_len(vec![None, Some(b"fourth".to_vec())].into_iter());
+
+    let array: BinaryArray<i32> = array.into();
+
+    assert_eq!(array.values().as_slice(), b"firstsecondthirdfourth");
+    assert_eq!(array.offsets().as_slice(), &[0, 5, 11, 16, 16, 22]);
+    assert_eq!(
+        array.validity(),
+        Some(&Bitmap::from_u8_slice(&[0b00010111], 5))
+    );
+}
+
+#[test]
+fn extend_trusted_len() {
+    let mut array = MutableBinaryArray::<i32>::new();
+
+    array.extend_trusted_len(vec![Some(b"first".to_vec()), Some(b"second".to_vec())].into_iter());
+    array.extend_trusted_len(vec![None, Some(b"third".to_vec())].into_iter());
+
+    let array: BinaryArray<i32> = array.into();
+
+    assert_eq!(array.values().as_slice(), b"firstsecondthird");
+    assert_eq!(array.offsets().as_slice(), &[0, 5, 11, 11, 16]);
+    assert_eq!(
+        array.validity(),
+        Some(&Bitmap::from_u8_slice(&[0b00001011], 4))
+    );
+}


### PR DESCRIPTION
This PR adds `TrustedLen`-based extend and extend_unchecked methods for MutableBinaryArray.