### PR TITLE
Simplified IPC APIs

### DIFF
--- a/examples/extension.rs
+++ b/examples/extension.rs
@@ -37,7 +37,8 @@ fn main() -> Result<()> {
 fn write_ipc<W: Write + Seek>(writer: W, array: impl Array + 'static) -> Result<W> {
     let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), false)]);
 
-    let mut writer = write::FileWriter::try_new(writer, &schema)?;
+    let options = write::WriteOptions { compression: None };
+    let mut writer = write::FileWriter::try_new(writer, &schema, options)?;
 
     let batch = RecordBatch::try_new(Arc::new(schema), vec![Arc::new(array)])?;
 

--- a/examples/ipc_file_write.rs
+++ b/examples/ipc_file_write.rs
@@ -10,7 +10,8 @@ use arrow2::record_batch::RecordBatch;
 fn write_batches(path: &str, schema: &Schema, batches: &[RecordBatch]) -> Result<()> {
     let file = File::create(path)?;
 
-    let mut writer = write::FileWriter::try_new(file, schema)?;
+    let options = write::WriteOptions { compression: None };
+    let mut writer = write::FileWriter::try_new(file, schema, options)?;
 
     for batch in batches {
         writer.write(batch)?

--- a/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -20,7 +20,7 @@ use std::fs::File;
 
 use arrow2::error::Result;
 use arrow2::io::ipc::read;
-use arrow2::io::ipc::write::StreamWriter;
+use arrow2::io::ipc::write;
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
@@ -30,7 +30,8 @@ fn main() -> Result<()> {
     let mut reader = read::FileReader::new(f, metadata, None);
     let schema = reader.schema();
 
-    let mut writer = StreamWriter::try_new(std::io::stdout(), schema)?;
+    let options = write::WriteOptions { compression: None };
+    let mut writer = write::StreamWriter::try_new(std::io::stdout(), schema, options)?;
 
     reader.try_for_each(|batch| {
         let batch = batch?;

--- a/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -20,7 +20,7 @@ use std::fs::File;
 use clap::{App, Arg};
 
 use arrow2::io::ipc::read;
-use arrow2::io::ipc::write::FileWriter;
+use arrow2::io::ipc::write;
 use arrow2::{
     error::{ArrowError, Result},
     io::json_integration::*,
@@ -81,7 +81,8 @@ fn json_to_arrow(json_name: &str, arrow_name: &str, verbose: bool) -> Result<()>
     let json_file = read_json_file(json_name)?;
 
     let arrow_file = File::create(arrow_name)?;
-    let mut writer = FileWriter::try_new(arrow_file, &json_file.schema)?;
+    let options = write::WriteOptions { compression: None };
+    let mut writer = write::FileWriter::try_new(arrow_file, &json_file.schema, options)?;
 
     for b in json_file.batches {
         writer.write(&b)?;

--- a/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -19,7 +19,7 @@ use std::io;
 
 use arrow2::error::Result;
 use arrow2::io::ipc::read;
-use arrow2::io::ipc::write::FileWriter;
+use arrow2::io::ipc::write;
 
 fn main() -> Result<()> {
     let mut reader = io::stdin();
@@ -29,7 +29,8 @@ fn main() -> Result<()> {
 
     let writer = io::stdout();
 
-    let mut writer = FileWriter::try_new(writer, schema)?;
+    let options = write::WriteOptions { compression: None };
+    let mut writer = write::FileWriter::try_new(writer, schema, options)?;
 
     arrow_stream_reader.try_for_each(|batch| writer.write(&batch?.unwrap()))?;
     writer.finish()?;

--- a/integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -78,8 +78,9 @@ async fn upload_data(
 ) -> Result {
     let (mut upload_tx, upload_rx) = mpsc::channel(10);
 
-    let options = write::IpcWriteOptions::default();
-    let mut schema = flight::serialize_schema(&schema, &options);
+    let options = write::WriteOptions { compression: None };
+
+    let mut schema = flight::serialize_schema(&schema);
     schema.flight_descriptor = Some(descriptor.clone());
     upload_tx.send(schema).await?;
 
@@ -129,7 +130,7 @@ async fn send_batch(
     upload_tx: &mut mpsc::Sender<FlightData>,
     metadata: &[u8],
     batch: &RecordBatch,
-    options: &write::IpcWriteOptions,
+    options: &write::WriteOptions,
 ) -> Result {
     let (dictionary_flight_data, mut batch_flight_data) = serialize_batch(batch, options);
 

--- a/integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
+++ b/integration-testing/src/flight_server_scenarios/auth_basic_proto.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 use arrow_format::flight::data::*;
 use arrow_format::flight::service::flight_service_server::{FlightService, FlightServiceServer};
 use futures::{channel::mpsc, sink::SinkExt, Stream, StreamExt};
-use tokio::sync::Mutex;
 use tonic::{metadata::MetadataMap, transport::Server, Request, Response, Status, Streaming};
 
 type TonicStream<T> = Pin<Box<dyn Stream<Item = T> + Send + Sync + 'static>>;
@@ -37,7 +36,6 @@ pub async fn scenario_setup(port: &str) -> Result {
     let service = AuthBasicProtoScenarioImpl {
         username: AUTH_USERNAME.into(),
         password: AUTH_PASSWORD.into(),
-        peer_identity: Arc::new(Mutex::new(None)),
     };
     let addr = super::listen_on(port).await?;
     let svc = FlightServiceServer::new(service);
@@ -54,7 +52,6 @@ pub async fn scenario_setup(port: &str) -> Result {
 pub struct AuthBasicProtoScenarioImpl {
     username: Arc<str>,
     password: Arc<str>,
-    peer_identity: Arc<Mutex<Option<String>>>,
 }
 
 impl AuthBasicProtoScenarioImpl {

--- a/integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -21,8 +21,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use arrow2::io::flight::{serialize_batch, serialize_schema};
-use arrow_format::flight::data::*;
 use arrow_format::flight::data::flight_descriptor::*;
+use arrow_format::flight::data::*;
 use arrow_format::flight::service::flight_service_server::*;
 use arrow_format::ipc::Message::{root_as_message, Message, MessageHeader};
 use arrow_format::ipc::Schema as ArrowSchema;
@@ -108,9 +108,9 @@ impl FlightService for FlightServiceImpl {
             .get(&key)
             .ok_or_else(|| Status::not_found(format!("Could not find flight. {}", key)))?;
 
-        let options = ipc::write::IpcWriteOptions::default();
+        let options = ipc::write::WriteOptions { compression: None };
 
-        let schema = std::iter::once(Ok(serialize_schema(&flight.schema, &options)));
+        let schema = std::iter::once(Ok(serialize_schema(&flight.schema)));
 
         let batches = flight
             .chunks
@@ -171,8 +171,7 @@ impl FlightService for FlightServiceImpl {
 
                 let total_records: usize = flight.chunks.iter().map(|chunk| chunk.num_rows()).sum();
 
-                let options = ipc::write::IpcWriteOptions::default();
-                let schema = serialize_schema_to_info(&flight.schema, &options).expect(
+                let schema = serialize_schema_to_info(&flight.schema).expect(
                     "Could not generate schema bytes from schema stored by a DoPut; \
                          this should be impossible",
                 );

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -30,7 +30,7 @@
 //! # Examples
 //! Read and write to a file:
 //! ```
-//! use arrow2::io::ipc::{{read::{FileReader, read_file_metadata}}, {write::FileWriter}};
+//! use arrow2::io::ipc::{{read::{FileReader, read_file_metadata}}, {write::{FileWriter, WriteOptions}}};
 //! # use std::fs::File;
 //! # use std::sync::Arc;
 //! # use arrow2::datatypes::{Field, Schema, DataType};
@@ -43,7 +43,8 @@
 //! let x_coord = Field::new("x", DataType::Int32, false);
 //! let y_coord = Field::new("y", DataType::Int32, false);
 //! let schema = Schema::new(vec![x_coord, y_coord]);
-//! let mut writer = FileWriter::try_new(file, &schema)?;
+//! let options = WriteOptions {compression: None};
+//! let mut writer = FileWriter::try_new(file, &schema, options)?;
 //!
 //! // Setup the data
 //! let x_data = Int32Array::from_slice([-1i32, 1]);

--- a/src/io/ipc/write/mod.rs
+++ b/src/io/ipc/write/mod.rs
@@ -5,8 +5,7 @@ mod serialize;
 mod stream;
 mod writer;
 
-pub use arrow_format::ipc::Schema::MetadataVersion;
-pub use common::{Compression, IpcWriteOptions};
+pub use common::{Compression, WriteOptions};
 pub use schema::schema_to_bytes;
 pub use serialize::{write, write_dictionary};
 pub use stream::StreamWriter;

--- a/src/io/ipc/write/schema.rs
+++ b/src/io/ipc/write/schema.rs
@@ -4,10 +4,9 @@ use arrow_format::ipc::flatbuffers::FlatBufferBuilder;
 use crate::datatypes::*;
 
 use super::super::convert;
-use super::MetadataVersion;
 
 /// Converts
-pub fn schema_to_bytes(schema: &Schema, version: MetadataVersion) -> Vec<u8> {
+pub fn schema_to_bytes(schema: &Schema) -> Vec<u8> {
     let mut fbb = FlatBufferBuilder::new();
     let schema = {
         let fb = convert::schema_to_fb_offset(&mut fbb, schema);
@@ -15,7 +14,7 @@ pub fn schema_to_bytes(schema: &Schema, version: MetadataVersion) -> Vec<u8> {
     };
 
     let mut message = ipc::Message::MessageBuilder::new(&mut fbb);
-    message.add_version(version);
+    message.add_version(ipc::Schema::MetadataVersion::V5);
     message.add_header_type(ipc::Message::MessageHeader::Schema);
     message.add_bodyLength(0);
     message.add_header(schema);

--- a/src/io/ipc/write/stream.rs
+++ b/src/io/ipc/write/stream.rs
@@ -23,8 +23,7 @@
 use std::io::Write;
 
 use super::common::{
-    encoded_batch, write_continuation, write_message, DictionaryTracker, EncodedData,
-    IpcWriteOptions,
+    encoded_batch, write_continuation, write_message, DictionaryTracker, EncodedData, WriteOptions,
 };
 use super::schema_to_bytes;
 
@@ -42,7 +41,7 @@ pub struct StreamWriter<W: Write> {
     /// The object to write to
     writer: W,
     /// IPC write options
-    write_options: IpcWriteOptions,
+    write_options: WriteOptions,
     /// Whether the writer footer has been written, and the writer is finished
     finished: bool,
     /// Keeps track of dictionaries that have been written
@@ -51,22 +50,13 @@ pub struct StreamWriter<W: Write> {
 
 impl<W: Write> StreamWriter<W> {
     /// Try create a new writer, with the schema written as part of the header
-    pub fn try_new(writer: W, schema: &Schema) -> Result<Self> {
-        let write_options = IpcWriteOptions::default();
-        Self::try_new_with_options(writer, schema, write_options)
-    }
-
-    pub fn try_new_with_options(
-        mut writer: W,
-        schema: &Schema,
-        write_options: IpcWriteOptions,
-    ) -> Result<Self> {
+    pub fn try_new(mut writer: W, schema: &Schema, write_options: WriteOptions) -> Result<Self> {
         // write the schema, set the written bytes to the schema
         let encoded_message = EncodedData {
-            ipc_message: schema_to_bytes(schema, *write_options.metadata_version()),
+            ipc_message: schema_to_bytes(schema),
             arrow_data: vec![],
         };
-        write_message(&mut writer, encoded_message, &write_options)?;
+        write_message(&mut writer, encoded_message)?;
         Ok(Self {
             writer,
             write_options,
@@ -88,16 +78,16 @@ impl<W: Write> StreamWriter<W> {
                 .expect("StreamWriter is configured to not error on dictionary replacement");
 
         for encoded_dictionary in encoded_dictionaries {
-            write_message(&mut self.writer, encoded_dictionary, &self.write_options)?;
+            write_message(&mut self.writer, encoded_dictionary)?;
         }
 
-        write_message(&mut self.writer, encoded_message, &self.write_options)?;
+        write_message(&mut self.writer, encoded_message)?;
         Ok(())
     }
 
     /// Write continuation bytes, and mark the stream as done
     pub fn finish(&mut self) -> Result<()> {
-        write_continuation(&mut self.writer, &self.write_options, 0)?;
+        write_continuation(&mut self.writer, 0)?;
 
         self.finished = true;
 

--- a/src/io/parquet/write/schema.rs
+++ b/src/io/parquet/write/schema.rs
@@ -12,14 +12,14 @@ use parquet2::{
 use crate::{
     datatypes::{DataType, Field, Schema, TimeUnit},
     error::{ArrowError, Result},
-    io::ipc::write::{schema_to_bytes, MetadataVersion},
+    io::ipc::write::schema_to_bytes,
     io::parquet::write::decimal_length_from_precision,
 };
 
 use super::super::ARROW_SCHEMA_META_KEY;
 
 pub fn schema_to_metadata_key(schema: &Schema) -> KeyValue {
-    let serialized_schema = schema_to_bytes(schema, MetadataVersion::V5);
+    let serialized_schema = schema_to_bytes(schema);
 
     // manually prepending the length to the schema as arrow uses the legacy IPC format
     // TODO: change after addressing ARROW-9777

--- a/tests/it/io/ipc/write/file.rs
+++ b/tests/it/io/ipc/write/file.rs
@@ -13,9 +13,10 @@ fn round_trip(batch: RecordBatch) -> Result<()> {
 
     // write IPC version 5
     let written_result = {
-        let options =
-            IpcWriteOptions::try_new(8, false, MetadataVersion::V5, Some(Compression::ZSTD))?;
-        let mut writer = FileWriter::try_new_with_options(result, batch.schema(), options)?;
+        let options = WriteOptions {
+            compression: Some(Compression::ZSTD),
+        };
+        let mut writer = FileWriter::try_new(result, batch.schema(), options)?;
         writer.write(&batch)?;
         writer.finish()?;
         writer.into_inner()
@@ -50,8 +51,8 @@ fn test_file(version: &str, file_name: &str, compressed: bool) -> Result<()> {
 
     // write IPC version 5
     let written_result = {
-        let options = IpcWriteOptions::try_new(8, false, MetadataVersion::V5, compression)?;
-        let mut writer = FileWriter::try_new_with_options(result, &schema, options)?;
+        let options = WriteOptions { compression };
+        let mut writer = FileWriter::try_new(result, &schema, options)?;
         for batch in batches {
             writer.write(&batch)?;
         }

--- a/tests/it/io/ipc/write/stream.rs
+++ b/tests/it/io/ipc/write/stream.rs
@@ -3,7 +3,7 @@ use std::io::Cursor;
 use arrow2::error::Result;
 use arrow2::io::ipc::read::read_stream_metadata;
 use arrow2::io::ipc::read::StreamReader;
-use arrow2::io::ipc::write::{IpcWriteOptions, MetadataVersion, StreamWriter};
+use arrow2::io::ipc::write::{StreamWriter, WriteOptions};
 
 use crate::io::ipc::common::read_arrow_stream;
 use crate::io::ipc::common::read_gzip_json;
@@ -15,8 +15,8 @@ fn test_file(version: &str, file_name: &str) {
 
     // write IPC version 5
     {
-        let options = IpcWriteOptions::try_new(8, false, MetadataVersion::V5, None).unwrap();
-        let mut writer = StreamWriter::try_new_with_options(&mut result, &schema, options).unwrap();
+        let options = WriteOptions { compression: None };
+        let mut writer = StreamWriter::try_new(&mut result, &schema, options).unwrap();
         for batch in batches {
             writer.write(&batch).unwrap();
         }


### PR DESCRIPTION
This PR removes old functionality to write to legacy versions of the IPC format. V5 is quite standard at this point in time by now.

This also simplifies the write options for IPC, removing unused options and making all options explicit.

# Backward incompatible changes

To migrate to the new API:
* pass the write options to `StreamWriter::try_new` and `FileWriter::try_new`
* Rename `IpcWriteOptions` to `WriteOptions`
* Initialize `WriteOptions` using `WriteOptions { compression }`

# Deprecated

* option `ipc_legacy_format`: we no longer support that
* option `alignment`: this was not even correct AFAIK, since it was not consistent across the module.