### PR TITLE
Refactored comparison `Operator`

### DIFF
--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -178,7 +178,7 @@ impl<O: Offset> Utf8Array<O> {
 impl<O: Offset> Utf8Array<O> {
     /// Returns the length of this array
     #[inline]
-    fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.offsets.len() - 1
     }
 

--- a/src/compute/comparison/binary.rs
+++ b/src/compute/comparison/binary.rs
@@ -1,39 +1,20 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//! Comparison functions for [`BinaryArray`]
+use crate::{
+    array::{BinaryArray, BooleanArray, Offset},
+    bitmap::Bitmap,
+    datatypes::DataType,
+};
 
-use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
-use crate::scalar::{BinaryScalar, Scalar};
-use crate::{array::*, bitmap::Bitmap};
-
-use super::{super::utils::combine_validities, Operator};
+use super::super::utils::combine_validities;
 
 /// Evaluate `op(lhs, rhs)` for [`BinaryArray`]s using a specified
 /// comparison function.
-fn compare_op<O, F>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>, op: F) -> Result<BooleanArray>
+fn compare_op<O, F>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>, op: F) -> BooleanArray
 where
     O: Offset,
     F: Fn(&[u8], &[u8]) -> bool,
 {
-    if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Cannot perform comparison operation on arrays of different length".to_string(),
-        ));
-    }
+    assert_eq!(lhs.len(), rhs.len());
 
     let validity = combine_validities(lhs.validity(), rhs.validity());
 
@@ -43,7 +24,7 @@ where
         .map(|(lhs, rhs)| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);
 
-    Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
+    BooleanArray::from_data(DataType::Boolean, values, validity)
 }
 
 /// Evaluate `op(lhs, rhs)` for [`BinaryArray`] and scalar using
@@ -62,123 +43,74 @@ where
 }
 
 /// Perform `lhs == rhs` operation on [`BinaryArray`].
-fn eq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+/// # Panic
+/// iff the arrays do not have the same length.
+pub fn eq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a == b)
 }
 
 /// Perform `lhs == rhs` operation on [`BinaryArray`] and a scalar.
-fn eq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+pub fn eq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a == b)
 }
 
 /// Perform `lhs != rhs` operation on [`BinaryArray`].
-fn neq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+/// # Panic
+/// iff the arrays do not have the same length.
+pub fn neq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a != b)
 }
 
 /// Perform `lhs != rhs` operation on [`BinaryArray`] and a scalar.
-fn neq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+pub fn neq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a != b)
 }
 
 /// Perform `lhs < rhs` operation on [`BinaryArray`].
-fn lt<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+pub fn lt<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a < b)
 }
 
 /// Perform `lhs < rhs` operation on [`BinaryArray`] and a scalar.
-fn lt_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+pub fn lt_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a < b)
 }
 
 /// Perform `lhs <= rhs` operation on [`BinaryArray`].
-fn lt_eq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+pub fn lt_eq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a <= b)
 }
 
 /// Perform `lhs <= rhs` operation on [`BinaryArray`] and a scalar.
-fn lt_eq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+pub fn lt_eq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a <= b)
 }
 
 /// Perform `lhs > rhs` operation on [`BinaryArray`].
-fn gt<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+pub fn gt<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a > b)
 }
 
 /// Perform `lhs > rhs` operation on [`BinaryArray`] and a scalar.
-fn gt_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+pub fn gt_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a > b)
 }
 
 /// Perform `lhs >= rhs` operation on [`BinaryArray`].
-fn gt_eq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> Result<BooleanArray> {
+pub fn gt_eq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a >= b)
 }
 
 /// Perform `lhs >= rhs` operation on [`BinaryArray`] and a scalar.
