### PR TITLE
Improved multiversion of hash.

### DIFF
--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -20,7 +20,8 @@ use crate::{
 use super::arity::unary;
 
 #[multiversion]
-#[clone(target = "x86_64+aes+sse3+ssse3+avx+avx2")]
+#[clone(target = "[x86|x86_64]+avx+avx2")]
+#[clone(target = "x86+sse")]
 /// Element-wise hash of a [`PrimitiveArray`]. Validity is preserved.
 pub fn hash_primitive<T: NativeType + Hash>(array: &PrimitiveArray<T>) -> PrimitiveArray<u64> {
     let state = new_state!();
@@ -29,7 +30,8 @@ pub fn hash_primitive<T: NativeType + Hash>(array: &PrimitiveArray<T>) -> Primit
 }
 
 #[multiversion]
-#[clone(target = "x86_64+aes+sse3+ssse3+avx+avx2")]
+#[clone(target = "[x86|x86_64]+avx+avx2")]
+#[clone(target = "x86+sse")]
 /// Element-wise hash of a [`BooleanArray`]. Validity is preserved.
 pub fn hash_boolean(array: &BooleanArray) -> PrimitiveArray<u64> {
     let state = new_state!();
@@ -40,7 +42,8 @@ pub fn hash_boolean(array: &BooleanArray) -> PrimitiveArray<u64> {
 }
 
 #[multiversion]
-#[clone(target = "x86_64+aes+sse3+ssse3+avx+avx2")]
+#[clone(target = "[x86|x86_64]+avx+avx2")]
+#[clone(target = "x86+sse")]
 /// Element-wise hash of a [`Utf8Array`]. Validity is preserved.
 pub fn hash_utf8<O: Offset>(array: &Utf8Array<O>) -> PrimitiveArray<u64> {
     let state = new_state!();
@@ -52,6 +55,9 @@ pub fn hash_utf8<O: Offset>(array: &Utf8Array<O>) -> PrimitiveArray<u64> {
     PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().cloned())
 }
 
+#[multiversion]
+#[clone(target = "[x86|x86_64]+avx+avx2")]
+#[clone(target = "x86+sse")]
 /// Element-wise hash of a [`BinaryArray`]. Validity is preserved.
 pub fn hash_binary<O: Offset>(array: &BinaryArray<O>) -> PrimitiveArray<u64> {
     let state = new_state!();


### PR DESCRIPTION
I noticed that multiversion recommends one `clone` per arch/instruction set. @Dandandan , do you remember why we used all the sets in a single clone? My feeling is that it will create a single clone iff the whole set is hit, instead of one clone per set, but I may be mistaken here.

