### PR TITLE
Speedup/simplify bitwise operations (avoid extra allocation)

### DIFF
--- a/benches/bitwise.rs
+++ b/benches/bitwise.rs
@@ -1,4 +1,4 @@
-use std::ops::{BitOr, BitXor, Not};
+use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use num_traits::NumCast;

--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -20,6 +20,11 @@ where
     let mut a3_chunks = a3.chunks();
     let mut a4_chunks = a4.chunks();
 
+    let rem_a1 = a1_chunks.remainder();
+    let rem_a2 = a2_chunks.remainder();
+    let rem_a3 = a3_chunks.remainder();
+    let rem_a4 = a4_chunks.remainder();
+
     let chunks = a1_chunks
         .by_ref()
         .zip(a2_chunks.by_ref())
@@ -27,17 +32,11 @@ where
         .zip(a4_chunks.by_ref())
         .map(|(((a1, a2), a3), a4)| op(a1, a2, a3, a4));
     // Soundness: `BitChunks` is a trusted len iterator
-    let mut buffer = unsafe { MutableBuffer::from_chunk_iter_unchecked(chunks) };
-
-    let remainder_bytes = a1_chunks.remainder_len().saturating_add(7) / 8;
-    let rem = op(
-        a1_chunks.remainder(),
-        a2_chunks.remainder(),
-        a3_chunks.remainder(),
-        a4_chunks.remainder(),
-    );
-    let rem = &rem.to_ne_bytes()[..remainder_bytes];
-    buffer.extend_from_slice(rem);
+    let buffer = unsafe {
+        MutableBuffer::from_chunk_iter_unchecked(
+            chunks.chain(std::iter::once(op(rem_a1, rem_a2, rem_a3, rem_a4))),
+        )
+    };
 
     let length = a1.len();
 
@@ -55,22 +54,21 @@ where
     let mut a2_chunks = a2.chunks();
     let mut a3_chunks = a3.chunks();
 
+    let rem_a1 = a1_chunks.remainder();
+    let rem_a2 = a2_chunks.remainder();
+    let rem_a3 = a3_chunks.remainder();
+
     let chunks = a1_chunks
         .by_ref()
         .zip(a2_chunks.by_ref())
         .zip(a3_chunks.by_ref())
         .map(|((a1, a2), a3)| op(a1, a2, a3));
     // Soundness: `BitChunks` is a trusted len iterator
-    let mut buffer = unsafe { MutableBuffer::from_chunk_iter_unchecked(chunks) };
-
-    let remainder_bytes = a1_chunks.remainder_len().saturating_add(7) / 8;
-    let rem = op(
-        a1_chunks.remainder(),
-        a2_chunks.remainder(),
-        a3_chunks.remainder(),
-    );
-    let rem = &rem.to_ne_bytes()[..remainder_bytes];
-    buffer.extend_from_slice(rem);
+    let buffer = unsafe {
+        MutableBuffer::from_chunk_iter_unchecked(
+            chunks.chain(std::iter::once(op(rem_a1, rem_a2, rem_a3))),
+        )
+    };
 
     let length = a1.len();
 

--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -82,7 +82,6 @@ where
         .zip(rhs_chunks)
         .map(|(left, right)| op(left, right));
 
-    // Soundness: `BitChunks` is a trusted len iterator
     let buffer =
         MutableBuffer::from_chunk_iter(chunks.chain(std::iter::once(op(rem_lhs, rem_rhs))));
 

--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -15,10 +15,10 @@ where
     assert_eq!(a1.len(), a2.len());
     assert_eq!(a1.len(), a3.len());
     assert_eq!(a1.len(), a4.len());
-    let mut a1_chunks = a1.chunks();
-    let mut a2_chunks = a2.chunks();
-    let mut a3_chunks = a3.chunks();
-    let mut a4_chunks = a4.chunks();
+    let a1_chunks = a1.chunks();
+    let a2_chunks = a2.chunks();
+    let a3_chunks = a3.chunks();
+    let a4_chunks = a4.chunks();
 
     let rem_a1 = a1_chunks.remainder();
     let rem_a2 = a2_chunks.remainder();
@@ -26,17 +26,13 @@ where
     let rem_a4 = a4_chunks.remainder();
 
     let chunks = a1_chunks
