### PR TITLE
Made `try_push_valid` public again

### DIFF
--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -136,7 +136,9 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
     }
 
     #[inline]
-    fn try_push_valid(&mut self) -> Result<()> {
+    /// Needs to be called when a valid value was extended to this array.
+    /// This is a relatively low level function, prefer `try_push` when you can.
+    pub fn try_push_valid(&mut self) -> Result<()> {
         let size = self.values.len();
         let size = O::from_usize(size).ok_or(ArrowError::KeyOverflowError)?; // todo: make this error
         assert!(size >= *self.offsets.last().unwrap());


### PR DESCRIPTION
This adds a `pub` to `fn MutableListArray::try_push_valid`. This was already public in previous releases. Maybe it got private due to some trait refactors?