### PR TITLE
improve utf8 init validity

### DIFF
--- a/src/array/boolean/mutable.rs
+++ b/src/array/boolean/mutable.rs
@@ -170,7 +170,7 @@ impl MutableBooleanArray {
     }
 
     fn init_validity(&mut self) {
-        let mut validity = MutableBitmap::new();
+        let mut validity = MutableBitmap::with_capacity(self.values.capacity());
         validity.extend_constant(self.len(), true);
         validity.set(self.len() - 1, false);
         self.validity = Some(validity)

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -177,7 +177,7 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
     fn init_validity(&mut self) {
         let len = self.offsets.len() - 1;
 
-        let mut validity = MutableBitmap::new();
+        let mut validity = MutableBitmap::with_capacity(self.offsets.capacity());
         validity.extend_constant(len, true);
         validity.set(len - 1, false);
         self.validity = Some(validity)

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -217,7 +217,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     }
 
     fn init_validity(&mut self) {
-        let mut validity = MutableBitmap::new();
+        let mut validity = MutableBitmap::with_capacity(self.values.capacity());
         validity.extend_constant(self.len(), true);
         validity.set(self.len() - 1, false);
         self.validity = Some(validity)

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -152,11 +152,10 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     fn init_validity(&mut self) {
-        self.validity = Some(MutableBitmap::from_trusted_len_iter(
-            std::iter::repeat(true)
-                .take(self.len() - 1)
-                .chain(std::iter::once(false)),
-        ))
+        let mut validity = MutableBitmap::with_capacity(self.offsets.capacity());
+        validity.extend_constant(self.len(), true);
+        validity.set(self.len() - 1, false);
+        self.validity = Some(validity);
     }
 
     /// Converts itself into an [`Array`].


### PR DESCRIPTION
The utf8 version did still create an initial validity bitmap from a `chained` iterator instead of the more performance `extend_constant`. This PR changes that so that it aligns with the other arrays.

I also allocate the initial size of `MutableBitmap` to the `capacity` of the data array. If a user has intialized the `structs` `with_capacity` this information is already known.