### PR TITLE
Fixed version of parquet2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ futures = { version = "0.3", optional = true }
 # for faster hashing
 ahash = { version = "0.7", optional = true }
 
-parquet2 = { version = "0.5", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { version = "0.5.2", optional = true, default_features = false, features = ["stream"] }
 
 avro-rs = { version = "0.13", optional = true, default_features = false }
 

--- a/src/io/parquet/read/statistics/mod.rs
+++ b/src/io/parquet/read/statistics/mod.rs
@@ -72,7 +72,7 @@ pub fn deserialize_statistics(stats: &dyn ParquetStatistics) -> Result<Box<dyn S
                 DataType::Float64,
             ))))
         }
-        PhysicalType::FixedLenByteArray(_) =>{
+        PhysicalType::FixedLenByteArray(_) => {
             let stats = stats.as_any().downcast_ref().unwrap();
             fixlen::statistics_from_fix_len(stats, stats.descriptor.type_())
         }

--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -257,7 +257,6 @@ fn v1_decimal_26_nullable() -> Result<()> {
     test_pyarrow_integration(9, 1, "basic", false, false)
 }
 
-
 #[test]
 fn v1_decimal_26_required() -> Result<()> {
     test_pyarrow_integration(8, 1, "basic", false, true)
@@ -287,7 +286,6 @@ fn v2_decimal_18_required() -> Result<()> {
 fn v2_decimal_26_nullable() -> Result<()> {
     test_pyarrow_integration(9, 2, "basic", false, false)
 }
-
 
 #[test]
 fn v2_decimal_26_required() -> Result<()> {


### PR DESCRIPTION
We depend on a feature that is only available in `0.5.3`, so we need to bump it.