-        .by_ref()
-        .zip(a2_chunks.by_ref())
-        .zip(a3_chunks.by_ref())
-        .zip(a4_chunks.by_ref())
+        .zip(a2_chunks)
+        .zip(a3_chunks)
+        .zip(a4_chunks)
         .map(|(((a1, a2), a3), a4)| op(a1, a2, a3, a4));
-    // Soundness: `BitChunks` is a trusted len iterator
-    let buffer = unsafe {
-        MutableBuffer::from_chunk_iter_unchecked(
-            chunks.chain(std::iter::once(op(rem_a1, rem_a2, rem_a3, rem_a4))),
-        )
-    };
+    let buffer = MutableBuffer::from_chunk_iter(
+        chunks.chain(std::iter::once(op(rem_a1, rem_a2, rem_a3, rem_a4))),
+    );
 
     let length = a1.len();
 
@@ -50,25 +46,21 @@ where
 {
     assert_eq!(a1.len(), a2.len());
     assert_eq!(a1.len(), a3.len());
-    let mut a1_chunks = a1.chunks();
-    let mut a2_chunks = a2.chunks();
-    let mut a3_chunks = a3.chunks();
+    let a1_chunks = a1.chunks();
+    let a2_chunks = a2.chunks();
+    let a3_chunks = a3.chunks();
 
     let rem_a1 = a1_chunks.remainder();
     let rem_a2 = a2_chunks.remainder();
     let rem_a3 = a3_chunks.remainder();
 
     let chunks = a1_chunks
-        .by_ref()
-        .zip(a2_chunks.by_ref())
-        .zip(a3_chunks.by_ref())
+        .zip(a2_chunks)
+        .zip(a3_chunks)
         .map(|((a1, a2), a3)| op(a1, a2, a3));
-    // Soundness: `BitChunks` is a trusted len iterator
-    let buffer = unsafe {
-        MutableBuffer::from_chunk_iter_unchecked(
-            chunks.chain(std::iter::once(op(rem_a1, rem_a2, rem_a3))),
-        )
-    };
+
+    let buffer =
+        MutableBuffer::from_chunk_iter(chunks.chain(std::iter::once(op(rem_a1, rem_a2, rem_a3))));
 
     let length = a1.len();
 
@@ -81,22 +73,18 @@ where
     F: Fn(u64, u64) -> u64,
 {
     assert_eq!(lhs.len(), rhs.len());
-    let mut lhs_chunks = lhs.chunks();
-    let mut rhs_chunks = rhs.chunks();
+    let lhs_chunks = lhs.chunks();
+    let rhs_chunks = rhs.chunks();
     let rem_lhs = lhs_chunks.remainder();
     let rem_rhs = rhs_chunks.remainder();
 
     let chunks = lhs_chunks
-        .by_ref()
-        .zip(rhs_chunks.by_ref())
+        .zip(rhs_chunks)
         .map(|(left, right)| op(left, right));
 
     // Soundness: `BitChunks` is a trusted len iterator
-    let buffer = unsafe {
-        MutableBuffer::from_chunk_iter_unchecked(
-            chunks.chain(std::iter::once(op(rem_lhs, rem_rhs))),
-        )
-    };
+    let buffer =
+        MutableBuffer::from_chunk_iter(chunks.chain(std::iter::once(op(rem_lhs, rem_rhs))));
 
     let length = lhs.len();
 

--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -1,6 +1,6 @@
 use std::ops::{BitAnd, BitOr, BitXor, Not};
 
-use crate::{bitmap::utils::BitChunk, buffer::MutableBuffer};
+use crate::buffer::MutableBuffer;
 
 use super::{
     utils::{BitChunkIterExact, BitChunksExact},
@@ -95,11 +95,9 @@ where
 
     // Soundness: `BitChunks` is a trusted len iterator
     let buffer = unsafe {
-        MutableBuffer::from_chunk_iter_unchecked(chunks.chain(std::iter::once(
-            BitChunk::from_ne_bytes(
-                op(rem_lhs, rem_rhs).to_ne_bytes(),
-            ),
-        )))
+        MutableBuffer::from_chunk_iter_unchecked(
+            chunks.chain(std::iter::once(op(rem_lhs, rem_rhs))),
+        )
     };
 
     let length = lhs.len();


### PR DESCRIPTION
Avoids an extra allocation for binary bitwise ops.