### PR TITLE
amortize bitmap writes -20/65 %

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,3 +265,7 @@ harness = false
 [[bench]]
 name = "bitwise"
 harness = false
+
+[[bench]]
+name = "mutable"
+harness = false

--- a/benches/mutable.rs
+++ b/benches/mutable.rs
@@ -1,0 +1,49 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use arrow2::array::*;
+use arrow2::bitmap::MutableBitmap;
+use arrow2::util::bench_util::*;
+use arrow2::{compute::aggregate::*, datatypes::DataType};
+use rand::Rng;
+
+fn create_bools(null_density: f32, size: usize) -> Vec<bool> {
+    let mut rng = seedable_rng();
+
+    (0..size)
+        .map(|_| {
+            if rng.gen::<f32>() < null_density {
+                false
+            } else {
+                true
+            }
+        })
+        .collect()
+}
+
+fn bench_build(values: &[bool]) {
+    criterion::black_box({
+        let mut bitmap = MutableBitmap::new();
+
+        values.iter().for_each(|v| bitmap.push(*v));
+    })
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+
+        let null_density = 0.2;
+        let values = create_bools(null_density, size);
+
+        c.bench_function(
+            &format!(
+                "mutable bitmap 2^{} null density: {}",
+                log2_size, null_density
+            ),
+            |b| b.iter(|| bench_build(&values)),
+        );
+    });
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -123,11 +123,10 @@ impl<O: Offset> MutableBinaryArray<O> {
     }
 
     fn init_validity(&mut self) {
-        self.validity = Some(MutableBitmap::from_trusted_len_iter(
-            std::iter::repeat(true)
-                .take(self.len() - 1)
-                .chain(std::iter::once(false)),
-        ))
+        let mut validity = MutableBitmap::with_capacity(self.values.capacity());
+        validity.extend_constant(self.len(), true);
+        validity.set(self.len() - 1, false);
+        self.validity = Some(validity);
     }
 
     /// Converts itself into an [`Array`].

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -76,11 +76,23 @@ impl MutableBitmap {
     /// Pushes a new bit to the [`MutableBitmap`], re-sizing it if necessary.
     #[inline]
     pub fn push(&mut self, value: bool) {
-        if self.length % 8 == 0 {
-            self.buffer.push(0);
+        // loop unrolling is still cool
+        // 64 / 8 = 8
+        if self.length % 64 == 0 {
+            self.buffer.push(u8::MAX); // 1
+            self.buffer.push(u8::MAX); // 2
+            self.buffer.push(u8::MAX); // ..
+            self.buffer.push(u8::MAX);
+            self.buffer.push(u8::MAX);
+            self.buffer.push(u8::MAX);
+            self.buffer.push(u8::MAX); // 7
+            self.buffer.push(u8::MAX); // 8
         }
-        let byte = self.buffer.as_mut_slice().last_mut().unwrap();
-        *byte = set(*byte, self.length % 8, value);
+
+        if !value {
+            let bytes = self.buffer.as_mut_slice();
+            set_bit(bytes, self.length, false)
+        }
         self.length += 1;
     }
 

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -93,7 +93,10 @@ impl MutableBitmap {
             let bytes = self.buffer.as_mut_slice();
             set_bit(bytes, self.length, false)
         }
-        self.length += 1;
+        // Soundness
+        // the buffer is guaranteed to be minimal this length of initialized data.
+        // there may be 64 bytes more initialized.
+        unsafe { self.set_len(self.length + 1) }
     }
 
     /// Returns the capacity of [`MutableBitmap`] in number of bits.

--- a/tests/it/array/binary/mod.rs
+++ b/tests/it/array/binary/mod.rs
@@ -21,7 +21,7 @@ fn basics() {
     assert_eq!(array.offsets().as_slice(), &[0, 5, 5, 11]);
     assert_eq!(
         array.validity(),
-        Some(&Bitmap::from_u8_slice(&[0b00000101], 3))
+        Some(&Bitmap::from_u8_slice(&[0b11111101], 3))
     );
     assert!(array.is_valid(0));
     assert!(!array.is_valid(1));

--- a/tests/it/bitmap/mutable.rs
+++ b/tests/it/bitmap/mutable.rs
@@ -204,7 +204,7 @@ fn extend_set() {
 
     let mut b = MutableBitmap::from(&[false]);
     b.extend_constant(6, true);
-    assert_eq!(b.as_slice(), &[0b01111110]);
+    assert_eq!(b.as_slice(), &[0b11111110]);
     assert_eq!(b.len(), 1 + 6);
 
     let mut b = MutableBitmap::from(&[false]);
@@ -214,7 +214,7 @@ fn extend_set() {
 
     let mut b = MutableBitmap::from(&[false, false, false, false]);
     b.extend_constant(2, true);
-    assert_eq!(b.as_slice(), &[0b00110000]);
+    assert_eq!(b.as_slice(), &[0b11110000]);
     assert_eq!(b.len(), 4 + 2);
 
     let mut b = MutableBitmap::from(&[false, false, false, false]);
@@ -224,7 +224,7 @@ fn extend_set() {
 
     let mut b = MutableBitmap::from(&[true, true]);
     b.extend_constant(3, true);
-    assert_eq!(b.as_slice(), &[0b00011111]);
+    assert_eq!(b.as_slice(), &[0b11111111]);
     assert_eq!(b.len(), 2 + 3);
 }
 
@@ -232,22 +232,22 @@ fn extend_set() {
 fn extend_unset() {
     let mut b = MutableBitmap::new();
     b.extend_constant(6, false);
-    assert_eq!(b.as_slice(), &[0b0000000]);
+    assert_eq!(b.as_slice(), &[0b11000000]);
     assert_eq!(b.len(), 6);
 
     let mut b = MutableBitmap::from(&[true]);
     b.extend_constant(6, false);
-    assert_eq!(b.as_slice(), &[0b00000001]);
+    assert_eq!(b.as_slice(), &[0b10000001]);
     assert_eq!(b.len(), 1 + 6);
 
     let mut b = MutableBitmap::from(&[true]);
     b.extend_constant(9, false);
-    assert_eq!(b.as_slice(), &[0b0000001, 0b00000000]);
+    assert_eq!(b.as_slice(), &[0b0000001, 0b11111100]);
     assert_eq!(b.len(), 1 + 9);
 
     let mut b = MutableBitmap::from(&[true, true, true, true]);
     b.extend_constant(2, false);
-    assert_eq!(b.as_slice(), &[0b00001111]);
+    assert_eq!(b.as_slice(), &[0b11001111]);
     assert_eq!(b.len(), 4 + 2);
 }
 

--- a/tests/it/bitmap/mutable.rs
+++ b/tests/it/bitmap/mutable.rs
@@ -35,7 +35,7 @@ fn push() {
     let bitmap: Bitmap = bitmap.into();
     assert_eq!(bitmap.len(), 10);
 
-    assert_eq!(bitmap.as_slice().0, &[0b11111001, 0b00000011]);
+    assert_eq!(bitmap.as_slice().0, &[0b11111001, 0b11111111]);
 }
 
 #[test]
@@ -47,7 +47,7 @@ fn push_small() {
     let bitmap: Option<Bitmap> = bitmap.into();
     let bitmap = bitmap.unwrap();
     assert_eq!(bitmap.len(), 3);
-    assert_eq!(bitmap.as_slice().0[0], 0b00000011);
+    assert_eq!(bitmap.as_slice().0[0], 0b11111011);
 }
 
 #[test]


### PR DESCRIPTION
Under the assumption that most values are valid in columnar data, this optimization amortizes buffer writes.

# 32 byte padding 20% nulls
```
Gnuplot not found, using plotters backend
mutable bitmap 2^10 null density: 0.2                        
                        time:   [908.97 ns 910.39 ns 911.86 ns]
                        change: [-62.709% -62.449% -62.225%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

mutable bitmap 2^12 null density: 0.2                        
                        time:   [5.1081 us 5.1150 us 5.1219 us]
                        change: [-59.712% -59.191% -58.725%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) low mild
  1 (1.00%) high severe

mutable bitmap 2^14 null density: 0.2                        
                        time:   [40.246 us 40.255 us 40.264 us]
                        change: [-22.369% -22.315% -22.257%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe

mutable bitmap 2^16 null density: 0.2                        
                        time:   [171.26 us 171.29 us 171.31 us]
                        change: [-17.411% -17.104% -16.862%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

mutable bitmap 2^18 null density: 0.2                        
                        time:   [688.20 us 690.00 us 691.89 us]
                        change: [-17.547% -17.240% -16.950%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low mild
  13 (13.00%) high severe

mutable bitmap 2^20 null density: 0.2                        
                        time:   [2.7371 ms 2.7376 ms 2.7381 ms]
                        change: [-16.795% -16.677% -16.596%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

```

# 64 byte padding
```
Gnuplot not found, using plotters backend
mutable bitmap 2^10 null density: 0.2                        
                        time:   [902.64 ns 904.23 ns 906.11 ns]
                        change: [-62.930% -62.660% -62.402%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

mutable bitmap 2^12 null density: 0.2                        
                        time:   [4.4016 us 4.4114 us 4.4207 us]
                        change: [-65.324% -64.875% -64.470%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild

mutable bitmap 2^14 null density: 0.2                        
                        time:   [38.471 us 38.531 us 38.596 us]
                        change: [-25.864% -25.780% -25.687%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe

mutable bitmap 2^16 null density: 0.2                        
                        time:   [165.35 us 165.43 us 165.52 us]
                        change: [-20.224% -19.925% -19.689%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  8 (8.00%) high severe

mutable bitmap 2^18 null density: 0.2                        
                        time:   [664.31 us 665.01 us 665.88 us]
                        change: [-20.301% -20.032% -19.782%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) high mild
  12 (12.00%) high severe

mutable bitmap 2^20 null density: 0.2                        
                        time:   [2.6512 ms 2.6517 ms 2.6523 ms]
                        change: [-19.406% -19.291% -19.213%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

```

# 128 byte padding 20% nulls

```

Gnuplot not found, using plotters backend
mutable bitmap 2^10 null density: 0.2                        
                        time:   [877.51 ns 878.98 ns 880.64 ns]
                        change: [-63.942% -63.667% -63.416%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

mutable bitmap 2^12 null density: 0.2                        
                        time:   [4.5646 us 4.5833 us 4.6024 us]
                        change: [-63.864% -63.400% -62.982%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild

mutable bitmap 2^14 null density: 0.2                        
                        time:   [39.049 us 39.086 us 39.125 us]
                        change: [-24.770% -24.708% -24.644%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

mutable bitmap 2^16 null density: 0.2                        
                        time:   [165.88 us 165.92 us 165.95 us]
                        change: [-19.995% -19.701% -19.464%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  1 (1.00%) high mild

mutable bitmap 2^18 null density: 0.2                        
                        time:   [667.19 us 667.33 us 667.47 us]
                        change: [-20.024% -19.771% -19.537%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

mutable bitmap 2^20 null density: 0.2                        
                        time:   [2.6646 ms 2.6651 ms 2.6657 ms]
                        change: [-18.998% -18.882% -18.805%] (p = 0.00 < 0.05)
                        Performance has improved.

```


# 64 byte padding 50% nulls

```
mutable bitmap 2^10 null density: 0.5                        
                        time:   [1.1637 us 1.1652 us 1.1667 us]
                        change: [-64.233% -64.085% -63.852%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

mutable bitmap 2^12 null density: 0.5                        
                        time:   [12.352 us 12.358 us 12.363 us]
                        change: [-29.097% -28.958% -28.813%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

mutable bitmap 2^14 null density: 0.5                        
                        time:   [68.040 us 68.088 us 68.143 us]
                        change: [-7.6155% -7.1695% -6.6459%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

mutable bitmap 2^16 null density: 0.5                        
                        time:   [277.77 us 277.82 us 277.87 us]
                        change: [-5.2811% -5.2403% -5.1994%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

mutable bitmap 2^18 null density: 0.5                        
                        time:   [1.1194 ms 1.1221 ms 1.1254 ms]
                        change: [-4.2597% -4.0346% -3.7621%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

mutable bitmap 2^20 null density: 0.5                        
                        time:   [4.4462 ms 4.4514 ms 4.4590 ms]
                        change: [-7.0317% -6.8308% -6.6046%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe

```