-fn gt_eq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
+pub fn gt_eq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a >= b)
-}
-
-/// Compare two [`BinaryArray`]s using the given [`Operator`].
-///
-/// # Errors
-/// When the two arrays have different lengths.
-///
-/// Check the [crate::compute::comparison](module documentation) for usage
-/// examples.
-pub fn compare<O: Offset>(
-    lhs: &BinaryArray<O>,
-    rhs: &BinaryArray<O>,
-    op: Operator,
-) -> Result<BooleanArray> {
-    match op {
-        Operator::Eq => eq(lhs, rhs),
-        Operator::Neq => neq(lhs, rhs),
-        Operator::Gt => gt(lhs, rhs),
-        Operator::GtEq => gt_eq(lhs, rhs),
-        Operator::Lt => lt(lhs, rhs),
-        Operator::LtEq => lt_eq(lhs, rhs),
-    }
-}
-
-/// Compare a [`BinaryArray`] and a scalar value using the given
-/// [`Operator`].
-///
-/// Check the [crate::compute::comparison](module documentation) for usage
-/// examples.
-pub fn compare_scalar<O: Offset>(
-    lhs: &BinaryArray<O>,
-    rhs: &BinaryScalar<O>,
-    op: Operator,
-) -> BooleanArray {
-    if !rhs.is_valid() {
-        return BooleanArray::new_null(DataType::Boolean, lhs.len());
-    }
-    compare_scalar_non_null(lhs, rhs.value(), op)
-}
-
-pub fn compare_scalar_non_null<O: Offset>(
-    lhs: &BinaryArray<O>,
-    rhs: &[u8],
-    op: Operator,
-) -> BooleanArray {
-    match op {
-        Operator::Eq => eq_scalar(lhs, rhs),
-        Operator::Neq => neq_scalar(lhs, rhs),
-        Operator::Gt => gt_scalar(lhs, rhs),
-        Operator::GtEq => gt_eq_scalar(lhs, rhs),
-        Operator::Lt => lt_scalar(lhs, rhs),
-        Operator::LtEq => lt_eq_scalar(lhs, rhs),
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn test_generic<O: Offset, F: Fn(&BinaryArray<O>, &BinaryArray<O>) -> Result<BooleanArray>>(
+    fn test_generic<O: Offset, F: Fn(&BinaryArray<O>, &BinaryArray<O>) -> BooleanArray>(
         lhs: Vec<&[u8]>,
         rhs: Vec<&[u8]>,
         op: F,
@@ -187,7 +119,7 @@ mod tests {
         let lhs = BinaryArray::<O>::from_slice(lhs);
         let rhs = BinaryArray::<O>::from_slice(rhs);
         let expected = BooleanArray::from_slice(expected);
-        assert_eq!(op(&lhs, &rhs).unwrap(), expected);
+        assert_eq!(op(&lhs, &rhs), expected);
     }
 
     fn test_generic_scalar<O: Offset, F: Fn(&BinaryArray<O>, &[u8]) -> BooleanArray>(

--- a/src/compute/comparison/boolean.rs
+++ b/src/compute/comparison/boolean.rs
@@ -1,16 +1,14 @@
-use crate::array::*;
-use crate::bitmap::Bitmap;
-use crate::buffer::MutableBuffer;
-use crate::datatypes::DataType;
-use crate::scalar::{BooleanScalar, Scalar};
+//! Comparison functions for [`BooleanArray`]
 use crate::{
-    bitmap::MutableBitmap,
-    error::{ArrowError, Result},
+    array::BooleanArray,
+    bitmap::{Bitmap, MutableBitmap},
+    buffer::MutableBuffer,
+    datatypes::DataType,
 };
 
-use super::{super::utils::combine_validities, Operator};
+use super::super::utils::combine_validities;
 
-pub fn compare_values_op<F>(lhs: &Bitmap, rhs: &Bitmap, op: F) -> MutableBitmap
+fn compare_values_op<F>(lhs: &Bitmap, rhs: &Bitmap, op: F) -> MutableBitmap
 where
     F: Fn(u8, u8) -> u8,
 {
@@ -33,25 +31,16 @@ where
 
 /// Evaluate `op(lhs, rhs)` for [`BooleanArray`]s using a specified
 /// comparison function.
-fn compare_op<F>(lhs: &BooleanArray, rhs: &BooleanArray, op: F) -> Result<BooleanArray>
+fn compare_op<F>(lhs: &BooleanArray, rhs: &BooleanArray, op: F) -> BooleanArray
 where
     F: Fn(u8, u8) -> u8,
 {
-    if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Cannot perform comparison operation on arrays of different length".to_string(),
-        ));
-    }
-
+    assert_eq!(lhs.len(), rhs.len());
     let validity = combine_validities(lhs.validity(), rhs.validity());
 
     let values = compare_values_op(lhs.values(), rhs.values(), op);
 
-    Ok(BooleanArray::from_data(
-        DataType::Boolean,
-        values.into(),
-        validity,
-    ))
+    BooleanArray::from_data(DataType::Boolean, values.into(), validity)
 }
 
 /// Evaluate `op(left, right)` for [`BooleanArray`] and scalar using
@@ -75,12 +64,12 @@ where
     BooleanArray::from_data(DataType::Boolean, values, lhs.validity().cloned())
 }
 
-/// Perform `lhs == rhs` operation on two arrays.
-pub fn eq(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
+/// Perform `lhs == rhs` operation on two [`BooleanArray`]s.
+pub fn eq(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| !(a ^ b))
 }
 
-/// Perform `left == right` operation on an array and a scalar value.
+/// Perform `lhs == rhs` operation on a [`BooleanArray`] and a scalar value.
 pub fn eq_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
     if rhs {
         lhs.clone()
@@ -89,8 +78,8 @@ pub fn eq_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
     }
 }
 
-/// Perform `left != right` operation on two arrays.
-pub fn neq(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
+/// `lhs != rhs` for [`BooleanArray`]
+pub fn neq(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a ^ b)
 }
 
@@ -100,7 +89,7 @@ pub fn neq_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
 }
 
 /// Perform `left < right` operation on two arrays.
-pub fn lt(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
+pub fn lt(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| !a & b)
 }
 
@@ -118,7 +107,7 @@ pub fn lt_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
 }
 
 /// Perform `left <= right` operation on two arrays.
-pub fn lt_eq(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
+pub fn lt_eq(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| !a | b)
 }
 
@@ -134,7 +123,7 @@ pub fn lt_eq_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
 
 /// Perform `left > right` operation on two arrays. Non-null values are greater than null
 /// values.
-pub fn gt(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
+pub fn gt(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a & !b)
 }
 
@@ -154,7 +143,7 @@ pub fn gt_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
 
 /// Perform `left >= right` operation on two arrays. Non-null values are greater than null
 /// values.
-pub fn gt_eq(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
+pub fn gt_eq(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a | !b)
 }
 
@@ -168,47 +157,6 @@ pub fn gt_eq_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
     }
 }
 
-/// Compare two [`BooleanArray`]s using the given [`Operator`].
-///
-/// # Errors
-/// When the two arrays have different lengths.
-///
-/// Check the [crate::compute::comparison](module documentation) for usage
-/// examples.
-pub fn compare(lhs: &BooleanArray, rhs: &BooleanArray, op: Operator) -> Result<BooleanArray> {
-    match op {
-        Operator::Eq => eq(lhs, rhs),
-        Operator::Neq => neq(lhs, rhs),
-        Operator::Gt => gt(lhs, rhs),
-        Operator::GtEq => gt_eq(lhs, rhs),
-        Operator::Lt => lt(lhs, rhs),
-        Operator::LtEq => lt_eq(lhs, rhs),
-    }
-}
-
-/// Compare a [`BooleanArray`] and a scalar value using the given
-/// [`Operator`].
-///
-/// Check the [crate::compute::comparison](module documentation) for usage
-/// examples.
-pub fn compare_scalar(lhs: &BooleanArray, rhs: &BooleanScalar, op: Operator) -> BooleanArray {
-    if !rhs.is_valid() {
-        return BooleanArray::new_null(DataType::Boolean, lhs.len());
-    }
-    compare_scalar_non_null(lhs, rhs.value(), op)
-}
-
-pub fn compare_scalar_non_null(lhs: &BooleanArray, rhs: bool, op: Operator) -> BooleanArray {
-    match op {
-        Operator::Eq => eq_scalar(lhs, rhs),
-        Operator::Neq => neq_scalar(lhs, rhs),
-        Operator::Gt => gt_scalar(lhs, rhs),
-        Operator::GtEq => gt_eq_scalar(lhs, rhs),
-        Operator::Lt => lt_scalar(lhs, rhs),
-        Operator::LtEq => lt_eq_scalar(lhs, rhs),
-    }
-}
-
 // disable wrapping inside literal vectors used for test data and assertions
 #[rustfmt::skip::macros(vec)]
 #[cfg(test)]
