### PR TITLE
Fixed s3 example

### DIFF
--- a/examples/s3/Cargo.toml
+++ b/examples/s3/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 
 [dependencies]
 arrow2 = { path = "../../", default-features = false, features = ["io_parquet", "io_parquet_compression"] }
-rust-s3 = { version = "0.27.0-rc4", features = ["tokio"] }
+rust-s3 = { version = "0.27.0", features = ["tokio"] }
 futures = "0.3"
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/s3/src/main.rs
+++ b/examples/s3/src/main.rs
@@ -50,7 +50,8 @@ async fn main() -> Result<()> {
 
     // pages of the first row group and first column
     // This is IO bounded and SHOULD be done in a shared thread pool (e.g. Tokio)
-    let pages = get_page_stream(&metadata, 0, 0, &mut reader, vec![]).await?;
+    let column_metadata = &metadata.row_groups[0].columns()[0];
+    let pages = get_page_stream(column_metadata, &mut reader, None, vec![]).await?;
 
     // decompress the pages. This is CPU bounded and SHOULD be done in a dedicated thread pool (e.g. Rayon)
     let pages = pages.map(|compressed_page| decompress(compressed_page?, &mut vec![]));


### PR DESCRIPTION
There was a compilation error in the s3 example. It seems that `Cargo test` does not cover examples within packages, so we will also need to add CI tooling to `check` them.