### PR TITLE
Simplified dictionary indexes

### DIFF
--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use crate::{
     bitmap::Bitmap,
-    datatypes::DataType,
+    datatypes::{DataType, IntegerType},
     scalar::{new_scalar, Scalar},
-    types::{NativeType, NaturalDataType},
+    types::NativeType,
 };
 
 mod ffi;
@@ -16,19 +16,35 @@ pub use mutable::*;
 use super::{new_empty_array, primitive::PrimitiveArray, Array};
 
 /// Trait denoting [`NativeType`]s that can be used as keys of a dictionary.
-pub trait DictionaryKey:
-    NativeType + NaturalDataType + num_traits::NumCast + num_traits::FromPrimitive
-{
+pub trait DictionaryKey: NativeType + num_traits::NumCast + num_traits::FromPrimitive {
+    /// The corresponding [`IntegerType`] of this key
+    const KEY_TYPE: IntegerType;
 }
 
-impl DictionaryKey for i8 {}
-impl DictionaryKey for i16 {}
-impl DictionaryKey for i32 {}
-impl DictionaryKey for i64 {}
-impl DictionaryKey for u8 {}
-impl DictionaryKey for u16 {}
-impl DictionaryKey for u32 {}
-impl DictionaryKey for u64 {}
+impl DictionaryKey for i8 {
+    const KEY_TYPE: IntegerType = IntegerType::Int8;
+}
+impl DictionaryKey for i16 {
+    const KEY_TYPE: IntegerType = IntegerType::Int16;
+}
+impl DictionaryKey for i32 {
+    const KEY_TYPE: IntegerType = IntegerType::Int32;
+}
+impl DictionaryKey for i64 {
+    const KEY_TYPE: IntegerType = IntegerType::Int64;
+}
+impl DictionaryKey for u8 {
+    const KEY_TYPE: IntegerType = IntegerType::UInt8;
+}
+impl DictionaryKey for u16 {
+    const KEY_TYPE: IntegerType = IntegerType::UInt16;
+}
+impl DictionaryKey for u32 {
+    const KEY_TYPE: IntegerType = IntegerType::UInt32;
+}
+impl DictionaryKey for u64 {
+    const KEY_TYPE: IntegerType = IntegerType::UInt64;
+}
 
 /// An [`Array`] whose values are encoded by keys. This [`Array`] is useful when the cardinality of
 /// values is low compared to the length of the [`Array`].
@@ -59,10 +75,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
 
     /// The canonical method to create a new [`DictionaryArray`].
     pub fn from_data(keys: PrimitiveArray<K>, values: Arc<dyn Array>) -> Self {
-        let data_type = DataType::Dictionary(
-            Box::new(keys.data_type().clone()),
-            Box::new(values.data_type().clone()),
-        );
+        let data_type = DataType::Dictionary(K::KEY_TYPE, Box::new(values.data_type().clone()));
 
         Self {
             data_type,

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -31,10 +31,7 @@ impl<K: DictionaryKey, M: MutableArray> From<MutableDictionaryArray<K, M>> for D
 impl<K: DictionaryKey, M: MutableArray> From<M> for MutableDictionaryArray<K, M> {
     fn from(values: M) -> Self {
         Self {
-            data_type: DataType::Dictionary(
-                Box::new(K::DATA_TYPE),
-                Box::new(values.data_type().clone()),
-            ),
+            data_type: DataType::Dictionary(K::KEY_TYPE, Box::new(values.data_type().clone())),
             keys: MutablePrimitiveArray::<K>::new(),
             map: HashedMap::default(),
             values,
@@ -47,10 +44,7 @@ impl<K: DictionaryKey, M: MutableArray + Default> MutableDictionaryArray<K, M> {
     pub fn new() -> Self {
         let values = M::default();
         Self {
-            data_type: DataType::Dictionary(
-                Box::new(K::DATA_TYPE),
-                Box::new(values.data_type().clone()),
-            ),
+            data_type: DataType::Dictionary(K::KEY_TYPE, Box::new(values.data_type().clone())),
             keys: MutablePrimitiveArray::<K>::new(),
             map: HashedMap::default(),
             values,

--- a/src/array/equal/mod.rs
+++ b/src/array/equal/mod.rs
@@ -215,7 +215,7 @@ pub fn equal(lhs: &dyn Array, rhs: &dyn Array) -> bool {
             struct_::equal(lhs, rhs)
         }
         Dictionary(key_type) => {
-            with_match_physical_dictionary_key_type!(key_type, |$T| {
+            match_integer_type!(key_type, |$T| {
                 let lhs = lhs.as_any().downcast_ref().unwrap();
                 let rhs = rhs.as_any().downcast_ref().unwrap();
                 dictionary::equal::<$T>(lhs, rhs)

--- a/src/array/ffi.rs
+++ b/src/array/ffi.rs
@@ -74,7 +74,7 @@ pub fn offset_buffers_children_dictionary(array: &dyn Array) -> BuffersChildren 
         Union => ffi_dyn!(array, UnionArray),
         Map => ffi_dyn!(array, MapArray),
         Dictionary(key_type) => {
-            with_match_physical_dictionary_key_type!(key_type, |$T| {
+            match_integer_type!(key_type, |$T| {
                 let array = array.as_any().downcast_ref::<DictionaryArray<$T>>().unwrap();
                 (
                     array.offset().unwrap(),

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -174,28 +174,11 @@ macro_rules! fmt_dyn {
     }};
 }
 
-macro_rules! with_match_dictionary_key_type {(
+macro_rules! match_integer_type {(
     $key_type:expr, | $_:tt $T:ident | $($body:tt)*
 ) => ({
     macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    match $key_type {
-        DataType::Int8 => __with_ty__! { i8 },
-        DataType::Int16 => __with_ty__! { i16 },
-        DataType::Int32 => __with_ty__! { i32 },
-        DataType::Int64 => __with_ty__! { i64 },
-        DataType::UInt8 => __with_ty__! { u8 },
-        DataType::UInt16 => __with_ty__! { u16 },
-        DataType::UInt32 => __with_ty__! { u32 },
-        DataType::UInt64 => __with_ty__! { u64 },
-        _ => ::core::unreachable!("A dictionary key type can only be of integer types"),
-    }
-})}
-
-macro_rules! with_match_physical_dictionary_key_type {(
-    $key_type:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use crate::datatypes::DictionaryIndexType::*;
+    use crate::datatypes::IntegerType::*;
     match $key_type {
         Int8 => __with_ty__! { i8 },
         Int16 => __with_ty__! { i16 },
@@ -251,7 +234,7 @@ impl Display for dyn Array {
             Struct => fmt_dyn!(self, StructArray, f),
             Union => fmt_dyn!(self, UnionArray, f),
             Dictionary(key_type) => {
-                with_match_physical_dictionary_key_type!(key_type, |$T| {
+                match_integer_type!(key_type, |$T| {
                     fmt_dyn!(self, DictionaryArray::<$T>, f)
                 })
             }
@@ -281,7 +264,7 @@ pub fn new_empty_array(data_type: DataType) -> Box<dyn Array> {
         Union => Box::new(UnionArray::new_empty(data_type)),
         Map => Box::new(MapArray::new_empty(data_type)),
         Dictionary(key_type) => {
-            with_match_physical_dictionary_key_type!(key_type, |$T| {
+            match_integer_type!(key_type, |$T| {
                 Box::new(DictionaryArray::<$T>::new_empty(data_type))
             })
         }
@@ -311,7 +294,7 @@ pub fn new_null_array(data_type: DataType, length: usize) -> Box<dyn Array> {
         Union => Box::new(UnionArray::new_null(data_type, length)),
         Map => Box::new(MapArray::new_null(data_type, length)),
         Dictionary(key_type) => {
-            with_match_physical_dictionary_key_type!(key_type, |$T| {
+            match_integer_type!(key_type, |$T| {
                 Box::new(DictionaryArray::<$T>::new_null(data_type, length))
             })
         }
@@ -349,7 +332,7 @@ pub fn clone(array: &dyn Array) -> Box<dyn Array> {
         Union => clone_dyn!(array, UnionArray),
         Map => clone_dyn!(array, MapArray),
         Dictionary(key_type) => {
-            with_match_physical_dictionary_key_type!(key_type, |$T| {
+            match_integer_type!(key_type, |$T| {
                 clone_dyn!(array, DictionaryArray::<$T>)
             })
         }

--- a/src/array/ord.rs
+++ b/src/array/ord.rs
@@ -216,15 +216,15 @@ pub fn build_compare(left: &dyn Array, right: &dyn Array) -> Result<DynComparato
         (Binary, Binary) => compare_binary::<i32>(left, right),
         (LargeBinary, LargeBinary) => compare_binary::<i64>(left, right),
         (Dictionary(key_type_lhs, _), Dictionary(key_type_rhs, _)) => {
-            match (key_type_lhs.as_ref(), key_type_rhs.as_ref()) {
-                (UInt8, UInt8) => dyn_dict!(u8, left, right),
-                (UInt16, UInt16) => dyn_dict!(u16, left, right),
-                (UInt32, UInt32) => dyn_dict!(u32, left, right),
-                (UInt64, UInt64) => dyn_dict!(u64, left, right),
-                (Int8, Int8) => dyn_dict!(i8, left, right),
-                (Int16, Int16) => dyn_dict!(i16, left, right),
-                (Int32, Int32) => dyn_dict!(i32, left, right),
-                (Int64, Int64) => dyn_dict!(i64, left, right),
+            match (key_type_lhs, key_type_rhs) {
+                (IntegerType::UInt8, IntegerType::UInt8) => dyn_dict!(u8, left, right),
+                (IntegerType::UInt16, IntegerType::UInt16) => dyn_dict!(u16, left, right),
+                (IntegerType::UInt32, IntegerType::UInt32) => dyn_dict!(u32, left, right),
+                (IntegerType::UInt64, IntegerType::UInt64) => dyn_dict!(u64, left, right),
+                (IntegerType::Int8, IntegerType::Int8) => dyn_dict!(i8, left, right),
+                (IntegerType::Int16, IntegerType::Int16) => dyn_dict!(i16, left, right),
+                (IntegerType::Int32, IntegerType::Int32) => dyn_dict!(i32, left, right),
+                (IntegerType::Int64, IntegerType::Int64) => dyn_dict!(i64, left, right),
                 (lhs, _) => {
                     return Err(ArrowError::InvalidArgumentError(format!(
                         "Dictionaries do not support keys of type {:?}",

--- a/src/compute/cast/dictionary_to.rs
+++ b/src/compute/cast/dictionary_to.rs
@@ -114,8 +114,9 @@ pub(super) fn dictionary_cast_dyn<K: DictionaryKey>(
             let values = cast(values.as_ref(), to_values_type, options)?.into();
 
             // create the appropriate array type
-            with_match_dictionary_key_type!(to_keys_type.as_ref(), |$T| {
-                key_cast!(keys, values, array, to_keys_type, $T)
+            let data_type = (*to_keys_type).into();
+            match_integer_type!(to_keys_type, |$T| {
+                key_cast!(keys, values, array, &data_type, $T)
             })
         }
         _ => unpack_dictionary::<K>(keys, values.as_ref(), to_type, options),

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -375,31 +375,12 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             Ok(Box::new(list_array))
         }
 
-        (Dictionary(index_type, _), _) => match **index_type {
-            DataType::Int8 => dictionary_cast_dyn::<i8>(array, to_type, options),
-            DataType::Int16 => dictionary_cast_dyn::<i16>(array, to_type, options),
-            DataType::Int32 => dictionary_cast_dyn::<i32>(array, to_type, options),
-            DataType::Int64 => dictionary_cast_dyn::<i64>(array, to_type, options),
-            DataType::UInt8 => dictionary_cast_dyn::<u8>(array, to_type, options),
-            DataType::UInt16 => dictionary_cast_dyn::<u16>(array, to_type, options),
-            DataType::UInt32 => dictionary_cast_dyn::<u32>(array, to_type, options),
-            DataType::UInt64 => dictionary_cast_dyn::<u64>(array, to_type, options),
-            _ => unreachable!(),
-        },
-        (_, Dictionary(index_type, value_type)) => match **index_type {
-            DataType::Int8 => cast_to_dictionary::<i8>(array, value_type, options),
-            DataType::Int16 => cast_to_dictionary::<i16>(array, value_type, options),
-            DataType::Int32 => cast_to_dictionary::<i32>(array, value_type, options),
-            DataType::Int64 => cast_to_dictionary::<i64>(array, value_type, options),
-            DataType::UInt8 => cast_to_dictionary::<u8>(array, value_type, options),
-            DataType::UInt16 => cast_to_dictionary::<u16>(array, value_type, options),
-            DataType::UInt32 => cast_to_dictionary::<u32>(array, value_type, options),
-            DataType::UInt64 => cast_to_dictionary::<u64>(array, value_type, options),
-            _ => Err(ArrowError::NotYetImplemented(format!(
-                "Casting from type {:?} to dictionary type {:?} not supported",
-                from_type, to_type,
-            ))),
-        },
+        (Dictionary(index_type, _), _) => match_integer_type!(index_type, |$T| {
+            dictionary_cast_dyn::<$T>(array, to_type, options)
+        }),
+        (_, Dictionary(index_type, value_type)) => match_integer_type!(index_type, |$T| {
+            cast_to_dictionary::<$T>(array, value_type, options)
+        }),
         (_, Boolean) => match from_type {
             UInt8 => primitive_to_boolean_dyn::<u8>(array, to_type.clone()),
             UInt16 => primitive_to_boolean_dyn::<u16>(array, to_type.clone()),

--- a/src/compute/take/mod.rs
+++ b/src/compute/take/mod.rs
@@ -71,7 +71,7 @@ pub fn take<O: Index>(values: &dyn Array, indices: &PrimitiveArray<O>) -> Result
             Ok(Box::new(binary::take::<i64, _>(values, indices)))
         }
         Dictionary(key_type) => {
-            with_match_physical_dictionary_key_type!(key_type, |$T| {
+            match_integer_type!(key_type, |$T| {
                 let values = values.as_any().downcast_ref().unwrap();
                 Ok(Box::new(dict::take::<$T, _>(&values, indices)))
             })
@@ -103,46 +103,36 @@ pub fn take<O: Index>(values: &dyn Array, indices: &PrimitiveArray<O>) -> Result
 /// assert_eq!(can_take(&data_type), true);
 /// ```
 pub fn can_take(data_type: &DataType) -> bool {
-    match data_type {
+    matches!(
+        data_type,
         DataType::Null
-        | DataType::Boolean
-        | DataType::Int8
-        | DataType::Int16
-        | DataType::Int32
-        | DataType::Date32
-        | DataType::Time32(_)
-        | DataType::Interval(_)
-        | DataType::Int64
-        | DataType::Date64
-        | DataType::Time64(_)
-        | DataType::Duration(_)
-        | DataType::Timestamp(_, _)
-        | DataType::UInt8
-        | DataType::UInt16
-        | DataType::UInt32
-        | DataType::UInt64
-        | DataType::Float16
-        | DataType::Float32
-        | DataType::Float64
-        | DataType::Decimal(_, _)
-        | DataType::Utf8
-        | DataType::LargeUtf8
-        | DataType::Binary
-        | DataType::LargeBinary
-        | DataType::Struct(_)
-        | DataType::List(_)
-        | DataType::LargeList(_) => true,
-        DataType::Dictionary(key_type, _) => matches!(
-            key_type.as_ref(),
-            DataType::Int8
-                | DataType::Int16
-                | DataType::Int32
-                | DataType::Int64
-                | DataType::UInt8
-                | DataType::UInt16
-                | DataType::UInt32
-                | DataType::UInt64
-        ),
-        _ => false,
-    }
+            | DataType::Boolean
+            | DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Date32
+            | DataType::Time32(_)
+            | DataType::Interval(_)
+            | DataType::Int64
+            | DataType::Date64
+            | DataType::Time64(_)
+            | DataType::Duration(_)
+            | DataType::Timestamp(_, _)
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float16
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Decimal(_, _)
+            | DataType::Utf8
+            | DataType::LargeUtf8
+            | DataType::Binary
+            | DataType::LargeBinary
+            | DataType::Struct(_)
+            | DataType::List(_)
+            | DataType::LargeList(_)
+            | DataType::Dictionary(_, _)
+    )
 }

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -128,7 +128,7 @@ pub enum DataType {
     ///
     /// This type mostly used to represent low cardinality string
     /// arrays or a limited set of primitive types as integers.
-    Dictionary(Box<DataType>, Box<DataType>),
+    Dictionary(IntegerType, Box<DataType>),
     /// Decimal value with precision and scale
     /// precision is the number of digits in the number and
     /// scale is the number of decimal places.
@@ -267,7 +267,7 @@ impl DataType {
             Struct(_) => PhysicalType::Struct,
             Union(_, _, _) => PhysicalType::Union,
             Map(_, _) => PhysicalType::Map,
-            Dictionary(key, _) => PhysicalType::Dictionary(to_dictionary_index_type(key.as_ref())),
+            Dictionary(key, _) => PhysicalType::Dictionary(*key),
             Extension(_, key, _) => key.to_physical_type(),
         }
     }
@@ -284,17 +284,18 @@ impl DataType {
     }
 }
 
-fn to_dictionary_index_type(data_type: &DataType) -> DictionaryIndexType {
-    match data_type {
-        DataType::Int8 => DictionaryIndexType::Int8,
-        DataType::Int16 => DictionaryIndexType::Int16,
-        DataType::Int32 => DictionaryIndexType::Int32,
-        DataType::Int64 => DictionaryIndexType::Int64,
-        DataType::UInt8 => DictionaryIndexType::UInt8,
-        DataType::UInt16 => DictionaryIndexType::UInt16,
-        DataType::UInt32 => DictionaryIndexType::UInt32,
-        DataType::UInt64 => DictionaryIndexType::UInt64,
-        _ => ::core::unreachable!("A dictionary key type can only be of integer types"),
+impl From<IntegerType> for DataType {
+    fn from(item: IntegerType) -> Self {
+        match item {
+            IntegerType::Int8 => DataType::Int8,
+            IntegerType::Int16 => DataType::Int16,
+            IntegerType::Int32 => DataType::Int32,
+            IntegerType::Int64 => DataType::Int64,
+            IntegerType::UInt8 => DataType::UInt8,
+            IntegerType::UInt16 => DataType::UInt16,
+            IntegerType::UInt32 => DataType::UInt32,
+            IntegerType::UInt64 => DataType::UInt64,
+        }
     }
 }
 

--- a/src/datatypes/physical_type.rs
+++ b/src/datatypes/physical_type.rs
@@ -31,8 +31,8 @@ pub enum PhysicalType {
     Union,
     /// A nested type.
     Map,
-    /// A dictionary encoded array by `DictionaryIndexType`.
-    Dictionary(DictionaryIndexType),
+    /// A dictionary encoded array by `IntegerType`.
+    Dictionary(IntegerType),
 }
 
 /// The set of all (physical) primitive types.
@@ -70,7 +70,7 @@ pub enum PrimitiveType {
 /// the set of valid indices types of a dictionary-encoded Array.
 /// Each type corresponds to a variant of [`crate::array::DictionaryArray`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum DictionaryIndexType {
+pub enum IntegerType {
     /// A signed 8-bit integer.
     Int8,
     /// A signed 16-bit integer.

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -27,7 +27,7 @@ pub unsafe fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
         FixedSizeList => Box::new(FixedSizeListArray::try_from_ffi(array)?),
         Struct => Box::new(StructArray::try_from_ffi(array)?),
         Dictionary(key_type) => {
-            with_match_physical_dictionary_key_type!(key_type, |$T| {
+            match_integer_type!(key_type, |$T| {
                 Box::new(DictionaryArray::<$T>::try_from_ffi(array)?)
             })
         }

--- a/src/ffi/bridge.rs
+++ b/src/ffi/bridge.rs
@@ -33,7 +33,7 @@ pub fn align_to_c_data_interface(array: Arc<dyn Array>) -> Arc<dyn Array> {
         Union => ffi_dyn!(array, UnionArray),
         Map => ffi_dyn!(array, MapArray),
         Dictionary(key_type) => {
-            with_match_physical_dictionary_key_type!(key_type, |$T| {
+            match_integer_type!(key_type, |$T| {
                 ffi_dyn!(array, DictionaryArray<$T>)
             })
         }

--- a/src/io/avro/read/nested.rs
+++ b/src/io/avro/read/nested.rs
@@ -137,7 +137,7 @@ impl FixedItemsUtf8Dictionary {
     pub fn with_capacity(values: Utf8Array<i32>, capacity: usize) -> Self {
         Self {
             data_type: DataType::Dictionary(
-                Box::new(DataType::Int32),
+                IntegerType::Int32,
                 Box::new(values.data_type().clone()),
             ),
             keys: MutablePrimitiveArray::<i32>::with_capacity(capacity),

--- a/src/io/avro/read/schema.rs
+++ b/src/io/avro/read/schema.rs
@@ -169,7 +169,7 @@ fn schema_to_field(
         AvroSchema::Enum { .. } => {
             return Ok(Field::new(
                 name.unwrap_or_default(),
-                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Utf8)),
                 false,
             ))
         }

--- a/src/io/csv/write/serialize.rs
+++ b/src/io/csv/write/serialize.rs
@@ -1,5 +1,6 @@
 use lexical_core::ToLexical;
 
+use crate::datatypes::IntegerType;
 use crate::temporal_conversions;
 use crate::types::{Index, NativeType};
 use crate::util::lexical_to_bytes_mut;
@@ -268,14 +269,14 @@ pub fn new_serializer<'a>(
             ))
         }
         DataType::Dictionary(keys_dt, values_dt) => match &**values_dt {
-            DataType::LargeUtf8 => match &**keys_dt {
-                DataType::UInt32 => serialize_utf8_dict::<u32, i64>(array.as_any()),
-                DataType::UInt64 => serialize_utf8_dict::<u64, i64>(array.as_any()),
+            DataType::LargeUtf8 => match *keys_dt {
+                IntegerType::UInt32 => serialize_utf8_dict::<u32, i64>(array.as_any()),
+                IntegerType::UInt64 => serialize_utf8_dict::<u64, i64>(array.as_any()),
                 _ => todo!(),
             },
-            DataType::Utf8 => match &**keys_dt {
-                DataType::UInt32 => serialize_utf8_dict::<u32, i32>(array.as_any()),
-                DataType::UInt64 => serialize_utf8_dict::<u64, i32>(array.as_any()),
+            DataType::Utf8 => match *keys_dt {
+                IntegerType::UInt32 => serialize_utf8_dict::<u32, i32>(array.as_any()),
+                IntegerType::UInt64 => serialize_utf8_dict::<u64, i32>(array.as_any()),
                 _ => todo!(),
             },
             _ => {

--- a/src/io/ipc/read/deserialize.rs
+++ b/src/io/ipc/read/deserialize.rs
@@ -164,7 +164,7 @@ pub fn read<R: Read + Seek>(
         )
         .map(|x| Arc::new(x) as Arc<dyn Array>),
         Dictionary(key_type) => {
-            with_match_physical_dictionary_key_type!(key_type, |$T| {
+            match_integer_type!(key_type, |$T| {
                 read_dictionary::<$T, _>(
                     field_nodes,
                     buffers,

--- a/src/io/ipc/write/common.rs
+++ b/src/io/ipc/write/common.rs
@@ -251,7 +251,7 @@ impl DictionaryTracker {
     pub fn insert(&mut self, dict_id: i64, array: &Arc<dyn Array>) -> Result<bool> {
         let values = match array.data_type() {
             DataType::Dictionary(key_type, _) => {
-                with_match_dictionary_key_type!(key_type.as_ref(), |$T| {
+                match_integer_type!(key_type, |$T| {
                     let array = array
                         .as_any()
                         .downcast_ref::<DictionaryArray<$T>>()

--- a/src/io/ipc/write/serialize.rs
+++ b/src/io/ipc/write/serialize.rs
@@ -471,7 +471,7 @@ pub fn write_dictionary(
 ) -> usize {
     match array.data_type() {
         DataType::Dictionary(key_type, _) => {
-            with_match_dictionary_key_type!(key_type.as_ref(), |$T| {
+            match_integer_type!(key_type, |$T| {
                 _write_dictionary::<$T>(
                     array,
                     buffers,

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -255,7 +255,7 @@ pub fn read(rows: &[&Value], data_type: DataType) -> Arc<dyn Array> {
         DataType::LargeBinary => Arc::new(read_binary::<i64>(rows)),
         DataType::Struct(_) => Arc::new(read_struct(rows, data_type)),
         DataType::Dictionary(key_type, _) => {
-            with_match_dictionary_key_type!(key_type.as_ref(), |$T| {
+            match_integer_type!(key_type, |$T| {
                 Arc::new(read_dictionary::<$T>(rows, data_type))
             })
         }

--- a/src/io/json_integration/mod.rs
+++ b/src/io/json_integration/mod.rs
@@ -98,13 +98,13 @@ impl From<&Field> for ArrowJsonField {
 pub struct ArrowJsonFieldDictionary {
     pub id: i64,
     #[serde(rename = "indexType")]
-    pub index_type: DictionaryIndexType,
+    pub index_type: IntegerType,
     #[serde(rename = "isOrdered")]
     pub is_ordered: bool,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
-pub struct DictionaryIndexType {
+pub struct IntegerType {
     pub name: String,
     #[serde(rename = "isSigned")]
     pub is_signed: bool,

--- a/src/io/json_integration/read.rs
+++ b/src/io/json_integration/read.rs
@@ -364,7 +364,7 @@ pub fn to_array(
             Ok(Arc::new(array))
         }
         Dictionary(key_type) => {
-            with_match_physical_dictionary_key_type!(key_type, |$T| {
+            match_integer_type!(key_type, |$T| {
                 to_dictionary::<$T>(data_type, dict_id.unwrap(), json_col, dictionaries)
             })
         }

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -327,17 +327,9 @@ pub fn page_iter_to_array<I: FallibleStreamingIterator<Item = DataPage, Error = 
             create_list(data_type, &mut nested, values)
         }
 
-        Dictionary(ref key, _) => match key.as_ref() {
-            Int8 => dict_read::<i8, _>(iter, metadata, data_type),
-            Int16 => dict_read::<i16, _>(iter, metadata, data_type),
-            Int32 => dict_read::<i32, _>(iter, metadata, data_type),
-            Int64 => dict_read::<i64, _>(iter, metadata, data_type),
-            UInt8 => dict_read::<u8, _>(iter, metadata, data_type),
-            UInt16 => dict_read::<u16, _>(iter, metadata, data_type),
-            UInt32 => dict_read::<u32, _>(iter, metadata, data_type),
-            UInt64 => dict_read::<u64, _>(iter, metadata, data_type),
-            _ => unreachable!(),
-        },
+        Dictionary(key_type, _) => match_integer_type!(key_type, |$T| {
+            dict_read::<$T, _>(iter, metadata, data_type)
+        }),
 
         other => Err(ArrowError::NotYetImplemented(format!(
             "Reading {:?} from parquet still not implemented",

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -117,7 +117,7 @@ pub fn array_to_pages(
 ) -> Result<DynIter<'static, Result<EncodedPage>>> {
     match array.data_type() {
         DataType::Dictionary(key_type, _) => {
-            with_match_dictionary_key_type!(key_type.as_ref(), |$T| {
+            match_integer_type!(key_type, |$T| {
                 dictionary::array_to_pages::<$T>(
                     array.as_any().downcast_ref().unwrap(),
                     descriptor,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -64,7 +64,6 @@ pub unsafe trait NativeType:
     + std::fmt::Display
     + PartialEq
     + Default
-    + Sized
     + 'static
 {
     /// Type denoting its representation as bytes.

--- a/tests/it/compute/cast.rs
+++ b/tests/it/compute/cast.rs
@@ -483,7 +483,7 @@ fn utf8_to_dict() {
     let array = Utf8Array::<i32>::from(&[Some("one"), None, Some("three"), Some("one")]);
 
     // Cast to a dictionary (same value type, Utf8)
-    let cast_type = DataType::Dictionary(Box::new(DataType::UInt8), Box::new(DataType::Utf8));
+    let cast_type = DataType::Dictionary(u8::KEY_TYPE, Box::new(DataType::Utf8));
     let result = cast(&array, &cast_type, CastOptions::default()).expect("cast failed");
 
     let mut expected = MutableDictionaryArray::<u8, MutableUtf8Array<i32>>::new();
@@ -514,7 +514,7 @@ fn i32_to_dict() {
     let array = Int32Array::from(&[Some(1), None, Some(3), Some(1)]);
 
     // Cast to a dictionary (same value type, Utf8)
-    let cast_type = DataType::Dictionary(Box::new(DataType::UInt8), Box::new(DataType::Int32));
+    let cast_type = DataType::Dictionary(u8::KEY_TYPE, Box::new(DataType::Int32));
     let result = cast(&array, &cast_type, CastOptions::default()).expect("cast failed");
 
     let mut expected = MutableDictionaryArray::<u8, MutablePrimitiveArray<i32>>::new();
@@ -617,7 +617,7 @@ fn dict_to_dict_bad_index_value_primitive() {
     }
     let array: ArrayRef = Arc::new(builder.finish());
 
-    let cast_type = Dictionary(Box::new(Int8), Box::new(Utf8));
+    let cast_type = Dictionary(i8::KEY_TYPE, Box::new(Utf8));
     let res = cast(&array, &cast_type, CastOptions::default());
     assert, CastOptions::default())!(res.is_err());
     let actual_error = format!("{:?}", res);
@@ -649,7 +649,7 @@ fn dict_to_dict_bad_index_value_utf8() {
     }
     let array: ArrayRef = Arc::new(builder.finish());
 
-    let cast_type = Dictionary(Box::new(Int8), Box::new(Utf8));
+    let cast_type = Dictionary(i8::KEY_TYPE, Box::new(Utf8));
     let res = cast(&array, &cast_type, CastOptions::default());
     assert, CastOptions::default())!(res.is_err());
     let actual_error = format!("{:?}", res);

--- a/tests/it/ffi.rs
+++ b/tests/it/ffi.rs
@@ -196,7 +196,7 @@ fn schema() -> Result<()> {
 
     let field = Field::new(
         "a",
-        DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+        DataType::Dictionary(u32::KEY_TYPE, Box::new(DataType::Utf8)),
         true,
     );
     test_round_trip_schema(field)?;

--- a/tests/it/io/avro/read/mod.rs
+++ b/tests/it/io/avro/read/mod.rs
@@ -69,7 +69,7 @@ fn schema() -> (AvroSchema, Schema) {
         ),
         Field::new(
             "enum",
-            DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+            DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::Utf8)),
             false,
         ),
         Field::new(

--- a/tests/it/io/csv/write.rs
+++ b/tests/it/io/csv/write.rs
@@ -17,7 +17,7 @@ fn data() -> RecordBatch {
         Field::new("c6", DataType::Time32(TimeUnit::Second), false),
         Field::new(
             "c7",
-            DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+            DataType::Dictionary(u32::KEY_TYPE, Box::new(DataType::Utf8)),
             false,
         ),
     ]);

--- a/tests/it/io/json/mod.rs
+++ b/tests/it/io/json/mod.rs
@@ -117,7 +117,7 @@ fn case_dict() -> (String, Schema, Vec<Box<dyn Array>>) {
 
     let data_type = DataType::List(Box::new(Field::new(
         "item",
-        DataType::Dictionary(Box::new(DataType::UInt64), Box::new(DataType::Utf8)),
+        DataType::Dictionary(u64::KEY_TYPE, Box::new(DataType::Utf8)),
         true,
     )));
 

--- a/tests/it/io/print.rs
+++ b/tests/it/io/print.rs
@@ -87,7 +87,7 @@ fn write_null() -> Result<()> {
 #[test]
 fn write_dictionary() -> Result<()> {
     // define a schema.
-    let field_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8));
+    let field_type = DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::Utf8));
     let schema = Arc::new(Schema::new(vec![Field::new("d1", field_type, true)]));
 
     let mut array = MutableDictionaryArray::<i32, MutableUtf8Array<i32>>::new();
@@ -119,7 +119,7 @@ fn write_dictionary() -> Result<()> {
 #[test]
 fn dictionary_validities() -> Result<()> {
     // define a schema.
-    let field_type = DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Int32));
+    let field_type = DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::Int32));
     let schema = Arc::new(Schema::new(vec![Field::new("d1", field_type, true)]));
 
     let keys = PrimitiveArray::<i32>::from([Some(1), None, Some(0)]);


### PR DESCRIPTION
The `Box<DataType>` in `DataType::Dictionary(Box<DataType>, _)` is not sufficiently restrictive as there are only 8 possible variants on the dictionary keys. This PR changes it to `DataType::Dictionary(IntegerType, _)`, allowing `match` to cover all cases.

## Backward incompatible changes

As a user declaring dictionaries, to migrate to the new behavior, change

```rust
DataType::Dictionary(Box::new(DataType::Int32), Box::new(values))
```

to

```rust
DataType::Dictionary(i32::KEY_TYPE, Box::new(values))
```

As a user writing kernels, use `arrow2::datatypes::IntegerType` to match the cases.