@@ -219,7 +167,7 @@ mod tests {
         ($KERNEL:ident, $A_VEC:expr, $B_VEC:expr, $EXPECTED:expr) => {
             let a = BooleanArray::from_slice($A_VEC);
             let b = BooleanArray::from_slice($B_VEC);
-            let c = $KERNEL(&a, &b).unwrap();
+            let c = $KERNEL(&a, &b);
             assert_eq!(BooleanArray::from_slice($EXPECTED), c);
         };
     }
@@ -228,7 +176,7 @@ mod tests {
         ($KERNEL:ident, $A_VEC:expr, $B_VEC:expr, $EXPECTED:expr) => {
             let a = BooleanArray::from($A_VEC);
             let b = BooleanArray::from($B_VEC);
-            let c = $KERNEL(&a, &b).unwrap();
+            let c = $KERNEL(&a, &b);
             assert_eq!(BooleanArray::from($EXPECTED), c);
         };
     }
@@ -261,7 +209,7 @@ mod tests {
         let a = BooleanArray::from_slice(&[true, true, false]);
         let b = BooleanArray::from_slice(&[true, true, true, true, false]);
         let c = b.slice(2, 3);
-        let d = eq(&c, &a).unwrap();
+        let d = eq(&c, &a);
         assert_eq!(d, BooleanArray::from_slice(&[true, true, true]));
     }
 

--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -1,359 +1,423 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 //! Basic comparison kernels.
 //!
 //! The module contains functions that compare either an array and a scalar
 //! or two arrays of the same [`DataType`]. The scalar-oriented functions are
-//! suffixed with `_scalar`. In general, these comparison functions receive as
-//! inputs the two items for comparison and an [`Operator`] which specifies the
-//! type of comparison that will be conducted, such as `<=` ([`Operator::LtEq`]).
+//! suffixed with `_scalar`.
 //!
-//! Much like the parent module [`compute`](crate::compute), the comparison functions
-//! have two variants - a statically typed one ([`primitive_compare`])
-//! which expects concrete types such as [`Int8Array`] and a dynamically typed
-//! variant ([`compare`]) that compares values of type `&dyn Array` and errors
-//! if the underlying concrete types mismsatch. The statically-typed functions
-//! are appropriately prefixed with the concrete types they expect.
-//!
-//! Also note that the scalar-based comparison functions for the concrete types,
-//! like [`primitive_compare_scalar`], are infallible and always return a
-//! [`BooleanArray`] while the rest of the functions always wrap the returned
-//! array in a [`Result`] due to their internal checks of the data types and
-//! lengths.
+//! The functions are organized in two variants:
+//! * statically typed
+//! * dynamically typed
+//! The statically typed are available under each module of this module (e.g. [`primitive::eq`], [`primitive::lt_scalar`])
+//! The dynamically typed are available in this module (e.g. [`eq`] or [`lt_scalar`]).
 //!
 //! # Examples
 //!
 //! Compare two [`PrimitiveArray`]s:
 //! ```
-//! use arrow2::compute::comparison::{primitive_compare, Operator};
-//! # use arrow2::array::{BooleanArray, PrimitiveArray};
-//! # use arrow2::error::{ArrowError, Result};
+//! use arrow2::array::{BooleanArray, PrimitiveArray};
+//! use arrow2::compute::comparison::primitive::gt;
 //!
 //! let array1 = PrimitiveArray::<i32>::from([Some(1), None, Some(2)]);
-//! let array2 = PrimitiveArray::<i32>::from([Some(1), None, Some(1)]);
-//! let result = primitive_compare(&array1, &array2, Operator::Gt)?;
+//! let array2 = PrimitiveArray::<i32>::from([Some(1), Some(3), Some(1)]);
+//! let result = gt(&array1, &array2);
 //! assert_eq!(result, BooleanArray::from([Some(false), None, Some(true)]));
-//! # Ok::<(), ArrowError>(())
 //! ```
-//! Compare two dynamically-typed arrays (trait objects):
+//!
+//! Compare two dynamically-typed [`Array`]s (trait objects):
 //! ```
-//! use arrow2::compute::comparison::{compare, Operator};
-//! # use arrow2::array::{Array, BooleanArray, PrimitiveArray};
-//! # use arrow2::error::{ArrowError, Result};
+//! use arrow2::array::{Array, BooleanArray, PrimitiveArray};
+//! use arrow2::compute::comparison::eq;
 //!
 //! let array1: &dyn Array = &PrimitiveArray::<f64>::from(&[Some(10.0), None, Some(20.0)]);
 //! let array2: &dyn Array = &PrimitiveArray::<f64>::from(&[Some(10.0), None, Some(10.0)]);
-//! let result = compare(array1, array2, Operator::LtEq)?;
+//! let result = eq(array1, array2);
 //! assert_eq!(result, BooleanArray::from([Some(true), None, Some(false)]));
