### PR TITLE
Improved performance of utf8 check for ascii-only (-40% parquet reading ascii-only columns)

### DIFF
--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -75,6 +75,11 @@ pub fn check_offsets_minimal<O: Offset>(offsets: &[O], values_len: usize) -> usi
 /// * any slice of `values` between two consecutive pairs from `offsets` is invalid `utf8`, or
 /// * any offset is larger or equal to `values_len`.
 pub fn check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) {
+    if values.iter().all(|x| *x <= 127) {
+        // all values are ASCII => each element is valid utf8 (we only need to check offsets)
+        return check_offsets(offsets, values.len());
+    }
+
     offsets.windows(2).for_each(|window| {
         let start = window[0].to_usize();
         let end = window[1].to_usize();


### PR DESCRIPTION
```bash
read utf8 2^20          time:   [8.1475 ms 8.2333 ms 8.3429 ms]                           
                        change: [-42.546% -41.204% -39.859%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
```

Big kudos to @ritchie46 for point out this optimization on https://github.com/pola-rs/polars/pull/1553

There are other optimizations on that PR, but this is already pretty big for a +5 ^_^