### PR TITLE
Simplified trait in compute.

### DIFF
--- a/src/compute/arithmetics/basic/add.rs
+++ b/src/compute/arithmetics/basic/add.rs
@@ -10,7 +10,7 @@ use crate::{
     bitmap::Bitmap,
     compute::{
         arithmetics::{
-            ArrayAdd, ArrayCheckedAdd, ArrayOverflowingAdd, ArraySaturatingAdd, NotI128,
+            ArrayAdd, ArrayCheckedAdd, ArrayOverflowingAdd, ArraySaturatingAdd, NativeArithmetics,
         },
         arity::{
             binary, binary_checked, binary_with_bitmap, unary, unary_checked, unary_with_bitmap,
@@ -87,7 +87,7 @@ where
 /// ```
 pub fn checked_add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
-    T: NativeType + CheckedAdd<Output = T> + Zero,
+    T: NativeType + CheckedAdd<Output = T>,
 {
     check_same_type(lhs, rhs)?;
 
@@ -158,7 +158,7 @@ where
 // Implementation of ArrayAdd trait for PrimitiveArrays
 impl<T> ArrayAdd<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + Add<Output = T> + NotI128,
+    T: NativeArithmetics + Add<Output = T>,
 {
     type Output = Self;
 
@@ -169,7 +169,7 @@ where
 
 impl<T> ArrayWrappingAdd<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + WrappingAdd<Output = T> + NotI128,
+    T: NativeArithmetics + WrappingAdd<Output = T>,
 {
     type Output = Self;
 
@@ -181,7 +181,7 @@ where
 // Implementation of ArrayCheckedAdd trait for PrimitiveArrays
 impl<T> ArrayCheckedAdd<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + CheckedAdd<Output = T> + Zero + NotI128,
+    T: NativeArithmetics + CheckedAdd<Output = T>,
 {
     type Output = Self;
 
@@ -193,7 +193,7 @@ where
 // Implementation of ArraySaturatingAdd trait for PrimitiveArrays
 impl<T> ArraySaturatingAdd<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + SaturatingAdd<Output = T> + NotI128,
+    T: NativeArithmetics + SaturatingAdd<Output = T>,
 {
     type Output = Self;
 
@@ -205,7 +205,7 @@ where
 // Implementation of ArraySaturatingAdd trait for PrimitiveArrays
 impl<T> ArrayOverflowingAdd<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + OverflowingAdd<Output = T> + NotI128,
+    T: NativeArithmetics + OverflowingAdd<Output = T>,
 {
     type Output = Self;
 
@@ -271,7 +271,7 @@ where
 /// ```
 pub fn checked_add_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
-    T: NativeType + CheckedAdd<Output = T> + Zero,
+    T: NativeType + CheckedAdd<Output = T>,
 {
     let rhs = *rhs;
     let op = move |a: T| a.checked_add(&rhs);
@@ -331,7 +331,7 @@ where
 // Implementation of ArrayAdd trait for PrimitiveArrays with a scalar
 impl<T> ArrayAdd<T> for PrimitiveArray<T>
 where
-    T: NativeType + Add<Output = T> + NotI128,
+    T: NativeArithmetics + Add<Output = T>,
 {
     type Output = Self;
 
@@ -343,7 +343,7 @@ where
 // Implementation of ArrayCheckedAdd trait for PrimitiveArrays with a scalar
 impl<T> ArrayCheckedAdd<T> for PrimitiveArray<T>
 where
-    T: NativeType + CheckedAdd<Output = T> + Zero + NotI128,
+    T: NativeArithmetics + CheckedAdd<Output = T> + Zero,
 {
     type Output = Self;
 
@@ -355,7 +355,7 @@ where
 // Implementation of ArraySaturatingAdd trait for PrimitiveArrays with a scalar
 impl<T> ArraySaturatingAdd<T> for PrimitiveArray<T>
 where
-    T: NativeType + SaturatingAdd<Output = T> + NotI128,
+    T: NativeArithmetics + SaturatingAdd<Output = T>,
 {
     type Output = Self;
 
@@ -367,7 +367,7 @@ where
 // Implementation of ArraySaturatingAdd trait for PrimitiveArrays with a scalar
 impl<T> ArrayOverflowingAdd<T> for PrimitiveArray<T>
 where
-    T: NativeType + OverflowingAdd<Output = T> + NotI128,
+    T: NativeArithmetics + OverflowingAdd<Output = T>,
 {
     type Output = Self;
 

--- a/src/compute/arithmetics/basic/div.rs
+++ b/src/compute/arithmetics/basic/div.rs
@@ -8,7 +8,7 @@ use crate::datatypes::DataType;
 use crate::{
     array::{Array, PrimitiveArray},
     compute::{
-        arithmetics::{ArrayCheckedDiv, ArrayDiv, NotI128},
+        arithmetics::{ArrayCheckedDiv, ArrayDiv, NativeArithmetics},
         arity::{binary, binary_checked, unary, unary_checked},
     },
     error::Result,
@@ -68,7 +68,7 @@ where
 /// ```
 pub fn checked_div<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
-    T: NativeType + CheckedDiv<Output = T> + Zero,
+    T: NativeArithmetics + CheckedDiv<Output = T>,
 {
     check_same_type(lhs, rhs)?;
 
@@ -80,7 +80,7 @@ where
 // Implementation of ArrayDiv trait for PrimitiveArrays
 impl<T> ArrayDiv<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + Div<Output = T> + NotI128,
+    T: NativeArithmetics + Div<Output = T>,
 {
     type Output = Self;
 
@@ -92,7 +92,7 @@ where
 // Implementation of ArrayCheckedDiv trait for PrimitiveArrays
 impl<T> ArrayCheckedDiv<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + CheckedDiv<Output = T> + Zero + NotI128,
+    T: NativeArithmetics + CheckedDiv<Output = T>,
 {
     type Output = Self;
 
@@ -210,7 +210,7 @@ where
 // Implementation of ArrayDiv trait for PrimitiveArrays with a scalar
 impl<T> ArrayDiv<T> for PrimitiveArray<T>
 where
-    T: NativeType + Div<Output = T> + NotI128 + NumCast,
+    T: NativeType + Div<Output = T> + NativeArithmetics + NumCast,
 {
     type Output = Self;
 
@@ -222,7 +222,7 @@ where
 // Implementation of ArrayCheckedDiv trait for PrimitiveArrays with a scalar
 impl<T> ArrayCheckedDiv<T> for PrimitiveArray<T>
 where
-    T: NativeType + CheckedDiv<Output = T> + Zero + NotI128,
+    T: NativeType + CheckedDiv<Output = T> + Zero + NativeArithmetics,
 {
     type Output = Self;
 

--- a/src/compute/arithmetics/basic/mul.rs
+++ b/src/compute/arithmetics/basic/mul.rs
@@ -1,7 +1,7 @@
 //! Definition of basic mul operations with primitive arrays
 use std::ops::Mul;
 
-use num_traits::{ops::overflowing::OverflowingMul, CheckedMul, SaturatingMul, WrappingMul, Zero};
+use num_traits::{ops::overflowing::OverflowingMul, CheckedMul, SaturatingMul, WrappingMul};
 
 use crate::compute::arithmetics::basic::check_same_type;
 use crate::compute::arithmetics::ArrayWrappingMul;
@@ -10,7 +10,7 @@ use crate::{
     bitmap::Bitmap,
     compute::{
         arithmetics::{
-            ArrayCheckedMul, ArrayMul, ArrayOverflowingMul, ArraySaturatingMul, NotI128,
+            ArrayCheckedMul, ArrayMul, ArrayOverflowingMul, ArraySaturatingMul, NativeArithmetics,
         },
         arity::{
             binary, binary_checked, binary_with_bitmap, unary, unary_checked, unary_with_bitmap,
@@ -88,7 +88,7 @@ where
 /// ```
 pub fn checked_mul<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
-    T: NativeType + CheckedMul<Output = T> + Zero,
+    T: NativeType + CheckedMul<Output = T>,
 {
     check_same_type(lhs, rhs)?;
 
@@ -159,7 +159,7 @@ where
 // Implementation of ArrayMul trait for PrimitiveArrays
 impl<T> ArrayMul<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + Mul<Output = T> + NotI128,
+    T: NativeArithmetics + Mul<Output = T>,
 {
     type Output = Self;
 
@@ -170,7 +170,7 @@ where
 
 impl<T> ArrayWrappingMul<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + WrappingMul<Output = T> + NotI128,
+    T: NativeArithmetics + WrappingMul<Output = T>,
 {
     type Output = Self;
 
@@ -182,7 +182,7 @@ where
 // Implementation of ArrayCheckedMul trait for PrimitiveArrays
 impl<T> ArrayCheckedMul<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + CheckedMul<Output = T> + Zero + NotI128,
+    T: NativeArithmetics + CheckedMul<Output = T>,
 {
     type Output = Self;
 
@@ -194,7 +194,7 @@ where
 // Implementation of ArraySaturatingMul trait for PrimitiveArrays
 impl<T> ArraySaturatingMul<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + SaturatingMul<Output = T> + NotI128,
+    T: NativeArithmetics + SaturatingMul<Output = T>,
 {
     type Output = Self;
 
@@ -206,7 +206,7 @@ where
 // Implementation of ArraySaturatingMul trait for PrimitiveArrays
 impl<T> ArrayOverflowingMul<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + OverflowingMul<Output = T> + NotI128,
+    T: NativeArithmetics + OverflowingMul<Output = T>,
 {
     type Output = Self;
 
@@ -271,7 +271,7 @@ where
 /// ```
 pub fn checked_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
-    T: NativeType + CheckedMul<Output = T> + Zero,
+    T: NativeType + CheckedMul<Output = T>,
 {
     let rhs = *rhs;
     let op = move |a: T| a.checked_mul(&rhs);
@@ -331,7 +331,7 @@ where
 // Implementation of ArrayMul trait for PrimitiveArrays with a scalar
 impl<T> ArrayMul<T> for PrimitiveArray<T>
 where
-    T: NativeType + Mul<Output = T> + NotI128,
+    T: NativeType + Mul<Output = T> + NativeArithmetics,
 {
     type Output = Self;
 
@@ -343,7 +343,7 @@ where
 // Implementation of ArrayCheckedMul trait for PrimitiveArrays with a scalar
 impl<T> ArrayCheckedMul<T> for PrimitiveArray<T>
 where
-    T: NativeType + CheckedMul<Output = T> + Zero + NotI128,
+    T: NativeArithmetics + CheckedMul<Output = T>,
 {
     type Output = Self;
 
@@ -355,7 +355,7 @@ where
 // Implementation of ArraySaturatingMul trait for PrimitiveArrays with a scalar
 impl<T> ArraySaturatingMul<T> for PrimitiveArray<T>
 where
-    T: NativeType + SaturatingMul<Output = T> + NotI128,
+    T: NativeArithmetics + SaturatingMul<Output = T>,
 {
     type Output = Self;
 
@@ -367,7 +367,7 @@ where
 // Implementation of ArraySaturatingMul trait for PrimitiveArrays with a scalar
 impl<T> ArrayOverflowingMul<T> for PrimitiveArray<T>
 where
-    T: NativeType + OverflowingMul<Output = T> + NotI128,
+    T: NativeArithmetics + OverflowingMul<Output = T>,
 {
     type Output = Self;
 

--- a/src/compute/arithmetics/basic/rem.rs
+++ b/src/compute/arithmetics/basic/rem.rs
@@ -1,13 +1,13 @@
 use std::ops::Rem;
 
-use num_traits::{CheckedRem, NumCast, Zero};
+use num_traits::{CheckedRem, NumCast};
 
 use crate::compute::arithmetics::basic::check_same_type;
 use crate::datatypes::DataType;
 use crate::{
     array::{Array, PrimitiveArray},
     compute::{
-        arithmetics::{ArrayCheckedRem, ArrayRem, NotI128},
+        arithmetics::{ArrayCheckedRem, ArrayRem, NativeArithmetics},
         arity::{binary, binary_checked, unary, unary_checked},
     },
     error::Result,
@@ -57,7 +57,7 @@ where
 /// ```
 pub fn checked_rem<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
-    T: NativeType + CheckedRem<Output = T> + Zero,
+    T: NativeType + CheckedRem<Output = T>,
 {
     check_same_type(lhs, rhs)?;
 
@@ -68,7 +68,7 @@ where
 
 impl<T> ArrayRem<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + Rem<Output = T> + NotI128,
+    T: NativeArithmetics + Rem<Output = T>,
 {
     type Output = Self;
 
@@ -79,7 +79,7 @@ where
 
 impl<T> ArrayCheckedRem<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + CheckedRem<Output = T> + Zero + NotI128,
+    T: NativeArithmetics + CheckedRem<Output = T>,
 {
     type Output = Self;
 
@@ -187,7 +187,7 @@ where
 /// ```
 pub fn checked_rem_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
-    T: NativeType + CheckedRem<Output = T> + Zero,
+    T: NativeType + CheckedRem<Output = T>,
 {
     let rhs = *rhs;
     let op = move |a: T| a.checked_rem(&rhs);
@@ -197,7 +197,7 @@ where
 
 impl<T> ArrayRem<T> for PrimitiveArray<T>
 where
-    T: NativeType + Rem<Output = T> + NotI128 + NumCast,
+    T: NativeArithmetics + Rem<Output = T> + NumCast,
 {
     type Output = Self;
 
@@ -208,7 +208,7 @@ where
 
 impl<T> ArrayCheckedRem<T> for PrimitiveArray<T>
 where
-    T: NativeType + CheckedRem<Output = T> + Zero + NotI128,
+    T: NativeArithmetics + CheckedRem<Output = T>,
 {
     type Output = Self;
 

--- a/src/compute/arithmetics/basic/sub.rs
+++ b/src/compute/arithmetics/basic/sub.rs
@@ -1,7 +1,7 @@
 //! Definition of basic sub operations with primitive arrays
 use std::ops::Sub;
 
-use num_traits::{ops::overflowing::OverflowingSub, CheckedSub, SaturatingSub, WrappingSub, Zero};
+use num_traits::{ops::overflowing::OverflowingSub, CheckedSub, SaturatingSub, WrappingSub};
 
 use crate::compute::arithmetics::basic::check_same_type;
 use crate::compute::arithmetics::ArrayWrappingSub;
@@ -10,7 +10,7 @@ use crate::{
     bitmap::Bitmap,
     compute::{
         arithmetics::{
-            ArrayCheckedSub, ArrayOverflowingSub, ArraySaturatingSub, ArraySub, NotI128,
+            ArrayCheckedSub, ArrayOverflowingSub, ArraySaturatingSub, ArraySub, NativeArithmetics,
         },
         arity::{
             binary, binary_checked, binary_with_bitmap, unary, unary_checked, unary_with_bitmap,
@@ -87,7 +87,7 @@ where
 /// ```
 pub fn checked_sub<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
 where
-    T: NativeType + CheckedSub<Output = T> + Zero,
+    T: NativeType + CheckedSub<Output = T>,
 {
     check_same_type(lhs, rhs)?;
 
@@ -158,7 +158,7 @@ where
 // Implementation of ArraySub trait for PrimitiveArrays
 impl<T> ArraySub<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + Sub<Output = T> + NotI128,
+    T: NativeArithmetics + Sub<Output = T>,
 {
     type Output = Self;
 
@@ -169,7 +169,7 @@ where
 
 impl<T> ArrayWrappingSub<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + WrappingSub<Output = T> + NotI128,
+    T: NativeArithmetics + WrappingSub<Output = T>,
 {
     type Output = Self;
 
@@ -181,7 +181,7 @@ where
 // Implementation of ArrayCheckedSub trait for PrimitiveArrays
 impl<T> ArrayCheckedSub<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + CheckedSub<Output = T> + Zero + NotI128,
+    T: NativeArithmetics + CheckedSub<Output = T>,
 {
     type Output = Self;
 
@@ -193,7 +193,7 @@ where
 // Implementation of ArraySaturatingSub trait for PrimitiveArrays
 impl<T> ArraySaturatingSub<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + SaturatingSub<Output = T> + NotI128,
+    T: NativeArithmetics + SaturatingSub<Output = T>,
 {
     type Output = Self;
 
@@ -205,7 +205,7 @@ where
 // Implementation of ArraySaturatingSub trait for PrimitiveArrays
 impl<T> ArrayOverflowingSub<PrimitiveArray<T>> for PrimitiveArray<T>
 where
-    T: NativeType + OverflowingSub<Output = T>,
+    T: NativeArithmetics + OverflowingSub<Output = T>,
 {
     type Output = Self;
 
@@ -271,7 +271,7 @@ where
 /// ```
 pub fn checked_sub_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
 where
-    T: NativeType + CheckedSub<Output = T> + Zero,
+    T: NativeType + CheckedSub<Output = T>,
 {
     let rhs = *rhs;
     let op = move |a: T| a.checked_sub(&rhs);
@@ -331,7 +331,7 @@ where
 // Implementation of ArraySub trait for PrimitiveArrays with a scalar
 impl<T> ArraySub<T> for PrimitiveArray<T>
 where
-    T: NativeType + Sub<Output = T> + NotI128,
+    T: NativeArithmetics + Sub<Output = T>,
 {
     type Output = Self;
 
@@ -343,7 +343,7 @@ where
 // Implementation of ArrayCheckedSub trait for PrimitiveArrays with a scalar
 impl<T> ArrayCheckedSub<T> for PrimitiveArray<T>
 where
-    T: NativeType + CheckedSub<Output = T> + Zero + NotI128,
+    T: NativeArithmetics + CheckedSub<Output = T>,
 {
     type Output = Self;
 
@@ -355,7 +355,7 @@ where
 // Implementation of ArraySaturatingSub trait for PrimitiveArrays with a scalar
 impl<T> ArraySaturatingSub<T> for PrimitiveArray<T>
 where
-    T: NativeType + SaturatingSub<Output = T> + NotI128,
+    T: NativeArithmetics + SaturatingSub<Output = T>,
 {
     type Output = Self;
 
@@ -367,7 +367,7 @@ where
 // Implementation of ArraySaturatingSub trait for PrimitiveArrays with a scalar
 impl<T> ArrayOverflowingSub<T> for PrimitiveArray<T>
 where
-    T: NativeType + OverflowingSub<Output = T> + NotI128,
+    T: NativeArithmetics + OverflowingSub<Output = T>,
 {
     type Output = Self;
 

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -474,16 +474,18 @@ pub trait ArrayCheckedRem<Rhs> {
     fn checked_rem(&self, rhs: &Rhs) -> Result<Self::Output>;
 }
 
-// The decimal primitive array defines different arithmetic functions and
-// it requires specialization
-pub unsafe trait NotI128 {}
-unsafe impl NotI128 for u8 {}
-unsafe impl NotI128 for u16 {}
-unsafe impl NotI128 for u32 {}
-unsafe impl NotI128 for u64 {}
-unsafe impl NotI128 for i8 {}
-unsafe impl NotI128 for i16 {}
-unsafe impl NotI128 for i32 {}
-unsafe impl NotI128 for i64 {}
-unsafe impl NotI128 for f32 {}
-unsafe impl NotI128 for f64 {}
+/// Trait describing a [`NativeType`] whose semantics of arithmetic in Arrow equals
+/// the semantics in Rust.
+/// A counter example is `i128`, that in arrow represents a decimal while in rust represents
+/// a signed integer.
+pub trait NativeArithmetics: NativeType {}
+impl NativeArithmetics for u8 {}
+impl NativeArithmetics for u16 {}
+impl NativeArithmetics for u32 {}
+impl NativeArithmetics for u64 {}
+impl NativeArithmetics for i8 {}
+impl NativeArithmetics for i16 {}
+impl NativeArithmetics for i32 {}
+impl NativeArithmetics for i64 {}
+impl NativeArithmetics for f32 {}
+impl NativeArithmetics for f64 {}


### PR DESCRIPTION
To migrate, rename `NotI128` to `NativeArithmetics`.