-//! # Ok::<(), ArrowError>(())
 //! ```
-//! Compare an array of strings to a "scalar", i.e a word (note that we use
-//! [`Operator::Neq`]):
+//!
+//! Compare (not equal) a [`Utf8Array`] to a word:
 //! ```
-//! use arrow2::compute::comparison::{utf8_compare_scalar, Operator};
-//! # use arrow2::array::{Array, BooleanArray, Utf8Array};
-//! # use arrow2::scalar::Utf8Scalar;
-//! # use arrow2::error::{ArrowError, Result};
+//! use arrow2::array::{BooleanArray, Utf8Array};
+//! use arrow2::compute::comparison::utf8::neq_scalar;
 //!
 //! let array = Utf8Array::<i32>::from([Some("compute"), None, Some("compare")]);
-//! let word = Utf8Scalar::new(Some("compare"));
-//! let result = utf8_compare_scalar(&array, &word, Operator::Neq);
+//! let result = neq_scalar(&array, "compare");
 //! assert_eq!(result, BooleanArray::from([Some(true), None, Some(false)]));
-//! # Ok::<(), ArrowError>(())
 //! ```
 
 use crate::array::*;
 use crate::datatypes::{DataType, IntervalUnit};
-use crate::error::{ArrowError, Result};
-use crate::scalar::Scalar;
+use crate::scalar::*;
 
-mod binary;
-mod boolean;
-mod primitive;
-mod utf8;
+pub mod binary;
+pub mod boolean;
+pub mod primitive;
+pub mod utf8;
 
 mod simd;
 pub use simd::{Simd8, Simd8Lanes};
 
-pub use binary::compare as binary_compare;
-pub use binary::compare_scalar as binary_compare_scalar;
-pub use boolean::compare as boolean_compare;
-pub use boolean::compare_scalar as boolean_compare_scalar;
-pub use primitive::compare as primitive_compare;
-pub use primitive::compare_scalar as primitive_compare_scalar;
 pub(crate) use primitive::compare_values_op as primitive_compare_values_op;
-pub use utf8::compare as utf8_compare;
-pub use utf8::compare_scalar as utf8_compare_scalar;
 
-/// Comparison operators, such as `>` ([`Operator::Gt`])
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Operator {
-    /// Less than
-    Lt,
-    /// Less than or equal to
-    LtEq,
-    /// Greater than
-    Gt,
-    /// Greater than or equal to
-    GtEq,
-    /// Equal
-    Eq,
-    /// Not equal
-    Neq,
+macro_rules! compare {
+    ($lhs:expr, $rhs:expr, $op:tt) => {{
+        let lhs = $lhs;
+        let rhs = $rhs;
+        assert_eq!(
+            lhs.data_type().to_logical_type(),
+            rhs.data_type().to_logical_type()
+        );
+
+        use DataType::*;
+        let data_type = lhs.data_type().to_logical_type();
+        match data_type {
+            Boolean => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                boolean::$op(lhs, rhs)
+            }
+            Int8 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                primitive::$op::<i8>(lhs, rhs)
+            }
+            Int16 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                primitive::$op::<i16>(lhs, rhs)
+            }
+            Int32 | Date32 | Time32(_) | Interval(IntervalUnit::YearMonth) => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                primitive::$op::<i32>(lhs, rhs)
+            }
+            Int64 | Timestamp(_, _) | Date64 | Time64(_) | Duration(_) => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                primitive::$op::<i64>(lhs, rhs)
+            }
+            UInt8 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                primitive::$op::<u8>(lhs, rhs)
+            }
+            UInt16 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                primitive::$op::<u16>(lhs, rhs)
+            }
+            UInt32 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                primitive::$op::<u32>(lhs, rhs)
+            }
+            UInt64 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                primitive::$op::<u64>(lhs, rhs)
+            }
+            Float16 => unreachable!(),
+            Float32 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                primitive::$op::<f32>(lhs, rhs)
+            }
+            Float64 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                primitive::$op::<f64>(lhs, rhs)
+            }
+            Utf8 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                utf8::$op::<i32>(lhs, rhs)
+            }
+            LargeUtf8 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                utf8::$op::<i64>(lhs, rhs)
+            }
+            Decimal(_, _) => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                primitive::$op::<i128>(lhs, rhs)
+            }
+            Binary => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                binary::$op::<i32>(lhs, rhs)
+            }
+            LargeBinary => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                binary::$op::<i64>(lhs, rhs)
+            }
+            _ => todo!("Comparisons of {:?} are not yet supported", data_type),
+        }
+    }};
 }
 
