### PR TITLE
make substring kernel work on utf8 data

### DIFF
--- a/src/compute/substring.rs
+++ b/src/compute/substring.rs
@@ -64,7 +64,7 @@ fn utf8_substring<O: Offset>(array: &Utf8Array<O>, start: O, length: &Option<O>)
     });
 
     let new = Utf8Array::<O>::from_trusted_len_values_iter(iter);
-    new.with_validity(array.validity().map(|x| x.clone()))
+    new.with_validity(array.validity().cloned())
 }
 
 fn binary_substring<O: Offset>(

--- a/tests/it/compute/substring.rs
+++ b/tests/it/compute/substring.rs
@@ -48,6 +48,7 @@ fn with_nulls_utf8<O: Offset>() -> Result<()> {
 
             let result = result.as_any().downcast_ref::<Utf8Array<O>>().unwrap();
             let expected = Utf8Array::<O>::from(&expected);
+
             assert_eq!(&expected, result);
             Ok(())
         })?;
@@ -117,6 +118,13 @@ fn without_nulls_utf8<O: Offset>() -> Result<()> {
             Some(4),
             vec!["llo", "", "ord"],
         ),
+        (
+            vec!["😇🔥🥺", "", "😇🔥🗺️"],
+            0,
+            Some(2),
+            vec!["😇🔥", "", "😇🔥"],
+        ),
+        (vec!["π1π", "", "α1απ"], 1, Some(4), vec!["1π", "", "1απ"]),
     ];
 
     cases


### PR DESCRIPTION
The `substring` kernel, sliced `[u8]` data, not taking account utf8 `char` boundaries. This PR fixes that.