### PR TITLE
Fix FFI of sliced arrays

### DIFF
--- a/arrow-pyarrow-integration-testing/tests/test_sql.py
+++ b/arrow-pyarrow-integration-testing/tests/test_sql.py
@@ -39,14 +39,51 @@ class TestCase(unittest.TestCase):
         # No leak of C++ memory
         self.assertEqual(self.old_allocated_cpp, pyarrow.total_allocated_bytes())
 
-    def test_string_roundtrip(self):
-        """
-        Python -> Rust -> Python
-        """
+    def test_primitive(self):
+        a = pyarrow.array([0, None, 2, 3, 4])
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
+
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type
+
+    def test_primitive_sliced(self):
+        a = pyarrow.array([0, None, 2, 3, 4]).slice(1, 2)
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
+
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type
+
+    def test_boolean(self):
+        a = pyarrow.array([True, None, False, True, False])
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
+
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type
+
+    def test_boolean_sliced(self):
+        a = pyarrow.array([True, None, False, True, False]).slice(1, 2)
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
+
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type
+
+    def test_string(self):
         a = pyarrow.array(["a", None, "ccc"])
         b = arrow_pyarrow_integration_testing.round_trip_array(a)
         c = pyarrow.array(["a", None, "ccc"])
         self.assertEqual(b, c)