-/// Compares each slot of `lhs` against each slot of `rhs`.
-/// # Error
-/// Errors iff:
-/// * `lhs.data_type() != rhs.data_type()` or
-/// * `lhs.len() != rhs.len()` or
-/// * the datatype is not supported (use [`can_compare`] to tell whether it is supported)
-pub fn compare(lhs: &dyn Array, rhs: &dyn Array, operator: Operator) -> Result<BooleanArray> {
-    let data_type = lhs.data_type();
-    if data_type != rhs.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Comparison is only supported for arrays of the same logical type".to_string(),
-        ));
-    }
-    match data_type {
-        DataType::Boolean => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            boolean::compare(lhs, rhs, operator)
-        }
-        DataType::Int8 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare::<i8>(lhs, rhs, operator)
-        }
-        DataType::Int16 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare::<i16>(lhs, rhs, operator)
-        }
-        DataType::Int32
-        | DataType::Date32
-        | DataType::Time32(_)
-        | DataType::Interval(IntervalUnit::YearMonth) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare::<i32>(lhs, rhs, operator)
-        }
-        DataType::Int64
-        | DataType::Timestamp(_, None)
-        | DataType::Date64
-        | DataType::Time64(_)
-        | DataType::Duration(_) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare::<i64>(lhs, rhs, operator)
-        }
-        DataType::UInt8 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare::<u8>(lhs, rhs, operator)
-        }
-        DataType::UInt16 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare::<u16>(lhs, rhs, operator)
-        }
-        DataType::UInt32 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare::<u32>(lhs, rhs, operator)
-        }
-        DataType::UInt64 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare::<u64>(lhs, rhs, operator)
-        }
-        DataType::Float16 => unreachable!(),
-        DataType::Float32 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare::<f32>(lhs, rhs, operator)
-        }
-        DataType::Float64 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare::<f64>(lhs, rhs, operator)
-        }
-        DataType::Utf8 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            utf8::compare::<i32>(lhs, rhs, operator)
-        }
-        DataType::LargeUtf8 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            utf8::compare::<i64>(lhs, rhs, operator)
-        }
-        DataType::Decimal(_, _) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare::<i128>(lhs, rhs, operator)
-        }
-        DataType::Binary => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            binary::compare::<i32>(lhs, rhs, operator)
-        }
-        DataType::LargeBinary => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            binary::compare::<i64>(lhs, rhs, operator)
-        }
-        _ => Err(ArrowError::NotYetImplemented(format!(
-            "Comparison between {:?} is not supported",
-            data_type
-        ))),
-    }
+/// `==` between two [`Array`]s.
+/// Use [`can_eq`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * the arrays do not have have the same logical type
+/// * the arrays do not have the same length
+/// * the operation is not supported for the logical type
+pub fn eq(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
+    compare!(lhs, rhs, eq)
 }
 
-/// Compares all slots of `lhs` against `rhs`.
-/// # Error
-/// Errors iff:
-/// * `lhs.data_type() != rhs.data_type()` or
-/// * the datatype is not supported (use [`can_compare`] to tell whether it is supported)
-pub fn compare_scalar(
-    lhs: &dyn Array,
-    rhs: &dyn Scalar,
-    operator: Operator,
-) -> Result<BooleanArray> {
-    let data_type = lhs.data_type();
-    if data_type != rhs.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Comparison is only supported for the same logical type".to_string(),
-        ));
-    }
-    Ok(match data_type {
-        DataType::Boolean => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            boolean::compare_scalar(lhs, rhs, operator)
-        }
-        DataType::Int8 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare_scalar::<i8>(lhs, rhs, operator)
-        }
-        DataType::Int16 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare_scalar::<i16>(lhs, rhs, operator)
-        }
-        DataType::Int32
-        | DataType::Date32
-        | DataType::Time32(_)
-        | DataType::Interval(IntervalUnit::YearMonth) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare_scalar::<i32>(lhs, rhs, operator)
-        }
-        DataType::Int64
-        | DataType::Timestamp(_, None)
-        | DataType::Date64
-        | DataType::Time64(_)
-        | DataType::Duration(_) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare_scalar::<i64>(lhs, rhs, operator)
-        }
-        DataType::UInt8 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare_scalar::<u8>(lhs, rhs, operator)
-        }
-        DataType::UInt16 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare_scalar::<u16>(lhs, rhs, operator)
-        }
-        DataType::UInt32 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare_scalar::<u32>(lhs, rhs, operator)
-        }
-        DataType::UInt64 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare_scalar::<u64>(lhs, rhs, operator)
-        }
-        DataType::Float16 => unreachable!(),
-        DataType::Float32 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare_scalar::<f32>(lhs, rhs, operator)
-        }
-        DataType::Float64 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare_scalar::<f64>(lhs, rhs, operator)
-        }
-        DataType::Decimal(_, _) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            primitive::compare_scalar::<i128>(lhs, rhs, operator)
-        }
-        DataType::Utf8 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            utf8::compare_scalar::<i32>(lhs, rhs, operator)
-        }
-        DataType::LargeUtf8 => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            utf8::compare_scalar::<i64>(lhs, rhs, operator)
-        }
-        DataType::Binary => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            binary::compare_scalar::<i32>(lhs, rhs, operator)
-        }
-        DataType::LargeBinary => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            binary::compare_scalar::<i64>(lhs, rhs, operator)
-        }
-        _ => {
-            return Err(ArrowError::NotYetImplemented(format!(
-                "Comparison between {:?} is not supported",
-                data_type
-            )))
-        }
-    })
+/// `!=` between two [`Array`]s.
+/// Use [`can_neq`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * the arrays do not have have the same logical type
+/// * the arrays do not have the same length
+/// * the operation is not supported for the logical type
+pub fn neq(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
+    compare!(lhs, rhs, neq)
 }
