### PR TITLE
Improved performance of `bitmap::from_trusted` (3x)

### DIFF
--- a/benches/bitmap.rs
+++ b/benches/bitmap.rs
@@ -53,6 +53,26 @@ fn add_benchmark(c: &mut Criterion) {
                 })
             },
         );
+
+        let iter = (0..size)
+            .into_iter()
+            .map(|x| x % 3 == 0)
+            .collect::<Vec<_>>();
+        c.bench_function(&format!("bitmap from_trusted_len 2^{}", log2_size), |b| {
+            b.iter(|| {
+                MutableBitmap::from_trusted_len_iter(iter.iter().copied());
+            })
+        });
+
+        c.bench_function(
+            &format!("bitmap extend_from_trusted_len_iter 2^{}", log2_size),
+            |b| {
+                b.iter(|| {
+                    let mut a = MutableBitmap::from(&[true]);
+                    a.extend_from_trusted_len_iter(iter.iter().copied());
+                })
+            },
+        );
     });
 }
 

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -1,3 +1,4 @@
+use std::hint::unreachable_unchecked;
 use std::iter::FromIterator;
 
 use crate::bitmap::utils::merge_reversed;
@@ -309,23 +310,58 @@ impl FromIterator<bool> for MutableBitmap {
     }
 }
 
+/// # Safety
+/// The iterator must be trustedLen and its len must be least `len`.
 #[inline]