+
+    def test_string_sliced(self):
+        a = pyarrow.array(["a", None, "ccc"]).slice(1, 2)
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
+
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type
 
     def test_decimal_roundtrip(self):
         """
@@ -75,10 +112,17 @@ class TestCase(unittest.TestCase):
             assert a.to_pylist() == b.to_pylist()
             assert a.type == b.type
 
-    def test_struct_array(self):
-        """
-        Python -> Rust -> Python
-        """
+    def test_list_sliced(self):
+        a = pyarrow.array(
+            [[], None, [1, 2], [4, 5, 6]], pyarrow.list_(pyarrow.int64())
+        ).slice(1, 2)
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
+
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type
+
+    def test_struct(self):
         fields = [
             ("f1", pyarrow.int32()),
             ("f2", pyarrow.string()),
@@ -95,6 +139,27 @@ class TestCase(unittest.TestCase):
         )
         b = arrow_pyarrow_integration_testing.round_trip_array(a)
 
+        b.validate(full=True)
+        assert a.to_pylist() == b.to_pylist()
+        assert a.type == b.type
+
+    # see https://issues.apache.org/jira/browse/ARROW-14383
+    def _test_struct_sliced(self):
+        fields = [
+            ("f1", pyarrow.int32()),
+            ("f2", pyarrow.string()),
+        ]
+        a = pyarrow.array(
+            [
+                {"f1": 1, "f2": "a"},
+                None,
+                {"f1": 3, "f2": None},
+                {"f1": None, "f2": "d"},
+                {"f1": None, "f2": None},
+            ],
+            pyarrow.struct(fields),
+        ).slice(1, 2)
+        b = arrow_pyarrow_integration_testing.round_trip_array(a)
         b.validate(full=True)
         assert a.to_pylist() == b.to_pylist()
         assert a.type == b.type

--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -1,5 +1,6 @@
 use crate::{
     array::{FromFfi, Offset, ToFfi},
+    bitmap::align,
     datatypes::DataType,
     ffi,
 };
@@ -12,14 +13,41 @@ unsafe impl<O: Offset> ToFfi for BinaryArray<O> {
     fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            std::ptr::NonNull::new(self.offsets.as_ptr() as *mut u8),
-            std::ptr::NonNull::new(self.values.as_ptr() as *mut u8),
+            Some(self.offsets.as_ptr().cast::<u8>()),
+            Some(self.values.as_ptr().cast::<u8>()),
         ]
     }
 
-    #[inline]
-    fn offset(&self) -> usize {
-        self.offset
+    fn offset(&self) -> Option<usize> {
+        let offset = self.offsets.offset();
+        if let Some(bitmap) = self.validity.as_ref() {
+            if bitmap.offset() == offset {
+                Some(offset)
+            } else {
+                None
+            }
+        } else {
+            Some(offset)
+        }
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        let offset = self.offsets.offset();
+
+        let validity = self.validity.as_ref().map(|bitmap| {
+            if bitmap.offset() == offset {
+                bitmap.clone()
+            } else {
+                align(bitmap, offset)
+            }
+        });
+
+        Self {
+            data_type: self.data_type.clone(),
+            validity,
+            offsets: self.offsets.clone(),
+            values: self.values.clone(),
+        }
     }
 }
 

--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -1,7 +1,6 @@
 use crate::{
     array::{FromFfi, Offset, ToFfi},
     bitmap::align,
-    datatypes::DataType,
     ffi,
 };
 
@@ -54,29 +53,13 @@ unsafe impl<O: Offset> ToFfi for BinaryArray<O> {
 impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryArray<O> {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
         let data_type = array.field().data_type().clone();
-        let expected = if O::is_large() {
-            DataType::LargeBinary
-        } else {
-            DataType::Binary
-        };
-        assert_eq!(data_type, expected);
 
-        let length = array.array().len();
-        let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() }?;
-        let mut offsets = unsafe { array.buffer::<O>(0) }?;
+        let validity = unsafe { array.validity() }?;
+        let offsets = unsafe { array.buffer::<O>(0) }?;
         let values = unsafe { array.buffer::<u8>(1) }?;
 
-        if offset > 0 {
-            offsets = offsets.slice(offset, length);
-            validity = validity.map(|x| x.slice(offset, length))
-        }
-
         Ok(Self::from_data_unchecked(
-            Self::default_data_type(),
-            offsets,
-            values,
-            validity,
+            data_type, offsets, values, validity,
         ))
     }
 }

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -23,7 +23,6 @@ pub struct BinaryArray<O: Offset> {
     offsets: Buffer<O>,
     values: Buffer<u8>,
     validity: Option<Bitmap>,
-    offset: usize,
 }
 
 // constructors
@@ -71,7 +70,6 @@ impl<O: Offset> BinaryArray<O> {
             offsets,
             values,
             validity,
-            offset: 0,
         }
     }
 
@@ -113,7 +111,6 @@ impl<O: Offset> BinaryArray<O> {
             offsets,
             values,
             validity,
-            offset: 0,
         }
     }
 
@@ -146,7 +143,6 @@ impl<O: Offset> BinaryArray<O> {
             offsets,
             values: self.values.clone(),
             validity,
-            offset: self.offset + offset,
         }
     }
 

--- a/src/array/boolean/ffi.rs
+++ b/src/array/boolean/ffi.rs
@@ -1,5 +1,6 @@
 use crate::{
     array::{FromFfi, ToFfi},
+    bitmap::align,
     datatypes::DataType,
     ffi,
 };
@@ -16,8 +17,35 @@ unsafe impl ToFfi for BooleanArray {
         ]
     }
 
-    fn offset(&self) -> usize {
-        self.offset
+    fn offset(&self) -> Option<usize> {
+        let offset = self.values.offset();
+        if let Some(bitmap) = self.validity.as_ref() {
+            if bitmap.offset() == offset {
+                Some(offset)
+            } else {
+                None
+            }
+        } else {
+            Some(offset)
+        }
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        let offset = self.values.offset();
+
+        let validity = self.validity.as_ref().map(|bitmap| {
+            if bitmap.offset() == offset {
+                bitmap.clone()
+            } else {
+                align(bitmap, offset)
+            }
+        });
+
+        Self {
+            data_type: self.data_type.clone(),
+            validity,
+            values: self.values.clone(),
+        }
     }
 }
 

--- a/src/array/boolean/ffi.rs
+++ b/src/array/boolean/ffi.rs
@@ -1,7 +1,6 @@
 use crate::{
     array::{FromFfi, ToFfi},
     bitmap::align,
-    datatypes::DataType,
     ffi,
 };
 
@@ -52,16 +51,8 @@ unsafe impl ToFfi for BooleanArray {
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for BooleanArray {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
         let data_type = array.field().data_type().clone();
-        assert_eq!(data_type, DataType::Boolean);
-        let length = array.array().len();
-        let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() }?;
-        let mut values = unsafe { array.bitmap(0) }?;
-
-        if offset > 0 {
-            values = values.slice(offset, length);
-            validity = validity.map(|x| x.slice(offset, length))
-        }
+        let validity = unsafe { array.validity() }?;
+        let values = unsafe { array.bitmap(0) }?;
         Ok(Self::from_data(data_type, values, validity))
     }
 }

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -20,7 +20,6 @@ pub struct BooleanArray {
     data_type: DataType,
     values: Bitmap,
     validity: Option<Bitmap>,
-    offset: usize,
 }
 
 impl BooleanArray {
@@ -50,7 +49,6 @@ impl BooleanArray {
             data_type,
             values,
             validity,
-            offset: 0,
         }
     }
 
@@ -83,7 +81,6 @@ impl BooleanArray {
             data_type: self.data_type.clone(),
             values: self.values.clone().slice_unchecked(offset, length),
             validity,
-            offset: self.offset + offset,
         }
     }
 

--- a/src/array/dictionary/ffi.rs
+++ b/src/array/dictionary/ffi.rs
@@ -19,7 +19,7 @@ unsafe impl<K: DictionaryKey> ToFfi for DictionaryArray<K> {
         Self {
             data_type: self.data_type.clone(),
             keys: self.keys.to_ffi_aligned(),
-            values: self.values,
+            values: self.values.clone(),
         }
     }
 }

--- a/src/array/dictionary/ffi.rs
+++ b/src/array/dictionary/ffi.rs
@@ -27,17 +27,10 @@ unsafe impl<K: DictionaryKey> ToFfi for DictionaryArray<K> {
 impl<K: DictionaryKey, A: ffi::ArrowArrayRef> FromFfi<A> for DictionaryArray<K> {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
         // keys: similar to PrimitiveArray, but the datatype is the inner one
-        let length = array.array().len();
-        let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() }?;
-        let mut values = unsafe { array.buffer::<K>(0) }?;
+        let validity = unsafe { array.validity() }?;
+        let values = unsafe { array.buffer::<K>(0) }?;
 
-        if offset > 0 {
-            values = values.slice(offset, length);
-            validity = validity.map(|x| x.slice(offset, length))
-        }
         let keys = PrimitiveArray::<K>::from_data(K::DATA_TYPE, values, validity);
-        // values
         let values = array.dictionary()?.unwrap();
         let values = ffi::try_from(values)?.into();
 

--- a/src/array/dictionary/ffi.rs
+++ b/src/array/dictionary/ffi.rs
@@ -11,9 +11,16 @@ unsafe impl<K: DictionaryKey> ToFfi for DictionaryArray<K> {
         self.keys.buffers()
     }
 
-    #[inline]
-    fn offset(&self) -> usize {
-        self.offset
+    fn offset(&self) -> Option<usize> {
+        self.keys.offset()
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        Self {
+            data_type: self.data_type.clone(),
+            keys: self.keys.to_ffi_aligned(),
+            values: self.values,
+        }
     }
 }
 

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -37,7 +37,6 @@ pub struct DictionaryArray<K: DictionaryKey> {
     data_type: DataType,
     keys: PrimitiveArray<K>,
     values: Arc<dyn Array>,
-    offset: usize,
 }
 
 impl<K: DictionaryKey> DictionaryArray<K> {
@@ -69,7 +68,6 @@ impl<K: DictionaryKey> DictionaryArray<K> {
             data_type,
             keys,
             values,
-            offset: 0,
         }
     }
 
@@ -81,7 +79,6 @@ impl<K: DictionaryKey> DictionaryArray<K> {
             data_type: self.data_type.clone(),
             keys: self.keys.clone().slice(offset, length),
             values: self.values.clone(),
-            offset: self.offset + offset,
         }
     }
 
@@ -93,7 +90,6 @@ impl<K: DictionaryKey> DictionaryArray<K> {
             data_type: self.data_type.clone(),
             keys: self.keys.clone().slice_unchecked(offset, length),
             values: self.values.clone(),
-            offset: self.offset + offset,
         }
     }
 

--- a/src/array/ffi.rs
+++ b/src/array/ffi.rs
@@ -7,7 +7,7 @@ use crate::error::Result;
 
 /// Trait describing how a struct presents itself to the
 /// [C data interface](https://arrow.apache.org/docs/format/CDataInterface.html) (FFI).
-/// Safety:
+/// # Safety
 /// Implementing this trait incorrect will lead to UB
 pub(crate) unsafe trait ToFfi {
     /// The pointers to the buffers.

--- a/src/array/fixed_size_binary/ffi.rs
+++ b/src/array/fixed_size_binary/ffi.rs
@@ -1,0 +1,44 @@
+use crate::{array::ToFfi, bitmap::align};
+
+use super::FixedSizeBinaryArray;
+
+unsafe impl ToFfi for FixedSizeBinaryArray {
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
+        vec![
+            self.validity.as_ref().map(|x| x.as_ptr()),
+            Some(self.values.as_ptr().cast::<u8>()),
+        ]
+    }
+
+    fn offset(&self) -> Option<usize> {
+        let offset = self.values.offset() / self.size as usize;
+        if let Some(bitmap) = self.validity.as_ref() {
+            if bitmap.offset() == offset {
+                Some(offset)
+            } else {
+                None
+            }
+        } else {
+            Some(offset)
+        }
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        let offset = self.values.offset() / self.size;
+
+        let validity = self.validity.as_ref().map(|bitmap| {
+            if bitmap.offset() == offset {
+                bitmap.clone()
+            } else {
+                align(bitmap, offset)
+            }
+        });
+
+        Self {
+            size: self.size,
+            data_type: self.data_type.clone(),
+            validity,
+            values: self.values.clone(),
+        }
+    }
+}

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -1,7 +1,8 @@
 use crate::{bitmap::Bitmap, buffer::Buffer, datatypes::DataType, error::Result};
 
-use super::{display_fmt, display_helper, ffi::ToFfi, Array};
+use super::{display_fmt, display_helper, Array};
 
+mod ffi;
 mod iterator;
 mod mutable;
 pub use mutable::*;
@@ -14,7 +15,6 @@ pub struct FixedSizeBinaryArray {
     data_type: DataType,
     values: Buffer<u8>,
     validity: Option<Bitmap>,
-    offset: usize,
 }
 
 impl FixedSizeBinaryArray {
@@ -47,7 +47,6 @@ impl FixedSizeBinaryArray {
             data_type,
             values,
             validity,
-            offset: 0,
         }
     }
 
@@ -83,7 +82,6 @@ impl FixedSizeBinaryArray {
             size: self.size,
             values,
             validity,
-            offset: self.offset + offset,
         }
     }
 
@@ -179,19 +177,6 @@ impl std::fmt::Display for FixedSizeBinaryArray {
         let a = |x: &[u8]| display_helper(x.iter().map(|x| Some(format!("{:b}", x)))).join(" ");
         let iter = self.iter().map(|x| x.map(a));
         display_fmt(iter, "FixedSizeBinaryArray", f, false)
-    }
-}
-
-unsafe impl ToFfi for FixedSizeBinaryArray {
-    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
-        vec![
-            self.validity.as_ref().map(|x| x.as_ptr()),
-            std::ptr::NonNull::new(self.values.as_ptr() as *mut u8),
-        ]
-    }
-
-    fn offset(&self) -> usize {
-        self.offset
     }
 }
 

--- a/src/array/fixed_size_list/ffi.rs
+++ b/src/array/fixed_size_list/ffi.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+
+use super::super::{ffi::ToFfi, Array};
+use super::FixedSizeListArray;
+
+unsafe impl ToFfi for FixedSizeListArray {
+    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
+        vec![self.validity.as_ref().map(|x| x.as_ptr())]
+    }
+
+    fn children(&self) -> Vec<Arc<dyn Array>> {
+        vec![self.values().clone()]
+    }
+
+    fn offset(&self) -> Option<usize> {
+        Some(
+            self.validity
+                .as_ref()
+                .map(|bitmap| bitmap.offset())
+                .unwrap_or_default(),
+        )
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        self.clone()
+    }
+}

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -5,8 +5,9 @@ use crate::{
     datatypes::{DataType, Field},
 };
 
-use super::{display_fmt, ffi::ToFfi, new_empty_array, new_null_array, Array};
+use super::{display_fmt, new_empty_array, new_null_array, Array};
 
+mod ffi;
 mod iterator;
 pub use iterator::*;
 mod mutable;
@@ -20,7 +21,6 @@ pub struct FixedSizeListArray {
     data_type: DataType,
     values: Arc<dyn Array>,
     validity: Option<Bitmap>,
-    offset: usize,
 }
 
 impl FixedSizeListArray {
@@ -60,7 +60,6 @@ impl FixedSizeListArray {
             data_type,
             values,
             validity,
-            offset: 0,
         }
     }
 
@@ -97,7 +96,6 @@ impl FixedSizeListArray {
             size: self.size,
             values,
             validity,
-            offset: self.offset + offset,
         }
     }
 
@@ -192,19 +190,5 @@ impl Array for FixedSizeListArray {
 impl std::fmt::Display for FixedSizeListArray {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         display_fmt(self.iter(), "FixedSizeListArray", f, true)
-    }
-}
-
-unsafe impl ToFfi for FixedSizeListArray {
-    fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
-        vec![self.validity.as_ref().map(|x| x.as_ptr())]
-    }
-
-    fn offset(&self) -> usize {
-        self.offset
-    }
-
-    fn children(&self) -> Vec<Arc<dyn Array>> {
-        vec![self.values().clone()]
     }
 }

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -53,17 +53,11 @@ unsafe impl<O: Offset> ToFfi for ListArray<O> {
 impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for ListArray<O> {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
         let data_type = array.field().data_type().clone();
-        let length = array.array().len();
-        let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() }?;
-        let mut offsets = unsafe { array.buffer::<O>(0) }?;
-        let child = array.child(0)?;
+        let validity = unsafe { array.validity() }?;
+        let offsets = unsafe { array.buffer::<O>(0) }?;
+        let child = unsafe { array.child(0)? };
         let values = ffi::try_from(child)?.into();
 
-        if offset > 0 {
-            offsets = offsets.slice(offset, length);
-            validity = validity.map(|x| x.slice(offset, length))
-        }
         Ok(Self::from_data(data_type, offsets, values, validity))
     }
 }

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::{array::FromFfi, error::Result, ffi};
+use crate::{array::FromFfi, bitmap::align, error::Result, ffi};
 
 use super::super::{ffi::ToFfi, specification::Offset, Array};
 use super::ListArray;
@@ -9,16 +9,44 @@ unsafe impl<O: Offset> ToFfi for ListArray<O> {
     fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            std::ptr::NonNull::new(self.offsets.as_ptr() as *mut u8),
+            Some(self.offsets.as_ptr().cast::<u8>()),
         ]
-    }
-
-    fn offset(&self) -> usize {
-        self.offset
     }
 
     fn children(&self) -> Vec<Arc<dyn Array>> {
         vec![self.values.clone()]
+    }
+
+    fn offset(&self) -> Option<usize> {
+        let offset = self.offsets.offset();
+        if let Some(bitmap) = self.validity.as_ref() {
+            if bitmap.offset() == offset {
+                Some(offset)
+            } else {
+                None
+            }
+        } else {
+            Some(offset)
+        }
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        let offset = self.offsets.offset();
+
+        let validity = self.validity.as_ref().map(|bitmap| {
+            if bitmap.offset() == offset {
+                bitmap.clone()
+            } else {
+                align(bitmap, offset)
+            }
+        });
+
+        Self {
+            data_type: self.data_type.clone(),
+            validity,
+            offsets: self.offsets.clone(),
+            values: self.values.clone(),
+        }
     }
 }
 

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -25,7 +25,6 @@ pub struct ListArray<O: Offset> {
     offsets: Buffer<O>,
     values: Arc<dyn Array>,
     validity: Option<Bitmap>,
-    offset: usize,
 }
 
 impl<O: Offset> ListArray<O> {
@@ -78,7 +77,6 @@ impl<O: Offset> ListArray<O> {
             offsets,
             values,
             validity,
-            offset: 0,
         }
     }
 
@@ -107,7 +105,6 @@ impl<O: Offset> ListArray<O> {
             offsets,
             values: self.values.clone(),
             validity,
-            offset: self.offset + offset,
         }
     }
 
@@ -144,8 +141,8 @@ impl<O: Offset> ListArray<O> {
     /// Assumes that the `i < self.len`.
     #[inline]
     pub unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array> {
-        let offset = *self.offsets.as_ptr().add(i);
-        let offset_1 = *self.offsets.as_ptr().add(i + 1);
+        let offset = *self.offsets.get_unchecked(i);
+        let offset_1 = *self.offsets.get_unchecked(i + 1);
         let length = (offset_1 - offset).to_usize();
 
         self.values.slice_unchecked(offset.to_usize(), length)

--- a/src/array/map/ffi.rs
+++ b/src/array/map/ffi.rs
@@ -18,7 +18,16 @@ unsafe impl ToFfi for MapArray {
     }
 
     fn offset(&self) -> Option<usize> {
-        todo!()
+        let offset = self.offsets.offset();
+        if let Some(bitmap) = self.validity.as_ref() {
+            if bitmap.offset() == offset {
+                Some(offset)
+            } else {
+                None
+            }
+        } else {
+            Some(offset)
+        }
     }
 
     fn to_ffi_aligned(&self) -> Self {
@@ -44,17 +53,11 @@ unsafe impl ToFfi for MapArray {
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for MapArray {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
         let data_type = array.field().data_type().clone();
-        let length = array.array().len();
-        let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() }?;
-        let mut offsets = unsafe { array.buffer::<i32>(0) }?;
+        let validity = unsafe { array.validity() }?;
+        let offsets = unsafe { array.buffer::<i32>(0) }?;
         let child = array.child(0)?;
         let values = ffi::try_from(child)?.into();
 
-        if offset > 0 {
-            offsets = offsets.slice(offset, length);
-            validity = validity.map(|x| x.slice(offset, length))
-        }
         Ok(Self::from_data(data_type, offsets, values, validity))
     }
 }

--- a/src/array/map/ffi.rs
+++ b/src/array/map/ffi.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::{array::FromFfi, error::Result, ffi};
+use crate::{array::FromFfi, bitmap::align, error::Result, ffi};
 
 use super::super::{ffi::ToFfi, Array};
 use super::MapArray;
@@ -9,16 +9,35 @@ unsafe impl ToFfi for MapArray {
     fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            std::ptr::NonNull::new(self.offsets.as_ptr() as *mut u8),
+            Some(self.offsets.as_ptr().cast::<u8>()),
         ]
-    }
-
-    fn offset(&self) -> usize {
-        self.offset
     }
 
     fn children(&self) -> Vec<Arc<dyn Array>> {
         vec![self.field.clone()]
+    }
+
+    fn offset(&self) -> Option<usize> {
+        todo!()
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        let offset = self.offsets.offset();
+
+        let validity = self.validity.as_ref().map(|bitmap| {
+            if bitmap.offset() == offset {
+                bitmap.clone()
+            } else {
+                align(bitmap, offset)
+            }
+        });
+
+        Self {
+            data_type: self.data_type.clone(),
+            validity,
+            offsets: self.offsets.clone(),
+            field: self.field.clone(),
+        }
     }
 }
 

--- a/src/array/map/mod.rs
+++ b/src/array/map/mod.rs
@@ -22,7 +22,6 @@ pub struct MapArray {
     field: Arc<dyn Array>,
     // invariant: offsets.len() - 1 == Bitmap::len()
     validity: Option<Bitmap>,
-    offset: usize,
 }
 
 impl MapArray {
@@ -81,7 +80,6 @@ impl MapArray {
             data_type,
             field,
             offsets,
-            offset: 0,
             validity,
         }
     }
@@ -111,7 +109,6 @@ impl MapArray {
             offsets,
             field: self.field.clone(),
             validity,
-            offset: self.offset + offset,
         }
     }
 }
@@ -148,8 +145,8 @@ impl MapArray {
     /// Assumes that the `i < self.len`.
     #[inline]
     pub unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array> {
-        let offset = *self.offsets.as_ptr().add(i);
-        let offset_1 = *self.offsets.as_ptr().add(i + 1);
+        let offset = *self.offsets.get_unchecked(i);
+        let offset_1 = *self.offsets.get_unchecked(i + 1);
         let length = (offset_1 - offset).to_usize();
 
         self.field.slice_unchecked(offset.to_usize(), length)

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -393,9 +393,9 @@ pub use struct_::StructArray;
 pub use union::UnionArray;
 pub use utf8::{MutableUtf8Array, Utf8Array, Utf8ValuesIter};
 
-pub(crate) use self::ffi::buffers_children_dictionary;
-pub use self::ffi::FromFfi;
-pub use self::ffi::ToFfi;
+pub(crate) use self::ffi::offset_buffers_children_dictionary;
+pub(crate) use self::ffi::FromFfi;
+pub(crate) use self::ffi::ToFfi;
 
 /// A trait describing the ability of a struct to create itself from a iterator.
 /// This is similar to [`Extend`], but accepted the creation to error.

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -7,7 +7,6 @@ use super::{ffi::ToFfi, Array};
 pub struct NullArray {
     data_type: DataType,
     length: usize,
-    offset: usize,
 }
 
 impl NullArray {
@@ -23,19 +22,14 @@ impl NullArray {
 
     /// Returns a new [`NullArray`].
     pub fn from_data(data_type: DataType, length: usize) -> Self {
-        Self {
-            data_type,
-            length,
-            offset: 0,
-        }
+        Self { data_type, length }
     }
 
     /// Returns a slice of the [`NullArray`].
-    pub fn slice(&self, offset: usize, length: usize) -> Self {
+    pub fn slice(&self, _offset: usize, length: usize) -> Self {
         Self {
             data_type: self.data_type.clone(),
             length,
-            offset: self.offset + offset,
         }
     }
 }
@@ -82,8 +76,11 @@ unsafe impl ToFfi for NullArray {
         vec![]
     }
 
-    #[inline]
-    fn offset(&self) -> usize {
-        self.offset
+    fn offset(&self) -> Option<usize> {
+        Some(0)
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        self.clone()
     }
 }

--- a/src/array/primitive/ffi.rs
+++ b/src/array/primitive/ffi.rs
@@ -1,5 +1,6 @@
 use crate::{
     array::{FromFfi, ToFfi},
+    bitmap::align,
     ffi,
     types::NativeType,
 };
@@ -12,13 +13,39 @@ unsafe impl<T: NativeType> ToFfi for PrimitiveArray<T> {
     fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            std::ptr::NonNull::new(self.values.as_ptr() as *mut u8),
+            Some(self.values.as_ptr().cast::<u8>()),
         ]
     }
 
-    #[inline]
-    fn offset(&self) -> usize {
-        self.offset
+    fn offset(&self) -> Option<usize> {
+        let offset = self.values.offset();
+        if let Some(bitmap) = self.validity.as_ref() {
+            if bitmap.offset() == offset {
+                Some(offset)
+            } else {
+                None
+            }
+        } else {
+            Some(offset)
+        }
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        let offset = self.values.offset();
+
+        let validity = self.validity.as_ref().map(|bitmap| {
+            if bitmap.offset() == offset {
+                bitmap.clone()
+            } else {
+                align(bitmap, offset)
+            }
+        });
+
+        Self {
+            data_type: self.data_type.clone(),
+            validity,
+            values: self.values.clone(),
+        }
     }
 }
 

--- a/src/array/primitive/ffi.rs
+++ b/src/array/primitive/ffi.rs
@@ -52,15 +52,9 @@ unsafe impl<T: NativeType> ToFfi for PrimitiveArray<T> {
 impl<T: NativeType, A: ffi::ArrowArrayRef> FromFfi<A> for PrimitiveArray<T> {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
         let data_type = array.field().data_type().clone();
-        let length = array.array().len();
-        let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() }?;
-        let mut values = unsafe { array.buffer::<T>(0) }?;
+        let validity = unsafe { array.validity() }?;
+        let values = unsafe { array.buffer::<T>(0) }?;
 
-        if offset > 0 {
-            values = values.slice(offset, length);
-            validity = validity.map(|x| x.slice(offset, length))
-        }
         Ok(Self::from_data(data_type, values, validity))
     }
 }

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -35,7 +35,6 @@ pub struct PrimitiveArray<T: NativeType> {
     data_type: DataType,
     values: Buffer<T>,
     validity: Option<Bitmap>,
-    offset: usize,
 }
 
 impl<T: NativeType> PrimitiveArray<T> {
@@ -75,7 +74,6 @@ impl<T: NativeType> PrimitiveArray<T> {
             data_type,
             values,
             validity,
-            offset: 0,
         }
     }
 
@@ -108,7 +106,6 @@ impl<T: NativeType> PrimitiveArray<T> {
             data_type: self.data_type.clone(),
             values: self.values.clone().slice_unchecked(offset, length),
             validity,
-            offset: self.offset + offset,
         }
     }
 
@@ -150,7 +147,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// Caller must be sure that `i < self.len()`
     #[inline]
     pub unsafe fn value_unchecked(&self, i: usize) -> T {
-        *self.values().as_ptr().add(i)
+        *self.values.get_unchecked(i)
     }
 
     /// Returns a new [`PrimitiveArray`] with a different logical type.
@@ -171,7 +168,6 @@ impl<T: NativeType> PrimitiveArray<T> {
             data_type,
             values: self.values,
             validity: self.validity,
-            offset: self.offset,
         }
     }
 }

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -223,11 +223,6 @@ unsafe impl ToFfi for StructArray {
         vec![self.validity.as_ref().map(|x| x.as_ptr())]
     }
 
-    fn offset(&self) -> usize {
-        // we do not support offsets in structs. Instead, if an FFI we slice the incoming arrays
-        0
-    }
-
     fn children(&self) -> Vec<Arc<dyn Array>> {
         self.values.clone()
     }

--- a/src/array/struct_.rs
+++ b/src/array/struct_.rs
@@ -226,6 +226,19 @@ unsafe impl ToFfi for StructArray {
     fn children(&self) -> Vec<Arc<dyn Array>> {
         self.values.clone()
     }
+
+    fn offset(&self) -> Option<usize> {
+        Some(
+            self.validity
+                .as_ref()
+                .map(|bitmap| bitmap.offset())
+                .unwrap_or_default(),
+        )
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        self.clone()
+    }
 }
 
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for StructArray {

--- a/src/array/union/ffi.rs
+++ b/src/array/union/ffi.rs
@@ -23,11 +23,11 @@ unsafe impl ToFfi for UnionArray {
     }
 
     fn offset(&self) -> Option<usize> {
-        todo!()
+        Some(self.types.offset())
     }
 
     fn to_ffi_aligned(&self) -> Self {
-        todo!()
+        self.clone()
     }
 }
 

--- a/src/array/union/ffi.rs
+++ b/src/array/union/ffi.rs
@@ -10,20 +10,24 @@ unsafe impl ToFfi for UnionArray {
         if let Some(offsets) = &self.offsets {
             vec![
                 None,
-                std::ptr::NonNull::new(self.types.as_ptr() as *mut u8),
-                std::ptr::NonNull::new(offsets.as_ptr() as *mut u8),
+                Some(self.types.as_ptr().cast::<u8>()),
+                Some(offsets.as_ptr().cast::<u8>()),
             ]
         } else {
-            vec![None, std::ptr::NonNull::new(self.types.as_ptr() as *mut u8)]
+            vec![None, Some(self.types.as_ptr().cast::<u8>())]
         }
-    }
-
-    fn offset(&self) -> usize {
-        self.offset
     }
 
     fn children(&self) -> Vec<Arc<dyn Array>> {
         self.fields.clone()
+    }
+
+    fn offset(&self) -> Option<usize> {
+        todo!()
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        todo!()
     }
 }
 

--- a/src/array/utf8/ffi.rs
+++ b/src/array/utf8/ffi.rs
@@ -51,17 +51,11 @@ unsafe impl<O: Offset> ToFfi for Utf8Array<O> {
 
 impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for Utf8Array<O> {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let length = array.array().len();
-        let offset = array.array().offset();
-        let mut validity = unsafe { array.validity() }?;
-        let mut offsets = unsafe { array.buffer::<O>(0) }?;
+        let data_type = array.field().data_type().clone();
+        let validity = unsafe { array.validity() }?;
+        let offsets = unsafe { array.buffer::<O>(0) }?;
         let values = unsafe { array.buffer::<u8>(1)? };
 
-        if offset > 0 {
-            offsets = offsets.slice(offset, length);
-            validity = validity.map(|x| x.slice(offset, length))
-        }
-        let data_type = Self::default_data_type();
         Ok(Self::from_data_unchecked(
             data_type, offsets, values, validity,
         ))

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -36,7 +36,6 @@ pub struct Utf8Array<O: Offset> {
     offsets: Buffer<O>,
     values: Buffer<u8>,
     validity: Option<Bitmap>,
-    offset: usize,
 }
 
 impl<O: Offset> Utf8Array<O> {
@@ -86,7 +85,6 @@ impl<O: Offset> Utf8Array<O> {
             offsets,
             values,
             validity,
-            offset: 0,
         }
     }
 
@@ -128,7 +126,6 @@ impl<O: Offset> Utf8Array<O> {
             offsets,
             values,
             validity,
-            offset: 0,
         }
     }
 
@@ -161,7 +158,6 @@ impl<O: Offset> Utf8Array<O> {
             offsets,
             values: self.values.clone(),
             validity,
-            offset: self.offset + offset,
         }
     }
 

--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -132,9 +132,9 @@ where
     }
 }
 
-// create a new bitmap semantically equal to ``bitmap`` but with an offset equal to ``offset``
+// create a new [`Bitmap`] semantically equal to ``bitmap`` but with an offset equal to ``offset``
 pub(crate) fn align(bitmap: &Bitmap, new_offset: usize) -> Bitmap {
-    let (slice, offset, length) = bitmap.as_slice();
+    let length = bitmap.len();
 
     let bitmap: Bitmap = std::iter::repeat(false)
         .take(new_offset)

--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -132,6 +132,18 @@ where
     }
 }
 
+// create a new bitmap semantically equal to ``bitmap`` but with an offset equal to ``offset``
+pub(crate) fn align(bitmap: &Bitmap, new_offset: usize) -> Bitmap {
+    let (slice, offset, length) = bitmap.as_slice();
+
+    let bitmap: Bitmap = std::iter::repeat(false)
+        .take(new_offset)
+        .chain(bitmap.iter())
+        .collect();
+
+    bitmap.slice(new_offset, length)
+}
+
 #[inline]
 fn and(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
     binary(lhs, rhs, |x, y| x & y)

--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -168,6 +168,12 @@ impl Bitmap {
     pub(crate) fn as_ptr(&self) -> std::ptr::NonNull<u8> {
         self.bytes.ptr()
     }
+
+    /// Returns a pointer to the start of this [`Bitmap`] (ignores `offsets`)
+    /// This pointer is allocated iff `self.len() > 0`.
+    pub(crate) fn offset(&self) -> usize {
+        self.offset
+    }
 }
 
 impl<P: AsRef<[bool]>> From<P> for Bitmap {

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -121,6 +121,7 @@ impl<T: NativeType> Buffer<T> {
         self.data.ptr()
     }
 
+    /// Returns a offset of this buffer
     pub(crate) fn offset(&self) -> usize {
         self.offset
     }

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -117,8 +117,12 @@ impl<T: NativeType> Buffer<T> {
 
     /// Returns a pointer to the start of this buffer.
     #[inline]
-    pub fn as_ptr(&self) -> *const T {
-        unsafe { self.data.ptr().as_ptr().add(self.offset) }
+    pub(crate) fn as_ptr(&self) -> std::ptr::NonNull<T> {
+        self.data.ptr()
+    }
+
+    pub(crate) fn offset(&self) -> usize {
+        self.offset
     }
 }
 

--- a/src/ffi/bridge.rs
+++ b/src/ffi/bridge.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use crate::array::*;
+
+macro_rules! ffi_dyn {
+    ($array:expr, $ty:ty) => {{
+        let a = $array.as_any().downcast_ref::<$ty>().unwrap();
+        if a.offset().is_some() {
+            $array
+        } else {
+            Arc::new(a.to_ffi_aligned())
+        }
+    }};
+}
+
+pub fn align_to_c_data_interface(array: Arc<dyn Array>) -> Arc<dyn Array> {
+    use crate::datatypes::PhysicalType::*;
+    match array.data_type().to_physical_type() {
+        Null => ffi_dyn!(array, NullArray),
+        Boolean => ffi_dyn!(array, BooleanArray),
+        Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+            ffi_dyn!(array, PrimitiveArray<$T>)
+        }),
+        Binary => ffi_dyn!(array, BinaryArray<i32>),
+        LargeBinary => ffi_dyn!(array, BinaryArray<i64>),
+        FixedSizeBinary => ffi_dyn!(array, FixedSizeBinaryArray),
+        Utf8 => ffi_dyn!(array, Utf8Array::<i32>),
+        LargeUtf8 => ffi_dyn!(array, Utf8Array::<i64>),
+        List => ffi_dyn!(array, ListArray::<i32>),
+        LargeList => ffi_dyn!(array, ListArray::<i64>),
+        FixedSizeList => ffi_dyn!(array, FixedSizeListArray),
+        Struct => ffi_dyn!(array, StructArray),
+        Union => ffi_dyn!(array, UnionArray),
+        Map => ffi_dyn!(array, MapArray),
+        Dictionary(key_type) => {
+            with_match_physical_dictionary_key_type!(key_type, |$T| {
+                ffi_dyn!(array, DictionaryArray<$T>)
+            })
+        }
+    }
+}

--- a/src/ffi/ffi.rs
+++ b/src/ffi/ffi.rs
@@ -18,7 +18,7 @@
 use std::{ptr::NonNull, sync::Arc};
 
 use crate::{
-    array::{buffers_children_dictionary, Array},
+    array::{offset_buffers_children_dictionary, Array},
     bitmap::{utils::bytes_for, Bitmap},
     buffer::{
         bytes::{Bytes, Deallocation},
@@ -96,7 +96,8 @@ impl Ffi_ArrowArray {
     /// This method releases `buffers`. Consumers of this struct *must* call `release` before
     /// releasing this struct, or contents in `buffers` leak.
     pub(crate) fn new(array: Arc<dyn Array>) -> Self {
-        let (buffers, children, dictionary) = buffers_children_dictionary(array.as_ref());
+        let (offset, buffers, children, dictionary) =
+            offset_buffers_children_dictionary(array.as_ref());
 
         let buffers_ptr = buffers
             .iter()

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -2,6 +2,7 @@
 //! contains FFI bindings to import and export [`Array`](crate::array::Array) via
 //! Arrow's [C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html)
 mod array;
+mod bridge;
 #[allow(clippy::module_inception)]
 mod ffi;
 mod schema;
@@ -24,6 +25,8 @@ use self::schema::to_field;
 /// # Safety
 /// The pointer `ptr` must be allocated and valid
 pub unsafe fn export_array_to_c(array: Arc<dyn Array>, ptr: *mut Ffi_ArrowArray) {
+    let array = bridge::align_to_c_data_interface(array);
+
     *ptr = Ffi_ArrowArray::new(array);
 }
 

--- a/tests/it/ffi.rs
+++ b/tests/it/ffi.rs
@@ -1,13 +1,12 @@
 use arrow2::array::*;
+use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::{DataType, Field, TimeUnit};
 use arrow2::{error::Result, ffi};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-fn test_round_trip(expected: impl Array + Clone + 'static) -> Result<()> {
-    let array: Arc<dyn Array> = Arc::new(expected.clone());
+fn _test_round_trip(array: Arc<dyn Array>, expected: Box<dyn Array>) -> Result<()> {
     let field = Field::new("a", array.data_type().clone(), true);
-    let expected = Box::new(expected) as Box<dyn Array>;
 
     let array_ptr = Box::new(ffi::Ffi_ArrowArray::empty());
     let schema_ptr = Box::new(ffi::Ffi_ArrowSchema::empty());
@@ -30,6 +29,15 @@ fn test_round_trip(expected: impl Array + Clone + 'static) -> Result<()> {
     assert_eq!(&result_array, &expected);
     assert_eq!(result_field, field);
     Ok(())
+}
+
+fn test_round_trip(expected: impl Array + Clone + 'static) -> Result<()> {
+    let array: Arc<dyn Array> = Arc::new(expected.clone());
+    let expected = Box::new(expected) as Box<dyn Array>;
+    _test_round_trip(array.clone(), clone(expected.as_ref()))?;
+
+    // sliced
+    _test_round_trip(array.slice(1, 2).into(), expected.slice(1, 2))
 }
 
 fn test_round_trip_schema(field: Field) -> Result<()> {
@@ -134,6 +142,17 @@ fn list_list() -> Result<()> {
     array.try_extend(data)?;
 
     let array: ListArray<i32> = array.into();
+
+    test_round_trip(array)
+}
+
+#[test]
+fn struct_() -> Result<()> {
+    let data_type = DataType::Struct(vec![Field::new("a", DataType::Int32, true)]);
+    let values = vec![Arc::new(Int32Array::from([Some(1), None, Some(3)])) as Arc<dyn Array>];
+    let validity = Bitmap::from([true, false, true]);
+
+    let array = StructArray::from_data(data_type, values, validity.into());
 
     test_round_trip(array)
 }


### PR DESCRIPTION
This PR closes #538 by re-aligning buffers prior to exporting to the C data interface.

## Background

Given two arrays, `a` and `b`, on which `a` is sliced and `b` has no validity, the computation of `equal(a, b)` is optimally done by equating the values (`bitmap`) and cloning the validity of `a`.

The c data interface allows arrays to be sliced at zero cost via a constant "offset", denoting by how much an array is offsetted by, but it does not allow individual bitmaps to be sliced. Consequently, implementations of the arrow format must "de-offset" the bitmaps to align them.

In the example above, this means that the validity of `a` cannot be combined with the resulting values bitmap because it has a different `offset`. Instead, a new validity must be computed that has a zero offset (and thus aligned with the offset of the resulting values bitmap).

This crate currently supports the former compute model because it tracks individual bitmap and buffer offsets. However, doing so forbids us from passing the bitmaps _as is_ via the c data interface, as the c data interface only accepts a single offset per array (and not per buffer).

## Solution

This PR de-offsets the bitmaps when they are to be passed to the C data interface, thereby delaying when to de-offset happens: at the c-data interface boundary as opposed to at every compute operation.

Note that this is a relatively small set of use-cases because most of the times the arrays are not sliced.

## Alternatives

The alternative is to fallback to what other implementations do: de-offset the buffers on every operation. However, this resulted in a 15% performance drop in some of the kernels and a much more complex implementation of kernels since they all have to remember to de-offset bitmaps.