-/// Checks if an array of type `datatype` can be compared with another array of
-/// the same type.
-///
-/// # Examples
-/// ```
-/// use arrow2::compute::comparison::can_compare;
-/// use arrow2::datatypes::{DataType};
-///
-/// let data_type = DataType::Int8;
-/// assert_eq!(can_compare(&data_type), true);
-///
-/// let data_type = DataType::LargeBinary;
-/// assert_eq!(can_compare(&data_type), true)
-/// ```
-pub fn can_compare(data_type: &DataType) -> bool {
+
+/// `<` between two [`Array`]s.
+/// Use [`can_lt`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * the arrays do not have have the same logical type
+/// * the arrays do not have the same length
+/// * the operation is not supported for the logical type
+pub fn lt(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
+    compare!(lhs, rhs, lt)
+}
+
+/// `<=` between two [`Array`]s.
+/// Use [`can_lt_eq`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * the arrays do not have have the same logical type
+/// * the arrays do not have the same length
+/// * the operation is not supported for the logical type
+pub fn lt_eq(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
+    compare!(lhs, rhs, lt_eq)
+}
+
+/// `>` between two [`Array`]s.
+/// Use [`can_gt`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * the arrays do not have have the same logical type
+/// * the arrays do not have the same length
+/// * the operation is not supported for the logical type
+pub fn gt(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
+    compare!(lhs, rhs, gt)
+}
+
+/// `>=` between two [`Array`]s.
+/// Use [`can_gt_eq`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * the arrays do not have have the same logical type
+/// * the arrays do not have the same length
+/// * the operation is not supported for the logical type
+pub fn gt_eq(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
+    compare!(lhs, rhs, gt_eq)
+}
+
+macro_rules! compare_scalar {
+    ($lhs:expr, $rhs:expr, $op:tt) => {{
+        let lhs = $lhs;
+        let rhs = $rhs;
+        assert_eq!(
+            lhs.data_type().to_logical_type(),
+            rhs.data_type().to_logical_type()
+        );
+        if !rhs.is_valid() {
+            return BooleanArray::new_null(DataType::Boolean, lhs.len());
+        }
+
+        use DataType::*;
+        let data_type = lhs.data_type().to_logical_type();
+        match data_type {
+            Boolean => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<BooleanScalar>().unwrap();
+                boolean::$op(lhs, rhs.value())
+            }
+            Int8 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<PrimitiveScalar<i8>>().unwrap();
+                primitive::$op::<i8>(lhs, rhs.value())
+            }
+            Int16 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<PrimitiveScalar<i16>>().unwrap();
+                primitive::$op::<i16>(lhs, rhs.value())
+            }
+            Int32 | Date32 | Time32(_) | Interval(IntervalUnit::YearMonth) => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<PrimitiveScalar<i32>>().unwrap();
+                primitive::$op::<i32>(lhs, rhs.value())
+            }
+            Int64 | Timestamp(_, _) | Date64 | Time64(_) | Duration(_) => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<PrimitiveScalar<i64>>().unwrap();
+                primitive::$op::<i64>(lhs, rhs.value())
+            }
+            UInt8 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<PrimitiveScalar<u8>>().unwrap();
+                primitive::$op::<u8>(lhs, rhs.value())
+            }
+            UInt16 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<PrimitiveScalar<u16>>().unwrap();
+                primitive::$op::<u16>(lhs, rhs.value())
+            }
+            UInt32 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<PrimitiveScalar<u32>>().unwrap();
+                primitive::$op::<u32>(lhs, rhs.value())
+            }
+            UInt64 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<PrimitiveScalar<u64>>().unwrap();
+                primitive::$op::<u64>(lhs, rhs.value())
+            }
+            Float16 => unreachable!(),
+            Float32 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<PrimitiveScalar<f32>>().unwrap();
+                primitive::$op::<f32>(lhs, rhs.value())
+            }
+            Float64 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<PrimitiveScalar<f64>>().unwrap();
+                primitive::$op::<f64>(lhs, rhs.value())
+            }
+            Utf8 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<Utf8Scalar<i32>>().unwrap();
+                utf8::$op::<i32>(lhs, rhs.value())
+            }
+            LargeUtf8 => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<Utf8Scalar<i64>>().unwrap();
+                utf8::$op::<i64>(lhs, rhs.value())
+            }
+            Decimal(_, _) => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs
+                    .as_any()
+                    .downcast_ref::<PrimitiveScalar<i128>>()
+                    .unwrap();
+                primitive::$op::<i128>(lhs, rhs.value())
+            }
+            Binary => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<BinaryScalar<i32>>().unwrap();
+                binary::$op::<i32>(lhs, rhs.value())
+            }
+            LargeBinary => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref::<BinaryScalar<i64>>().unwrap();
+                binary::$op::<i64>(lhs, rhs.value())
+            }
+            _ => todo!("Comparisons of {:?} are not yet supported", data_type),
+        }
+    }};
+}
+
+/// `==` between an [`Array`] and a [`Scalar`].
+/// Use [`can_eq`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * they do not have have the same logical type
+/// * the operation is not supported for the logical type
+pub fn eq_scalar(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArray {
+    compare_scalar!(lhs, rhs, eq_scalar)
+}
+
+/// `!=` between an [`Array`] and a [`Scalar`].
+/// Use [`can_neq`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * they do not have have the same logical type
+/// * the operation is not supported for the logical type
+pub fn neq_scalar(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArray {
+    compare_scalar!(lhs, rhs, neq_scalar)
+}
+
+/// `<` between an [`Array`] and a [`Scalar`].
+/// Use [`can_lt`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * they do not have have the same logical type
+/// * the operation is not supported for the logical type
+pub fn lt_scalar(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArray {
+    compare_scalar!(lhs, rhs, lt_scalar)
+}
+
+/// `<=` between an [`Array`] and a [`Scalar`].
+/// Use [`can_lt_eq`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * they do not have have the same logical type
+/// * the operation is not supported for the logical type
+pub fn lt_eq_scalar(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArray {
+    compare_scalar!(lhs, rhs, lt_eq_scalar)
+}
+
+/// `>` between an [`Array`] and a [`Scalar`].
+/// Use [`can_gt`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * they do not have have the same logical type
+/// * the operation is not supported for the logical type
+pub fn gt_scalar(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArray {
+    compare_scalar!(lhs, rhs, gt_scalar)
+}
+
+/// `>=` between an [`Array`] and a [`Scalar`].
+/// Use [`can_gt_eq`] to check whether the operation is valid
+/// # Panic
+/// Panics iff either:
+/// * they do not have have the same logical type
+/// * the operation is not supported for the logical type
+pub fn gt_eq_scalar(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArray {
+    compare_scalar!(lhs, rhs, gt_eq_scalar)
+}
+
+/// Returns whether a [`DataType`] is comparable (either array or scalar) comparison.
+pub fn can_eq(data_type: &DataType) -> bool {
+    can_compare(data_type)
+}
+
+/// Returns whether a [`DataType`] is comparable (either array or scalar) comparison.
+pub fn can_neq(data_type: &DataType) -> bool {
+    can_compare(data_type)
+}
+
+/// Returns whether a [`DataType`] is comparable (either array or scalar) comparison.
+pub fn can_lt(data_type: &DataType) -> bool {
+    can_compare(data_type)
+}
+
+/// Returns whether a [`DataType`] is comparable (either array or scalar) comparison.
+pub fn can_lt_eq(data_type: &DataType) -> bool {
+    can_compare(data_type)
+}
+
+/// Returns whether a [`DataType`] is comparable (either array or scalar) comparison.
+pub fn can_gt(data_type: &DataType) -> bool {
+    can_compare(data_type)
+}
+
+/// Returns whether a [`DataType`] is comparable (either array or scalar) comparison.
+pub fn can_gt_eq(data_type: &DataType) -> bool {
+    can_compare(data_type)
+}
+
+// The list of operations currently supported.
+fn can_compare(data_type: &DataType) -> bool {
     matches!(
         data_type,
         DataType::Boolean
@@ -364,7 +428,7 @@ pub fn can_compare(data_type: &DataType) -> bool {
             | DataType::Time32(_)
             | DataType::Interval(_)
             | DataType::Int64
-            | DataType::Timestamp(_, None)
+            | DataType::Timestamp(_, _)
             | DataType::Date64
             | DataType::Time64(_)
             | DataType::Duration(_)

--- a/src/compute/comparison/utf8.rs
+++ b/src/compute/comparison/utf8.rs
@@ -1,40 +1,20 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//! Comparison functions for [`Utf8Array`]
+use crate::{
+    array::{BooleanArray, Offset, Utf8Array},
+    bitmap::Bitmap,
+    datatypes::DataType,
+};
 
-use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
-use crate::scalar::{Scalar, Utf8Scalar};
-use crate::{array::*, bitmap::Bitmap};
-
-use super::{super::utils::combine_validities, Operator};
+use super::super::utils::combine_validities;
 
 /// Evaluate `op(lhs, rhs)` for [`Utf8Array`]s using a specified
 /// comparison function.
-fn compare_op<O, F>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>, op: F) -> Result<BooleanArray>
+fn compare_op<O, F>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>, op: F) -> BooleanArray
 where
     O: Offset,
     F: Fn(&str, &str) -> bool,
 {
-    if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Cannot perform comparison operation on arrays of different length".to_string(),
-        ));
-    }
-
+    assert_eq!(lhs.len(), rhs.len());
     let validity = combine_validities(lhs.validity(), rhs.validity());
 
     let values = lhs
@@ -43,7 +23,7 @@ where
         .map(|(lhs, rhs)| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);
 
-    Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
+    BooleanArray::from_data(DataType::Boolean, values, validity)
 }
 
 /// Evaluate `op(lhs, rhs)` for [`Utf8Array`] and scalar using
@@ -62,123 +42,70 @@ where
 }
 
 /// Perform `lhs == rhs` operation on [`Utf8Array`].
-fn eq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
+pub fn eq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a == b)
 }
 
 /// Perform `lhs == rhs` operation on [`Utf8Array`] and a scalar.
-fn eq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
+pub fn eq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a == b)
 }
 
 /// Perform `lhs != rhs` operation on [`Utf8Array`].
