### PR TITLE
Simplified reading parquet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,9 @@ futures = { version = "0.3", optional = true }
 # for faster hashing
 ahash = { version = "0.7", optional = true }
 
-parquet2 = { version = "0.5.2", optional = true, default_features = false, features = ["stream"] }
+#parquet2 = { version = "0.5.2", optional = true, default_features = false, features = ["stream"] }
+#parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "reuse_compress", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { path = "../parquet2", optional = true, default_features = false, features = ["stream"] }
 
 avro-rs = { version = "0.13", optional = true, default_features = false }
 
@@ -100,7 +102,7 @@ full = [
     "io_avro",
     "regex",
     "merge_sort",
-    "compute",
+    #"compute",
     # parses timezones used in timestamp conversions
     "chrono-tz"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ futures = { version = "0.3", optional = true }
 ahash = { version = "0.7", optional = true }
 
 #parquet2 = { version = "0.5.2", optional = true, default_features = false, features = ["stream"] }
-parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "reuse_compress", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "simplify_codec", optional = true, default_features = false, features = ["stream"] }
 #parquet2 = { path = "../parquet2", optional = true, default_features = false, features = ["stream"] }
 
 avro-rs = { version = "0.13", optional = true, default_features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,9 +61,7 @@ futures = { version = "0.3", optional = true }
 # for faster hashing
 ahash = { version = "0.7", optional = true }
 
-#parquet2 = { version = "0.5.2", optional = true, default_features = false, features = ["stream"] }
-parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "simplify_codec", optional = true, default_features = false, features = ["stream"] }
-#parquet2 = { path = "../parquet2", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { version = "0.6", optional = true, default_features = false, features = ["stream"] }
 
 avro-rs = { version = "0.13", optional = true, default_features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,8 @@ futures = { version = "0.3", optional = true }
 ahash = { version = "0.7", optional = true }
 
 #parquet2 = { version = "0.5.2", optional = true, default_features = false, features = ["stream"] }
-#parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "reuse_compress", optional = true, default_features = false, features = ["stream"] }
-parquet2 = { path = "../parquet2", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "reuse_compress", optional = true, default_features = false, features = ["stream"] }
+#parquet2 = { path = "../parquet2", optional = true, default_features = false, features = ["stream"] }
 
 avro-rs = { version = "0.13", optional = true, default_features = false }
 
@@ -102,7 +102,7 @@ full = [
     "io_avro",
     "regex",
     "merge_sort",
-    #"compute",
+    "compute",
     # parses timezones used in timestamp conversions
     "chrono-tz"
 ]

--- a/examples/parquet_read.rs
+++ b/examples/parquet_read.rs
@@ -1,11 +1,12 @@
 use std::fs::File;
+use std::io::BufReader;
 
 use arrow2::io::parquet::read;
 use arrow2::{array::Array, error::Result};
 
 fn read_column_chunk(path: &str, row_group: usize, column: usize) -> Result<Box<dyn Array>> {
     // Open a file, a common operation in Rust
-    let mut file = File::open(path)?;
+    let mut file = BufReader::new(File::open(path)?);
 
     // Read the files' metadata. This has a small IO cost because it requires seeking to the end
     // of the file to read its footer.

--- a/examples/parquet_write.rs
+++ b/examples/parquet_write.rs
@@ -1,13 +1,15 @@
 use std::fs::File;
 use std::iter::once;
 
+use arrow2::error::ArrowError;
 use arrow2::io::parquet::write::to_parquet_schema;
 use arrow2::{
     array::{Array, Int32Array},
     datatypes::{Field, Schema},
     error::Result,
     io::parquet::write::{
-        array_to_page, write_file, Compression, DynIter, Encoding, Version, WriteOptions,
+        array_to_pages, write_file, Compression, Compressor, DynIter, DynStreamingIterator,
+        Encoding, FallibleStreamingIterator, Version, WriteOptions,
     },
 };
 
@@ -24,17 +26,22 @@ fn write_single_array(path: &str, array: &dyn Array, field: Field) -> Result<()>
     // map arrow fields to parquet fields
     let parquet_schema = to_parquet_schema(&schema)?;
 
-    // Declare the row group iterator. This must be an iterator of iterators of iterators:
-    // * first iterator of row groups
-    // * second iterator of column chunks
-    // * third iterator of pages
-    // an array can be divided in multiple pages via `.slice(offset, length)` (`O(1)`).
-    // All column chunks within a row group MUST have the same length.
-    let row_groups = once(Result::Ok(DynIter::new(once(Ok(DynIter::new(
-        once(array)
-            .zip(parquet_schema.columns().to_vec().into_iter())
-            .map(|(array, descriptor)| array_to_page(array, descriptor, options, encoding)),
-    ))))));
+    let descriptor = parquet_schema.columns()[0].clone();
+
+    // Declare the row group iterator. This must be an iterator of iterators of streaming iterators
+    // * first iterator over row groups
+    let row_groups = once(Result::Ok(DynIter::new(
+        // * second iterator over column chunks (we assume no struct arrays -> `once` column)
+        once(
+            // * third iterator over (compressed) pages; dictionary encoding may lead to multiple pages per array.
+            array_to_pages(array, descriptor, options, encoding).map(move |pages| {
+                let encoded_pages = DynIter::new(pages.map(|x| Ok(x?)));
+                let compressed_pages = Compressor::new(encoded_pages, options.compression, vec![])
+                    .map_err(ArrowError::from);
+                DynStreamingIterator::new(compressed_pages)
+            }),
+        ),
+    )));
 
     // Create a new empty file
     let mut file = File::create(path)?;

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -11,3 +11,9 @@ impl From<parquet2::error::ParquetError> for ArrowError {
         ArrowError::External("".to_string(), Box::new(error))
     }
 }
+
+impl From<ArrowError> for parquet2::error::ParquetError {
+    fn from(error: ArrowError) -> Self {
+        parquet2::error::ParquetError::General(error.to_string())
+    }
+}

--- a/src/io/parquet/read/binary/nested.rs
+++ b/src/io/parquet/read/binary/nested.rs
@@ -4,7 +4,8 @@ use parquet2::{
     encoding::{hybrid_rle::HybridRleDecoder, Encoding},
     metadata::{ColumnChunkMetaData, ColumnDescriptor},
     page::DataPage,
-    read::{levels::get_bit_width, StreamingIterator},
+    read::levels::get_bit_width,
+    FallibleStreamingIterator,
 };
 
 use super::super::nested_utils::*;
@@ -153,8 +154,7 @@ pub fn iter_to_array<O, I, E>(
 where
     O: Offset,
     ArrowError: From<E>,
-    E: Clone,
-    I: StreamingIterator<Item = std::result::Result<DataPage, E>>,
+    I: FallibleStreamingIterator<Item = DataPage, Error = E>,
 {
     let capacity = metadata.num_values() as usize;
     let mut values = MutableBuffer::<u8>::with_capacity(0);
@@ -164,9 +164,9 @@ where
 
     let (mut nested, is_nullable) = init_nested(metadata.descriptor().base_type(), capacity);
 
-    while let Some(page) = iter.next() {
+    while let Some(page) = iter.next()? {
         extend_from_page(
-            page.as_ref().map_err(|x| x.clone())?,
+            page,
             metadata.descriptor(),
             is_nullable,
             &mut nested,

--- a/src/io/parquet/read/boolean/nested.rs
+++ b/src/io/parquet/read/boolean/nested.rs
@@ -4,7 +4,8 @@ use parquet2::{
     encoding::{hybrid_rle::HybridRleDecoder, Encoding},
     metadata::{ColumnChunkMetaData, ColumnDescriptor},
     page::DataPage,
-    read::{levels::get_bit_width, StreamingIterator},
+    read::levels::get_bit_width,
+    FallibleStreamingIterator,
 };
 
 use super::super::nested_utils::*;
@@ -137,8 +138,7 @@ pub fn iter_to_array<I, E>(
 ) -> Result<Box<dyn Array>>
 where
     ArrowError: From<E>,
-    E: Clone,
-    I: StreamingIterator<Item = std::result::Result<DataPage, E>>,
+    I: FallibleStreamingIterator<Item = DataPage, Error = E>,
 {
     let capacity = metadata.num_values() as usize;
     let mut values = MutableBitmap::with_capacity(capacity);
@@ -146,9 +146,9 @@ where
 
     let (mut nested, is_nullable) = init_nested(metadata.descriptor().base_type(), capacity);
 
-    while let Some(page) = iter.next() {
+    while let Some(page) = iter.next()? {
         extend_from_page(
-            page.as_ref().map_err(|x| x.clone())?,
+            page,
             metadata.descriptor(),
             is_nullable,
             &mut nested,

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -13,8 +13,8 @@ pub use parquet2::{
     page::{CompressedDataPage, DataPage, DataPageHeader},
     read::{
         decompress, get_page_iterator as _get_page_iterator, get_page_stream as _get_page_stream,
-        read_metadata as _read_metadata, read_metadata_async as _read_metadata_async, Decompressor,
-        PageFilter, PageIterator,
+        read_metadata as _read_metadata, read_metadata_async as _read_metadata_async,
+        BasicDecompressor, Decompressor, PageFilter, PageIterator,
     },
     schema::types::{
         LogicalType, ParquetType, PhysicalType, PrimitiveConvertedType,

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -8,18 +8,20 @@ use std::{
 use futures::{AsyncRead, AsyncSeek, Stream};
 pub use parquet2::{
     error::ParquetError,
+    fallible_streaming_iterator,
     metadata::{ColumnChunkMetaData, ColumnDescriptor, RowGroupMetaData},
     page::{CompressedDataPage, DataPage, DataPageHeader},
     read::{
         decompress, get_page_iterator as _get_page_iterator, get_page_stream as _get_page_stream,
-        read_metadata as _read_metadata, read_metadata_async as _read_metadata_async,
-        streaming_iterator, Decompressor, PageFilter, PageIterator, StreamingIterator,
+        read_metadata as _read_metadata, read_metadata_async as _read_metadata_async, Decompressor,
+        PageFilter, PageIterator,
     },
     schema::types::{
         LogicalType, ParquetType, PhysicalType, PrimitiveConvertedType,
         TimeUnit as ParquetTimeUnit, TimestampType,
     },
     types::int96_to_i64_ns,
+    FallibleStreamingIterator,
 };
 
 use crate::{
@@ -82,7 +84,7 @@ pub async fn read_metadata_async<R: AsyncRead + AsyncSeek + Send + Unpin>(
 
 fn dict_read<
     K: DictionaryKey,
-    I: StreamingIterator<Item = std::result::Result<DataPage, ParquetError>>,
+    I: FallibleStreamingIterator<Item = DataPage, Error = ParquetError>,
 >(
     iter: &mut I,
     metadata: &ColumnChunkMetaData,
@@ -164,9 +166,7 @@ fn dict_read<
 }
 
 /// Converts an iterator of [`DataPage`] into a single [`Array`].
-pub fn page_iter_to_array<
-    I: StreamingIterator<Item = std::result::Result<DataPage, ParquetError>>,
->(
+pub fn page_iter_to_array<I: FallibleStreamingIterator<Item = DataPage, Error = ParquetError>>(
     iter: &mut I,
     metadata: &ColumnChunkMetaData,
     data_type: DataType,

--- a/src/io/parquet/read/primitive/mod.rs
+++ b/src/io/parquet/read/primitive/mod.rs
@@ -6,7 +6,7 @@ mod utils;
 use std::sync::Arc;
 
 use futures::{pin_mut, Stream, StreamExt};
-use parquet2::{page::DataPage, read::StreamingIterator, types::NativeType};
+use parquet2::{page::DataPage, types::NativeType, FallibleStreamingIterator};
 
 use super::nested_utils::*;
 use super::{ColumnChunkMetaData, ColumnDescriptor};
@@ -30,22 +30,15 @@ pub fn iter_to_array<T, A, I, E, F>(
 where
     ArrowError: From<E>,
     T: NativeType,
-    E: Clone,
     A: ArrowNativeType,
     F: Copy + Fn(T) -> A,
-    I: StreamingIterator<Item = std::result::Result<DataPage, E>>,
+    I: FallibleStreamingIterator<Item = DataPage, Error = E>,
 {
     let capacity = metadata.num_values() as usize;
     let mut values = MutableBuffer::<A>::with_capacity(capacity);
     let mut validity = MutableBitmap::with_capacity(capacity);
-    while let Some(page) = iter.next() {
-        basic::extend_from_page(
-            page.as_ref().map_err(|x| x.clone())?,
-            metadata.descriptor(),
-            &mut values,
-            &mut validity,
-            op,
-        )?
+    while let Some(page) = iter.next()? {
+        basic::extend_from_page(page, metadata.descriptor(), &mut values, &mut validity, op)?
     }
 
     let data_type = match data_type {
@@ -114,7 +107,7 @@ where
     E: Clone,
     A: ArrowNativeType,
     F: Copy + Fn(T) -> A,
-    I: StreamingIterator<Item = std::result::Result<DataPage, E>>,
+    I: FallibleStreamingIterator<Item = DataPage, Error = E>,
 {
     let capacity = metadata.num_values() as usize;
     let mut values = MutableBuffer::<A>::with_capacity(capacity);
@@ -122,9 +115,9 @@ where
 
     let (mut nested, is_nullable) = init_nested(metadata.descriptor().base_type(), capacity);
 
-    while let Some(page) = iter.next() {
+    while let Some(page) = iter.next()? {
         nested::extend_from_page(
-            page.as_ref().map_err(|x| x.clone())?,
+            page,
             metadata.descriptor(),
             is_nullable,
             &mut nested,

--- a/src/io/parquet/write/binary/basic.rs
+++ b/src/io/parquet/write/binary/basic.rs
@@ -79,7 +79,13 @@ pub fn array_to_page<O: Offset>(
 
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(buffer, options, definition_levels_byte_length)?;
+    let mut compressed_buffer = vec![];
+    let _was_compressed = utils::compress(
+        &mut buffer,
+        &mut compressed_buffer,
+        options,
+        definition_levels_byte_length,
+    )?;
 
     let statistics = if options.write_statistics {
         Some(build_statistics(array, descriptor.clone()))
@@ -88,7 +94,7 @@ pub fn array_to_page<O: Offset>(
     };
 
     utils::build_plain_page(
-        buffer,
+        compressed_buffer,
         array.len(),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/binary/nested.rs
+++ b/src/io/parquet/write/binary/nested.rs
@@ -35,8 +35,10 @@ where
 
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(
-        buffer,
+    let mut compressed_buffer = vec![];
+    let _was_compressed = utils::compress(
+        &mut buffer,
+        &mut compressed_buffer,
         options,
         definition_levels_byte_length + repetition_levels_byte_length,
     )?;
@@ -48,7 +50,7 @@ where
     };
 
     utils::build_plain_page(
-        buffer,
+        compressed_buffer,
         levels::num_values(nested.offsets()),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/binary/nested.rs
+++ b/src/io/parquet/write/binary/nested.rs
@@ -1,5 +1,5 @@
 use parquet2::{
-    encoding::Encoding, metadata::ColumnDescriptor, page::CompressedDataPage, write::WriteOptions,
+    encoding::Encoding, metadata::ColumnDescriptor, page::DataPage, write::WriteOptions,
 };
 
 use super::super::{levels, utils};
@@ -15,7 +15,7 @@ pub fn array_to_page<O, OO>(
     options: WriteOptions,
     descriptor: ColumnDescriptor,
     nested: levels::NestedInfo<OO>,
-) -> Result<CompressedDataPage>
+) -> Result<DataPage>
 where
     OO: Offset,
     O: Offset,
@@ -33,16 +33,6 @@ where
 
     encode_plain(array, is_optional, &mut buffer);
 
-    let uncompressed_page_size = buffer.len();
-
-    let mut compressed_buffer = vec![];
-    let _was_compressed = utils::compress(
-        &mut buffer,
-        &mut compressed_buffer,
-        options,
-        definition_levels_byte_length + repetition_levels_byte_length,
-    )?;
-
     let statistics = if options.write_statistics {
         Some(build_statistics(array, descriptor.clone()))
     } else {
@@ -50,10 +40,9 @@ where
     };
 
     utils::build_plain_page(
-        compressed_buffer,
+        buffer,
         levels::num_values(nested.offsets()),
         array.null_count(),
-        uncompressed_page_size,
         repetition_levels_byte_length,
         definition_levels_byte_length,
         statistics,

--- a/src/io/parquet/write/boolean/basic.rs
+++ b/src/io/parquet/write/boolean/basic.rs
@@ -62,7 +62,13 @@ pub fn array_to_page(
 
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(buffer, options, definition_levels_byte_length)?;
+    let mut compressed_buffer = vec![];
+    let _was_compressed = utils::compress(
+        &mut buffer,
+        &mut compressed_buffer,
+        options,
+        definition_levels_byte_length,
+    )?;
 
     let statistics = if options.write_statistics {
         Some(build_statistics(array))
@@ -71,7 +77,7 @@ pub fn array_to_page(
     };
 
     utils::build_plain_page(
-        buffer,
+        compressed_buffer,
         array.len(),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -34,8 +34,10 @@ where
 
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(
-        buffer,
+    let mut compressed_buffer = vec![];
+    let _was_compressed = utils::compress(
+        &mut buffer,
+        &mut compressed_buffer,
         options,
         definition_levels_byte_length + repetition_levels_byte_length,
     )?;
@@ -47,7 +49,7 @@ where
     };
 
     utils::build_plain_page(
-        buffer,
+        compressed_buffer,
         levels::num_values(nested.offsets()),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -1,5 +1,5 @@
 use parquet2::{
-    encoding::Encoding, metadata::ColumnDescriptor, page::CompressedDataPage, write::WriteOptions,
+    encoding::Encoding, metadata::ColumnDescriptor, page::DataPage, write::WriteOptions,
 };
 
 use super::super::{levels, utils};
@@ -15,7 +15,7 @@ pub fn array_to_page<O>(
     options: WriteOptions,
     descriptor: ColumnDescriptor,
     nested: levels::NestedInfo<O>,
-) -> Result<CompressedDataPage>
+) -> Result<DataPage>
 where
     O: Offset,
 {
@@ -32,16 +32,6 @@ where
 
     encode_plain(array, is_optional, &mut buffer)?;
 
-    let uncompressed_page_size = buffer.len();
-
-    let mut compressed_buffer = vec![];
-    let _was_compressed = utils::compress(
-        &mut buffer,
-        &mut compressed_buffer,
-        options,
-        definition_levels_byte_length + repetition_levels_byte_length,
-    )?;
-
     let statistics = if options.write_statistics {
         Some(build_statistics(array))
     } else {
@@ -49,10 +39,9 @@ where
     };
 
     utils::build_plain_page(
-        compressed_buffer,
+        buffer,
         levels::num_values(nested.offsets()),
         array.null_count(),
-        uncompressed_page_size,
         repetition_levels_byte_length,
         definition_levels_byte_length,
         statistics,

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -1,7 +1,7 @@
 use parquet2::{
     encoding::{hybrid_rle::encode_u32, Encoding},
     metadata::ColumnDescriptor,
-    page::{CompressedDictPage, CompressedPage},
+    page::{EncodedDictPage, EncodedPage},
     write::{DynIter, WriteOptions},
 };
 
@@ -21,7 +21,7 @@ fn encode_keys<K: DictionaryKey>(
     validity: Option<&Bitmap>,
     descriptor: ColumnDescriptor,
     options: WriteOptions,
-) -> Result<CompressedPage> {
+) -> Result<EncodedPage> {
     let is_optional = is_type_nullable(descriptor.type_());
 
     let mut buffer = vec![];
@@ -94,21 +94,10 @@ fn encode_keys<K: DictionaryKey>(
         encode_u32(&mut buffer, keys, num_bits)?;
     }
 
-    let uncompressed_page_size = buffer.len();
-
-    let mut compressed_buffer = vec![];
-    let _was_compressed = utils::compress(
-        &mut buffer,
-        &mut compressed_buffer,
-        options,
-        definition_levels_byte_length,
-    )?;
-
     utils::build_plain_page(
-        compressed_buffer,
+        buffer,
         array.len(),
         array.null_count(),
-        uncompressed_page_size,
         0,
         definition_levels_byte_length,
         None,
@@ -116,7 +105,7 @@ fn encode_keys<K: DictionaryKey>(
         options,
         Encoding::RleDictionary,
     )
-    .map(CompressedPage::Data)
+    .map(EncodedPage::Data)
 }
 
 macro_rules! dyn_prim {
@@ -125,9 +114,7 @@ macro_rules! dyn_prim {
 
         let mut buffer = vec![];
         primitive_encode_plain::<$from, $to>(values, false, &mut buffer);
-        let buffer = utils::compress(buffer, $options, 0)?;
-
-        CompressedPage::Dict(CompressedDictPage::new(buffer, values.len()))
+        EncodedDictPage::new(buffer, values.len())
     }};
 }
 
@@ -136,7 +123,7 @@ pub fn array_to_pages<K: DictionaryKey>(
     descriptor: ColumnDescriptor,
     options: WriteOptions,
     encoding: Encoding,
-) -> Result<DynIter<'static, Result<CompressedPage>>>
+) -> Result<DynIter<'static, Result<EncodedPage>>>
 where
     PrimitiveArray<K>: std::fmt::Display,
 {
@@ -163,32 +150,28 @@ where
 
                     let mut buffer = vec![];
                     utf8_encode_plain::<i32>(values, false, &mut buffer);
-                    let buffer = utils::compress(buffer, options, 0)?;
-                    CompressedPage::Dict(CompressedDictPage::new(buffer, values.len()))
+                    EncodedDictPage::new(buffer, values.len())
                 }
                 DataType::LargeUtf8 => {
                     let values = array.values().as_any().downcast_ref().unwrap();
 
                     let mut buffer = vec![];
                     utf8_encode_plain::<i64>(values, false, &mut buffer);
-                    let buffer = utils::compress(buffer, options, 0)?;
-                    CompressedPage::Dict(CompressedDictPage::new(buffer, values.len()))
+                    EncodedDictPage::new(buffer, values.len())
                 }
                 DataType::Binary => {
                     let values = array.values().as_any().downcast_ref().unwrap();
 
                     let mut buffer = vec![];
                     binary_encode_plain::<i32>(values, false, &mut buffer);
-                    let buffer = utils::compress(buffer, options, 0)?;
-                    CompressedPage::Dict(CompressedDictPage::new(buffer, values.len()))
+                    EncodedDictPage::new(buffer, values.len())
                 }
                 DataType::LargeBinary => {
                     let values = array.values().as_any().downcast_ref().unwrap();
 
                     let mut buffer = vec![];
                     binary_encode_plain::<i64>(values, false, &mut buffer);
-                    let buffer = utils::compress(buffer, options, 0)?;
-                    CompressedPage::Dict(CompressedDictPage::new(buffer, values.len()))
+                    EncodedDictPage::new(buffer, values.len())
                 }
                 other => {
                     return Err(ArrowError::NotYetImplemented(format!(
@@ -197,6 +180,7 @@ where
                     )))
                 }
             };
+            let dict_page = EncodedPage::Dict(dict_page);
 
             // write DataPage pointing to DictPage
             let data_page =

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -96,10 +96,16 @@ fn encode_keys<K: DictionaryKey>(
 
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(buffer, options, definition_levels_byte_length)?;
+    let mut compressed_buffer = vec![];
+    let _was_compressed = utils::compress(
+        &mut buffer,
+        &mut compressed_buffer,
+        options,
+        definition_levels_byte_length,
+    )?;
 
     utils::build_plain_page(
-        buffer,
+        compressed_buffer,
         array.len(),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -12,8 +12,6 @@ mod utils;
 
 pub mod stream;
 
-use std::sync::Arc;
-
 use crate::array::*;
 use crate::bitmap::Bitmap;
 use crate::buffer::{Buffer, MutableBuffer};
@@ -35,6 +33,7 @@ pub use parquet2::{
         write_file as parquet_write_file, Compressor, DynIter, DynStreamingIterator, RowGroupIter,
         Version, WriteOptions,
     },
+    FallibleStreamingIterator,
 };
 pub use record_batch::RowGroupIterator;
 use schema::schema_to_metadata_key;
@@ -110,7 +109,7 @@ pub fn can_encode(data_type: &DataType, encoding: Encoding) -> bool {
 
 /// Returns an iterator of [`EncodedPage`].
 pub fn array_to_pages(
-    array: Arc<dyn Array>,
+    array: &dyn Array,
     descriptor: ColumnDescriptor,
     options: WriteOptions,
     encoding: Encoding,
@@ -126,7 +125,7 @@ pub fn array_to_pages(
                 )
             })
         }
-        _ => array_to_page(array.as_ref(), descriptor, options, encoding)
+        _ => array_to_page(array, descriptor, options, encoding)
             .map(|page| DynIter::new(std::iter::once(Ok(page)))),
     }
 }

--- a/src/io/parquet/write/primitive/basic.rs
+++ b/src/io/parquet/write/primitive/basic.rs
@@ -67,7 +67,13 @@ where
 
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(buffer, options, definition_levels_byte_length)?;
+    let mut compressed_buffer = vec![];
+    let _was_compressed = utils::compress(
+        &mut buffer,
+        &mut compressed_buffer,
+        options,
+        definition_levels_byte_length,
+    )?;
 
     let statistics = if options.write_statistics {
         Some(build_statistics(array, descriptor.clone()))
@@ -76,7 +82,7 @@ where
     };
 
     utils::build_plain_page(
-        buffer,
+        compressed_buffer,
         array.len(),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/primitive/nested.rs
+++ b/src/io/parquet/write/primitive/nested.rs
@@ -1,5 +1,5 @@
 use parquet2::{
-    encoding::Encoding, metadata::ColumnDescriptor, page::CompressedDataPage, types::NativeType,
+    encoding::Encoding, metadata::ColumnDescriptor, page::DataPage, types::NativeType,
     write::WriteOptions,
 };
 
@@ -18,7 +18,7 @@ pub fn array_to_page<T, R, O>(
     options: WriteOptions,
     descriptor: ColumnDescriptor,
     nested: levels::NestedInfo<O>,
-) -> Result<CompressedDataPage>
+) -> Result<DataPage>
 where
     T: ArrowNativeType,
     R: NativeType,
@@ -38,16 +38,6 @@ where
 
     encode_plain(array, is_optional, &mut buffer);
 
-    let uncompressed_page_size = buffer.len();
-
-    let mut compressed_buffer = vec![];
-    let _was_compressed = utils::compress(
-        &mut buffer,
-        &mut compressed_buffer,
-        options,
-        definition_levels_byte_length + repetition_levels_byte_length,
-    )?;
-
     let statistics = if options.write_statistics {
         Some(build_statistics(array, descriptor.clone()))
     } else {
@@ -55,10 +45,9 @@ where
     };
 
     utils::build_plain_page(
-        compressed_buffer,
+        buffer,
         levels::num_values(nested.offsets()),
         array.null_count(),
-        uncompressed_page_size,
         repetition_levels_byte_length,
         definition_levels_byte_length,
         statistics,

--- a/src/io/parquet/write/primitive/nested.rs
+++ b/src/io/parquet/write/primitive/nested.rs
@@ -40,8 +40,10 @@ where
 
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(
-        buffer,
+    let mut compressed_buffer = vec![];
+    let _was_compressed = utils::compress(
+        &mut buffer,
+        &mut compressed_buffer,
         options,
         definition_levels_byte_length + repetition_levels_byte_length,
     )?;
@@ -53,7 +55,7 @@ where
     };
 
     utils::build_plain_page(
-        buffer,
+        compressed_buffer,
         levels::num_values(nested.offsets()),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/utf8/basic.rs
+++ b/src/io/parquet/write/utf8/basic.rs
@@ -78,7 +78,13 @@ pub fn array_to_page<O: Offset>(
 
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(buffer, options, definition_levels_byte_length)?;
+    let mut compressed_buffer = vec![];
+    let _was_compressed = utils::compress(
+        &mut buffer,
+        &mut compressed_buffer,
+        options,
+        definition_levels_byte_length,
+    )?;
 
     let statistics = if options.write_statistics {
         Some(build_statistics(array, descriptor.clone()))
@@ -87,7 +93,7 @@ pub fn array_to_page<O: Offset>(
     };
 
     utils::build_plain_page(
-        buffer,
+        compressed_buffer,
         array.len(),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/utf8/basic.rs
+++ b/src/io/parquet/write/utf8/basic.rs
@@ -1,7 +1,7 @@
 use parquet2::{
     encoding::Encoding,
     metadata::ColumnDescriptor,
-    page::CompressedDataPage,
+    page::DataPage,
     statistics::{serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics},
     write::WriteOptions,
 };
@@ -43,7 +43,7 @@ pub fn array_to_page<O: Offset>(
     options: WriteOptions,
     descriptor: ColumnDescriptor,
     encoding: Encoding,
-) -> Result<CompressedDataPage> {
+) -> Result<DataPage> {
     let validity = array.validity();
     let is_optional = is_type_nullable(descriptor.type_());
 
@@ -76,16 +76,6 @@ pub fn array_to_page<O: Offset>(
         }
     }
 
-    let uncompressed_page_size = buffer.len();
-
-    let mut compressed_buffer = vec![];
-    let _was_compressed = utils::compress(
-        &mut buffer,
-        &mut compressed_buffer,
-        options,
-        definition_levels_byte_length,
-    )?;
-
     let statistics = if options.write_statistics {
         Some(build_statistics(array, descriptor.clone()))
     } else {
@@ -93,10 +83,9 @@ pub fn array_to_page<O: Offset>(
     };
 
     utils::build_plain_page(
-        compressed_buffer,
+        buffer,
         array.len(),
         array.null_count(),
-        uncompressed_page_size,
         0,
         definition_levels_byte_length,
         statistics,

--- a/src/io/parquet/write/utf8/nested.rs
+++ b/src/io/parquet/write/utf8/nested.rs
@@ -35,8 +35,10 @@ where
 
     let uncompressed_page_size = buffer.len();
 
-    let buffer = utils::compress(
-        buffer,
+    let mut compressed_buffer = vec![];
+    let _was_compressed = utils::compress(
+        &mut buffer,
+        &mut compressed_buffer,
         options,
         definition_levels_byte_length + repetition_levels_byte_length,
     )?;
@@ -48,7 +50,7 @@ where
     };
 
     utils::build_plain_page(
-        buffer,
+        compressed_buffer,
         levels::num_values(nested.offsets()),
         array.null_count(),
         uncompressed_page_size,

--- a/src/io/parquet/write/utf8/nested.rs
+++ b/src/io/parquet/write/utf8/nested.rs
@@ -1,5 +1,5 @@
 use parquet2::{
-    encoding::Encoding, metadata::ColumnDescriptor, page::CompressedDataPage, write::WriteOptions,
+    encoding::Encoding, metadata::ColumnDescriptor, page::DataPage, write::WriteOptions,
 };
 
 use super::super::{levels, utils};
@@ -15,7 +15,7 @@ pub fn array_to_page<O, OO>(
     options: WriteOptions,
     descriptor: ColumnDescriptor,
     nested: levels::NestedInfo<OO>,
-) -> Result<CompressedDataPage>
+) -> Result<DataPage>
 where
     OO: Offset,
     O: Offset,
@@ -33,16 +33,6 @@ where
 
     encode_plain(array, is_optional, &mut buffer);
 
-    let uncompressed_page_size = buffer.len();
-
-    let mut compressed_buffer = vec![];
-    let _was_compressed = utils::compress(
-        &mut buffer,
-        &mut compressed_buffer,
-        options,
-        definition_levels_byte_length + repetition_levels_byte_length,
-    )?;
-
     let statistics = if options.write_statistics {
         Some(build_statistics(array, descriptor.clone()))
     } else {
@@ -50,10 +40,9 @@ where
     };
 
     utils::build_plain_page(
-        compressed_buffer,
+        buffer,
         levels::num_values(nested.offsets()),
         array.null_count(),
-        uncompressed_page_size,
         repetition_levels_byte_length,
         definition_levels_byte_length,
         statistics,

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -499,7 +499,7 @@ fn integration_write(schema: &Schema, batches: &[RecordBatch]) -> Result<Vec<u8>
                 } else {
                     Encoding::Plain
                 };
-                array_to_pages(array.clone(), descriptor, options, encoding).map(|pages| {
+                array_to_pages(array.as_ref(), descriptor, options, encoding).map(|pages| {
                     let encoded_pages = DynIter::new(pages.map(|x| Ok(x?)));
                     let compressed_pages =
                         Compressor::new(encoded_pages, options.compression, vec![])

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -1,6 +1,7 @@
 use std::io::{Cursor, Read, Seek};
 use std::sync::Arc;
 
+use arrow2::error::ArrowError;
 use arrow2::{
     array::*, bitmap::Bitmap, buffer::Buffer, datatypes::*, error::Result,
     io::parquet::read::statistics::*, io::parquet::read::*, io::parquet::write::*,
@@ -492,13 +493,19 @@ fn integration_write(schema: &Schema, batches: &[RecordBatch]) -> Result<Vec<u8>
             .columns()
             .iter()
             .zip(descritors.clone())
-            .map(|(array, type_)| {
+            .map(|(array, descriptor)| {
                 let encoding = if let DataType::Dictionary(_, _) = array.data_type() {
                     Encoding::RleDictionary
                 } else {
                     Encoding::Plain
                 };
-                array_to_pages(array.clone(), type_, options, encoding)
+                array_to_pages(array.clone(), descriptor, options, encoding).map(|pages| {
+                    let encoded_pages = DynIter::new(pages.map(|x| Ok(x?)));
+                    let compressed_pages =
+                        Compressor::new(encoded_pages, options.compression, vec![])
+                            .map_err(ArrowError::from);
+                    DynStreamingIterator::new(compressed_pages)
+                })
             });
         let iterator = DynIter::new(iterator);
         Ok(iterator)


### PR DESCRIPTION
This PR simplifies the code to read `parquet`, making it a bit more future proof and opening the doors to improve performance in writing by re-using buffers (improvements upstream).

I do not observe differences in performance (vs main) in the following parquet configurations:

* single page vs multiple pages
* compressed vs uncompressed
* different types

It generates flamegraphs that imo are quite optimized:

<img width="1440" alt="Screenshot 2021-10-16 at 06 44 55" src="https://user-images.githubusercontent.com/2772607/137574124-4aef6198-cf49-4a62-966e-eeaea51fec3a.png">

This corresponds to

```bash
cargo flamegraph --features io_parquet,io_parquet_compression \
    --example parquet_read fixtures/pyarrow3/v1/multi/snappy/benches_1048576.parquet \
    1 0
```

i.e. reading a f64 column from a single row group with 1M rows with a page size of 1Mb (default in pyarrow).

<img width="1440" alt="Screenshot 2021-10-16 at 06 53 44" src="https://user-images.githubusercontent.com/2772607/137574258-e803c019-9902-467f-bca1-74ce2b4341f3.png">

(same but for a utf8 column (column index 2))

The majority of the time is used deserializing the data to arrow, which means that the main gains to have continue to be on that front.

## Backward incompatible

* The API to read parquet now uses `FallibleStreamingIterator` instead of `StreamingIterator` (of `Result<Page>`). As before, we re-export these APIs in `io::parquet::read`.
* The API to write parquet now expects the user to decompress the pages. This is only relevant when not using `RowGroupIterator` (i.e. in parallelizing). This is now enforced by the type system (`DataPage` vs `CompressedDataPage`), so that we do not get it wrong.
