### PR TITLE
Ignored RUSTSEC-2020-0071 and RUSTSEC-2020-0159

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,13 @@
+[advisories]
+ignore = [
+    # title: Potential segfault in the time crate
+    # This can be ignored because it only affects users that use the feature flag "clock" of "chrono",
+    # which we do not. Specifically: 
+    # * the call of "localtime_r" [is unsound](https://github.com/chronotope/chrono/issues/602#issuecomment-940445390)
+    # * that call [is part of the module "sys"](https://docs.rs/chrono/0.4.19/src/chrono/sys/unix.rs.html#84)
+    # * "sys" is only available on feature "clock": https://docs.rs/chrono/0.4.19/src/chrono/lib.rs.html#456
+    # 
+    # Therefore, this advisory does not affect us.
+    "RUSTSEC-2020-0071",
+    "RUSTSEC-2020-0159", # same as previous
+]


### PR DESCRIPTION
See description on the reasons to ignore. TL;DR: we do not use that feature (`"clock"`) because we do not use local offsets.

The original arrow implementation uses it to cast utf8 to timestamp, but we removed it [as part of a refactor](https://github.com/jorgecarleitao/arrow2/pull/376) to make the cast consistent with the arrow spec (and to not depend on `libc` ^_^).