-fn neq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
+pub fn neq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a != b)
 }
 
 /// Perform `lhs != rhs` operation on [`Utf8Array`] and a scalar.
-fn neq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
+pub fn neq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a != b)
 }
 
 /// Perform `lhs < rhs` operation on [`Utf8Array`].
-fn lt<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
+pub fn lt<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a < b)
 }
 
 /// Perform `lhs < rhs` operation on [`Utf8Array`] and a scalar.
-fn lt_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
+pub fn lt_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a < b)
 }
 
 /// Perform `lhs <= rhs` operation on [`Utf8Array`].
-fn lt_eq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
+pub fn lt_eq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a <= b)
 }
 
 /// Perform `lhs <= rhs` operation on [`Utf8Array`] and a scalar.
-fn lt_eq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
+pub fn lt_eq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a <= b)
 }
 
 /// Perform `lhs > rhs` operation on [`Utf8Array`].
-fn gt<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
+pub fn gt<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a > b)
 }
 
 /// Perform `lhs > rhs` operation on [`Utf8Array`] and a scalar.
-fn gt_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
+pub fn gt_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a > b)
 }
 
 /// Perform `lhs >= rhs` operation on [`Utf8Array`].
-fn gt_eq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Result<BooleanArray> {
+pub fn gt_eq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> BooleanArray {
     compare_op(lhs, rhs, |a, b| a >= b)
 }
 
 /// Perform `lhs >= rhs` operation on [`Utf8Array`] and a scalar.
-fn gt_eq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
+pub fn gt_eq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     compare_op_scalar(lhs, rhs, |a, b| a >= b)
-}
-
-/// Compare two [`Utf8Array`]s using the given [`Operator`].
-///
-/// # Errors
-/// When the two arrays have different lengths.
-///
-/// Check the [crate::compute::comparison](module documentation) for usage
-/// examples.
-pub fn compare<O: Offset>(
-    lhs: &Utf8Array<O>,
-    rhs: &Utf8Array<O>,
-    op: Operator,
-) -> Result<BooleanArray> {
-    match op {
-        Operator::Eq => eq(lhs, rhs),
-        Operator::Neq => neq(lhs, rhs),
-        Operator::Gt => gt(lhs, rhs),
-        Operator::GtEq => gt_eq(lhs, rhs),
-        Operator::Lt => lt(lhs, rhs),
-        Operator::LtEq => lt_eq(lhs, rhs),
-    }
-}
-
-/// Compare a [`Utf8Array`] and a scalar value using the given
-/// [`Operator`].
-///
-/// Check the [crate::compute::comparison](module documentation) for usage
-/// examples.
-pub fn compare_scalar<O: Offset>(
-    lhs: &Utf8Array<O>,
-    rhs: &Utf8Scalar<O>,
-    op: Operator,
-) -> BooleanArray {
-    if !rhs.is_valid() {
-        return BooleanArray::new_null(DataType::Boolean, lhs.len());
-    }
-    compare_scalar_non_null(lhs, rhs.value(), op)
-}
-
-pub fn compare_scalar_non_null<O: Offset>(
-    lhs: &Utf8Array<O>,
-    rhs: &str,
-    op: Operator,
-) -> BooleanArray {
-    match op {
-        Operator::Eq => eq_scalar(lhs, rhs),
-        Operator::Neq => neq_scalar(lhs, rhs),
-        Operator::Gt => gt_scalar(lhs, rhs),
-        Operator::GtEq => gt_eq_scalar(lhs, rhs),
-        Operator::Lt => lt_scalar(lhs, rhs),
-        Operator::LtEq => lt_eq_scalar(lhs, rhs),
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn test_generic<O: Offset, F: Fn(&Utf8Array<O>, &Utf8Array<O>) -> Result<BooleanArray>>(
+    fn test_generic<O: Offset, F: Fn(&Utf8Array<O>, &Utf8Array<O>) -> BooleanArray>(
         lhs: Vec<&str>,
         rhs: Vec<&str>,
         op: F,
@@ -187,7 +114,7 @@ mod tests {
         let lhs = Utf8Array::<O>::from_slice(lhs);
         let rhs = Utf8Array::<O>::from_slice(rhs);
         let expected = BooleanArray::from_slice(expected);
-        assert_eq!(op(&lhs, &rhs).unwrap(), expected);
+        assert_eq!(op(&lhs, &rhs), expected);
     }
 
     fn test_generic_scalar<O: Offset, F: Fn(&Utf8Array<O>, &str) -> BooleanArray>(

--- a/src/compute/regex_match.rs
+++ b/src/compute/regex_match.rs
@@ -6,9 +6,9 @@ use regex::Regex;
 
 use super::utils::{combine_validities, unary_utf8_boolean};
 use crate::array::{BooleanArray, Offset, Utf8Array};
+use crate::bitmap::Bitmap;
 use crate::datatypes::DataType;
 use crate::error::{ArrowError, Result};
-use crate::{array::*, bitmap::Bitmap};
 
 /// Regex matches
 pub fn regex_match<O: Offset>(values: &Utf8Array<O>, regex: &Utf8Array<O>) -> Result<BooleanArray> {

--- a/src/compute/sort/utf8.rs
+++ b/src/compute/sort/utf8.rs
@@ -1,5 +1,5 @@
-use crate::array::{Array, Offset, PrimitiveArray, Utf8Array};
 use crate::array::{DictionaryArray, DictionaryKey};
+use crate::array::{Offset, PrimitiveArray, Utf8Array};
 use crate::types::Index;
 
 use super::common;

--- a/tests/it/compute/comparison.rs
+++ b/tests/it/compute/comparison.rs
@@ -1,5 +1,5 @@
 use arrow2::array::new_null_array;
-use arrow2::compute::comparison::{can_compare, compare, compare_scalar, Operator};
+use arrow2::compute::comparison::{can_eq, eq, eq_scalar};
 use arrow2::datatypes::DataType::*;
 use arrow2::datatypes::TimeUnit;
 use arrow2::scalar::new_scalar;
@@ -42,11 +42,8 @@ fn consistency() {
     // array <> array
     datatypes.clone().into_iter().for_each(|d1| {
         let array = new_null_array(d1.clone(), 10);
-        let op = Operator::Eq;
-        if can_compare(&d1) {
-            assert!(compare(array.as_ref(), array.as_ref(), op).is_ok());
-        } else {
-            assert!(compare(array.as_ref(), array.as_ref(), op).is_err());
+        if can_eq(&d1) {
+            eq(array.as_ref(), array.as_ref());
         }
     });
 
@@ -54,11 +51,8 @@ fn consistency() {
     datatypes.into_iter().for_each(|d1| {
         let array = new_null_array(d1.clone(), 10);
         let scalar = new_scalar(array.as_ref(), 0);
-        let op = Operator::Eq;
-        if can_compare(&d1) {
-            assert!(compare_scalar(array.as_ref(), scalar.as_ref(), op).is_ok());
-        } else {
-            assert!(compare_scalar(array.as_ref(), scalar.as_ref(), op).is_err());
+        if can_eq(&d1) {
+            eq_scalar(array.as_ref(), scalar.as_ref());
         }
     });
 }


### PR DESCRIPTION
This PR removes the `Operator` and replaces it by different function calls as proposed by #527 . This does not close that issue yet because a similar PR is necessary for the arithmetic kernels.

# Backward incompatible changes

This PR removes the enum `Operator` in `compute::comparison`. Instead, the API is composed by

```
arrow2::compute::comparison::Y;
arrow2::compute::comparison::X::Y;
// where X \in {primitive, boolean, utf8, binary}
// where Y \in {eq, neq, lt, lt_eq, gt, gt_eq, eq_scalar, neq_scalar, lt_scalar, lt_eq_scalar, gt_scalar, gt_eq_scalar}
```

the functions inside each `X` are statically-typed (e.g. expect `Utf8Array`), while the functions `arrow2::compute::comparison::Y` are dynamically-typed (i.e. expect `Array` and `Scalar`).

As usual, each dynamic variant contains a `can_Y(&DataType)` that returns whether the operation is valid / is implemented.

Also, the functions no longer return a `Result` and instead simply panic; this is because:
* there is no obvious recovery when the arrays have a different length; the user should check that before using these functions.
* whether a type is valid for each function is already exposed in `can_Y`, which users can use to check whether the operation will panic or not.

This simplifies the overall API and allows implementing equality to types that have no partial or total order defined.