### PR TITLE
Transform like pattern to regex

### DIFF
--- a/tests/it/compute/like.rs
+++ b/tests/it/compute/like.rs
@@ -4,24 +4,26 @@ use arrow2::error::Result;
 
 #[test]
 fn test_like_binary() -> Result<()> {
-    let strings = BinaryArray::<i32>::from_slice(&["Arrow", "Arrow", "Arrow", "Arrow", "Ar"]);
-    let patterns = BinaryArray::<i32>::from_slice(&["A%", "B%", "%r_ow", "A_", "A_"]);
+    let strings =
+        BinaryArray::<i32>::from_slice(&["Arrow", "Arrow", "Arrow", "Arrow", "Ar", "Arrow"]);
+    let patterns = BinaryArray::<i32>::from_slice(&["A%", "B%", "%r_ow", "A_", "A_", "A\\%"]);
     let result = like_binary(&strings, &patterns).unwrap();
     assert_eq!(
         result,
-        BooleanArray::from_slice(&[true, false, true, false, true])
+        BooleanArray::from_slice(&[true, false, true, false, true, false])
     );
     Ok(())
 }
 
 #[test]
 fn test_nlike_binary() -> Result<()> {
-    let strings = BinaryArray::<i32>::from_slice(&["Arrow", "Arrow", "Arrow", "Arrow", "Ar"]);
-    let patterns = BinaryArray::<i32>::from_slice(&["A%", "B%", "%r_ow", "A_", "A_"]);
+    let strings =
+        BinaryArray::<i32>::from_slice(&["Arrow", "Arrow", "Arrow", "Arrow", "Ar", "Arrow"]);
+    let patterns = BinaryArray::<i32>::from_slice(&["A%", "B%", "%r_ow", "A_", "A_", "A\\%"]);
     let result = nlike_binary(&strings, &patterns).unwrap();
     assert_eq!(
         result,
-        BooleanArray::from_slice(&[false, true, false, true, false])
+        BooleanArray::from_slice(&[false, true, false, true, false, true])
     );
     Ok(())
 }


### PR DESCRIPTION
Add transform like pattern to regex to fixes https://github.com/datafuselabs/databend/issues/2478 .

1. Use backslash to escape the regex special character.
2. Process the backslash escape.

e.g. 
'Hello\\._World%\\%' tranform to '^Hello\\\\\\..World.*%$'.