### PR TITLE
Added support to read struct arrays from parquet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,9 @@ futures = { version = "0.3", optional = true }
 # for faster hashing
 ahash = { version = "0.7", optional = true }
 
-parquet2 = { version = "0.6", optional = true, default_features = false, features = ["stream"] }
+#parquet2 = { version = "0.6", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "struct", optional = true, default_features = false, features = ["stream"] }
+#parquet2 = { path = "../parquet2", optional = true, default_features = false, features = ["stream"] }
 
 avro-rs = { version = "0.13", optional = true, default_features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,12 +66,12 @@ futures = { version = "0.3", optional = true }
 # for faster hashing
 ahash = { version = "0.7", optional = true }
 
-#parquet2 = { version = "0.6", optional = true, default_features = false, features = ["stream"] }
-parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "struct", optional = true, default_features = false, features = ["stream"] }
-#parquet2 = { path = "../parquet2", optional = true, default_features = false, features = ["stream"] }
+# parquet support
+parquet2 = { version = "0.7", optional = true, default_features = false, features = ["stream"] }
 
+# avro
 avro-rs = { version = "0.13", optional = true, default_features = false }
-
+# compression of avro
 libflate = { version = "1.1.1", optional = true }
 
 # for division/remainder optimization at runtime

--- a/examples/parquet_read.rs
+++ b/examples/parquet_read.rs
@@ -4,38 +4,32 @@ use std::io::BufReader;
 use arrow2::io::parquet::read;
 use arrow2::{array::Array, error::Result};
 
-fn read_column_chunk(path: &str, row_group: usize, column: usize) -> Result<Box<dyn Array>> {
+fn read_field(path: &str, row_group: usize, field: usize) -> Result<Box<dyn Array>> {
     // Open a file, a common operation in Rust
     let mut file = BufReader::new(File::open(path)?);
 
     // Read the files' metadata. This has a small IO cost because it requires seeking to the end
     // of the file to read its footer.
-    let file_metadata = read::read_metadata(&mut file)?;
+    let metadata = read::read_metadata(&mut file)?;
 
     // Convert the files' metadata into an arrow schema. This is CPU-only and amounts to
     // parse thrift if the arrow format is available on a key, or infering the arrow schema from
     // the parquet's physical, converted and logical types.
-    let arrow_schema = read::get_schema(&file_metadata)?;
+    let arrow_schema = read::get_schema(&metadata)?;
 
-    // get the columns' metadata
-    let metadata = file_metadata.row_groups[row_group].column(column);
-
-    // Construct an iterator over pages. This binds `file` to this iterator, and each iteration
-    // is IO intensive as it will read a compressed page into memory. There is almost no CPU work
-    // on this operation
-    let pages = read::get_page_iterator(metadata, &mut file, None, vec![])?;
+    // Created an iterator of column chunks. Each iteration
+    // yields an iterator of compressed pages. There is almost no CPU work in iterating.
+    let columns = read::get_column_iterator(&mut file, &metadata, row_group, field, None, vec![]);
 
     // get the columns' logical type
-    let data_type = arrow_schema.fields()[column].data_type().clone();
+    let data_type = arrow_schema.fields()[field].data_type().clone();
 
-    // This is the actual work. In this case, pages are read (by calling `iter.next()`) and are
-    // immediately decompressed, decoded, deserialized to arrow and deallocated.
-    // This uses a combination of IO and CPU. At this point, `array` is the arrow-corresponding
-    // array of the parquets' physical type.
-    // `Decompressor` re-uses an internal buffer for de-compression, thereby maximizing memory re-use.
-    let mut pages = read::Decompressor::new(pages, vec![]);
+    // This is the actual work. In this case, pages are read and
+    // decompressed, decoded and deserialized to arrow.
+    // Because `columns` is an iterator, it uses a combination of IO and CPU.
+    let (array, _, _) = read::column_iter_to_array(columns, data_type, vec![])?;
 
-    read::page_iter_to_array(&mut pages, metadata, data_type)
+    Ok(array)
 }
 
 fn main() -> Result<()> {
@@ -43,10 +37,10 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
 
     let file_path = &args[1];
-    let column = args[2].parse::<usize>().unwrap();
+    let field = args[2].parse::<usize>().unwrap();
     let row_group = args[3].parse::<usize>().unwrap();
 
-    let array = read_column_chunk(file_path, row_group, column)?;
+    let array = read_field(file_path, row_group, field)?;
     println!("{}", array);
     Ok(())
 }

--- a/examples/parquet_read.rs
+++ b/examples/parquet_read.rs
@@ -21,13 +21,13 @@ fn read_field(path: &str, row_group: usize, field: usize) -> Result<Box<dyn Arra
     // yields an iterator of compressed pages. There is almost no CPU work in iterating.
     let columns = read::get_column_iterator(&mut file, &metadata, row_group, field, None, vec![]);
 
-    // get the columns' logical type
-    let data_type = arrow_schema.fields()[field].data_type().clone();
+    // get the columns' field
+    let field = &arrow_schema.fields()[field];
 
     // This is the actual work. In this case, pages are read and
     // decompressed, decoded and deserialized to arrow.
     // Because `columns` is an iterator, it uses a combination of IO and CPU.
-    let (array, _, _) = read::column_iter_to_array(columns, data_type, vec![])?;
+    let (array, _, _) = read::column_iter_to_array(columns, field, vec![])?;
 
     Ok(array)
 }