-fn extend<I: Iterator<Item = bool>>(buffer: &mut [u8], length: usize, mut iterator: I) {
-    let chunks = length / 8;
-    let reminder = length % 8;
+unsafe fn get_byte_unchecked(len: usize, iterator: &mut impl Iterator<Item = bool>) -> u8 {
+    let mut byte_accum: u8 = 0;
+    let mut mask: u8 = 1;
+    for _ in 0..len {
+        let value = match iterator.next() {
+            Some(value) => value,
+            None => unsafe { unreachable_unchecked() },
+        };
 
-    buffer[..chunks].iter_mut().for_each(|byte| {
-        (0..8).for_each(|i| {
-            *byte = set(*byte, i, iterator.next().unwrap());
-        })
-    });
-
-    if reminder != 0 {
-        let last = &mut buffer[chunks];
-        iterator.enumerate().for_each(|(i, value)| {
-            *last = set(*last, i, value);
-        });
+        byte_accum |= match value {
+            true => mask,
+            false => 0,
+        };
+        mask <<= 1;
     }
+    byte_accum
+}
+
+/// Extends the [`MutableBuffer`] from `iterator`
+/// # Safety
+/// The iterator MUST be [`TrustedLen`].
+#[inline]
+unsafe fn extend_aligned_trusted_iter_unchecked(
+    buffer: &mut MutableBuffer<u8>,
+    mut iterator: impl Iterator<Item = bool>,
+) -> usize {
+    let additional_bits = iterator.size_hint().1.unwrap();
+    let chunks = additional_bits / 8;
+    let remainder = additional_bits % 8;
+
+    let additional = chunks + (remainder > 0) as usize;
+    buffer.reserve(additional);
+
+    if chunks > 0 {
+        for _ in 0..chunks {
+            // Soundness: iterator lenght is at least chunks * 8
+            let byte = unsafe { get_byte_unchecked(8, &mut iterator) };
+            // Soundness: capacity was allocated above
+            unsafe { buffer.push_unchecked(byte) };
+        }
+    }
+
+    if remainder > 0 {
+        // Soundness: iterator has exactly remainder items.
+        let byte = unsafe { get_byte_unchecked(remainder, &mut iterator) };
+        // Soundness: reserve above took remainder into account
+        unsafe { buffer.push_unchecked(byte) };
+    }
+    additional_bits
 }
 
 impl MutableBitmap {
@@ -339,6 +375,7 @@ impl MutableBitmap {
     /// Extends `self` from an iterator of trusted len.
     /// # Safety
     /// The caller must guarantee that the iterator has a trusted len.
+    #[inline]
     pub unsafe fn extend_from_trusted_len_iter_unchecked<I: Iterator<Item = bool>>(
         &mut self,
         mut iterator: I,
@@ -379,40 +416,33 @@ impl MutableBitmap {
         // everything is aligned; proceed with the bulk operation
         debug_assert_eq!(self.length % 8, 0);
 
-        self.buffer.extend_constant((length + 7) / 8, 0);
-
-        extend(&mut self.buffer[self.length / 8..], length, iterator);
+        unsafe { extend_aligned_trusted_iter_unchecked(&mut self.buffer, iterator) };
         self.length += length;
     }
 
     /// Creates a new [`MutableBitmap`] from an iterator of booleans.
     /// # Safety
     /// The iterator must report an accurate length.
+    #[inline]
     pub unsafe fn from_trusted_len_iter_unchecked<I>(iterator: I) -> Self
     where
         I: Iterator<Item = bool>,
     {
-        let length = iterator.size_hint().1.unwrap();
+        let mut buffer = MutableBuffer::<u8>::new();
 
-        let mut buffer = MutableBuffer::<u8>::from_len_zeroed((length + 7) / 8);
-
-        extend(&mut buffer, length, iterator);
+        let length = extend_aligned_trusted_iter_unchecked(&mut buffer, iterator);
 
         Self { buffer, length }
     }
 
     /// Creates a new [`MutableBitmap`] from an iterator of booleans.
+    #[inline]
     pub fn from_trusted_len_iter<I>(iterator: I) -> Self
     where
         I: TrustedLen<Item = bool>,
     {
-        let length = iterator.size_hint().1.unwrap();
-
-        let mut buffer = MutableBuffer::<u8>::from_len_zeroed((length + 7) / 8);
-
-        extend(&mut buffer, length, iterator);
-
-        Self { buffer, length }
+        // Safety: Iterator is `TrustedLen`
+        unsafe { Self::from_trusted_len_iter_unchecked(iterator) }
     }
 
     /// Creates a new [`MutableBitmap`] from an iterator of booleans.

--- a/tests/it/bitmap/mutable.rs
+++ b/tests/it/bitmap/mutable.rs
@@ -4,6 +4,13 @@ use arrow2::{
 };
 
 #[test]
+fn from_slice() {
+    let slice = &[true, false, true];
+    let a = MutableBitmap::from(slice);
+    assert_eq!(a.iter().collect::<Vec<_>>(), slice);
+}
+
+#[test]
 fn trusted_len() {
     let data = vec![true; 65];
     let bitmap = MutableBitmap::from_trusted_len_iter(data.into_iter());


### PR DESCRIPTION
Optimizes the creation and extending of `MutableBitmap`. It mostly re-arranges the code to leverage bitmap operations and the trustedLen invariant inside the hot loop.

```
Gnuplot not found, using plotters backend
bitmap from_trusted_len 2^10                                                                            
                        time:   [343.17 ns 344.70 ns 346.28 ns]
                        change: [-61.785% -61.465% -61.171%] (p = 0.00 < 0.05)

bitmap from_trusted_len 2^12                                                                             
                        time:   [1.2747 us 1.2815 us 1.2886 us]
                        change: [-63.765% -63.286% -62.869%] (p = 0.00 < 0.05)

bitmap from_trusted_len 2^14                                                                             
                        time:   [5.0600 us 5.0821 us 5.1083 us]
                        change: [-62.807% -62.486% -62.179%] (p = 0.00 < 0.05)

bitmap from_trusted_len 2^16                                                                             
                        time:   [20.037 us 20.147 us 20.256 us]
                        change: [-63.013% -62.660% -62.334%] (p = 0.00 < 0.05)

bitmap from_trusted_len 2^18                                                                            
                        time:   [80.056 us 80.641 us 81.273 us]
                        change: [-62.689% -62.358% -62.044%] (p = 0.00 < 0.05)

bitmap from_trusted_len 2^20                                                                            
                        time:   [317.06 us 318.74 us 320.50 us]
                        change: [-62.787% -62.497% -62.187%] (p = 0.00 < 0.05)

bitmap extend_from_trusted_len_iter 2^10                                                                            
                        time:   [454.37 ns 456.53 ns 458.83 ns]
                        change: [-54.421% -54.039% -53.670%] (p = 0.00 < 0.05)

bitmap extend_from_trusted_len_iter 2^12                                                                             
                        time:   [1.3878 us 1.3938 us 1.4003 us]
                        change: [-60.631% -60.227% -59.785%] (p = 0.00 < 0.05)

bitmap extend_from_trusted_len_iter 2^14                                                                             
                        time:   [5.1372 us 5.1573 us 5.1786 us]
                        change: [-61.752% -61.251% -60.609%] (p = 0.00 < 0.05)

bitmap extend_from_trusted_len_iter 2^16                                                                             
                        time:   [20.073 us 20.211 us 20.355 us]
                        change: [-62.762% -62.438% -62.100%] (p = 0.00 < 0.05)

bitmap extend_from_trusted_len_iter 2^18                                                                            
                        time:   [79.685 us 80.196 us 80.758 us]
                        change: [-62.818% -62.511% -62.186%] (p = 0.00 < 0.05)

bitmap extend_from_trusted_len_iter 2^20                                                                            
                        time:   [319.68 us 321.64 us 323.73 us]
                        change: [-62.872% -62.617% -62.346%] (p = 0.00 < 0.05)
```