### PR TITLE
Do not check offsets or utf8 validity in ffi (#505)

### DIFF
--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -44,7 +44,7 @@ impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryArray<O> {
             validity = validity.map(|x| x.slice(offset, length))
         }
 
-        Ok(Self::from_data(
+        Ok(Self::from_data_unchecked(
             Self::default_data_type(),
             offsets,
             values,

--- a/src/array/utf8/ffi.rs
+++ b/src/array/utf8/ffi.rs
@@ -33,6 +33,6 @@ impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for Utf8Array<O> {
             validity = validity.map(|x| x.slice(offset, length))
         }
         let data_type = Self::default_data_type();
-        Ok(Self::from_data(data_type, offsets, values, validity))
+        Ok(Self::from_data_unchecked(data_type, offsets, values, validity))
     }
 }


### PR DESCRIPTION
As declared in the spec, the purpose of FFI is to be a very low cost API. The method is already intrinsically unsafe because the data must already follow the spec.

Changed `Utf8Array::try_from_ffi` and `BinaryArray::try_from_ffi` to use `from_data_unchecked` instead of `from_data`.