### PR TITLE
Avoided redundant checks in creating an `Utf8Array` from `MutableUtf8Array`

### DIFF
--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -25,12 +25,17 @@ pub struct MutableUtf8Array<O: Offset> {
 
 impl<O: Offset> From<MutableUtf8Array<O>> for Utf8Array<O> {
     fn from(other: MutableUtf8Array<O>) -> Self {
-        Utf8Array::<O>::from_data(
-            other.data_type,
-            other.offsets.into(),
-            other.values.into(),
-            other.validity.map(|x| x.into()),
-        )
+        // Safety:
+        // `MutableUtf8Array` has the same invariants as `Utf8Array` and thus
+        // `Utf8Array` can be safely created from `MutableUtf8Array` without checks.
+        unsafe {
+            Utf8Array::<O>::from_data_unchecked(
+                other.data_type,
+                other.offsets.into(),
+                other.values.into(),
+                other.validity.map(|x| x.into()),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
This PR fixes a performance issue when creating `Utf8Array` from `MutableUtf8Array`: since `MutableUtf8Array` has the same invariants as `Utf8Array`, we can use `from_data_unchecked`, avoiding re-running expensive utf8 validation.