--- a/examples/parquet_read_parallel.rs
+++ b/examples/parquet_read_parallel.rs
@@ -64,14 +64,14 @@ fn parallel_read(path: &str, row_group: usize) -> Result<RecordBatch> {
             let arrow_schema_consumer = arrow_schema.clone();
             thread::spawn(move || {
                 let mut arrays = vec![];
-                while let Ok((field_i, field, column_chunks)) = rx_consumer.recv() {
+                while let Ok((field_i, parquet_field, column_chunks)) = rx_consumer.recv() {
                     let start = SystemTime::now();
-                    let data_type = arrow_schema_consumer.fields()[field_i].data_type().clone();
+                    let field = &arrow_schema_consumer.fields()[field_i];
                     println!("consumer {} start - {}", i, field_i);
 
-                    let columns = read::ReadColumnIterator::new(field, column_chunks);
+                    let columns = read::ReadColumnIterator::new(parquet_field, column_chunks);
 
-                    let array = read::column_iter_to_array(columns, data_type, vec![]).map(|x| x.0);
+                    let array = read::column_iter_to_array(columns, field, vec![]).map(|x| x.0);
                     println!(
                         "consumer {} end - {:?}: {}",
                         i,

--- a/examples/parquet_read_parallel.rs
+++ b/examples/parquet_read_parallel.rs
@@ -5,77 +5,98 @@ use std::sync::Arc;
 use std::thread;
 use std::time::SystemTime;
 
-use arrow2::{array::Array, error::Result, io::parquet::read};
+use arrow2::{
+    array::Array, error::Result, io::parquet::read, io::parquet::read::MutStreamingIterator,
+    record_batch::RecordBatch,
+};
 
-fn parallel_read(path: &str) -> Result<Vec<Box<dyn Array>>> {
-    // prepare a channel to send serialized records from threads
+fn parallel_read(path: &str, row_group: usize) -> Result<RecordBatch> {
+    // prepare a channel to send compressed pages across threads.
     let (tx, rx) = unbounded();
 
     let mut file = File::open(path)?;
     let file_metadata = read::read_metadata(&mut file)?;
     let arrow_schema = Arc::new(read::get_schema(&file_metadata)?);
 
-    let file_metadata = Arc::new(file_metadata);
-
     let start = SystemTime::now();
     // spawn a thread to produce `Vec<CompressedPage>` (IO bounded)
-    let producer_metadata = file_metadata.clone();
-    let child = thread::spawn(move || {
-        for column in 0..producer_metadata.schema().num_columns() {
-            for row_group in 0..producer_metadata.row_groups.len() {
-                let start = SystemTime::now();
-                let column_metadata = producer_metadata.row_groups[row_group].column(column);
-                println!("produce start: {} {}", column, row_group);
-                let pages = read::get_page_iterator(column_metadata, &mut file, None, vec![])
-                    .unwrap()
-                    .collect::<Vec<_>>();
-                println!(
-                    "produce end - {:?}: {} {}",
-                    start.elapsed().unwrap(),
-                    column,
-                    row_group
-                );
-                tx.send((column, row_group, pages)).unwrap();
+    let producer = thread::spawn(move || {
+        for field in 0..file_metadata.schema().fields().len() {
+            let start = SystemTime::now();
+
+            let mut columns = read::get_column_iterator(
+                &mut file,
+                &file_metadata,
+                row_group,
+                field,
+                None,
+                vec![],
+            );
+
+            println!("produce start - field: {}", field);
+
+            while let read::State::Some(mut new_iter) = columns.advance().unwrap() {
+                if let Some((pages, metadata)) = new_iter.get() {
+                    let pages = pages.collect::<Vec<_>>();
+
+                    tx.send((field, metadata.clone(), pages)).unwrap();
+                }
+                columns = new_iter;
             }
+            println!(
+                "produce end - {:?}: {} {}",
+                start.elapsed().unwrap(),
+                field,
+                row_group
+            );
         }
     });
 
-    let mut children = Vec::new();
-    // use 3 consumers of to decompress, decode and deserialize.
-    for _ in 0..3 {
-        let rx_consumer = rx.clone();
-        let metadata_consumer = file_metadata.clone();
-        let arrow_schema_consumer = arrow_schema.clone();
-        let child = thread::spawn(move || {
-            let (column, row_group, pages) = rx_consumer.recv().unwrap();
-            let start = SystemTime::now();
-            println!("consumer start - {} {}", column, row_group);
-            let metadata = metadata_consumer.row_groups[row_group].column(column);
-            let data_type = arrow_schema_consumer.fields()[column].data_type().clone();
+    // use 2 consumers for CPU-intensive to decompress, decode and deserialize.
+    #[allow(clippy::needless_collect)] // we need to collect to parallelize
+    let consumers = (0..2)
+        .map(|i| {
+            let rx_consumer = rx.clone();
+            let arrow_schema_consumer = arrow_schema.clone();
+            thread::spawn(move || {
+                let mut arrays = vec![];
+                while let Ok((field, metadata, pages)) = rx_consumer.recv() {
+                    let start = SystemTime::now();
+                    let data_type = arrow_schema_consumer.fields()[field].data_type().clone();
+                    println!("consumer {} start - {}", i, field);
 
-            let mut pages = read::BasicDecompressor::new(pages.into_iter(), vec![]);
+                    let mut pages = read::BasicDecompressor::new(pages.into_iter(), vec![]);
 
-            let array = read::page_iter_to_array(&mut pages, metadata, data_type);
-            println!(
-                "consumer end - {:?}: {} {}",
-                start.elapsed().unwrap(),
-                column,
-                row_group
-            );
-            array
-        });
-        children.push(child);
-    }
+                    let array = read::page_iter_to_array(&mut pages, &metadata, data_type);
+                    println!(
+                        "consumer {} end - {:?}: {}",
+                        i,
+                        start.elapsed().unwrap(),
+                        field
+                    );
 
-    child.join().expect("child thread panicked");
+                    arrays.push((field, array))
+                }
+                arrays
+            })
+        })
+        .collect::<Vec<_>>();
 
-    let arrays = children
+    producer.join().expect("producer thread panicked");
+
+    // collect all columns (join threads)
+    let mut columns = consumers
         .into_iter()
         .map(|x| x.join().unwrap())
-        .collect::<Result<Vec<_>>>()?;
+        .flatten()
+        .map(|x| Ok((x.0, x.1?)))
+        .collect::<Result<Vec<(usize, Box<dyn Array>)>>>()?;
+    // order may not be the same
+    columns.sort_unstable_by_key(|x| x.0);
+    let columns = columns.into_iter().map(|x| x.1.into()).collect();
     println!("Finished - {:?}", start.elapsed().unwrap());
 
-    Ok(arrays)
+    RecordBatch::try_new(arrow_schema, columns)
 }
 
 fn main() -> Result<()> {
@@ -83,8 +104,8 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     let file_path = &args[1];
 
-    let arrays = parallel_read(file_path)?;
-    for array in arrays {
+    let batch = parallel_read(file_path, 0)?;
+    for array in batch.columns() {
         println!("{}", array)
     }
     Ok(())

--- a/parquet_integration/write_parquet.py
+++ b/parquet_integration/write_parquet.py
@@ -184,6 +184,32 @@ def case_nested(size):
     )
 
 
+def case_struct(size):
+    string = ["Hello", None, "aa", "", None, "abc", None, None, "def", "aaa"]
+    boolean = [True, None, False, False, None, True, None, None, True, True]
+    struct_fields = [
+        ("f1", pa.utf8()),
+        ("f2", pa.bool_()),
+    ]
+    fields = [
+        pa.field(
+            "struct",
+            pa.struct(struct_fields),
+        )
+    ]
+    schema = pa.schema(fields)
+    return (
+        {
+            "struct": pa.StructArray.from_arrays(
+                [pa.array(string * size), pa.array(boolean * size)],
+                fields=struct_fields,
+            ),
+        },
+        schema,
+        f"struct_nullable_{size*10}.parquet",
+    )
+
+
 def write_pyarrow(
     case,
     size: int,
@@ -228,7 +254,7 @@ def write_pyarrow(
     )
 
 
-for case in [case_basic_nullable, case_basic_required, case_nested]:
+for case in [case_basic_nullable, case_basic_required, case_nested, case_struct]:
     for version in [1, 2]:
         for use_dict in [True, False]:
             write_pyarrow(case, 1, version, use_dict, False, False)

--- a/parquet_integration/write_parquet.py
+++ b/parquet_integration/write_parquet.py
@@ -191,18 +191,34 @@ def case_struct(size):
         ("f1", pa.utf8()),
         ("f2", pa.bool_()),
     ]
-    fields = [
-        pa.field(
-            "struct",
-            pa.struct(struct_fields),
-        )
-    ]
-    schema = pa.schema(fields)
+    schema = pa.schema(
+        [
+            pa.field(
+                "struct",
+                pa.struct(struct_fields),
+            ),
+            pa.field(
+                "struct_struct",
+                pa.struct(
+                    [
+                        ("f1", pa.struct(struct_fields)),
+                        ("f2", pa.bool_()),
+                    ]
+                ),
+            ),
+        ]
+    )
+
+    struct = pa.StructArray.from_arrays(
+        [pa.array(string * size), pa.array(boolean * size)],
+        fields=struct_fields,
+    )
     return (
         {
-            "struct": pa.StructArray.from_arrays(
-                [pa.array(string * size), pa.array(boolean * size)],
-                fields=struct_fields,
+            "struct": struct,
+            "struct_struct": pa.StructArray.from_arrays(
+                [struct, pa.array(boolean * size)],
+                names=["f1", "f2"],
             ),
         },
         schema,

--- a/src/io/parquet/read/README.md
+++ b/src/io/parquet/read/README.md
@@ -2,32 +2,33 @@
 
 ### LSB equivalence between definition levels and bitmaps
 
-* When the maximum repetition level is 0 and the maximum definition level is 1,
-  the RLE-encoded definition levels correspond exactly to Arrow's bitmap and can be
-  memcopied without further transformations.
-
-* Reading a parquet nested field can be done by reading each individual primitive
-  column and "building" the nested struct in arrow.
+When the maximum repetition level is 0 and the maximum definition level is 1,
+the RLE-encoded definition levels correspond exactly to Arrow's bitmap and can be
+memcopied without further transformations.
 
 ## Nested parquet groups are deserialized recursively
+
+Reading a parquet nested field is done by reading each primitive
+column sequentially, and build the nested struct recursively.
 
 Rows of nested parquet groups are encoded in the repetition and definition levels.
 In arrow, they correspond to:
 * list's offsets and validity
 * struct's validity
 
-An implementation that leverages this observation:
+The implementation in this module leverages this observation:
 
-When nested types are observed in a parquet column, we recurse over the struct to gather
-whether the type is a Struct or List and whether it is required or optional, which we store
-in a `Vec<Nested>`. `Nested` is an enum that can process definition and repetition
-levels depending on the type and nullability.
+Nested parquet fields are initially recursed over to gather
+whether the type is a Struct or List, and whether it is required or optional, which we store
+in `nested_info: Vec<Box<dyn Nested>>`. `Nested` is a trait object that receives definition
+and repetition levels depending on the type and nullability of the nested item.
+We process the definition and repetition levels into `nested_info`.
 
-When processing pages, we process the definition and repetition levels into `Vec`.
+When we finish a field, we recursively pop from `nested_info` as we build
+the `StructArray` or `ListArray`.
 
-When we finish a column chunk, we recursively pop `Vec` as we are building the `StructArray`
-or `ListArray`.
-
-With this approach, the only difference vs flat is that we cannot leverage the bitmap
-optimization, and instead need to deserialize the repetition and definition
-levels to `i32`.
+With this approach, the only difference vs flat is:
+1. we do not leverage the bitmap optimization, and instead need to deserialize the repetition
+   and definition levels to `i32`.
+2. we deserialize definition levels twice, once to extend the values/nullability and
+   one to extend `nested_info`.

--- a/src/io/parquet/read/README.md
+++ b/src/io/parquet/read/README.md
@@ -1,0 +1,33 @@
+## Observations
+
+### LSB equivalence between definition levels and bitmaps
+
+* When the maximum repetition level is 0 and the maximum definition level is 1,
+  the RLE-encoded definition levels correspond exactly to Arrow's bitmap and can be
+  memcopied without further transformations.
+
+* Reading a parquet nested field can be done by reading each individual primitive
+  column and "building" the nested struct in arrow.
+
+## Nested parquet groups are deserialized recursively
+
+Rows of nested parquet groups are encoded in the repetition and definition levels.
+In arrow, they correspond to:
+* list's offsets and validity
+* struct's validity
+
+An implementation that leverages this observation:
+
+When nested types are observed in a parquet column, we recurse over the struct to gather
+whether the type is a Struct or List and whether it is required or optional, which we store
+in a `Vec<Nested>`. `Nested` is an enum that can process definition and repetition
+levels depending on the type and nullability.
+
+When processing pages, we process the definition and repetition levels into `Vec`.
+
+When we finish a column chunk, we recursively pop `Vec` as we are building the `StructArray`
+or `ListArray`.
+
+With this approach, the only difference vs flat is that we cannot leverage the bitmap
+optimization, and instead need to deserialize the repetition and definition
+levels to `i32`.

--- a/src/io/parquet/read/binary/mod.rs
+++ b/src/io/parquet/read/binary/mod.rs
@@ -1,9 +1,97 @@
+use futures::{pin_mut, Stream, StreamExt};
+use parquet2::{metadata::ColumnChunkMetaData, page::DataPage, FallibleStreamingIterator};
+
+use crate::{
+    array::{Array, Offset},
+    bitmap::MutableBitmap,
+    buffer::MutableBuffer,
+    datatypes::DataType,
+    error::{ArrowError, Result},
+    io::parquet::read::binary::utils::finish_array,
+};
+
 mod basic;
 mod dictionary;
 mod nested;
 mod utils;
 
-pub use basic::iter_to_array;
-pub use basic::stream_to_array;
 pub use dictionary::iter_to_array as iter_to_dict_array;
-pub use nested::iter_to_array as iter_to_array_nested;
+
+use super::nested_utils::Nested;
+
+pub fn iter_to_array<O, I, E>(
+    mut iter: I,
+    metadata: &ColumnChunkMetaData,
+    data_type: DataType,
+    nested: &mut Vec<Box<dyn Nested>>,
+) -> Result<Box<dyn Array>>
+where
+    O: Offset,
+    ArrowError: From<E>,
+    I: FallibleStreamingIterator<Item = DataPage, Error = E>,
+{
+    let capacity = metadata.num_values() as usize;
+    let mut values = MutableBuffer::<u8>::with_capacity(0);
+    let mut offsets = MutableBuffer::<O>::with_capacity(1 + capacity);
+    offsets.push(O::default());
+    let mut validity = MutableBitmap::with_capacity(capacity);
+
+    let is_nullable = nested.pop().unwrap().is_nullable();
+
+    if nested.is_empty() {
+        while let Some(page) = iter.next()? {
+            basic::extend_from_page(
+                page,
+                metadata.descriptor(),
+                &mut offsets,
+                &mut values,
+                &mut validity,
+            )?
+        }
+    } else {
+        while let Some(page) = iter.next()? {
+            nested::extend_from_page(
+                page,
+                metadata.descriptor(),
+                is_nullable,
+                nested,
+                &mut offsets,
+                &mut values,
+                &mut validity,
+            )?
+        }
+    }
+    Ok(utils::finish_array(data_type, offsets, values, validity))
+}
+
+pub async fn stream_to_array<O, I, E>(
+    pages: I,
+    metadata: &ColumnChunkMetaData,
+    data_type: &DataType,
+) -> Result<Box<dyn Array>>
+where
+    ArrowError: From<E>,
+    O: Offset,
+    E: Clone,
+    I: Stream<Item = std::result::Result<DataPage, E>>,
+{
+    let capacity = metadata.num_values() as usize;
+    let mut values = MutableBuffer::<u8>::with_capacity(0);
+    let mut offsets = MutableBuffer::<O>::with_capacity(1 + capacity);
+    offsets.push(O::default());
+    let mut validity = MutableBitmap::with_capacity(capacity);
+
+    pin_mut!(pages); // needed for iteration
+
+    while let Some(page) = pages.next().await {
+        basic::extend_from_page(
+            page.as_ref().map_err(|x| x.clone())?,
+            metadata.descriptor(),
+            &mut offsets,
+            &mut values,
+            &mut validity,
+        )?
+    }
+
+    Ok(finish_array(data_type.clone(), offsets, values, validity))
+}

--- a/src/io/parquet/read/boolean/mod.rs
+++ b/src/io/parquet/read/boolean/mod.rs
@@ -1,6 +1,55 @@
+use crate::{
+    array::{Array, BooleanArray},
+    bitmap::MutableBitmap,
+    datatypes::DataType,
+    error::{ArrowError, Result},
+};
+
+use parquet2::{metadata::ColumnChunkMetaData, page::DataPage, FallibleStreamingIterator};
+
 mod basic;
 mod nested;
 
-pub use basic::iter_to_array;
 pub use basic::stream_to_array;
-pub use nested::iter_to_array as iter_to_array_nested;
+
+use super::nested_utils::Nested;
+
+pub fn iter_to_array<I, E>(
+    mut iter: I,
+    metadata: &ColumnChunkMetaData,
+    data_type: DataType,
+    nested: &mut Vec<Box<dyn Nested>>,
+) -> Result<Box<dyn Array>>
+where
+    ArrowError: From<E>,
+    I: FallibleStreamingIterator<Item = DataPage, Error = E>,
+{
+    let capacity = metadata.num_values() as usize;
+    let mut values = MutableBitmap::with_capacity(capacity);
+    let mut validity = MutableBitmap::with_capacity(capacity);
+
+    let is_nullable = nested.pop().unwrap().is_nullable();
+
+    if nested.is_empty() {
+        while let Some(page) = iter.next()? {
+            basic::extend_from_page(page, metadata.descriptor(), &mut values, &mut validity)?
+        }
+    } else {
+        while let Some(page) = iter.next()? {
+            nested::extend_from_page(
+                page,
+                metadata.descriptor(),
+                is_nullable,
+                nested,
+                &mut values,
+                &mut validity,
+            )?
+        }
+    }
+
+    Ok(Box::new(BooleanArray::from_data(
+        data_type,
+        values.into(),
+        validity.into(),
+    )))
+}

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -18,7 +18,7 @@ pub use parquet2::{
         decompress, get_column_iterator, get_page_iterator as _get_page_iterator,
         get_page_stream as _get_page_stream, read_metadata as _read_metadata,
         read_metadata_async as _read_metadata_async, BasicDecompressor, ColumnChunkIter,
-        Decompressor, MutStreamingIterator, PageFilter, PageIterator, State,
+        Decompressor, MutStreamingIterator, PageFilter, PageIterator, ReadColumnIterator, State,
     },
     schema::types::{
         LogicalType, ParquetType, PhysicalType, PrimitiveConvertedType,

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -30,7 +30,7 @@ pub use parquet2::{
 
 use crate::{
     array::{Array, DictionaryKey, NullArray, PrimitiveArray, StructArray},
-    datatypes::{DataType, IntervalUnit, TimeUnit},
+    datatypes::{DataType, Field, IntervalUnit, TimeUnit},
     error::{ArrowError, Result},
     io::parquet::read::nested_utils::{create_list, init_nested},
 };
@@ -366,7 +366,7 @@ fn finish_array(data_type: DataType, arrays: &mut VecDeque<Box<dyn Array>>) -> B
 #[allow(clippy::type_complexity)]
 pub fn column_iter_to_array<II, I>(
     mut columns: I,
-    data_type: DataType,
+    field: &Field,
     mut buffer: Vec<u8>,
 ) -> Result<(Box<dyn Array>, Vec<u8>, Vec<u8>)>
 where
@@ -374,7 +374,9 @@ where
     I: ColumnChunkIter<II>,
 {
     let mut nested_info = vec![];
-    init_nested(columns.field(), 0, &mut nested_info);
+    init_nested(field, 0, &mut nested_info);
+
+    let data_type = field.data_type().clone();
 
     let mut arrays = VecDeque::new();
     let page_buffer;

--- a/src/io/parquet/read/nested_utils.rs
+++ b/src/io/parquet/read/nested_utils.rs
@@ -229,7 +229,7 @@ pub fn init_nested(field: &Field, capacity: usize, container: &mut Vec<Box<dyn N
             }
             match field.data_type().to_logical_type() {
                 DataType::List(ref inner)
-                | DataType::List(ref inner)
+                | DataType::LargeList(ref inner)
                 | DataType::FixedSizeList(ref inner, _) => {
                     init_nested(inner.as_ref(), capacity, container)
                 }

--- a/src/io/parquet/read/primitive/mod.rs
+++ b/src/io/parquet/read/primitive/mod.rs
@@ -3,8 +3,6 @@ mod dictionary;
 mod nested;
 mod utils;
 
-use std::sync::Arc;
-
 use futures::{pin_mut, Stream, StreamExt};
 use parquet2::{page::DataPage, types::NativeType, FallibleStreamingIterator};
 
@@ -20,38 +18,6 @@ use crate::{
 };
 
 pub use dictionary::iter_to_array as iter_to_dict_array;
-
-pub fn iter_to_array<T, A, I, E, F>(
-    mut iter: I,
-    metadata: &ColumnChunkMetaData,
-    data_type: DataType,
-    op: F,
-) -> Result<Box<dyn Array>>
-where
-    ArrowError: From<E>,
-    T: NativeType,
-    A: ArrowNativeType,
-    F: Copy + Fn(T) -> A,
-    I: FallibleStreamingIterator<Item = DataPage, Error = E>,
-{
-    let capacity = metadata.num_values() as usize;
-    let mut values = MutableBuffer::<A>::with_capacity(capacity);
-    let mut validity = MutableBitmap::with_capacity(capacity);
-    while let Some(page) = iter.next()? {
-        basic::extend_from_page(page, metadata.descriptor(), &mut values, &mut validity, op)?
-    }
-
-    let data_type = match data_type {
-        DataType::Dictionary(_, values) => values.as_ref().clone(),
-        _ => data_type,
-    };
-
-    Ok(Box::new(PrimitiveArray::from_data(
-        data_type,
-        values.into(),
-        validity.into(),
-    )))
-}
 
 pub async fn stream_to_array<T, A, I, E, F>(
     pages: I,
@@ -95,12 +61,13 @@ where
     )))
 }
 
-pub fn iter_to_array_nested<T, A, I, E, F>(
+pub fn iter_to_array<T, A, I, E, F>(
     mut iter: I,
     metadata: &ColumnChunkMetaData,
     data_type: DataType,
+    nested: &mut Vec<Box<dyn Nested>>,
     op: F,
-) -> Result<(Arc<dyn Array>, Vec<Box<dyn Nested>>)>
+) -> Result<Box<dyn Array>>
 where
     ArrowError: From<E>,
     T: NativeType,
@@ -113,24 +80,34 @@ where
     let mut values = MutableBuffer::<A>::with_capacity(capacity);
     let mut validity = MutableBitmap::with_capacity(capacity);
 
-    let (mut nested, is_nullable) = init_nested(metadata.descriptor().base_type(), capacity);
+    let is_nullable = nested.pop().unwrap().is_nullable();
 
-    while let Some(page) = iter.next()? {
-        nested::extend_from_page(
-            page,
-            metadata.descriptor(),
-            is_nullable,
-            &mut nested,
-            &mut values,
-            &mut validity,
-            op,
-        )?
+    if nested.is_empty() {
+        while let Some(page) = iter.next()? {
+            basic::extend_from_page(page, metadata.descriptor(), &mut values, &mut validity, op)?
+        }
+    } else {
+        while let Some(page) = iter.next()? {
+            nested::extend_from_page(
+                page,
+                metadata.descriptor(),
+                is_nullable,
+                nested,
+                &mut values,
+                &mut validity,
+                op,
+            )?
+        }
     }
 
-    let values = Arc::new(PrimitiveArray::<A>::from_data(
+    let data_type = match data_type {
+        DataType::Dictionary(_, values) => values.as_ref().clone(),
+        _ => data_type,
+    };
+
+    Ok(Box::new(PrimitiveArray::from_data(
         data_type,
         values.into(),
         validity.into(),
-    ));
-    Ok((values, nested))
+    )))
 }

--- a/src/io/parquet/read/record_batch.rs
+++ b/src/io/parquet/read/record_batch.rs
@@ -1,6 +1,5 @@
 use std::{
     io::{Read, Seek},
-    rc::Rc,
     sync::Arc,
 };
 
@@ -11,8 +10,8 @@ use crate::{
 };
 
 use super::{
-    get_page_iterator, get_schema, page_iter_to_array, read_metadata, Decompressor, FileMetaData,
-    PageFilter, RowGroupMetaData,
+    column_iter_to_array, get_column_iterator, get_schema, read_metadata, FileMetaData, PageFilter,
+    RowGroupMetaData,
 };
 
 type GroupFilter = Arc<dyn Fn(usize, &RowGroupMetaData) -> bool>;
@@ -21,12 +20,12 @@ type GroupFilter = Arc<dyn Fn(usize, &RowGroupMetaData) -> bool>;
 pub struct RecordReader<R: Read + Seek> {
     reader: R,
     schema: Arc<Schema>,
-    indices: Rc<Vec<usize>>,
+    indices: Vec<usize>,
     buffer: Vec<u8>,
     decompress_buffer: Vec<u8>,
     groups_filter: Option<GroupFilter>,
     pages_filter: Option<PageFilter>,
-    metadata: Rc<FileMetaData>,
+    metadata: FileMetaData,
     current_group: usize,
     remaining_rows: usize,
 }
@@ -65,7 +64,10 @@ impl<R: Read + Seek> RecordReader<R> {
 
         if let Some(projection) = &projection {
             if indices.len() != projection.len() {
-                return Err(ArrowError::InvalidArgumentError("While reading parquet, some columns in the projection do not exist in the file".to_string()));
+                return Err(ArrowError::InvalidArgumentError(
+                    "While reading parquet, some columns in the projection do not exist in the file"
+                        .to_string(),
+                ));
             }
         }
 
@@ -77,10 +79,10 @@ impl<R: Read + Seek> RecordReader<R> {
         Ok(Self {
             reader,
             schema,
-            indices: Rc::new(indices),
+            indices,
             groups_filter,
             pages_filter,
-            metadata: Rc::new(metadata),
+            metadata,
             current_group: 0,
             buffer: vec![],
             decompress_buffer: vec![],
@@ -95,7 +97,7 @@ impl<R: Read + Seek> RecordReader<R> {
 
     /// Returns parquet's [`FileMetaData`].
     pub fn metadata(&self) -> &FileMetaData {
-        self.metadata.as_ref()
+        &self.metadata
     }
 
     /// Sets the groups filter
@@ -120,7 +122,7 @@ impl<R: Read + Seek> Iterator for RecordReader<R> {
         }
 
         let row_group = self.current_group;
-        let metadata = self.metadata.clone();
+        let metadata = &self.metadata;
         let group = &metadata.row_groups[row_group];
         if let Some(groups_filter) = self.groups_filter.as_ref() {
             if !(groups_filter)(row_group, group) {
@@ -128,7 +130,6 @@ impl<R: Read + Seek> Iterator for RecordReader<R> {
                 return self.next();
             }
         }
-        let columns_meta = group.columns();
 
         // todo: avoid these clones.
         let schema = self.schema().clone();
@@ -138,21 +139,19 @@ impl<R: Read + Seek> Iterator for RecordReader<R> {
 
         let a = schema.fields().iter().enumerate().try_fold(
             (b1, b2, Vec::with_capacity(schema.fields().len())),
-            |(b1, b2, mut columns), (column, field)| {
-                // column according to the file's indexing
-                let column = self.indices[column];
-                let column_metadata = &columns_meta[column];
-                let pages = get_page_iterator(
-                    column_metadata,
+            |(b1, b2, mut columns), (field_index, field)| {
+                let field_index = self.indices[field_index]; // project into the original schema
+                let column_iter = get_column_iterator(
                     &mut self.reader,
+                    &self.metadata,
+                    row_group,
+                    field_index,
                     self.pages_filter.clone(),
                     b1,
-                )?;
+                );
 
-                let mut pages = Decompressor::new(pages, b2);
-
-                let array =
-                    page_iter_to_array(&mut pages, column_metadata, field.data_type().clone())?;
+                let (array, b1, b2) =
+                    column_iter_to_array(column_iter, field.data_type().clone(), b2)?;
 
                 let array = if array.len() > remaining_rows {
                     array.slice(0, remaining_rows)
@@ -161,7 +160,6 @@ impl<R: Read + Seek> Iterator for RecordReader<R> {
                 };
 
                 columns.push(array.into());
-                let (b1, b2) = pages.into_buffers();
                 Result::Ok((b1, b2, columns))
             },
         );

--- a/src/io/parquet/read/record_batch.rs
+++ b/src/io/parquet/read/record_batch.rs
@@ -150,8 +150,7 @@ impl<R: Read + Seek> Iterator for RecordReader<R> {
                     b1,
                 );
 
-                let (array, b1, b2) =
-                    column_iter_to_array(column_iter, field.data_type().clone(), b2)?;
+                let (array, b1, b2) = column_iter_to_array(column_iter, field, b2)?;
 
                 let array = if array.len() > remaining_rows {
                     array.slice(0, remaining_rows)

--- a/src/io/parquet/write/binary/basic.rs
+++ b/src/io/parquet/write/binary/basic.rs
@@ -129,7 +129,7 @@ pub(crate) fn encode_delta<O: Offset>(
         if let Some(validity) = validity {
             let lengths = offsets
                 .windows(2)
-                .map(|w| (w[1] - w[0]).to_isize() as i32)
+                .map(|w| (w[1] - w[0]).to_isize() as i64)
                 .zip(validity.iter())
                 .flat_map(|(x, is_valid)| if is_valid { Some(x) } else { None });
             let length = offsets.len() - 1 - validity.null_count();
@@ -137,11 +137,11 @@ pub(crate) fn encode_delta<O: Offset>(
 
             delta_bitpacked::encode(lengths, buffer);
         } else {
-            let lengths = offsets.windows(2).map(|w| (w[1] - w[0]).to_isize() as i32);
+            let lengths = offsets.windows(2).map(|w| (w[1] - w[0]).to_isize() as i64);
             delta_bitpacked::encode(lengths, buffer);
         }
     } else {
-        let lengths = offsets.windows(2).map(|w| (w[1] - w[0]).to_isize() as i32);
+        let lengths = offsets.windows(2).map(|w| (w[1] - w[0]).to_isize() as i64);
         delta_bitpacked::encode(lengths, buffer);
     }
 

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -533,6 +533,63 @@ pub fn pyarrow_nested_nullable_statistics(column: usize) -> Option<Box<dyn Stati
     })
 }
 
+pub fn pyarrow_struct(column: usize) -> Box<dyn Array> {
+    match column {
+        0 => {
+            let string = [
+                Some("Hello"),
+                None,
+                Some("aa"),
+                Some(""),
+                None,
+                Some("abc"),
+                None,
+                None,
+                Some("def"),
+                Some("aaa"),
+            ];
+            let boolean = [
+                Some(true),
+                None,
+                Some(false),
+                Some(false),
+                None,
+                Some(true),
+                None,
+                None,
+                Some(true),
+                Some(true),
+            ];
+            let values = vec![
+                Arc::new(Utf8Array::<i32>::from(string)) as Arc<dyn Array>,
+                Arc::new(BooleanArray::from(boolean)) as Arc<dyn Array>,
+            ];
+            let fields = vec![
+                Field::new("f1", DataType::Utf8, true),
+                Field::new("f2", DataType::Boolean, true),
+            ];
+            Box::new(StructArray::from_data(
+                DataType::Struct(fields),
+                values,
+                None,
+            ))
+        }
+        _ => todo!(),
+    }
+}
+
+pub fn pyarrow_struct_statistics(column: usize) -> Option<Box<dyn Statistics>> {
+    match column {
+        0 => Some(Box::new(Utf8Statistics {
+            distinct_count: None,
+            null_count: Some(1),
+            min_value: Some("".to_string()),
+            max_value: Some("def".to_string()),
+        })),
+        _ => todo!(),
+    }
+}
+
 /// Round-trip with parquet using the same integration files used for IPC integration tests.
 fn integration_write(schema: &Schema, batches: &[RecordBatch]) -> Result<Vec<u8>> {
     let options = WriteOptions {

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -546,7 +546,7 @@ pub fn pyarrow_struct(column: usize) -> Box<dyn Array> {
         Some(true),
         Some(true),
     ];
-    let boolean = Arc::new(BooleanArray::from(boolean.clone())) as Arc<dyn Array>;
+    let boolean = Arc::new(BooleanArray::from(boolean)) as Arc<dyn Array>;
     let fields = vec![
         Field::new("f1", DataType::Utf8, true),
         Field::new("f2", DataType::Boolean, true),

--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -35,6 +35,7 @@ fn test_pyarrow_integration(
         ("basic", true) => pyarrow_required(column),
         ("basic", false) => pyarrow_nullable(column),
         ("nested", false) => pyarrow_nested_nullable(column),
+        ("struct", false) => pyarrow_struct(column),
         _ => unreachable!(),
     };
 
@@ -42,6 +43,7 @@ fn test_pyarrow_integration(
         ("basic", true) => pyarrow_required_statistics(column),
         ("basic", false) => pyarrow_nullable_statistics(column),
         ("nested", false) => pyarrow_nested_nullable_statistics(column),
+        ("struct", false) => pyarrow_struct_statistics(column),
         _ => unreachable!(),
     };
 
@@ -310,6 +312,11 @@ fn v2_decimal_26_nullable() -> Result<()> {
 #[test]
 fn v2_decimal_26_required() -> Result<()> {
     test_pyarrow_integration(8, 2, "basic", false, true)
+}
+
+#[test]
+fn v1_struct_optional() -> Result<()> {
+    test_pyarrow_integration(0, 1, "struct", false, false)
 }
 
 #[test]

--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -320,6 +320,11 @@ fn v1_struct_optional() -> Result<()> {
 }
 
 #[test]
+fn v1_struct_struct_optional() -> Result<()> {
+    test_pyarrow_integration(1, 1, "struct", false, false)
+}
+
+#[test]
 fn all_types() -> Result<()> {
     let path = "testing/parquet-testing/data/alltypes_plain.parquet";
     let reader = std::fs::File::open(path)?;


### PR DESCRIPTION
This PR adds support to read (nested) `StructArray` from parquet.

Integration test against pyarrow included.