### PR TITLE
Support dictionaries in nested types over IPC

### DIFF
--- a/integration-testing/unskip.patch
+++ b/integration-testing/unskip.patch
@@ -1,8 +1,8 @@
 diff --git a/dev/archery/archery/integration/datagen.py b/dev/archery/archery/integration/datagen.py
-index 2d90d6c86..d5a0bc833 100644
+index 6a077a893..cab6ecd37 100644
 --- a/dev/archery/archery/integration/datagen.py
 +++ b/dev/archery/archery/integration/datagen.py
-@@ -1569,8 +1569,7 @@ def get_generated_json_files(tempdir=None):
+@@ -1561,8 +1561,7 @@ def get_generated_json_files(tempdir=None):
          .skip_category('C#')
          .skip_category('JS'),   # TODO(ARROW-7900)
  
@@ -12,7 +12,7 @@ index 2d90d6c86..d5a0bc833 100644
  
          generate_decimal256_case()
          .skip_category('Go')  # TODO(ARROW-7948): Decimal + Go
-@@ -1582,18 +1581,15 @@ def get_generated_json_files(tempdir=None):
+@@ -1574,18 +1573,15 @@ def get_generated_json_files(tempdir=None):
  
          generate_interval_case()
          .skip_category('C#')
@@ -34,7 +34,7 @@ index 2d90d6c86..d5a0bc833 100644
  
          generate_non_canonical_map_case()
          .skip_category('C#')
-@@ -1611,14 +1607,12 @@ def get_generated_json_files(tempdir=None):
+@@ -1602,14 +1598,12 @@ def get_generated_json_files(tempdir=None):
          generate_nested_large_offsets_case()
          .skip_category('C#')
          .skip_category('Go')
@@ -51,7 +51,14 @@ index 2d90d6c86..d5a0bc833 100644
  
          generate_custom_metadata_case()
          .skip_category('C#')
-@@ -1649,8 +1643,7 @@ def get_generated_json_files(tempdir=None):
+@@ -1634,14 +1628,12 @@ def get_generated_json_files(tempdir=None):
+         .skip_category('C#')
+         .skip_category('Go')
+         .skip_category('Java')  # TODO(ARROW-7779)
+-        .skip_category('JS')
+-        .skip_category('Rust'),
++        .skip_category('JS'),
+ 
          generate_extension_case()
          .skip_category('C#')
          .skip_category('Go')  # TODO(ARROW-3039): requires dictionaries

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -13,7 +13,8 @@ mod mutable;
 pub use iterator::*;
 pub use mutable::*;
 
-use super::{new_empty_array, primitive::PrimitiveArray, Array};
+use super::display::get_value_display;
+use super::{display_fmt, new_empty_array, primitive::PrimitiveArray, Array};
 use crate::scalar::NullScalar;
 
 /// Trait denoting [`NativeType`]s that can be used as keys of a dictionary.
@@ -196,9 +197,10 @@ where
     PrimitiveArray<K>: std::fmt::Display,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{:?}{{", self.data_type())?;
-        writeln!(f, "keys: {},", self.keys())?;
-        writeln!(f, "values: {},", self.values())?;
-        write!(f, "}}")
+        let display = get_value_display(self);
+        let new_lines = false;
+        let head = &format!("{}", self.data_type());
+        let iter = self.iter().enumerate().map(|(i, x)| x.map(|_| display(i)));
+        display_fmt(iter, head, f, new_lines)
     }
 }

--- a/src/array/display.rs
+++ b/src/array/display.rs
@@ -165,7 +165,13 @@ pub fn get_value_display<'a>(array: &'a dyn Array) -> Box<dyn Fn(usize) -> Strin
                 .unwrap();
             let keys = a.keys();
             let display = get_display(a.values().as_ref());
