### PR TITLE
Fixed error in computing projection in `io::ipc::read::reader::FileReader`

### DIFF
--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -236,13 +236,11 @@ impl<R: Read + Seek> FileReader<R> {
     /// Panics iff the projection is not in increasing order (e.g. `[1, 0]` nor `[0, 1, 1]` are valid)
     pub fn new(reader: R, metadata: FileMetadata, projection: Option<Vec<usize>>) -> Self {
         if let Some(projection) = projection.as_ref() {
-            let _ = projection.iter().fold(0, |mut acc, v| {
+            let _ = projection.windows(2).for_each(|x| {
                 assert!(
-                    *v > acc,
+                    x[0] < x[1],
                     "The projection on IPC must be ordered and non-overlapping"
                 );
-                acc = *v;
-                acc
             });
         }
         let projection = projection.map(|projection| {

--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -236,7 +236,7 @@ impl<R: Read + Seek> FileReader<R> {
     /// Panics iff the projection is not in increasing order (e.g. `[1, 0]` nor `[0, 1, 1]` are valid)
     pub fn new(reader: R, metadata: FileMetadata, projection: Option<Vec<usize>>) -> Self {
         if let Some(projection) = projection.as_ref() {
-            let _ = projection.windows(2).for_each(|x| {
+            projection.windows(2).for_each(|x| {
                 assert!(
                     x[0] < x[1],
                     "The projection on IPC must be ordered and non-overlapping"

--- a/tests/it/io/ipc/read/file.rs
+++ b/tests/it/io/ipc/read/file.rs
@@ -178,5 +178,5 @@ fn test_projection(version: &str, file_name: &str, column: usize) -> Result<()> 
 fn read_projected() -> Result<()> {
     test_projection("1.0.0-littleendian", "generated_primitive", 1)?;
     test_projection("1.0.0-littleendian", "generated_dictionary", 2)?;
-    test_projection("1.0.0-littleendian", "generated_nested", 1)
+    test_projection("1.0.0-littleendian", "generated_nested", 0)
 }


### PR DESCRIPTION
Allow projection to be set to 0 in io::ipc::read::reader::FileReader::new by using `windows(2)`.
modified it according to [this comment](https://github.com/jorgecarleitao/arrow2/issues/594#issuecomment-965545539)

close #594 