### PR TITLE
fix growable negative keys

### DIFF
--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -14,6 +14,7 @@ pub use iterator::*;
 pub use mutable::*;
 
 use super::{new_empty_array, primitive::PrimitiveArray, Array};
+use crate::scalar::NullScalar;
 
 /// Trait denoting [`NativeType`]s that can be used as keys of a dictionary.
 pub trait DictionaryKey:
@@ -127,8 +128,12 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// Returns the value of the [`DictionaryArray`] at position `i`.
     #[inline]
     pub fn value(&self, index: usize) -> Box<dyn Scalar> {
-        let index = self.keys.value(index).to_usize().unwrap();
-        new_scalar(self.values.as_ref(), index)
+        if self.keys.is_null(index) {
+            Box::new(NullScalar::new())
+        } else {
+            let index = self.keys.value(index).to_usize().unwrap();
+            new_scalar(self.values.as_ref(), index)
+        }
     }
 }
 

--- a/src/array/growable/dictionary.rs
+++ b/src/array/growable/dictionary.rs
@@ -100,7 +100,7 @@ impl<'a, T: DictionaryKey> Growable<'a> for GrowableDictionary<'a, T> {
         self.key_values.extend(
             values
                 .iter()
-                .map(|x| T::from_usize(offset + x.to_usize().unwrap()).unwrap()),
+                .map(|x| T::from_usize(offset + x.to_usize().unwrap_or(0)).unwrap()),
         );
     }
 

--- a/src/array/growable/dictionary.rs
+++ b/src/array/growable/dictionary.rs
@@ -100,6 +100,7 @@ impl<'a, T: DictionaryKey> Growable<'a> for GrowableDictionary<'a, T> {
         self.key_values.extend(
             values
                 .iter()
+                // `.unwrap_or(0)` because this operation does not check for null values, which may contain any key.
                 .map(|x| T::from_usize(offset + x.to_usize().unwrap_or(0)).unwrap()),
         );
     }

--- a/tests/it/array/growable/dictionary.rs
+++ b/tests/it/array/growable/dictionary.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use arrow2::array::growable::{Growable, GrowableDictionary};
 use arrow2::array::*;
+use arrow2::datatypes::DataType;
 use arrow2::error::Result;
 
 #[test]
@@ -27,6 +28,22 @@ fn test_single() -> Result<()> {
 
     assert_eq!(result, expected);
     Ok(())
+}
+
+#[test]
+fn test_negative_keys() {
+    let vals = vec![Some("a"), Some("b"), Some("c")];
+    let keys = vec![0, 1, 2, -1];
+
+    let keys = PrimitiveArray::from_data(
+        DataType::Int32,
+        keys.into(),
+        Some(vec![true, true, true, false].into()),
+    );
+
+    let arr = DictionaryArray::from_data(keys, Arc::new(Utf8Array::<i32>::from(vals)));
+    // check that we don't panic with negative keys to usize conversion
+    arrow2::compute::concat::concatenate(&[&arr]).unwrap();
 }
 
 #[test]

--- a/tests/it/array/growable/dictionary.rs
+++ b/tests/it/array/growable/dictionary.rs
@@ -43,9 +43,10 @@ fn test_negative_keys() {
 
     let arr = DictionaryArray::from_data(keys, Arc::new(Utf8Array::<i32>::from(vals)));
     // check that we don't panic with negative keys to usize conversion
-    let out = arrow2::compute::concat::concatenate(&[&arr]).unwrap();
-    let out = out.as_any().downcast_ref::<DictionaryArray<i32>>().unwrap();
-    assert_eq!(out, &arr);
+    let mut growable = GrowableDictionary::new(&[&arr], false, 0);
+    growable.extend(0, 0, 4);
+    let out: DictionaryArray<i32> = growable.into();
+    assert_eq!(out, arr);
 }
 
 #[test]

--- a/tests/it/array/growable/dictionary.rs
+++ b/tests/it/array/growable/dictionary.rs
@@ -43,7 +43,9 @@ fn test_negative_keys() {
 
     let arr = DictionaryArray::from_data(keys, Arc::new(Utf8Array::<i32>::from(vals)));
     // check that we don't panic with negative keys to usize conversion
-    arrow2::compute::concat::concatenate(&[&arr]).unwrap();
+    let out = arrow2::compute::concat::concatenate(&[&arr]).unwrap();
+    let out = out.as_any().downcast_ref::<DictionaryArray<i32>>().unwrap();
+    assert_eq!(out, &arr);
 }
 
 #[test]


### PR DESCRIPTION
Pyarrow creates dictionary keys with negative integers, that are masked out by the validity bitmap.

This PR fixes conversion from those negative integers to usize, they are mapped to `0`, and that is ok, because the values are masked.

Related downstream issue: https://github.com/pola-rs/polars/issues/1686

Additionally the scalar API also read masked out values, so was incorrect.