-            Box::new(move |row: usize| display(keys.value(row) as usize))
+            Box::new(move |row: usize| {
+                if keys.is_null(row) {
+                    "".to_string()
+                }else {
+                    display(keys.value(row) as usize)
+                }
+            })
         }),
         Map(_, _) => todo!(),
         Struct(_) => {

--- a/src/array/equal/dictionary.rs
+++ b/src/array/equal/dictionary.rs
@@ -1,5 +1,14 @@
 use crate::array::{Array, DictionaryArray, DictionaryKey};
 
 pub(super) fn equal<K: DictionaryKey>(lhs: &DictionaryArray<K>, rhs: &DictionaryArray<K>) -> bool {
-    lhs.data_type() == rhs.data_type() && lhs.len() == rhs.len() && lhs.iter().eq(rhs.iter())
+    if !(lhs.data_type() == rhs.data_type() && lhs.len() == rhs.len()) {
+        return false;
+    };
+
+    // if x is not valid and y is but its child is not, the slots are equal.
+    lhs.iter().zip(rhs.iter()).all(|(x, y)| match (&x, &y) {
+        (None, Some(y)) => !y.is_valid(),
+        (Some(x), None) => !x.is_valid(),
+        _ => x == y,
+    })
 }

--- a/src/array/equal/dictionary.rs
+++ b/src/array/equal/dictionary.rs
@@ -1,14 +1,5 @@
 use crate::array::{Array, DictionaryArray, DictionaryKey};
 
 pub(super) fn equal<K: DictionaryKey>(lhs: &DictionaryArray<K>, rhs: &DictionaryArray<K>) -> bool {
-    if !(lhs.data_type() == rhs.data_type() && lhs.len() == rhs.len()) {
-        return false;
-    };
-
-    // if x is not valid and y is but its child is not, the slots are equal.
-    lhs.iter().zip(rhs.iter()).all(|(x, y)| match (&x, &y) {
-        (None, Some(y)) => !y.is_valid(),
-        (Some(x), None) => !x.is_valid(),
-        _ => x == y,
-    })
+    lhs.data_type() == rhs.data_type() && lhs.len() == rhs.len() && lhs.iter().eq(rhs.iter())
 }

--- a/src/datatypes/field.rs
+++ b/src/datatypes/field.rs
@@ -23,7 +23,7 @@ use super::DataType;
 
 /// A logical [`DataType`] and its associated metadata per
 /// [Arrow specification](https://arrow.apache.org/docs/cpp/api/datatype.html)
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Eq)]
 pub struct Field {
     /// Its name
     pub name: String,
@@ -37,6 +37,26 @@ pub struct Field {
     pub dict_is_ordered: bool,
     /// A map of key-value pairs containing additional custom meta data.
     pub metadata: Option<BTreeMap<String, String>>,
+}
+
+impl std::hash::Hash for Field {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+        self.data_type.hash(state);
+        self.nullable.hash(state);
+        self.dict_is_ordered.hash(state);
+        self.metadata.hash(state);
+    }
+}
+
+impl PartialEq for Field {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.data_type == other.data_type
+            && self.nullable == other.nullable
+            && self.dict_is_ordered == other.dict_is_ordered
+            && self.metadata == other.metadata
+    }
 }
 
 impl Field {

--- a/src/datatypes/schema.rs
+++ b/src/datatypes/schema.rs
@@ -164,14 +164,6 @@ impl Schema {
         Ok(&self.fields[self.index_of(name)?])
     }
 
-    /// Returns all [`Field`]s with dictionary id `dict_id`.
-    pub fn fields_with_dict_id(&self, dict_id: i64) -> Vec<&Field> {
-        self.fields
-            .iter()
-            .filter(|f| f.dict_id() == Some(dict_id))
-            .collect()
-    }
-
     /// Find the index of the column with the given name.
     pub fn index_of(&self, name: &str) -> Result<usize> {
         for i in 0..self.fields.len() {

--- a/src/io/flight/mod.rs
+++ b/src/io/flight/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::sync::Arc;
 
@@ -122,7 +123,7 @@ pub fn deserialize_batch(
     data: &FlightData,
     schema: Arc<Schema>,
     is_little_endian: bool,
-    dictionaries_by_field: &[Option<Arc<dyn Array>>],
+    dictionaries: &HashMap<usize, Arc<dyn Array>>,
 ) -> Result<RecordBatch> {
     // check that the data_header is a record batch message
     let message = ipc::Message::root_as_message(&data.data_header[..])
@@ -141,7 +142,7 @@ pub fn deserialize_batch(
                 schema.clone(),
                 None,
                 is_little_endian,
-                dictionaries_by_field,
+                dictionaries,
                 ipc::Schema::MetadataVersion::V5,
                 &mut reader,
                 0,

--- a/src/io/ipc/convert.rs
+++ b/src/io/ipc/convert.rs
@@ -663,24 +663,8 @@ pub(crate) fn get_fb_field_type<'a>(
             }
         }
         Struct(fields) => {
-            // struct's fields are children
-            let mut children = vec![];
-            for field in fields {
-                let inner_types = get_fb_field_type(field.data_type(), field.is_nullable(), fbb);
-                let field_name = fbb.create_string(field.name());
-                children.push(ipc::Field::create(
-                    fbb,
-                    &ipc::FieldArgs {
-                        name: Some(field_name),
-                        nullable: field.is_nullable(),
-                        type_type: inner_types.type_type,
-                        type_: Some(inner_types.type_),
-                        dictionary: None,
-                        children: inner_types.children,
-                        custom_metadata: None,
-                    },
-                ));
-            }
+            let children: Vec<_> = fields.iter().map(|field| build_field(fbb, field)).collect();
+
             FbFieldType {
                 type_type,
                 type_: ipc::Struct_Builder::new(fbb).finish().as_union_value(),

--- a/src/io/ipc/read/array/binary.rs
+++ b/src/io/ipc/read/array/binary.rs
@@ -25,7 +25,7 @@ pub fn read_binary<O: Offset, R: Read + Seek>(
 where
     Vec<u8>: TryInto<O::Bytes> + TryInto<<u8 as NativeType>::Bytes>,
 {
-    let field_node = field_nodes.pop_front().unwrap().0;
+    let field_node = field_nodes.pop_front().unwrap();
 
     let validity = read_validity(
         buffers,

--- a/src/io/ipc/read/array/boolean.rs
+++ b/src/io/ipc/read/array/boolean.rs
@@ -19,7 +19,7 @@ pub fn read_boolean<R: Read + Seek>(
     is_little_endian: bool,
     compression: Option<ipc::Message::BodyCompression>,
 ) -> Result<BooleanArray> {
-    let field_node = field_nodes.pop_front().unwrap().0;
+    let field_node = field_nodes.pop_front().unwrap();
 
     let length = field_node.length() as usize;
     let validity = read_validity(

--- a/src/io/ipc/read/array/dictionary.rs
+++ b/src/io/ipc/read/array/dictionary.rs
@@ -1,19 +1,24 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::convert::TryInto;
 use std::io::{Read, Seek};
+use std::sync::Arc;
 
 use arrow_format::ipc;
 
-use crate::array::{DictionaryArray, DictionaryKey};
+use crate::array::{Array, DictionaryArray, DictionaryKey};
+use crate::datatypes::Field;
 use crate::error::Result;
 
 use super::super::deserialize::Node;
 use super::{read_primitive, skip_primitive};
 
+#[allow(clippy::too_many_arguments)]
 pub fn read_dictionary<T: DictionaryKey, R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
+    field: &Field,
     buffers: &mut VecDeque<&ipc::Schema::Buffer>,
     reader: &mut R,
+    dictionaries: &HashMap<usize, Arc<dyn Array>>,
     block_offset: u64,
     compression: Option<ipc::Message::BodyCompression>,
     is_little_endian: bool,
@@ -21,7 +26,10 @@ pub fn read_dictionary<T: DictionaryKey, R: Read + Seek>(
 where
     Vec<u8>: TryInto<T::Bytes>,
 {
-    let values = field_nodes.front().unwrap().1.as_ref().unwrap();
+    let values = dictionaries
+        .get(&(field.dict_id().unwrap() as usize))
+        .unwrap()
+        .clone();
 
     let keys = read_primitive(
         field_nodes,
@@ -33,7 +41,7 @@ where
         compression,
     )?;
 
-    Ok(DictionaryArray::<T>::from_data(keys, values.clone()))
+    Ok(DictionaryArray::<T>::from_data(keys, values))
 }
 
 pub fn skip_dictionary(

--- a/src/io/ipc/read/array/fixed_size_binary.rs
+++ b/src/io/ipc/read/array/fixed_size_binary.rs
@@ -19,7 +19,7 @@ pub fn read_fixed_size_binary<R: Read + Seek>(
     is_little_endian: bool,
     compression: Option<ipc::Message::BodyCompression>,
 ) -> Result<FixedSizeBinaryArray> {
-    let field_node = field_nodes.pop_front().unwrap().0;
+    let field_node = field_nodes.pop_front().unwrap();
 
     let validity = read_validity(
         buffers,

--- a/src/io/ipc/read/array/fixed_size_list.rs
+++ b/src/io/ipc/read/array/fixed_size_list.rs
@@ -1,9 +1,10 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Seek};
+use std::sync::Arc;
 
 use arrow_format::ipc;
 
-use crate::array::FixedSizeListArray;
+use crate::array::{Array, FixedSizeListArray};
 use crate::datatypes::DataType;
 use crate::error::Result;
 
@@ -16,12 +17,13 @@ pub fn read_fixed_size_list<R: Read + Seek>(
     data_type: DataType,
     buffers: &mut VecDeque<&ipc::Schema::Buffer>,
     reader: &mut R,
+    dictionaries: &HashMap<usize, Arc<dyn Array>>,
     block_offset: u64,
     is_little_endian: bool,
     compression: Option<ipc::Message::BodyCompression>,
     version: ipc::Schema::MetadataVersion,
 ) -> Result<FixedSizeListArray> {
-    let field_node = field_nodes.pop_front().unwrap().0;
+    let field_node = field_nodes.pop_front().unwrap();
 
     let validity = read_validity(
         buffers,
@@ -32,13 +34,14 @@ pub fn read_fixed_size_list<R: Read + Seek>(
         compression,
     )?;
 
-    let (value_data_type, _) = FixedSizeListArray::get_child_and_size(&data_type);
+    let (field, _) = FixedSizeListArray::get_child_and_size(&data_type);
 
     let values = read(
         field_nodes,
-        value_data_type.data_type().clone(),
+        field,
         buffers,
         reader,
+        dictionaries,
         block_offset,
         is_little_endian,
         compression,

--- a/src/io/ipc/read/array/map.rs
+++ b/src/io/ipc/read/array/map.rs
@@ -1,9 +1,10 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Seek};
+use std::sync::Arc;
 
 use arrow_format::ipc;
 
-use crate::array::MapArray;
+use crate::array::{Array, MapArray};
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
 use crate::error::Result;
@@ -17,12 +18,13 @@ pub fn read_map<R: Read + Seek>(
     data_type: DataType,
     buffers: &mut VecDeque<&ipc::Schema::Buffer>,
     reader: &mut R,
+    dictionaries: &HashMap<usize, Arc<dyn Array>>,
     block_offset: u64,
     is_little_endian: bool,
     compression: Option<ipc::Message::BodyCompression>,
     version: ipc::Schema::MetadataVersion,
 ) -> Result<MapArray> {
-    let field_node = field_nodes.pop_front().unwrap().0;
+    let field_node = field_nodes.pop_front().unwrap();
 
     let validity = read_validity(
         buffers,
@@ -44,13 +46,14 @@ pub fn read_map<R: Read + Seek>(
     // Older versions of the IPC format sometimes do not report an offset
     .or_else(|_| Result::Ok(Buffer::<i32>::from(&[0i32])))?;
 
-    let value_data_type = MapArray::get_field(&data_type).data_type().clone();
+    let field = MapArray::get_field(&data_type);
 
     let field = read(
         field_nodes,
-        value_data_type,
+        field,
         buffers,
         reader,
+        dictionaries,
         block_offset,
         is_little_endian,
         compression,

--- a/src/io/ipc/read/array/null.rs
+++ b/src/io/ipc/read/array/null.rs
@@ -7,7 +7,7 @@ use super::super::deserialize::Node;
 pub fn read_null(field_nodes: &mut VecDeque<Node>, data_type: DataType) -> NullArray {
     NullArray::from_data(
         data_type,
-        field_nodes.pop_front().unwrap().0.length() as usize,
+        field_nodes.pop_front().unwrap().length() as usize,
     )
 }
 

--- a/src/io/ipc/read/array/primitive.rs
+++ b/src/io/ipc/read/array/primitive.rs
@@ -22,7 +22,7 @@ pub fn read_primitive<T: NativeType, R: Read + Seek>(
 where
     Vec<u8>: TryInto<T::Bytes>,
 {
-    let field_node = field_nodes.pop_front().unwrap().0;
+    let field_node = field_nodes.pop_front().unwrap();
 
     let validity = read_validity(
         buffers,

--- a/src/io/ipc/read/array/struct_.rs
+++ b/src/io/ipc/read/array/struct_.rs
@@ -1,9 +1,10 @@
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Seek};
+use std::sync::Arc;
 
 use arrow_format::ipc;
 
-use crate::array::StructArray;
+use crate::array::{Array, StructArray};
 use crate::datatypes::DataType;
 use crate::error::Result;
 
@@ -16,12 +17,13 @@ pub fn read_struct<R: Read + Seek>(
     data_type: DataType,
     buffers: &mut VecDeque<&ipc::Schema::Buffer>,
     reader: &mut R,
+    dictionaries: &HashMap<usize, Arc<dyn Array>>,
     block_offset: u64,
     is_little_endian: bool,
     compression: Option<ipc::Message::BodyCompression>,
     version: ipc::Schema::MetadataVersion,
 ) -> Result<StructArray> {
-    let field_node = field_nodes.pop_front().unwrap().0;
+    let field_node = field_nodes.pop_front().unwrap();
 
     let validity = read_validity(
         buffers,
@@ -39,9 +41,10 @@ pub fn read_struct<R: Read + Seek>(
         .map(|field| {
             read(
                 field_nodes,
-                field.data_type().clone(),
+                field,
                 buffers,
                 reader,
+                dictionaries,
                 block_offset,
                 is_little_endian,
                 compression,

--- a/src/io/ipc/read/array/utf8.rs
+++ b/src/io/ipc/read/array/utf8.rs
@@ -25,7 +25,7 @@ pub fn read_utf8<O: Offset, R: Read + Seek>(
 where
     Vec<u8>: TryInto<O::Bytes> + TryInto<<u8 as NativeType>::Bytes>,
 {
-    let field_node = field_nodes.pop_front().unwrap().0;
+    let field_node = field_nodes.pop_front().unwrap();
 
     let validity = read_validity(
         buffers,

--- a/src/io/ipc/write/common.rs
+++ b/src/io/ipc/write/common.rs
@@ -29,18 +29,6 @@ pub struct WriteOptions {
     pub compression: Option<Compression>,
 }
 
-fn get_dict_values(array: &dyn Array) -> &Arc<dyn Array> {
-    match array.data_type().to_physical_type() {
-        PhysicalType::Dictionary(key_type) => {
-            with_match_physical_dictionary_key_type!(key_type, |$T| {
-                let array = array.as_any().downcast_ref::<DictionaryArray<$T>>().unwrap();
-                array.values()
-            })
-        }
-        _ => unreachable!(),
-    }
-}
-
 fn encode_dictionary(
     field: &Field,
     array: &Arc<dyn Array>,
@@ -67,10 +55,7 @@ fn encode_dictionary(
                     is_native_little_endian(),
                 ));
             };
-
-            // todo: support nested dictionaries. Requires DataType::Dictionary to contain Field in values
-            let _ = get_dict_values(array.as_ref());
-            todo!()
+            Ok(())
         }
         Struct => {
             let values = array

--- a/src/io/ipc/write/common.rs
+++ b/src/io/ipc/write/common.rs
@@ -1,32 +1,14 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-//! Common utilities used to write to Arrow's IPC format.
-
 use std::{collections::HashMap, sync::Arc};
 
 use arrow_format::ipc;
 use arrow_format::ipc::flatbuffers::FlatBufferBuilder;
 use arrow_format::ipc::Message::CompressionType;
 
-use crate::array::Array;
+use crate::array::*;
+use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::io::ipc::endianess::is_native_little_endian;
 use crate::record_batch::RecordBatch;
-use crate::{array::DictionaryArray, datatypes::*};
 
 use super::{write, write_dictionary};
 
@@ -47,34 +29,188 @@ pub struct WriteOptions {
     pub compression: Option<Compression>,
 }
 
+fn get_dict_values(array: &dyn Array) -> &Arc<dyn Array> {
+    match array.data_type().to_physical_type() {
+        PhysicalType::Dictionary(key_type) => {
+            with_match_physical_dictionary_key_type!(key_type, |$T| {
+                let array = array.as_any().downcast_ref::<DictionaryArray<$T>>().unwrap();
+                array.values()
+            })
+        }
+        _ => unreachable!(),
+    }
+}
+
+fn encode_dictionary(
+    field: &Field,
+    array: &Arc<dyn Array>,
+    options: &WriteOptions,
+    dictionary_tracker: &mut DictionaryTracker,
+    encoded_dictionaries: &mut Vec<EncodedData>,
+) -> Result<()> {
+    use PhysicalType::*;
+    match array.data_type().to_physical_type() {
+        Utf8 | LargeUtf8 | Binary | LargeBinary | Primitive(_) | Boolean | Null
+        | FixedSizeBinary => Ok(()),
+        Dictionary(_) => {
+            let dict_id = field
+                .dict_id()
+                .expect("All Dictionary types have `dict_id`");
+
+            let emit = dictionary_tracker.insert(dict_id, array)?;
+
+            if emit {
+                encoded_dictionaries.push(dictionary_batch_to_bytes(
+                    dict_id,
+                    array.as_ref(),
+                    options,
+                    is_native_little_endian(),
+                ));
+            };
+
+            // todo: support nested dictionaries. Requires DataType::Dictionary to contain Field in values
+            let _ = get_dict_values(array.as_ref());
+            todo!()
+        }
+        Struct => {
+            let values = array
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .unwrap()
+                .values();
+            let fields = if let DataType::Struct(fields) = field.data_type() {
+                fields
+            } else {
+                unreachable!()
+            };
+            fields
+                .iter()
+                .zip(values.iter())
+                .try_for_each(|(field, values)| {
+                    encode_dictionary(
+                        field,
+                        values,
+                        options,
+                        dictionary_tracker,
+                        encoded_dictionaries,
+                    )
+                })
+        }
+        List => {
+            let values = array
+                .as_any()
+                .downcast_ref::<ListArray<i32>>()
+                .unwrap()
+                .values();
+            let field = if let DataType::List(field) = field.data_type() {
+                field.as_ref()
+            } else {
+                unreachable!()
+            };
+            encode_dictionary(
+                field,
+                values,
+                options,
+                dictionary_tracker,
+                encoded_dictionaries,
+            )
+        }
+        LargeList => {
+            let values = array
+                .as_any()
+                .downcast_ref::<ListArray<i64>>()
+                .unwrap()
+                .values();
+            let field = if let DataType::LargeList(field) = field.data_type() {
+                field.as_ref()
+            } else {
+                unreachable!()
+            };
+            encode_dictionary(
+                field,
+                values,
+                options,
+                dictionary_tracker,
+                encoded_dictionaries,
+            )
+        }
+        FixedSizeList => {
+            let values = array
+                .as_any()
+                .downcast_ref::<FixedSizeListArray>()
+                .unwrap()
+                .values();
+            let field = if let DataType::FixedSizeList(field, _) = field.data_type() {
+                field.as_ref()
+            } else {
+                unreachable!()
+            };
+            encode_dictionary(
+                field,
+                values,
+                options,
+                dictionary_tracker,
+                encoded_dictionaries,
+            )
+        }
+        Union => {
+            let values = array
+                .as_any()
+                .downcast_ref::<UnionArray>()
+                .unwrap()
+                .fields();
+            let fields = if let DataType::Union(fields, _, _) = field.data_type() {
+                fields
+            } else {
+                unreachable!()
+            };
+            fields
+                .iter()
+                .zip(values.iter())
+                .try_for_each(|(field, values)| {
+                    encode_dictionary(
+                        field,
+                        values,
+                        options,
+                        dictionary_tracker,
+                        encoded_dictionaries,
+                    )
+                })
+        }
+        Map => {
+            let values = array.as_any().downcast_ref::<MapArray>().unwrap().field();
+            let field = if let DataType::Map(field, _) = field.data_type() {
+                field.as_ref()
+            } else {
+                unreachable!()
+            };
+            encode_dictionary(
+                field,
+                values,
+                options,
+                dictionary_tracker,
+                encoded_dictionaries,
+            )
+        }
+    }
+}
+
 pub fn encoded_batch(
     batch: &RecordBatch,
     dictionary_tracker: &mut DictionaryTracker,
     options: &WriteOptions,
 ) -> Result<(Vec<EncodedData>, EncodedData)> {
-    // TODO: handle nested dictionaries
     let schema = batch.schema();
     let mut encoded_dictionaries = Vec::with_capacity(schema.fields().len());
 
-    for (i, field) in schema.fields().iter().enumerate() {
-        let column = batch.column(i);
-
-        if let DataType::Dictionary(_key_type, _value_type) = column.data_type() {
-            let dict_id = field
-                .dict_id()
-                .expect("All Dictionary types have `dict_id`");
-
-            let emit = dictionary_tracker.insert(dict_id, column)?;
-
-            if emit {
-                encoded_dictionaries.push(dictionary_batch_to_bytes(
-                    dict_id,
-                    column.as_ref(),
-                    options,
-                    is_native_little_endian(),
-                ));
-            }
-        }
+    for (field, column) in schema.fields().iter().zip(batch.columns()) {
+        encode_dictionary(
+            field,
+            column,
+            options,
+            dictionary_tracker,
+            &mut encoded_dictionaries,
+        )?;
     }
 
     let encoded_message = record_batch_to_bytes(batch, options);

--- a/src/io/ipc/write/stream.rs
+++ b/src/io/ipc/write/stream.rs
@@ -73,8 +73,7 @@ impl<W: Write> StreamWriter<W> {
         }
 
         let (encoded_dictionaries, encoded_message) =
-            encoded_batch(batch, &mut self.dictionary_tracker, &self.write_options)
-                .expect("StreamWriter is configured to not error on dictionary replacement");
+            encoded_batch(batch, &mut self.dictionary_tracker, &self.write_options)?;
 
         for encoded_dictionary in encoded_dictionaries {
             write_message(&mut self.writer, encoded_dictionary)?;

--- a/src/io/json_integration/mod.rs
+++ b/src/io/json_integration/mod.rs
@@ -20,13 +20,10 @@
 //! These utilities define structs that read the integration JSON format for integration testing purposes.
 
 use serde_derive::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use serde_json::Value;
 
-use crate::datatypes::*;
-
-mod schema;
-use schema::ToJson;
 mod read;
+mod schema;
 mod write;
 pub use read::to_record_batch;
 pub use write::from_record_batch;
@@ -62,36 +59,6 @@ pub struct ArrowJsonField {
     pub dictionary: Option<ArrowJsonFieldDictionary>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Value>,
-}
-
-impl From<&Field> for ArrowJsonField {
-    fn from(field: &Field) -> Self {
-        let metadata_value = match field.metadata() {
-            Some(kv_list) => {
-                let mut array = Vec::new();
-                for (k, v) in kv_list {
-                    let mut kv_map = Map::new();
-                    kv_map.insert(k.clone(), Value::String(v.clone()));
-                    array.push(Value::Object(kv_map));
-                }
-                if !array.is_empty() {
-                    Some(Value::Array(array))
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        };
-
-        Self {
-            name: field.name().to_string(),
-            field_type: field.data_type().to_json(),
-            nullable: field.is_nullable(),
-            children: vec![],
-            dictionary: None, // TODO: not enough info
-            metadata: metadata_value,
-        }
-    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/io/json_integration/read.rs
+++ b/src/io/json_integration/read.rs
@@ -357,7 +357,14 @@ pub fn to_array(
             let values = fields
                 .iter()
                 .zip(json_col.children.as_ref().unwrap())
-                .map(|(field, col)| to_array(field.data_type().clone(), None, col, dictionaries))
+                .map(|(field, col)| {
+                    to_array(
+                        field.data_type().clone(),
+                        field.dict_id(),
+                        col,
+                        dictionaries,
+                    )
+                })
                 .collect::<Result<Vec<_>>>()?;
 
             let array = StructArray::from_data(data_type, values, validity);

--- a/src/scalar/dictionary.rs
+++ b/src/scalar/dictionary.rs
@@ -1,0 +1,55 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use crate::{array::*, datatypes::DataType};
+
+use super::Scalar;
+
+/// The [`DictionaryArray`] equivalent of [`Array`] for [`Scalar`].
+#[derive(Debug, Clone)]
+pub struct DictionaryScalar<K: DictionaryKey> {
+    value: Option<Arc<dyn Scalar>>,
+    phantom: std::marker::PhantomData<K>,
+    data_type: DataType,
+}
+
+impl<K: DictionaryKey> PartialEq for DictionaryScalar<K> {
+    fn eq(&self, other: &Self) -> bool {
+        (self.data_type == other.data_type) && (self.value.as_ref() == other.value.as_ref())
+    }
+}
+
+impl<K: DictionaryKey> DictionaryScalar<K> {
+    /// returns a new [`DictionaryScalar`]
+    /// # Panics
+    /// iff
+    /// * the `data_type` is not `List` or `LargeList` (depending on this scalar's offset `O`)
+    /// * the child of the `data_type` is not equal to the `values`
+    #[inline]
+    pub fn new(data_type: DataType, value: Option<Arc<dyn Scalar>>) -> Self {
+        Self {
+            value,
+            phantom: std::marker::PhantomData,
+            data_type,
+        }
+    }
+
+    /// The values of the [`DictionaryScalar`]
+    pub fn value(&self) -> Option<&Arc<dyn Scalar>> {
+        self.value.as_ref()
+    }
+}
+
+impl<K: DictionaryKey> Scalar for DictionaryScalar<K> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn is_valid(&self) -> bool {
+        self.value.is_some()
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+}

--- a/src/scalar/equal.rs
+++ b/src/scalar/equal.rs
@@ -111,6 +111,16 @@ fn equal(lhs: &dyn Scalar, rhs: &dyn Scalar) -> bool {
             let rhs = rhs.as_any().downcast_ref::<ListScalar<i64>>().unwrap();
             lhs == rhs
         }
-        _ => unimplemented!(),
+        DataType::Dictionary(key_type, _) => match_integer_type!(key_type, |$T| {
+            let lhs = lhs.as_any().downcast_ref::<DictionaryScalar<$T>>().unwrap();
+            let rhs = rhs.as_any().downcast_ref::<DictionaryScalar<$T>>().unwrap();
+            lhs == rhs
+        }),
+        DataType::Struct(_) => {
+            let lhs = lhs.as_any().downcast_ref::<StructScalar>().unwrap();
+            let rhs = rhs.as_any().downcast_ref::<StructScalar>().unwrap();
+            lhs == rhs
+        }
+        other => unimplemented!("{}", other),
     }
 }

--- a/tests/it/io/ipc/read/file.rs
+++ b/tests/it/io/ipc/read/file.rs
@@ -135,6 +135,12 @@ fn read_generated_100_non_canonical_map() -> Result<()> {
 }
 
 #[test]
+fn read_generated_100_nested_dictionary() -> Result<()> {
+    test_file("1.0.0-littleendian", "generated_nested_dictionary")?;
+    test_file("1.0.0-bigendian", "generated_nested_dictionary")
+}
+
+#[test]
 fn read_generated_017_union() -> Result<()> {
     test_file("0.17.1", "generated_union")
 }

--- a/tests/it/io/ipc/read/file.rs
+++ b/tests/it/io/ipc/read/file.rs
@@ -13,9 +13,7 @@ fn test_file(version: &str, file_name: &str) -> Result<()> {
     ))?;
 
     // read expected JSON output
-    println!("reading json");
     let (schema, batches) = read_gzip_json(version, file_name)?;
-    println!("reading metadata");
 
     let metadata = read_file_metadata(&mut file)?;
     let reader = FileReader::new(file, metadata, None);
@@ -23,12 +21,7 @@ fn test_file(version: &str, file_name: &str) -> Result<()> {
     assert_eq!(&schema, reader.schema().as_ref());
 
     batches.iter().zip(reader).try_for_each(|(lhs, rhs)| {
-        for (c1, c2) in lhs.columns().iter().zip(rhs?.columns().iter()) {
-            println!("{}", c1);
-            println!("{}", c2);
-            assert_eq!(c1, c2);
-        }
-        //assert_eq!(lhs, &rhs?);
+        assert_eq!(lhs, &rhs?);
         Result::Ok(())
     })?;
     Ok(())

--- a/tests/it/io/ipc/read/file.rs
+++ b/tests/it/io/ipc/read/file.rs
@@ -13,7 +13,9 @@ fn test_file(version: &str, file_name: &str) -> Result<()> {
     ))?;
 
     // read expected JSON output
+    println!("reading json");
     let (schema, batches) = read_gzip_json(version, file_name)?;
+    println!("reading metadata");
 
     let metadata = read_file_metadata(&mut file)?;
     let reader = FileReader::new(file, metadata, None);
@@ -21,7 +23,12 @@ fn test_file(version: &str, file_name: &str) -> Result<()> {
     assert_eq!(&schema, reader.schema().as_ref());
 
     batches.iter().zip(reader).try_for_each(|(lhs, rhs)| {
-        assert_eq!(lhs, &rhs?);
+        for (c1, c2) in lhs.columns().iter().zip(rhs?.columns().iter()) {
+            println!("{}", c1);
+            println!("{}", c2);
+            assert_eq!(c1, c2);
+        }
+        //assert_eq!(lhs, &rhs?);
         Result::Ok(())
     })?;
     Ok(())

--- a/tests/it/io/ipc/write/file.rs
+++ b/tests/it/io/ipc/write/file.rs
@@ -251,6 +251,12 @@ fn write_100_map_non_canonical() -> Result<()> {
 }
 
 #[test]
+fn write_100_nested_dictionary() -> Result<()> {
+    test_file("1.0.0-littleendian", "generated_nested_dictionary", false)?;
+    test_file("1.0.0-bigendian", "generated_nested_dictionary", false)
+}
+
+#[test]
 fn write_generated_017_union() -> Result<()> {
     test_file("0.17.1", "generated_union", false)
 }


### PR DESCRIPTION
This PR:

* adds support to read dictionaries in nested types from IPC
* adds support to write dictionaries in nested types to IPC
* adds corresponding integration test

With this change, we support all but two integration tests: `decimal256` and `non-canonical maps` (which covers a technicality of the spec) and we become the most complete implementation of the arrow specification after the official C++ implementantion! Specifically, after this PR, the compatibility matrix becomes:

```python
file_objs = [
        generate_primitive_case([], name='primitive_no_batches'),
        generate_primitive_case([17, 20], name='primitive'),
        generate_primitive_case([0, 0, 0], name='primitive_zerolength'),

        generate_primitive_large_offsets_case([17, 20])
        .skip_category('C#')
        .skip_category('Go')
        .skip_category('JS'),

        generate_null_case([10, 0])
        .skip_category('C#')
        .skip_category('JS'),   # TODO(ARROW-7900)

        generate_null_trivial_case([0, 0])
        .skip_category('C#')
        .skip_category('JS'),   # TODO(ARROW-7900)

        generate_decimal128_case(),

        generate_decimal256_case()
        .skip_category('Go')  # TODO(ARROW-7948): Decimal + Go
        .skip_category('JS')
        .skip_category('Rust'),

        generate_datetime_case()
        .skip_category('C#'),

        generate_interval_case()
        .skip_category('C#')
        .skip_category('JS'),  # TODO(ARROW-5239): Intervals + JS

        generate_month_day_nano_interval_case()
        .skip_category('C#')
        .skip_category('JS'),


        generate_map_case()
        .skip_category('C#'),

        generate_non_canonical_map_case()
        .skip_category('C#')
        .skip_category('Java')   # TODO(ARROW-8715)
        .skip_category('JS')     # TODO(ARROW-8716)
        .skip_category('Rust'),

        generate_nested_case()
        .skip_category('C#'),

        generate_recursive_nested_case()
        .skip_category('C#'),

        generate_nested_large_offsets_case()
        .skip_category('C#')
        .skip_category('Go')
        .skip_category('JS'),

        generate_unions_case()
        .skip_category('C#')
        .skip_category('Go')
        .skip_category('JS'),

        generate_custom_metadata_case()
        .skip_category('C#')
        .skip_category('JS'),

        generate_duplicate_fieldnames_case()
        .skip_category('C#')
        .skip_category('Go')
        .skip_category('JS'),

        # TODO(ARROW-3039, ARROW-5267): Dictionaries in GO
        generate_dictionary_case()
        .skip_category('C#')
        .skip_category('Go'),

        generate_dictionary_unsigned_case()
        .skip_category('C#')
        .skip_category('Go')     # TODO(ARROW-9378)
        .skip_category('Java'),  # TODO(ARROW-9377)

        generate_nested_dictionary_case()
        .skip_category('C#')
        .skip_category('Go')
        .skip_category('Java')  # TODO(ARROW-7779)
        .skip_category('JS'),

        generate_extension_case()
        .skip_category('C#')
        .skip_category('Go')  # TODO(ARROW-3039): requires dictionaries
        .skip_category('JS'),
    ]
```

In particular, we support more cases of the IPC spec than Java, one of the two reference implementations of the specification (the other being C++).