### PR TITLE
Simplified arithmetics compute

### DIFF
--- a/benches/arithmetic_kernels.rs
+++ b/benches/arithmetic_kernels.rs
@@ -22,7 +22,7 @@ fn bench_add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>)
 where
     T: NativeType + Add<Output = T> + NumCast,
 {
-    criterion::black_box(add(lhs, rhs)).unwrap();
+    criterion::black_box(add(lhs, rhs));
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/benches/comparison_kernels.rs
+++ b/benches/comparison_kernels.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use arrow2::scalar::*;
 use arrow2::util::bench_util::*;
-use arrow2::{compute::comparison::*, datatypes::DataType};
+use arrow2::{compute::comparison::eq, datatypes::DataType};
 
 fn add_benchmark(c: &mut Criterion) {
     (10..=20).step_by(2).for_each(|log2_size| {

--- a/benches/write_ipc.rs
+++ b/benches/write_ipc.rs
@@ -16,7 +16,7 @@ fn write(array: &dyn Array) -> Result<()> {
     let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![clone(array).into()])?;
 
     let writer = Cursor::new(vec![]);
-    let mut writer = FileWriter::try_new(writer, &schema)?;
+    let mut writer = FileWriter::try_new(writer, &schema, Default::default())?;
 
     writer.write(&batch)
 }

--- a/examples/csv_read_async.rs
+++ b/examples/csv_read_async.rs
@@ -1,10 +1,8 @@
 use std::sync::Arc;
 
-use futures::io::Cursor;
 use tokio::fs::File;
 use tokio_util::compat::*;
 
-use arrow2::array::*;
 use arrow2::error::Result;
 use arrow2::io::csv::read_async::*;
 

--- a/examples/growable.rs
+++ b/examples/growable.rs
@@ -1,5 +1,5 @@
 use arrow2::array::growable::{Growable, GrowablePrimitive};
-use arrow2::array::{Array, PrimitiveArray};
+use arrow2::array::PrimitiveArray;
 
 fn main() {
     // say we have two sorted arrays

--- a/src/compute/arithmetics/basic/add.rs
+++ b/src/compute/arithmetics/basic/add.rs
@@ -8,8 +8,8 @@ use crate::{
     bitmap::Bitmap,
     compute::{
         arithmetics::{
-            basic::check_same_type, ArrayAdd, ArrayCheckedAdd, ArrayOverflowingAdd,
-            ArraySaturatingAdd, ArrayWrappingAdd, NativeArithmetics,
+            ArrayAdd, ArrayCheckedAdd, ArrayOverflowingAdd, ArraySaturatingAdd, ArrayWrappingAdd,
+            NativeArithmetics,
         },
         arity::{
             binary, binary_checked, binary_with_bitmap, unary, unary_checked, unary_with_bitmap,
@@ -28,7 +28,7 @@ use crate::{
 ///
 /// let a = PrimitiveArray::from([None, Some(6), None, Some(6)]);
 /// let b = PrimitiveArray::from([Some(5), None, None, Some(6)]);
-/// let result = add(&a, &b).unwrap();
+/// let result = add(&a, &b);
 /// let expected = PrimitiveArray::from([None, None, None, Some(12)]);
 /// assert_eq!(result, expected)
 /// ```
@@ -49,7 +49,7 @@ where
 ///
 /// let a = PrimitiveArray::from([Some(-100i8), Some(100i8), Some(100i8)]);
 /// let b = PrimitiveArray::from([Some(0i8), Some(100i8), Some(0i8)]);
-/// let result = wrapping_add(&a, &b).unwrap();
+/// let result = wrapping_add(&a, &b);
 /// let expected = PrimitiveArray::from([Some(-100i8), Some(-56i8), Some(100i8)]);
 /// assert_eq!(result, expected);
 /// ```
@@ -72,7 +72,7 @@ where
 ///
 /// let a = PrimitiveArray::from([Some(100i8), Some(100i8), Some(100i8)]);
 /// let b = PrimitiveArray::from([Some(0i8), Some(100i8), Some(0i8)]);
-/// let result = checked_add(&a, &b).unwrap();
+/// let result = checked_add(&a, &b);
 /// let expected = PrimitiveArray::from([Some(100i8), None, Some(100i8)]);
 /// assert_eq!(result, expected);
 /// ```
@@ -80,8 +80,6 @@ pub fn checked_add<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Primi
 where
     T: NativeType + CheckedAdd<Output = T>,
 {
-    check_same_type(lhs, rhs).unwrap();
-
     let op = move |a: T, b: T| a.checked_add(&b);
 
     binary_checked(lhs, rhs, lhs.data_type().clone(), op)
@@ -98,7 +96,7 @@ where
 ///
 /// let a = PrimitiveArray::from([Some(100i8)]);
 /// let b = PrimitiveArray::from([Some(100i8)]);
-/// let result = saturating_add(&a, &b).unwrap();
+/// let result = saturating_add(&a, &b);
 /// let expected = PrimitiveArray::from([Some(127)]);
 /// assert_eq!(result, expected);
 /// ```
@@ -123,7 +121,7 @@ where
 ///
 /// let a = PrimitiveArray::from([Some(1i8), Some(100i8)]);
 /// let b = PrimitiveArray::from([Some(1i8), Some(100i8)]);
-/// let (result, overflow) = overflowing_add(&a, &b).unwrap();
+/// let (result, overflow) = overflowing_add(&a, &b);
 /// let expected = PrimitiveArray::from([Some(2i8), Some(-56i8)]);
 /// assert_eq!(result, expected);
 /// ```

--- a/src/compute/arithmetics/basic/mod.rs
+++ b/src/compute/arithmetics/basic/mod.rs
@@ -36,7 +36,7 @@ use super::super::arity::{unary, unary_checked};
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::negate;
+/// use arrow2::compute::arithmetics::basic::negate;
 /// use arrow2::array::PrimitiveArray;
 ///
 /// let a = PrimitiveArray::from([None, Some(6), None, Some(7)]);
@@ -55,7 +55,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::checked_negate;
+/// use arrow2::compute::arithmetics::basic::checked_negate;
 /// use arrow2::array::{Array, PrimitiveArray};
 ///
 /// let a = PrimitiveArray::from([None, Some(6), Some(i8::MIN), Some(7)]);
@@ -75,7 +75,7 @@ where
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::wrapping_negate;
+/// use arrow2::compute::arithmetics::basic::wrapping_negate;
 /// use arrow2::array::{Array, PrimitiveArray};
 ///
 /// let a = PrimitiveArray::from([None, Some(6), Some(i8::MIN), Some(7)]);

--- a/src/compute/arithmetics/basic/mod.rs
+++ b/src/compute/arithmetics/basic/mod.rs
@@ -1,4 +1,4 @@
-//! Contains arithemtic functions for [`PrimitiveArray`](crate::array::PrimitiveArray)s.
+//! Contains arithemtic functions for [`PrimitiveArray`]s.
 //!
 //! Each operation has four variants, like the rest of Rust's ecosystem:
 //! * usual, that [`panic!`]s on overflow
@@ -20,3 +20,72 @@ pub use sub::*;
 
 mod common;
 pub(crate) use common::*;
+
+use std::ops::Neg;
+
+use num_traits::{CheckedNeg, WrappingNeg};
+
+use crate::{
+    array::{Array, PrimitiveArray},
+    types::NativeType,
+};
+
+use super::super::arity::{unary, unary_checked};
+
+/// Negates values from array.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::negate;
+/// use arrow2::array::PrimitiveArray;
+///
+/// let a = PrimitiveArray::from([None, Some(6), None, Some(7)]);
+/// let result = negate(&a);
+/// let expected = PrimitiveArray::from([None, Some(-6), None, Some(-7)]);
+/// assert_eq!(result, expected)
+/// ```
+pub fn negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
+where
+    T: NativeType + Neg<Output = T>,
+{
+    unary(array, |a| -a, array.data_type().clone())
+}
+
+/// Checked negates values from array.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::checked_negate;
+/// use arrow2::array::{Array, PrimitiveArray};
+///
+/// let a = PrimitiveArray::from([None, Some(6), Some(i8::MIN), Some(7)]);
+/// let result = checked_negate(&a);
+/// let expected = PrimitiveArray::from([None, Some(-6), None, Some(-7)]);
+/// assert_eq!(result, expected);
+/// assert!(!result.is_valid(2))
+/// ```
+pub fn checked_negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
+where
+    T: NativeType + CheckedNeg,
+{
+    unary_checked(array, |a| a.checked_neg(), array.data_type().clone())
+}
+
+/// Wrapping negates values from array.
+///
+/// # Examples
+/// ```
+/// use arrow2::compute::arithmetics::wrapping_negate;
+/// use arrow2::array::{Array, PrimitiveArray};
+///
+/// let a = PrimitiveArray::from([None, Some(6), Some(i8::MIN), Some(7)]);
+/// let result = wrapping_negate(&a);
+/// let expected = PrimitiveArray::from([None, Some(-6), Some(i8::MIN), Some(-7)]);
+/// assert_eq!(result, expected);
+/// ```
+pub fn wrapping_negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
+where
+    T: NativeType + WrappingNeg,
+{
+    unary(array, |a| a.wrapping_neg(), array.data_type().clone())
+}

--- a/src/compute/arithmetics/basic/mul.rs
+++ b/src/compute/arithmetics/basic/mul.rs
@@ -3,20 +3,18 @@ use std::ops::Mul;
 
 use num_traits::{ops::overflowing::OverflowingMul, CheckedMul, SaturatingMul, WrappingMul};
 
-use crate::compute::arithmetics::basic::check_same_type;
-use crate::compute::arithmetics::ArrayWrappingMul;
 use crate::{
     array::{Array, PrimitiveArray},
     bitmap::Bitmap,
     compute::{
         arithmetics::{
-            ArrayCheckedMul, ArrayMul, ArrayOverflowingMul, ArraySaturatingMul, NativeArithmetics,
+            ArrayCheckedMul, ArrayMul, ArrayOverflowingMul, ArraySaturatingMul, ArrayWrappingMul,
+            NativeArithmetics,
         },
         arity::{
             binary, binary_checked, binary_with_bitmap, unary, unary_checked, unary_with_bitmap,
         },
     },
-    error::Result,
     types::NativeType,
 };
 
@@ -30,16 +28,14 @@ use crate::{
 ///
 /// let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
 /// let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-/// let result = mul(&a, &b).unwrap();
+/// let result = mul(&a, &b);
 /// let expected = Int32Array::from(&[None, None, None, Some(36)]);
 /// assert_eq!(result, expected)
 /// ```
-pub fn mul<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+pub fn mul<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + Mul<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     binary(lhs, rhs, lhs.data_type().clone(), |a, b| a * b)
 }
 
@@ -53,19 +49,14 @@ where
 ///
 /// let a = PrimitiveArray::from([Some(100i8), Some(0x10i8), Some(100i8)]);
 /// let b = PrimitiveArray::from([Some(0i8), Some(0x10i8), Some(0i8)]);
-/// let result = wrapping_mul(&a, &b).unwrap();
+/// let result = wrapping_mul(&a, &b);
 /// let expected = PrimitiveArray::from([Some(0), Some(0), Some(0)]);
 /// assert_eq!(result, expected);
 /// ```
-pub fn wrapping_mul<T>(
-    lhs: &PrimitiveArray<T>,
-    rhs: &PrimitiveArray<T>,
-) -> Result<PrimitiveArray<T>>
+pub fn wrapping_mul<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + WrappingMul<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     let op = move |a: T, b: T| a.wrapping_mul(&b);
 
     binary(lhs, rhs, lhs.data_type().clone(), op)
@@ -82,16 +73,14 @@ where
 ///
 /// let a = Int8Array::from(&[Some(100i8), Some(100i8), Some(100i8)]);
 /// let b = Int8Array::from(&[Some(1i8), Some(100i8), Some(1i8)]);
-/// let result = checked_mul(&a, &b).unwrap();
+/// let result = checked_mul(&a, &b);
 /// let expected = Int8Array::from(&[Some(100i8), None, Some(100i8)]);
 /// assert_eq!(result, expected);
 /// ```
-pub fn checked_mul<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+pub fn checked_mul<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + CheckedMul<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     let op = move |a: T, b: T| a.checked_mul(&b);
 
     binary_checked(lhs, rhs, lhs.data_type().clone(), op)
@@ -108,19 +97,14 @@ where
 ///
 /// let a = Int8Array::from(&[Some(-100i8)]);
 /// let b = Int8Array::from(&[Some(100i8)]);
-/// let result = saturating_mul(&a, &b).unwrap();
+/// let result = saturating_mul(&a, &b);
 /// let expected = Int8Array::from(&[Some(-128)]);
 /// assert_eq!(result, expected);
 /// ```
-pub fn saturating_mul<T>(
-    lhs: &PrimitiveArray<T>,
-    rhs: &PrimitiveArray<T>,
-) -> Result<PrimitiveArray<T>>
+pub fn saturating_mul<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + SaturatingMul<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     let op = move |a: T, b: T| a.saturating_mul(&b);
 
     binary(lhs, rhs, lhs.data_type().clone(), op)
@@ -138,19 +122,17 @@ where
 ///
 /// let a = Int8Array::from(&[Some(1i8), Some(-100i8)]);
 /// let b = Int8Array::from(&[Some(1i8), Some(100i8)]);
-/// let (result, overflow) = overflowing_mul(&a, &b).unwrap();
+/// let (result, overflow) = overflowing_mul(&a, &b);
 /// let expected = Int8Array::from(&[Some(1i8), Some(-16i8)]);
 /// assert_eq!(result, expected);
 /// ```
 pub fn overflowing_mul<T>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<T>,
-) -> Result<(PrimitiveArray<T>, Bitmap)>
+) -> (PrimitiveArray<T>, Bitmap)
 where
     T: NativeType + OverflowingMul<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     let op = move |a: T, b: T| a.overflowing_mul(&b);
 
     binary_with_bitmap(lhs, rhs, lhs.data_type().clone(), op)
@@ -161,7 +143,7 @@ impl<T> ArrayMul<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + Mul<Output = T>,
 {
-    fn mul(&self, rhs: &PrimitiveArray<T>) -> Result<Self> {
+    fn mul(&self, rhs: &PrimitiveArray<T>) -> Self {
         mul(self, rhs)
     }
 }
@@ -170,7 +152,7 @@ impl<T> ArrayWrappingMul<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + WrappingMul<Output = T>,
 {
-    fn wrapping_mul(&self, rhs: &PrimitiveArray<T>) -> Result<Self> {
+    fn wrapping_mul(&self, rhs: &PrimitiveArray<T>) -> Self {
         wrapping_mul(self, rhs)
     }
 }
@@ -180,7 +162,7 @@ impl<T> ArrayCheckedMul<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + CheckedMul<Output = T>,
 {
-    fn checked_mul(&self, rhs: &PrimitiveArray<T>) -> Result<Self> {
+    fn checked_mul(&self, rhs: &PrimitiveArray<T>) -> Self {
         checked_mul(self, rhs)
     }
 }
@@ -190,7 +172,7 @@ impl<T> ArraySaturatingMul<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + SaturatingMul<Output = T>,
 {
-    fn saturating_mul(&self, rhs: &PrimitiveArray<T>) -> Result<Self> {
+    fn saturating_mul(&self, rhs: &PrimitiveArray<T>) -> Self {
         saturating_mul(self, rhs)
     }
 }
@@ -200,10 +182,11 @@ impl<T> ArrayOverflowingMul<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + OverflowingMul<Output = T>,
 {
-    fn overflowing_mul(&self, rhs: &PrimitiveArray<T>) -> Result<(Self, Bitmap)> {
+    fn overflowing_mul(&self, rhs: &PrimitiveArray<T>) -> (Self, Bitmap) {
         overflowing_mul(self, rhs)
     }
 }
+
 /// Multiply a scalar T to a primitive array of type T.
 /// Panics if the multiplication of the values overflows.
 ///
@@ -323,8 +306,8 @@ impl<T> ArrayMul<T> for PrimitiveArray<T>
 where
     T: NativeType + Mul<Output = T> + NativeArithmetics,
 {
-    fn mul(&self, rhs: &T) -> Result<Self> {
-        Ok(mul_scalar(self, rhs))
+    fn mul(&self, rhs: &T) -> Self {
+        mul_scalar(self, rhs)
     }
 }
 
@@ -333,8 +316,8 @@ impl<T> ArrayCheckedMul<T> for PrimitiveArray<T>
 where
     T: NativeArithmetics + CheckedMul<Output = T>,
 {
-    fn checked_mul(&self, rhs: &T) -> Result<Self> {
-        Ok(checked_mul_scalar(self, rhs))
+    fn checked_mul(&self, rhs: &T) -> Self {
+        checked_mul_scalar(self, rhs)
     }
 }
 
@@ -343,8 +326,8 @@ impl<T> ArraySaturatingMul<T> for PrimitiveArray<T>
 where
     T: NativeArithmetics + SaturatingMul<Output = T>,
 {
-    fn saturating_mul(&self, rhs: &T) -> Result<Self> {
-        Ok(saturating_mul_scalar(self, rhs))
+    fn saturating_mul(&self, rhs: &T) -> Self {
+        saturating_mul_scalar(self, rhs)
     }
 }
 
@@ -353,7 +336,7 @@ impl<T> ArrayOverflowingMul<T> for PrimitiveArray<T>
 where
     T: NativeArithmetics + OverflowingMul<Output = T>,
 {
-    fn overflowing_mul(&self, rhs: &T) -> Result<(Self, Bitmap)> {
-        Ok(overflowing_mul_scalar(self, rhs))
+    fn overflowing_mul(&self, rhs: &T) -> (Self, Bitmap) {
+        overflowing_mul_scalar(self, rhs)
     }
 }

--- a/src/compute/arithmetics/basic/rem.rs
+++ b/src/compute/arithmetics/basic/rem.rs
@@ -47,7 +47,7 @@ where
 ///
 /// let a = Int8Array::from(&[Some(-100i8), Some(10i8)]);
 /// let b = Int8Array::from(&[Some(100i8), Some(0i8)]);
-/// let result = checked_rem(&a, &b).unwrap();
+/// let result = checked_rem(&a, &b);
 /// let expected = Int8Array::from(&[Some(-0i8), None]);
 /// assert_eq!(result, expected);
 /// ```

--- a/src/compute/arithmetics/basic/rem.rs
+++ b/src/compute/arithmetics/basic/rem.rs
@@ -2,7 +2,6 @@ use std::ops::Rem;
 
 use num_traits::{CheckedRem, NumCast};
 
-use crate::compute::arithmetics::basic::check_same_type;
 use crate::datatypes::DataType;
 use crate::{
     array::{Array, PrimitiveArray},
@@ -10,7 +9,6 @@ use crate::{
         arithmetics::{ArrayCheckedRem, ArrayRem, NativeArithmetics},
         arity::{binary, binary_checked, unary, unary_checked},
     },
-    error::Result,
     types::NativeType,
 };
 use strength_reduce::{
@@ -27,16 +25,14 @@ use strength_reduce::{
 ///
 /// let a = Int32Array::from(&[Some(10), Some(7)]);
 /// let b = Int32Array::from(&[Some(5), Some(6)]);
-/// let result = rem(&a, &b).unwrap();
+/// let result = rem(&a, &b);
 /// let expected = Int32Array::from(&[Some(0), Some(1)]);
 /// assert_eq!(result, expected)
 /// ```
-pub fn rem<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+pub fn rem<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + Rem<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     binary(lhs, rhs, lhs.data_type().clone(), |a, b| a % b)
 }
 
@@ -55,12 +51,10 @@ where
 /// let expected = Int8Array::from(&[Some(-0i8), None]);
 /// assert_eq!(result, expected);
 /// ```
-pub fn checked_rem<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+pub fn checked_rem<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + CheckedRem<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     let op = move |a: T, b: T| a.checked_rem(&b);
 
     binary_checked(lhs, rhs, lhs.data_type().clone(), op)
@@ -70,7 +64,7 @@ impl<T> ArrayRem<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + Rem<Output = T>,
 {
-    fn rem(&self, rhs: &PrimitiveArray<T>) -> Result<Self> {
+    fn rem(&self, rhs: &PrimitiveArray<T>) -> Self {
         rem(self, rhs)
     }
 }
@@ -79,7 +73,7 @@ impl<T> ArrayCheckedRem<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + CheckedRem<Output = T>,
 {
-    fn checked_rem(&self, rhs: &PrimitiveArray<T>) -> Result<Self> {
+    fn checked_rem(&self, rhs: &PrimitiveArray<T>) -> Self {
         checked_rem(self, rhs)
     }
 }
@@ -195,8 +189,8 @@ impl<T> ArrayRem<T> for PrimitiveArray<T>
 where
     T: NativeArithmetics + Rem<Output = T> + NumCast,
 {
-    fn rem(&self, rhs: &T) -> Result<Self> {
-        Ok(rem_scalar(self, rhs))
+    fn rem(&self, rhs: &T) -> Self {
+        rem_scalar(self, rhs)
     }
 }
 
@@ -204,7 +198,7 @@ impl<T> ArrayCheckedRem<T> for PrimitiveArray<T>
 where
     T: NativeArithmetics + CheckedRem<Output = T>,
 {
-    fn checked_rem(&self, rhs: &T) -> Result<Self> {
-        Ok(checked_rem_scalar(self, rhs))
+    fn checked_rem(&self, rhs: &T) -> Self {
+        checked_rem_scalar(self, rhs)
     }
 }

--- a/src/compute/arithmetics/basic/sub.rs
+++ b/src/compute/arithmetics/basic/sub.rs
@@ -3,20 +3,18 @@ use std::ops::Sub;
 
 use num_traits::{ops::overflowing::OverflowingSub, CheckedSub, SaturatingSub, WrappingSub};
 
-use crate::compute::arithmetics::basic::check_same_type;
-use crate::compute::arithmetics::ArrayWrappingSub;
 use crate::{
     array::{Array, PrimitiveArray},
     bitmap::Bitmap,
     compute::{
         arithmetics::{
-            ArrayCheckedSub, ArrayOverflowingSub, ArraySaturatingSub, ArraySub, NativeArithmetics,
+            ArrayCheckedSub, ArrayOverflowingSub, ArraySaturatingSub, ArraySub, ArrayWrappingSub,
+            NativeArithmetics,
         },
         arity::{
             binary, binary_checked, binary_with_bitmap, unary, unary_checked, unary_with_bitmap,
         },
     },
-    error::Result,
     types::NativeType,
 };
 
@@ -30,16 +28,14 @@ use crate::{
 ///
 /// let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
 /// let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-/// let result = sub(&a, &b).unwrap();
+/// let result = sub(&a, &b);
 /// let expected = Int32Array::from(&[None, None, None, Some(0)]);
 /// assert_eq!(result, expected)
 /// ```
-pub fn sub<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+pub fn sub<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + Sub<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     binary(lhs, rhs, lhs.data_type().clone(), |a, b| a - b)
 }
 
@@ -53,19 +49,14 @@ where
 ///
 /// let a = PrimitiveArray::from([Some(-100i8), Some(-100i8), Some(100i8)]);
 /// let b = PrimitiveArray::from([Some(0i8), Some(100i8), Some(0i8)]);
-/// let result = wrapping_sub(&a, &b).unwrap();
+/// let result = wrapping_sub(&a, &b);
 /// let expected = PrimitiveArray::from([Some(-100i8), Some(56i8), Some(100i8)]);
 /// assert_eq!(result, expected);
 /// ```
-pub fn wrapping_sub<T>(
-    lhs: &PrimitiveArray<T>,
-    rhs: &PrimitiveArray<T>,
-) -> Result<PrimitiveArray<T>>
+pub fn wrapping_sub<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + WrappingSub<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     let op = move |a: T, b: T| a.wrapping_sub(&b);
 
     binary(lhs, rhs, lhs.data_type().clone(), op)
@@ -85,12 +76,10 @@ where
 /// let expected = Int8Array::from(&[Some(99i8), None, Some(100i8)]);
 /// assert_eq!(result, expected);
 /// ```
-pub fn checked_sub<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+pub fn checked_sub<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + CheckedSub<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     let op = move |a: T, b: T| a.checked_sub(&b);
 
     binary_checked(lhs, rhs, lhs.data_type().clone(), op)
@@ -107,19 +96,14 @@ where
 ///
 /// let a = Int8Array::from(&[Some(-100i8)]);
 /// let b = Int8Array::from(&[Some(100i8)]);
-/// let result = saturating_sub(&a, &b).unwrap();
+/// let result = saturating_sub(&a, &b);
 /// let expected = Int8Array::from(&[Some(-128)]);
 /// assert_eq!(result, expected);
 /// ```
-pub fn saturating_sub<T>(
-    lhs: &PrimitiveArray<T>,
-    rhs: &PrimitiveArray<T>,
-) -> Result<PrimitiveArray<T>>
+pub fn saturating_sub<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + SaturatingSub<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     let op = move |a: T, b: T| a.saturating_sub(&b);
 
     binary(lhs, rhs, lhs.data_type().clone(), op)
@@ -137,19 +121,17 @@ where
 ///
 /// let a = Int8Array::from(&[Some(1i8), Some(-100i8)]);
 /// let b = Int8Array::from(&[Some(1i8), Some(100i8)]);
-/// let (result, overflow) = overflowing_sub(&a, &b).unwrap();
+/// let (result, overflow) = overflowing_sub(&a, &b);
 /// let expected = Int8Array::from(&[Some(0i8), Some(56i8)]);
 /// assert_eq!(result, expected);
 /// ```
 pub fn overflowing_sub<T>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<T>,
-) -> Result<(PrimitiveArray<T>, Bitmap)>
+) -> (PrimitiveArray<T>, Bitmap)
 where
     T: NativeType + OverflowingSub<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
-
     let op = move |a: T, b: T| a.overflowing_sub(&b);
 
     binary_with_bitmap(lhs, rhs, lhs.data_type().clone(), op)
@@ -160,7 +142,7 @@ impl<T> ArraySub<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + Sub<Output = T>,
 {
-    fn sub(&self, rhs: &PrimitiveArray<T>) -> Result<Self> {
+    fn sub(&self, rhs: &PrimitiveArray<T>) -> Self {
         sub(self, rhs)
     }
 }
@@ -169,7 +151,7 @@ impl<T> ArrayWrappingSub<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + WrappingSub<Output = T>,
 {
-    fn wrapping_sub(&self, rhs: &PrimitiveArray<T>) -> Result<Self> {
+    fn wrapping_sub(&self, rhs: &PrimitiveArray<T>) -> Self {
         wrapping_sub(self, rhs)
     }
 }
@@ -179,7 +161,7 @@ impl<T> ArrayCheckedSub<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + CheckedSub<Output = T>,
 {
-    fn checked_sub(&self, rhs: &PrimitiveArray<T>) -> Result<Self> {
+    fn checked_sub(&self, rhs: &PrimitiveArray<T>) -> Self {
         checked_sub(self, rhs)
     }
 }
@@ -189,7 +171,7 @@ impl<T> ArraySaturatingSub<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + SaturatingSub<Output = T>,
 {
-    fn saturating_sub(&self, rhs: &PrimitiveArray<T>) -> Result<Self> {
+    fn saturating_sub(&self, rhs: &PrimitiveArray<T>) -> Self {
         saturating_sub(self, rhs)
     }
 }
@@ -199,7 +181,7 @@ impl<T> ArrayOverflowingSub<PrimitiveArray<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + OverflowingSub<Output = T>,
 {
-    fn overflowing_sub(&self, rhs: &PrimitiveArray<T>) -> Result<(Self, Bitmap)> {
+    fn overflowing_sub(&self, rhs: &PrimitiveArray<T>) -> (Self, Bitmap) {
         overflowing_sub(self, rhs)
     }
 }
@@ -323,8 +305,8 @@ impl<T> ArraySub<T> for PrimitiveArray<T>
 where
     T: NativeArithmetics + Sub<Output = T>,
 {
-    fn sub(&self, rhs: &T) -> Result<Self> {
-        Ok(sub_scalar(self, rhs))
+    fn sub(&self, rhs: &T) -> Self {
+        sub_scalar(self, rhs)
     }
 }
 
@@ -333,8 +315,8 @@ impl<T> ArrayCheckedSub<T> for PrimitiveArray<T>
 where
     T: NativeArithmetics + CheckedSub<Output = T>,
 {
-    fn checked_sub(&self, rhs: &T) -> Result<Self> {
-        Ok(checked_sub_scalar(self, rhs))
+    fn checked_sub(&self, rhs: &T) -> Self {
+        checked_sub_scalar(self, rhs)
     }
 }
 
@@ -343,8 +325,8 @@ impl<T> ArraySaturatingSub<T> for PrimitiveArray<T>
 where
     T: NativeArithmetics + SaturatingSub<Output = T>,
 {
-    fn saturating_sub(&self, rhs: &T) -> Result<Self> {
-        Ok(saturating_sub_scalar(self, rhs))
+    fn saturating_sub(&self, rhs: &T) -> Self {
+        saturating_sub_scalar(self, rhs)
     }
 }
 
@@ -353,7 +335,7 @@ impl<T> ArrayOverflowingSub<T> for PrimitiveArray<T>
 where
     T: NativeArithmetics + OverflowingSub<Output = T>,
 {
-    fn overflowing_sub(&self, rhs: &T) -> Result<(Self, Bitmap)> {
-        Ok(overflowing_sub_scalar(self, rhs))
+    fn overflowing_sub(&self, rhs: &T) -> (Self, Bitmap) {
+        overflowing_sub_scalar(self, rhs)
     }
 }

--- a/src/compute/arithmetics/basic/sub.rs
+++ b/src/compute/arithmetics/basic/sub.rs
@@ -72,7 +72,7 @@ where
 ///
 /// let a = Int8Array::from(&[Some(100i8), Some(-100i8), Some(100i8)]);
 /// let b = Int8Array::from(&[Some(1i8), Some(100i8), Some(0i8)]);
-/// let result = checked_sub(&a, &b).unwrap();
+/// let result = checked_sub(&a, &b);
 /// let expected = Int8Array::from(&[Some(99i8), None, Some(100i8)]);
 /// assert_eq!(result, expected);
 /// ```

--- a/src/compute/arithmetics/decimal/add.rs
+++ b/src/compute/arithmetics/decimal/add.rs
@@ -25,7 +25,7 @@ use super::{adjusted_precision_scale, get_parameters, max_value, number_digits};
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::add::add;
+/// use arrow2::compute::arithmetics::decimal::add;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
@@ -64,14 +64,14 @@ pub fn add(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveA
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::add::saturating_add;
+/// use arrow2::compute::arithmetics::decimal::saturating_add;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
 /// let a = PrimitiveArray::from([Some(99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = saturating_add(&a, &b).unwrap();
+/// let result = saturating_add(&a, &b);
 /// let expected = PrimitiveArray::from([Some(99999i128), Some(33300i128), None, Some(33300i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
@@ -108,7 +108,7 @@ pub fn saturating_add(
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::add::checked_add;
+/// use arrow2::compute::arithmetics::decimal::checked_add;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
@@ -172,13 +172,13 @@ impl ArraySaturatingAdd<PrimitiveArray<i128>> for PrimitiveArray<i128> {
 /// ```
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::add::adaptive_add;
+/// use arrow2::compute::arithmetics::decimal::adaptive_add;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
 /// let a = PrimitiveArray::from([Some(11111_11i128)]).to(DataType::Decimal(7, 2));
 /// let b = PrimitiveArray::from([Some(11111_111i128)]).to(DataType::Decimal(8, 3));
-/// let result = adaptive_add(&a, &b);
+/// let result = adaptive_add(&a, &b).unwrap();
 /// let expected = PrimitiveArray::from([Some(22222_221i128)]).to(DataType::Decimal(8, 3));
 ///
 /// assert_eq!(result, expected);

--- a/src/compute/arithmetics/decimal/add.rs
+++ b/src/compute/arithmetics/decimal/add.rs
@@ -32,13 +32,13 @@ use super::{adjusted_precision_scale, get_parameters, max_value, number_digits};
 /// let a = PrimitiveArray::from([Some(1i128), Some(1i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(1i128), Some(2i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = add(&a, &b).unwrap();
+/// let result = add(&a, &b);
 /// let expected = PrimitiveArray::from([Some(2i128), Some(3i128), None, Some(4i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
-pub fn add(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<PrimitiveArray<i128>> {
-    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type())?;
+pub fn add(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveArray<i128> {
+    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let max = max_value(precision);
     let op = move |a, b| {
@@ -79,8 +79,8 @@ pub fn add(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<Pri
 pub fn saturating_add(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
-) -> Result<PrimitiveArray<i128>> {
-    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type())?;
+) -> PrimitiveArray<i128> {
+    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let max = max_value(precision);
     let op = move |a, b| {
@@ -115,16 +115,13 @@ pub fn saturating_add(
 /// let a = PrimitiveArray::from([Some(99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = checked_add(&a, &b).unwrap();
+/// let result = checked_add(&a, &b);
 /// let expected = PrimitiveArray::from([None, Some(33300i128), None, Some(33300i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
-pub fn checked_add(
-    lhs: &PrimitiveArray<i128>,
-    rhs: &PrimitiveArray<i128>,
-) -> Result<PrimitiveArray<i128>> {
-    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type())?;
+pub fn checked_add(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveArray<i128> {
+    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let max = max_value(precision);
     let op = move |a, b| {
@@ -142,21 +139,21 @@ pub fn checked_add(
 
 // Implementation of ArrayAdd trait for PrimitiveArrays
 impl ArrayAdd<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn add(&self, rhs: &PrimitiveArray<i128>) -> Result<Self> {
+    fn add(&self, rhs: &PrimitiveArray<i128>) -> Self {
         add(self, rhs)
     }
 }
 
 // Implementation of ArrayCheckedAdd trait for PrimitiveArrays
 impl ArrayCheckedAdd<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn checked_add(&self, rhs: &PrimitiveArray<i128>) -> Result<Self> {
+    fn checked_add(&self, rhs: &PrimitiveArray<i128>) -> Self {
         checked_add(self, rhs)
     }
 }
 
 // Implementation of ArraySaturatingAdd trait for PrimitiveArrays
 impl ArraySaturatingAdd<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn saturating_add(&self, rhs: &PrimitiveArray<i128>) -> Result<Self> {
+    fn saturating_add(&self, rhs: &PrimitiveArray<i128>) -> Self {
         saturating_add(self, rhs)
     }
 }
@@ -181,7 +178,7 @@ impl ArraySaturatingAdd<PrimitiveArray<i128>> for PrimitiveArray<i128> {
 ///
 /// let a = PrimitiveArray::from([Some(11111_11i128)]).to(DataType::Decimal(7, 2));
 /// let b = PrimitiveArray::from([Some(11111_111i128)]).to(DataType::Decimal(8, 3));
-/// let result = adaptive_add(&a, &b).unwrap();
+/// let result = adaptive_add(&a, &b);
 /// let expected = PrimitiveArray::from([Some(22222_221i128)]).to(DataType::Decimal(8, 3));
 ///
 /// assert_eq!(result, expected);

--- a/src/compute/arithmetics/decimal/div.rs
+++ b/src/compute/arithmetics/decimal/div.rs
@@ -24,7 +24,7 @@ use super::{adjusted_precision_scale, get_parameters, max_value, number_digits};
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::div::div;
+/// use arrow2::compute::arithmetics::decimal::div;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
@@ -77,7 +77,7 @@ pub fn div(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveA
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::div::saturating_div;
+/// use arrow2::compute::arithmetics::decimal::saturating_div;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
@@ -126,7 +126,7 @@ pub fn saturating_div(
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::div::checked_div;
+/// use arrow2::compute::arithmetics::decimal::checked_div;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
@@ -188,13 +188,13 @@ impl ArrayCheckedDiv<PrimitiveArray<i128>> for PrimitiveArray<i128> {
 /// ```
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::div::adaptive_div;
+/// use arrow2::compute::arithmetics::decimal::adaptive_div;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
 /// let a = PrimitiveArray::from([Some(1000_00i128)]).to(DataType::Decimal(7, 2));
 /// let b = PrimitiveArray::from([Some(10_0000i128)]).to(DataType::Decimal(6, 4));
-/// let result = adaptive_div(&a, &b);
+/// let result = adaptive_div(&a, &b).unwrap();
 /// let expected = PrimitiveArray::from([Some(100_0000i128)]).to(DataType::Decimal(9, 4));
 ///
 /// assert_eq!(result, expected);

--- a/src/compute/arithmetics/decimal/div.rs
+++ b/src/compute/arithmetics/decimal/div.rs
@@ -31,13 +31,13 @@ use super::{adjusted_precision_scale, get_parameters, max_value, number_digits};
 /// let a = PrimitiveArray::from([Some(1_00i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(1_00i128), Some(2_00i128), Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = div(&a, &b).unwrap();
+/// let result = div(&a, &b);
 /// let expected = PrimitiveArray::from([Some(1_00i128), Some(2_00i128), Some(3_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
-pub fn div(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<PrimitiveArray<i128>> {
-    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type())?;
+pub fn div(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveArray<i128> {
+    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let scale = 10i128.pow(scale as u32);
     let max = max_value(precision);
@@ -84,7 +84,7 @@ pub fn div(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<Pri
 /// let a = PrimitiveArray::from([Some(999_99i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(000_01i128), Some(2_00i128), Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = saturating_div(&a, &b).unwrap();
+/// let result = saturating_div(&a, &b);
 /// let expected = PrimitiveArray::from([Some(999_99i128), Some(2_00i128), Some(3_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
@@ -92,8 +92,8 @@ pub fn div(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<Pri
 pub fn saturating_div(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
-) -> Result<PrimitiveArray<i128>> {
-    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type())?;
+) -> PrimitiveArray<i128> {
+    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let scale = 10i128.pow(scale as u32);
     let max = max_value(precision);
@@ -133,16 +133,13 @@ pub fn saturating_div(
 /// let a = PrimitiveArray::from([Some(1_00i128), Some(4_00i128), Some(6_00i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(000_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = checked_div(&a, &b).unwrap();
+/// let result = checked_div(&a, &b);
 /// let expected = PrimitiveArray::from([None, None, Some(3_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
-pub fn checked_div(
-    lhs: &PrimitiveArray<i128>,
-    rhs: &PrimitiveArray<i128>,
-) -> Result<PrimitiveArray<i128>> {
-    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type())?;
+pub fn checked_div(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveArray<i128> {
+    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let scale = 10i128.pow(scale as u32);
     let max = max_value(precision);
@@ -164,14 +161,14 @@ pub fn checked_div(
 
 // Implementation of ArrayDiv trait for PrimitiveArrays
 impl ArrayDiv<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn div(&self, rhs: &PrimitiveArray<i128>) -> Result<Self> {
+    fn div(&self, rhs: &PrimitiveArray<i128>) -> Self {
         div(self, rhs)
     }
 }
 
 // Implementation of ArrayCheckedDiv trait for PrimitiveArrays
 impl ArrayCheckedDiv<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn checked_div(&self, rhs: &PrimitiveArray<i128>) -> Result<Self> {
+    fn checked_div(&self, rhs: &PrimitiveArray<i128>) -> Self {
         checked_div(self, rhs)
     }
 }
@@ -197,7 +194,7 @@ impl ArrayCheckedDiv<PrimitiveArray<i128>> for PrimitiveArray<i128> {
 ///
 /// let a = PrimitiveArray::from([Some(1000_00i128)]).to(DataType::Decimal(7, 2));
 /// let b = PrimitiveArray::from([Some(10_0000i128)]).to(DataType::Decimal(6, 4));
-/// let result = adaptive_div(&a, &b).unwrap();
+/// let result = adaptive_div(&a, &b);
 /// let expected = PrimitiveArray::from([Some(100_0000i128)]).to(DataType::Decimal(9, 4));
 ///
 /// assert_eq!(result, expected);

--- a/src/compute/arithmetics/decimal/mod.rs
+++ b/src/compute/arithmetics/decimal/mod.rs
@@ -3,10 +3,14 @@
 //! precision and scale parameters. These affect the arithmetic operations and
 //! need to be considered while doing operations with Decimal numbers.
 
-pub mod add;
-pub mod div;
-pub mod mul;
-pub mod sub;
+mod add;
+pub use add::*;
+mod div;
+pub use div::*;
+mod mul;
+pub use mul::*;
+mod sub;
+pub use sub::*;
 
 use crate::datatypes::DataType;
 use crate::error::{ArrowError, Result};

--- a/src/compute/arithmetics/decimal/mul.rs
+++ b/src/compute/arithmetics/decimal/mul.rs
@@ -23,7 +23,7 @@ use super::{adjusted_precision_scale, get_parameters, max_value, number_digits};
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::mul::mul;
+/// use arrow2::compute::arithmetics::decimal::mul;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
@@ -78,7 +78,7 @@ pub fn mul(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveA
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::mul::saturating_mul;
+/// use arrow2::compute::arithmetics::decimal::saturating_mul;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
@@ -128,7 +128,7 @@ pub fn saturating_mul(
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::mul::checked_mul;
+/// use arrow2::compute::arithmetics::decimal::checked_mul;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
@@ -197,7 +197,7 @@ impl ArraySaturatingMul<PrimitiveArray<i128>> for PrimitiveArray<i128> {
 /// ```
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::mul::adaptive_mul;
+/// use arrow2::compute::arithmetics::decimal::adaptive_mul;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///

--- a/src/compute/arithmetics/decimal/mul.rs
+++ b/src/compute/arithmetics/decimal/mul.rs
@@ -30,13 +30,13 @@ use super::{adjusted_precision_scale, get_parameters, max_value, number_digits};
 /// let a = PrimitiveArray::from([Some(1_00i128), Some(1_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(1_00i128), Some(2_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = mul(&a, &b).unwrap();
+/// let result = mul(&a, &b);
 /// let expected = PrimitiveArray::from([Some(1_00i128), Some(2_00i128), None, Some(4_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
-pub fn mul(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<PrimitiveArray<i128>> {
-    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type())?;
+pub fn mul(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveArray<i128> {
+    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let scale = 10i128.pow(scale as u32);
     let max = max_value(precision);
@@ -85,7 +85,7 @@ pub fn mul(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<Pri
 /// let a = PrimitiveArray::from([Some(999_99i128), Some(1_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(10_00i128), Some(2_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = saturating_mul(&a, &b).unwrap();
+/// let result = saturating_mul(&a, &b);
 /// let expected = PrimitiveArray::from([Some(999_99i128), Some(2_00i128), None, Some(4_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
@@ -93,8 +93,8 @@ pub fn mul(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<Pri
 pub fn saturating_mul(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
-) -> Result<PrimitiveArray<i128>> {
-    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type())?;
+) -> PrimitiveArray<i128> {
+    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let scale = 10i128.pow(scale as u32);
     let max = max_value(precision);
@@ -135,16 +135,13 @@ pub fn saturating_mul(
 /// let a = PrimitiveArray::from([Some(999_99i128), Some(1_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(10_00i128), Some(2_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = checked_mul(&a, &b).unwrap();
+/// let result = checked_mul(&a, &b);
 /// let expected = PrimitiveArray::from([None, Some(2_00i128), None, Some(4_00i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
 /// ```
-pub fn checked_mul(
-    lhs: &PrimitiveArray<i128>,
-    rhs: &PrimitiveArray<i128>,
-) -> Result<PrimitiveArray<i128>> {
-    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type())?;
+pub fn checked_mul(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveArray<i128> {
+    let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let scale = 10i128.pow(scale as u32);
     let max = max_value(precision);
@@ -166,21 +163,21 @@ pub fn checked_mul(
 
 // Implementation of ArrayMul trait for PrimitiveArrays
 impl ArrayMul<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn mul(&self, rhs: &PrimitiveArray<i128>) -> Result<Self> {
+    fn mul(&self, rhs: &PrimitiveArray<i128>) -> Self {
         mul(self, rhs)
     }
 }
 
 // Implementation of ArrayCheckedMul trait for PrimitiveArrays
 impl ArrayCheckedMul<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn checked_mul(&self, rhs: &PrimitiveArray<i128>) -> Result<Self> {
+    fn checked_mul(&self, rhs: &PrimitiveArray<i128>) -> Self {
         checked_mul(self, rhs)
     }
 }
 
 // Implementation of ArraySaturatingMul trait for PrimitiveArrays
 impl ArraySaturatingMul<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn saturating_mul(&self, rhs: &PrimitiveArray<i128>) -> Result<Self> {
+    fn saturating_mul(&self, rhs: &PrimitiveArray<i128>) -> Self {
         saturating_mul(self, rhs)
     }
 }
@@ -233,12 +230,10 @@ pub fn adaptive_mul(
             // to the left to match the final scale
             let res = if lhs_s > rhs_s {
                 l.checked_mul(r * shift)
-                    .expect("Mayor overflow for multiplication")
             } else {
-                (l * shift)
-                    .checked_mul(*r)
-                    .expect("Mayor overflow for multiplication")
-            };
+                (l * shift).checked_mul(*r)
+            }
+            .expect("Mayor overflow for multiplication");
 
             let res = res / shift_1;
 

--- a/src/compute/arithmetics/decimal/sub.rs
+++ b/src/compute/arithmetics/decimal/sub.rs
@@ -22,14 +22,14 @@ use super::{adjusted_precision_scale, get_parameters, max_value, number_digits};
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::sub::sub;
+/// use arrow2::compute::arithmetics::decimal::sub;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
 /// let a = PrimitiveArray::from([Some(1i128), Some(1i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(1i128), Some(2i128), None, Some(2i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = sub(&a, &b).unwrap();
+/// let result = sub(&a, &b);
 /// let expected = PrimitiveArray::from([Some(0i128), Some(-1i128), None, Some(0i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
@@ -62,14 +62,14 @@ pub fn sub(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveA
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::sub::saturating_sub;
+/// use arrow2::compute::arithmetics::decimal::saturating_sub;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
 /// let a = PrimitiveArray::from([Some(-99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = saturating_sub(&a, &b).unwrap();
+/// let result = saturating_sub(&a, &b);
 /// let expected = PrimitiveArray::from([Some(-99999i128), Some(-11100i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
@@ -128,14 +128,14 @@ impl ArraySaturatingSub<PrimitiveArray<i128>> for PrimitiveArray<i128> {
 ///
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::sub::checked_sub;
+/// use arrow2::compute::arithmetics::decimal::checked_sub;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///
 /// let a = PrimitiveArray::from([Some(-99000i128), Some(11100i128), None, Some(22200i128)]).to(DataType::Decimal(5, 2));
 /// let b = PrimitiveArray::from([Some(01000i128), Some(22200i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
-/// let result = checked_sub(&a, &b).unwrap();
+/// let result = checked_sub(&a, &b);
 /// let expected = PrimitiveArray::from([None, Some(-11100i128), None, Some(11100i128)]).to(DataType::Decimal(5, 2));
 ///
 /// assert_eq!(result, expected);
@@ -171,7 +171,7 @@ pub fn checked_sub(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Pr
 /// ```
 /// # Examples
 /// ```
-/// use arrow2::compute::arithmetics::decimal::sub::adaptive_sub;
+/// use arrow2::compute::arithmetics::decimal::adaptive_sub;
 /// use arrow2::array::PrimitiveArray;
 /// use arrow2::datatypes::DataType;
 ///

--- a/src/compute/arithmetics/decimal/sub.rs
+++ b/src/compute/arithmetics/decimal/sub.rs
@@ -34,8 +34,8 @@ use super::{adjusted_precision_scale, get_parameters, max_value, number_digits};
 ///
 /// assert_eq!(result, expected);
 /// ```
-pub fn sub(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<PrimitiveArray<i128>> {
-    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type())?;
+pub fn sub(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveArray<i128> {
+    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let max = max_value(precision);
 
@@ -77,8 +77,8 @@ pub fn sub(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Result<Pri
 pub fn saturating_sub(
     lhs: &PrimitiveArray<i128>,
     rhs: &PrimitiveArray<i128>,
-) -> Result<PrimitiveArray<i128>> {
-    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type())?;
+) -> PrimitiveArray<i128> {
+    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let max = max_value(precision);
 
@@ -102,21 +102,21 @@ pub fn saturating_sub(
 
 // Implementation of ArraySub trait for PrimitiveArrays
 impl ArraySub<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn sub(&self, rhs: &PrimitiveArray<i128>) -> Result<Self> {
+    fn sub(&self, rhs: &PrimitiveArray<i128>) -> Self {
         sub(self, rhs)
     }
 }
 
 // Implementation of ArrayCheckedSub trait for PrimitiveArrays
 impl ArrayCheckedSub<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn checked_sub(&self, rhs: &PrimitiveArray<i128>) -> Result<Self> {
+    fn checked_sub(&self, rhs: &PrimitiveArray<i128>) -> Self {
         checked_sub(self, rhs)
     }
 }
 
 // Implementation of ArraySaturatingSub trait for PrimitiveArrays
 impl ArraySaturatingSub<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn saturating_sub(&self, rhs: &PrimitiveArray<i128>) -> Result<Self> {
+    fn saturating_sub(&self, rhs: &PrimitiveArray<i128>) -> Self {
         saturating_sub(self, rhs)
     }
 }
@@ -140,11 +140,8 @@ impl ArraySaturatingSub<PrimitiveArray<i128>> for PrimitiveArray<i128> {
 ///
 /// assert_eq!(result, expected);
 /// ```
-pub fn checked_sub(
-    lhs: &PrimitiveArray<i128>,
-    rhs: &PrimitiveArray<i128>,
-) -> Result<PrimitiveArray<i128>> {
-    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type())?;
+pub fn checked_sub(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveArray<i128> {
+    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
     let max = max_value(precision);
 

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -1,350 +1,262 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
-//! Defines basic arithmetic kernels for [`PrimitiveArray`]s.
-//!
-//! # Description
+//! Defines basic arithmetic kernels for [`PrimitiveArray`](crate::array::PrimitiveArray)s.
 //!
 //! The Arithmetics module is composed by basic arithmetics operations that can
-//! be performed on PrimitiveArray Arrays. These operations can be the building for
-//! any implementation using Arrow.
+//! be performed on [`PrimitiveArray`](crate::array::PrimitiveArray).
 //!
-//! Whenever possible, each of the operations in these modules has variations
-//! of the basic operation that offers different guarantees. These options are:
-//!
-//! * plain: The plain type (add, sub, mul, and div) don't offer any protection
-//!   when performing the operations. This means that if overflow is found,
-//!   then the operations will panic.
-//!
-//! * checked: A checked operation will change the validity Bitmap for the
-//!   offending operation. For example, if one of the operations overflows, the
-//!   validity will be changed to None, indicating a Null value.
-//!
-//! * saturating: If overflowing is presented in one operation, the resulting
-//!   value for that index will be saturated to the MAX or MIN value possible
-//!   for that type. For [`Decimal`](crate::datatypes::DataType::Decimal)
-//!   arrays, the saturated value is calculated considering the precision and
-//!   scale of the array.
-//!
-//! * overflowing: When an operation overflows, the resulting will be the
-//!   overflowed value for the operation. The result from the array operation
-//!   includes a Binary bitmap indicating which values overflowed.
-//!
-//! * adaptive: For [`Decimal`](crate::datatypes::DataType::Decimal) arrays,
-//!   the adaptive variation adjusts the precision and scale to avoid
-//!   saturation or overflowing.
-//!
-//! # New kernels
-//!
-//! When adding a new operation to this module, it is strongly suggested to
-//! follow the design description presented in the README.md file located in
-//! the [`compute`](crate::compute) module and the function descriptions
-//! presented in this document.
+//! Whenever possible, each operation declares variations
+//! of the basic operation that offers different guarantees:
+//! * plain: panics on overflowing and underflowing.
+//! * checked: turns an overflowing to a null.
+//! * saturating: turns the overflowing to the MAX or MIN value respectively.
+//! * overflowing: returns an extra [`Bitmap`] denoting whether the operation overflowed.
+//! * adaptive: for [`Decimal`](crate::datatypes::DataType::Decimal) only,
+//!   adjusts the precision and scale to make the resulting value fit.
 
 pub mod basic;
 pub mod decimal;
 pub mod time;
 
-use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
-
-use num_traits::{CheckedNeg, NumCast, WrappingNeg, Zero};
-
-use crate::datatypes::{DataType, IntervalUnit, TimeUnit};
-use crate::error::{ArrowError, Result};
-use crate::types::NativeType;
-use crate::{array::*, bitmap::Bitmap};
-
-use super::arity::{unary, unary_checked};
+use crate::{
+    array::Array,
+    bitmap::Bitmap,
+    datatypes::{DataType, IntervalUnit, TimeUnit},
+    types::NativeType,
+};
 
 // Macro to evaluate match branch in arithmetic function.
-// The macro is used to downcast both arrays to a primitive_array_type. If there
-// is an error then an ArrowError is return with the data_type that cause it.
-// It returns the result from the arithmetic_primitive function evaluated with
-// the Operator selected
 macro_rules! primitive {
-    ($lhs: expr, $rhs: expr, $op: expr, $array_type: ty) => {{
-        let res_lhs = $lhs.as_any().downcast_ref().unwrap();
-        let res_rhs = $rhs.as_any().downcast_ref().unwrap();
+    ($lhs:expr, $rhs:expr, $op:tt, $type:ty) => {{
+        let lhs = $lhs.as_any().downcast_ref().unwrap();
+        let rhs = $rhs.as_any().downcast_ref().unwrap();
 
-        let res = arithmetic_primitive::<$array_type>(res_lhs, $op, res_rhs);
-        Ok(Box::new(res) as Box<dyn Array>)
+        let result = basic::$op::<$type>(lhs, rhs);
+        Box::new(result) as Box<dyn Array>
     }};
 }
 
-/// Execute an arithmetic operation with two arrays. It uses the enum Operator
-/// to select the type of operation that is going to be performed with the two
-/// arrays
-pub fn arithmetic(lhs: &dyn Array, op: Operator, rhs: &dyn Array) -> Result<Box<dyn Array>> {
-    use DataType::*;
-    use Operator::*;
-    match (lhs.data_type(), op, rhs.data_type()) {
-        (Int8, _, Int8) => primitive!(lhs, rhs, op, i8),
-        (Int16, _, Int16) => primitive!(lhs, rhs, op, i16),
-        (Int32, _, Int32) => primitive!(lhs, rhs, op, i32),
-        (Int64, _, Int64) | (Duration(_), _, Duration(_)) => {
-            primitive!(lhs, rhs, op, i64)
+// Macro to create a `match` statement with dynamic dispatch to functions based on
+// the array's logical types
+macro_rules! arith {
+    ($lhs:expr, $rhs:expr, $op:tt $(, decimal = $op_decimal:tt )? $(, duration = $op_duration:tt )? $(, interval = $op_interval:tt )? $(, timestamp = $op_timestamp:tt )?) => {{
+        let lhs = $lhs;
+        let rhs = $rhs;
+        use DataType::*;
+        match (lhs.data_type(), rhs.data_type()) {
+            (Int8, Int8) => primitive!(lhs, rhs, $op, i8),
+            (Int16, Int16) => primitive!(lhs, rhs, $op, i16),
+            (Int32, Int32) => primitive!(lhs, rhs, $op, i32),
+            (Int64, Int64) | (Duration(_), Duration(_)) => {
+                primitive!(lhs, rhs, $op, i64)
+            }
+            (UInt8, UInt8) => primitive!(lhs, rhs, $op, u8),
+            (UInt16, UInt16) => primitive!(lhs, rhs, $op, u16),
+            (UInt32, UInt32) => primitive!(lhs, rhs, $op, u32),
+            (UInt64, UInt64) => primitive!(lhs, rhs, $op, u64),
+            (Float32, Float32) => primitive!(lhs, rhs, $op, f32),
+            (Float64, Float64) => primitive!(lhs, rhs, $op, f64),
+            $ (
+            (Decimal(_, _), Decimal(_, _)) => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                Box::new(decimal::$op_decimal(lhs, rhs)) as Box<dyn Array>
+            }
+            )?
+            $ (
+            (Time32(TimeUnit::Second), Duration(_))
+            | (Time32(TimeUnit::Millisecond), Duration(_))
+            | (Date32, Duration(_)) => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                Box::new(time::$op_duration::<i32>(lhs, rhs)) as Box<dyn Array>
+            }
+            (Time64(TimeUnit::Microsecond), Duration(_))
+            | (Time64(TimeUnit::Nanosecond), Duration(_))
+            | (Date64, Duration(_))
+            | (Timestamp(_, _), Duration(_)) => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                Box::new(time::$op_duration::<i64>(lhs, rhs)) as Box<dyn Array>
+            }
+            )?
+            $ (
+            (Timestamp(_, _), Interval(IntervalUnit::MonthDayNano)) => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                time::$op_interval(lhs, rhs).map(|x| Box::new(x) as Box<dyn Array>).unwrap()
+            }
+            )?
+            $ (
+            (Timestamp(_, None), Timestamp(_, None)) => {
+                let lhs = lhs.as_any().downcast_ref().unwrap();
+                let rhs = rhs.as_any().downcast_ref().unwrap();
+                time::$op_timestamp(lhs, rhs).map(|x| Box::new(x) as Box<dyn Array>).unwrap()
+            }
+            )?
+            _ => todo!(
+                "Addition of {:?} with {:?} is not supported",
+                lhs.data_type(),
+                rhs.data_type()
+            ),
         }
-        (UInt8, _, UInt8) => primitive!(lhs, rhs, op, u8),
-        (UInt16, _, UInt16) => primitive!(lhs, rhs, op, u16),
-        (UInt32, _, UInt32) => primitive!(lhs, rhs, op, u32),
-        (UInt64, _, UInt64) => primitive!(lhs, rhs, op, u64),
-        (Float32, _, Float32) => primitive!(lhs, rhs, op, f32),
-        (Float64, _, Float64) => primitive!(lhs, rhs, op, f64),
-        (Decimal(_, _), _, Decimal(_, _)) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-
-            let res = match op {
-                Add => decimal::add::add(lhs, rhs),
-                Subtract => decimal::sub::sub(lhs, rhs),
-                Multiply => decimal::mul::mul(lhs, rhs),
-                Divide => decimal::div::div(lhs, rhs),
-                Remainder => {
-                    return Err(ArrowError::NotYetImplemented(format!(
-                        "Arithmetics of ({:?}, {:?}, {:?}) is not supported",
-                        lhs, op, rhs
-                    )))
-                }
-            };
-
-            Ok(Box::new(res) as Box<dyn Array>)
-        }
-        (Time32(TimeUnit::Second), Add, Duration(_))
-        | (Time32(TimeUnit::Millisecond), Add, Duration(_))
-        | (Date32, Add, Duration(_)) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            time::add_duration::<i32>(lhs, rhs).map(|x| Box::new(x) as Box<dyn Array>)
-        }
-        (Time32(TimeUnit::Second), Subtract, Duration(_))
-        | (Time32(TimeUnit::Millisecond), Subtract, Duration(_))
-        | (Date32, Subtract, Duration(_)) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            time::subtract_duration::<i32>(lhs, rhs).map(|x| Box::new(x) as Box<dyn Array>)
-        }
-        (Time64(TimeUnit::Microsecond), Add, Duration(_))
-        | (Time64(TimeUnit::Nanosecond), Add, Duration(_))
-        | (Date64, Add, Duration(_))
-        | (Timestamp(_, _), Add, Duration(_)) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            time::add_duration::<i64>(lhs, rhs).map(|x| Box::new(x) as Box<dyn Array>)
-        }
-        (Timestamp(_, _), Add, Interval(IntervalUnit::MonthDayNano)) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            time::add_interval(lhs, rhs).map(|x| Box::new(x) as Box<dyn Array>)
-        }
-        (Time64(TimeUnit::Microsecond), Subtract, Duration(_))
-        | (Time64(TimeUnit::Nanosecond), Subtract, Duration(_))
-        | (Date64, Subtract, Duration(_))
-        | (Timestamp(_, _), Subtract, Duration(_)) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            time::subtract_duration::<i64>(lhs, rhs).map(|x| Box::new(x) as Box<dyn Array>)
-        }
-        (Timestamp(_, None), Subtract, Timestamp(_, None)) => {
-            let lhs = lhs.as_any().downcast_ref().unwrap();
-            let rhs = rhs.as_any().downcast_ref().unwrap();
-            time::subtract_timestamps(lhs, rhs).map(|x| Box::new(x) as Box<dyn Array>)
-        }
-        (lhs, op, rhs) => Err(ArrowError::NotYetImplemented(format!(
-            "Arithmetics of ({:?}, {:?}, {:?}) is not supported",
-            lhs, op, rhs
-        ))),
-    }
+    }};
 }
 
-/// Checks if an array of type `datatype` can perform basic arithmetic
-/// operations. These operations include add, subtract, multiply, divide.
-///
-/// # Examples
-/// ```
-/// use arrow2::compute::arithmetics::{can_arithmetic, Operator};
-/// use arrow2::datatypes::DataType;
-///
-/// let data_type = DataType::Int8;
-/// assert_eq!(can_arithmetic(&data_type, Operator::Add, &data_type), true);
-///
-/// let data_type = DataType::LargeBinary;
-/// assert_eq!(can_arithmetic(&data_type, Operator::Add, &data_type), false)
-/// ```
-pub fn can_arithmetic(lhs: &DataType, op: Operator, rhs: &DataType) -> bool {
-    use DataType::*;
-    use Operator::*;
-    if let (Decimal(_, _), Remainder, Decimal(_, _)) = (lhs, op, rhs) {
-        return false;
-    };
-
-    matches!(
-        (lhs, op, rhs),
-        (Int8, _, Int8)
-            | (Int16, _, Int16)
-            | (Int32, _, Int32)
-            | (Int64, _, Int64)
-            | (UInt8, _, UInt8)
-            | (UInt16, _, UInt16)
-            | (UInt32, _, UInt32)
-            | (UInt64, _, UInt64)
-            | (Float64, _, Float64)
-            | (Float32, _, Float32)
-            | (Duration(_), _, Duration(_))
-            | (Decimal(_, _), _, Decimal(_, _))
-            | (Date32, Subtract, Duration(_))
-            | (Date32, Add, Duration(_))
-            | (Date64, Subtract, Duration(_))
-            | (Date64, Add, Duration(_))
-            | (Time32(TimeUnit::Millisecond), Subtract, Duration(_))
-            | (Time32(TimeUnit::Second), Subtract, Duration(_))
-            | (Time32(TimeUnit::Millisecond), Add, Duration(_))
-            | (Time32(TimeUnit::Second), Add, Duration(_))
-            | (Time64(TimeUnit::Microsecond), Subtract, Duration(_))
-            | (Time64(TimeUnit::Nanosecond), Subtract, Duration(_))
-            | (Time64(TimeUnit::Microsecond), Add, Duration(_))
-            | (Time64(TimeUnit::Nanosecond), Add, Duration(_))
-            | (Timestamp(_, _), Subtract, Duration(_))
-            | (Timestamp(_, _), Add, Duration(_))
-            | (Timestamp(_, _), Add, Interval(IntervalUnit::MonthDayNano))
-            | (Timestamp(_, None), Subtract, Timestamp(_, None))
+/// Adds two [`Array`]s.
+/// # Panic
+/// This function panics iff
+/// * the opertion is not supported for the logical types (use [`can_add`] to check)
+/// * the arrays have a different length
+/// * one of the arrays is a timestamp with timezone and the timezone is not valid.
+pub fn add(lhs: &dyn Array, rhs: &dyn Array) -> Box<dyn Array> {
+    arith!(
+        lhs,
+        rhs,
+        add,
+        duration = add_duration,
+        interval = add_interval
     )
 }
 
-/// Arithmetic operator
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Operator {
-    /// Add
-    Add,
-    /// Subtract
-    Subtract,
-    /// Multiply
-    Multiply,
-    /// Divide
-    Divide,
-    /// Remainder
-    Remainder,
+/// Returns whether two [`DataType`]s can be added by [`add`].
+pub fn can_add(lhs: &DataType, rhs: &DataType) -> bool {
+    use DataType::*;
+    matches!(
+        (lhs, rhs),
+        (Int8, Int8)
+            | (Int16, Int16)
+            | (Int32, Int32)
+            | (Int64, Int64)
+            | (UInt8, UInt8)
+            | (UInt16, UInt16)
+            | (UInt32, UInt32)
+            | (UInt64, UInt64)
+            | (Float64, Float64)
+            | (Float32, Float32)
+            | (Duration(_), Duration(_))
+            | (Decimal(_, _), Decimal(_, _))
+            | (Date32, Duration(_))
+            | (Date64, Duration(_))
+            | (Time32(TimeUnit::Millisecond), Duration(_))
+            | (Time32(TimeUnit::Second), Duration(_))
+            | (Time64(TimeUnit::Microsecond), Duration(_))
+            | (Time64(TimeUnit::Nanosecond), Duration(_))
+            | (Timestamp(_, _), Duration(_))
+            | (Timestamp(_, _), Interval(IntervalUnit::MonthDayNano))
+    )
 }
 
-/// Perform arithmetic operations on two primitive arrays based on the Operator enum
-//
-pub fn arithmetic_primitive<T>(
-    lhs: &PrimitiveArray<T>,
-    op: Operator,
-    rhs: &PrimitiveArray<T>,
-) -> PrimitiveArray<T>
-where
-    T: NativeType
-        + Div<Output = T>
-        + Zero
-        + Add<Output = T>
-        + Sub<Output = T>
-        + Mul<Output = T>
-        + Rem<Output = T>,
-{
-    match op {
-        Operator::Add => basic::add(lhs, rhs),
-        Operator::Subtract => basic::sub(lhs, rhs),
-        Operator::Multiply => basic::mul(lhs, rhs),
-        Operator::Divide => basic::div(lhs, rhs),
-        Operator::Remainder => basic::rem(lhs, rhs),
-    }
+/// Subtracts two [`Array`]s.
+/// # Panic
+/// This function panics iff
+/// * the opertion is not supported for the logical types (use [`can_sub`] to check)
+/// * the arrays have a different length
+/// * one of the arrays is a timestamp with timezone and the timezone is not valid.
+pub fn sub(lhs: &dyn Array, rhs: &dyn Array) -> Box<dyn Array> {
+    arith!(
+        lhs,
+        rhs,
+        sub,
+        decimal = sub,
+        duration = subtract_duration,
+        timestamp = subtract_timestamps
+    )
 }
 
-/// Performs primitive operation on an array and and scalar
-pub fn arithmetic_primitive_scalar<T>(
-    lhs: &PrimitiveArray<T>,
-    op: Operator,
-    rhs: &T,
-) -> Result<PrimitiveArray<T>>
-where
-    T: NativeType
-        + Div<Output = T>
-        + Zero
-        + Add<Output = T>
-        + Sub<Output = T>
-        + Mul<Output = T>
-        + Rem<Output = T>
-        + NumCast,
-{
-    match op {
-        Operator::Add => Ok(basic::add_scalar(lhs, rhs)),
-        Operator::Subtract => Ok(basic::sub_scalar(lhs, rhs)),
-        Operator::Multiply => Ok(basic::mul_scalar(lhs, rhs)),
-        Operator::Divide => Ok(basic::div_scalar(lhs, rhs)),
-        Operator::Remainder => Ok(basic::rem_scalar(lhs, rhs)),
-    }
+/// Returns whether two [`DataType`]s can be subtracted by [`sub`].
+pub fn can_sub(lhs: &DataType, rhs: &DataType) -> bool {
+    use DataType::*;
+    matches!(
+        (lhs, rhs),
+        (Int8, Int8)
+            | (Int16, Int16)
+            | (Int32, Int32)
+            | (Int64, Int64)
+            | (UInt8, UInt8)
+            | (UInt16, UInt16)
+            | (UInt32, UInt32)
+            | (UInt64, UInt64)
+            | (Float64, Float64)
+            | (Float32, Float32)
+            | (Duration(_), Duration(_))
+            | (Decimal(_, _), Decimal(_, _))
+            | (Date32, Duration(_))
+            | (Date64, Duration(_))
+            | (Time32(TimeUnit::Millisecond), Duration(_))
+            | (Time32(TimeUnit::Second), Duration(_))
+            | (Time64(TimeUnit::Microsecond), Duration(_))
+            | (Time64(TimeUnit::Nanosecond), Duration(_))
+            | (Timestamp(_, _), Duration(_))
+            | (Timestamp(_, None), Timestamp(_, None))
+    )
 }
 
-/// Negates values from array.
-///
-/// # Examples
-/// ```
-/// use arrow2::compute::arithmetics::negate;
-/// use arrow2::array::PrimitiveArray;
-///
-/// let a = PrimitiveArray::from([None, Some(6), None, Some(7)]);
-/// let result = negate(&a);
-/// let expected = PrimitiveArray::from([None, Some(-6), None, Some(-7)]);
-/// assert_eq!(result, expected)
-/// ```
-pub fn negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
-where
-    T: NativeType + Neg<Output = T>,
-{
-    unary(array, |a| -a, array.data_type().clone())
+/// Multiply two [`Array`]s.
+/// # Panic
+/// This function panics iff
+/// * the opertion is not supported for the logical types (use [`can_mul`] to check)
+/// * the arrays have a different length
+pub fn mul(lhs: &dyn Array, rhs: &dyn Array) -> Box<dyn Array> {
+    arith!(lhs, rhs, mul, decimal = mul)
 }
 
-/// Checked negates values from array.
-///
-/// # Examples
-/// ```
-/// use arrow2::compute::arithmetics::checked_negate;
-/// use arrow2::array::{Array, PrimitiveArray};
-///
-/// let a = PrimitiveArray::from([None, Some(6), Some(i8::MIN), Some(7)]);
-/// let result = checked_negate(&a);
-/// let expected = PrimitiveArray::from([None, Some(-6), None, Some(-7)]);
-/// assert_eq!(result, expected);
-/// assert!(!result.is_valid(2))
-/// ```
-pub fn checked_negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
-where
-    T: NativeType + CheckedNeg,
-{
-    unary_checked(array, |a| a.checked_neg(), array.data_type().clone())
+/// Returns whether two [`DataType`]s can be multiplied by [`mul`].
+pub fn can_mul(lhs: &DataType, rhs: &DataType) -> bool {
+    use DataType::*;
+    matches!(
+        (lhs, rhs),
+        (Int8, Int8)
+            | (Int16, Int16)
+            | (Int32, Int32)
+            | (Int64, Int64)
+            | (UInt8, UInt8)
+            | (UInt16, UInt16)
+            | (UInt32, UInt32)
+            | (UInt64, UInt64)
+            | (Float64, Float64)
+            | (Float32, Float32)
+            | (Decimal(_, _), Decimal(_, _))
+    )
 }
 
-/// Wrapping negates values from array.
-///
-/// # Examples
-/// ```
-/// use arrow2::compute::arithmetics::wrapping_negate;
-/// use arrow2::array::{Array, PrimitiveArray};
-///
-/// let a = PrimitiveArray::from([None, Some(6), Some(i8::MIN), Some(7)]);
-/// let result = wrapping_negate(&a);
-/// let expected = PrimitiveArray::from([None, Some(-6), Some(i8::MIN), Some(-7)]);
-/// assert_eq!(result, expected);
-/// ```
-pub fn wrapping_negate<T>(array: &PrimitiveArray<T>) -> PrimitiveArray<T>
-where
-    T: NativeType + WrappingNeg,
-{
-    unary(array, |a| a.wrapping_neg(), array.data_type().clone())
+/// Divide of two [`Array`]s.
+/// # Panic
+/// This function panics iff
+/// * the opertion is not supported for the logical types (use [`can_div`] to check)
+/// * the arrays have a different length
+pub fn div(lhs: &dyn Array, rhs: &dyn Array) -> Box<dyn Array> {
+    arith!(lhs, rhs, div, decimal = div)
+}
+
+/// Returns whether two [`DataType`]s can be divided by [`div`].
+pub fn can_div(lhs: &DataType, rhs: &DataType) -> bool {
+    can_mul(lhs, rhs)
+}
+
+/// Remainder of two [`Array`]s.
+/// # Panic
+/// This function panics iff
+/// * the opertion is not supported for the logical types (use [`can_rem`] to check)
+/// * the arrays have a different length
+pub fn rem(lhs: &dyn Array, rhs: &dyn Array) -> Box<dyn Array> {
+    arith!(lhs, rhs, rem)
+}
+
+/// Returns whether two [`DataType`]s "can be remainder" by [`rem`].
+pub fn can_rem(lhs: &DataType, rhs: &DataType) -> bool {
+    use DataType::*;
+    matches!(
+        (lhs, rhs),
+        (Int8, Int8)
+            | (Int16, Int16)
+            | (Int32, Int32)
+            | (Int64, Int64)
+            | (UInt8, UInt8)
+            | (UInt16, UInt16)
+            | (UInt32, UInt32)
+            | (UInt64, UInt64)
+            | (Float64, Float64)
+            | (Float32, Float32)
+    )
 }
 
 /// Defines basic addition operation for primitive arrays

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -79,9 +79,9 @@ macro_rules! primitive {
     ($lhs: expr, $rhs: expr, $op: expr, $array_type: ty) => {{
         let res_lhs = $lhs.as_any().downcast_ref().unwrap();
         let res_rhs = $rhs.as_any().downcast_ref().unwrap();
-        arithmetic_primitive::<$array_type>(res_lhs, $op, res_rhs)
-            .map(Box::new)
-            .map(|x| x as Box<dyn Array>)
+
+        let res = arithmetic_primitive::<$array_type>(res_lhs, $op, res_rhs);
+        Ok(Box::new(res) as Box<dyn Array>)
     }};
 }
 
@@ -121,7 +121,7 @@ pub fn arithmetic(lhs: &dyn Array, op: Operator, rhs: &dyn Array) -> Result<Box<
                 }
             };
 
-            res.map(|x| Box::new(x) as Box<dyn Array>)
+            Ok(Box::new(res) as Box<dyn Array>)
         }
         (Time32(TimeUnit::Second), Add, Duration(_))
         | (Time32(TimeUnit::Millisecond), Add, Duration(_))
@@ -245,7 +245,7 @@ pub fn arithmetic_primitive<T>(
     lhs: &PrimitiveArray<T>,
     op: Operator,
     rhs: &PrimitiveArray<T>,
-) -> Result<PrimitiveArray<T>>
+) -> PrimitiveArray<T>
 where
     T: NativeType
         + Div<Output = T>
@@ -350,115 +350,115 @@ where
 /// Defines basic addition operation for primitive arrays
 pub trait ArrayAdd<Rhs>: Sized {
     /// Adds itself to `rhs`
-    fn add(&self, rhs: &Rhs) -> Result<Self>;
+    fn add(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines wrapping addition operation for primitive arrays
 pub trait ArrayWrappingAdd<Rhs>: Sized {
     /// Adds itself to `rhs` using wrapping addition
-    fn wrapping_add(&self, rhs: &Rhs) -> Result<Self>;
+    fn wrapping_add(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines checked addition operation for primitive arrays
 pub trait ArrayCheckedAdd<Rhs>: Sized {
     /// Checked add
-    fn checked_add(&self, rhs: &Rhs) -> Result<Self>;
+    fn checked_add(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines saturating addition operation for primitive arrays
 pub trait ArraySaturatingAdd<Rhs>: Sized {
     /// Saturating add
-    fn saturating_add(&self, rhs: &Rhs) -> Result<Self>;
+    fn saturating_add(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines Overflowing addition operation for primitive arrays
 pub trait ArrayOverflowingAdd<Rhs>: Sized {
     /// Overflowing add
-    fn overflowing_add(&self, rhs: &Rhs) -> Result<(Self, Bitmap)>;
+    fn overflowing_add(&self, rhs: &Rhs) -> (Self, Bitmap);
 }
 
 /// Defines basic subtraction operation for primitive arrays
 pub trait ArraySub<Rhs>: Sized {
     /// subtraction
-    fn sub(&self, rhs: &Rhs) -> Result<Self>;
+    fn sub(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines wrapping subtraction operation for primitive arrays
 pub trait ArrayWrappingSub<Rhs>: Sized {
     /// wrapping subtraction
-    fn wrapping_sub(&self, rhs: &Rhs) -> Result<Self>;
+    fn wrapping_sub(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines checked subtraction operation for primitive arrays
 pub trait ArrayCheckedSub<Rhs>: Sized {
     /// checked subtraction
-    fn checked_sub(&self, rhs: &Rhs) -> Result<Self>;
+    fn checked_sub(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines saturating subtraction operation for primitive arrays
 pub trait ArraySaturatingSub<Rhs>: Sized {
     /// saturarting subtraction
-    fn saturating_sub(&self, rhs: &Rhs) -> Result<Self>;
+    fn saturating_sub(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines Overflowing subtraction operation for primitive arrays
 pub trait ArrayOverflowingSub<Rhs>: Sized {
     /// overflowing subtraction
-    fn overflowing_sub(&self, rhs: &Rhs) -> Result<(Self, Bitmap)>;
+    fn overflowing_sub(&self, rhs: &Rhs) -> (Self, Bitmap);
 }
 
 /// Defines basic multiplication operation for primitive arrays
 pub trait ArrayMul<Rhs>: Sized {
     /// multiplication
-    fn mul(&self, rhs: &Rhs) -> Result<Self>;
+    fn mul(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines wrapping multiplication operation for primitive arrays
 pub trait ArrayWrappingMul<Rhs>: Sized {
     /// wrapping multiplication
-    fn wrapping_mul(&self, rhs: &Rhs) -> Result<Self>;
+    fn wrapping_mul(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines checked multiplication operation for primitive arrays
 pub trait ArrayCheckedMul<Rhs>: Sized {
     /// checked multiplication
-    fn checked_mul(&self, rhs: &Rhs) -> Result<Self>;
+    fn checked_mul(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines saturating multiplication operation for primitive arrays
 pub trait ArraySaturatingMul<Rhs>: Sized {
     /// saturating multiplication
-    fn saturating_mul(&self, rhs: &Rhs) -> Result<Self>;
+    fn saturating_mul(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines Overflowing multiplication operation for primitive arrays
 pub trait ArrayOverflowingMul<Rhs>: Sized {
     /// overflowing multiplication
-    fn overflowing_mul(&self, rhs: &Rhs) -> Result<(Self, Bitmap)>;
+    fn overflowing_mul(&self, rhs: &Rhs) -> (Self, Bitmap);
 }
 
 /// Defines basic division operation for primitive arrays
 pub trait ArrayDiv<Rhs>: Sized {
     /// division
-    fn div(&self, rhs: &Rhs) -> Result<Self>;
+    fn div(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines checked division operation for primitive arrays
 pub trait ArrayCheckedDiv<Rhs>: Sized {
     /// checked division
-    fn checked_div(&self, rhs: &Rhs) -> Result<Self>;
+    fn checked_div(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines basic reminder operation for primitive arrays
 pub trait ArrayRem<Rhs>: Sized {
     /// remainder
-    fn rem(&self, rhs: &Rhs) -> Result<Self>;
+    fn rem(&self, rhs: &Rhs) -> Self;
 }
 
 /// Defines checked reminder operation for primitive arrays
 pub trait ArrayCheckedRem<Rhs>: Sized {
     /// checked remainder
-    fn checked_rem(&self, rhs: &Rhs) -> Result<Self>;
+    fn checked_rem(&self, rhs: &Rhs) -> Self;
 }
 
 /// Trait describing a [`NativeType`] whose semantics of arithmetic in Arrow equals

--- a/src/compute/arithmetics/time.rs
+++ b/src/compute/arithmetics/time.rs
@@ -86,7 +86,7 @@ fn create_scale(lhs: &DataType, rhs: &DataType) -> Result<f64> {
 /// let duration = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)])
 ///     .to(DataType::Duration(TimeUnit::Second));
 ///
-/// let result = add_duration(&timestamp, &duration).unwrap();
+/// let result = add_duration(&timestamp, &duration);
 /// let expected = PrimitiveArray::from([
 ///     Some(100010i64),
 ///     Some(200020i64),
@@ -141,7 +141,7 @@ where
 /// let duration = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)])
 ///     .to(DataType::Duration(TimeUnit::Second));
 ///
-/// let result = subtract_duration(&timestamp, &duration).unwrap();
+/// let result = subtract_duration(&timestamp, &duration);
 /// let expected = PrimitiveArray::from([
 ///     Some(99990i64),
 ///     Some(199980i64),

--- a/src/compute/arithmetics/time.rs
+++ b/src/compute/arithmetics/time.rs
@@ -103,18 +103,18 @@ fn create_scale(lhs: &DataType, rhs: &DataType) -> Result<f64> {
 pub fn add_duration<T>(
     time: &PrimitiveArray<T>,
     duration: &PrimitiveArray<i64>,
-) -> Result<PrimitiveArray<T>>
+) -> PrimitiveArray<T>
 where
     f64: AsPrimitive<T>,
     T: NativeType + Add<T, Output = T>,
 {
-    let scale = create_scale(time.data_type(), duration.data_type())?;
+    let scale = create_scale(time.data_type(), duration.data_type()).unwrap();
 
     // Closure for the binary operation. The closure contains the scale
     // required to add a duration to the timestamp array.
     let op = move |a: T, b: i64| a + (b as f64 * scale).as_();
 
-    Ok(binary(time, duration, time.data_type().clone(), op))
+    binary(time, duration, time.data_type().clone(), op)
 }
 
 /// Subtract a duration to a time array (Timestamp, Time and Date). The timeunit
@@ -159,18 +159,18 @@ where
 pub fn subtract_duration<T>(
     time: &PrimitiveArray<T>,
     duration: &PrimitiveArray<i64>,
-) -> Result<PrimitiveArray<T>>
+) -> PrimitiveArray<T>
 where
     f64: AsPrimitive<T>,
     T: NativeType + Sub<T, Output = T>,
 {
-    let scale = create_scale(time.data_type(), duration.data_type())?;
+    let scale = create_scale(time.data_type(), duration.data_type()).unwrap();
 
     // Closure for the binary operation. The closure contains the scale
     // required to add a duration to the timestamp array.
     let op = move |a: T, b: i64| a - (b as f64 * scale).as_();
 
-    Ok(binary(time, duration, time.data_type().clone(), op))
+    binary(time, duration, time.data_type().clone(), op)
 }
 
 /// Calculates the difference between two timestamps returning an array of type

--- a/src/compute/arity.rs
+++ b/src/compute/arity.rs
@@ -140,13 +140,13 @@ pub fn binary<T, D, F>(
     rhs: &PrimitiveArray<D>,
     data_type: DataType,
     op: F,
-) -> Result<PrimitiveArray<T>>
+) -> PrimitiveArray<T>
 where
     T: NativeType,
     D: NativeType,
     F: Fn(T, D) -> T,
 {
-    check_same_len(lhs, rhs)?;
+    check_same_len(lhs, rhs).unwrap();
 
     let validity = combine_validities(lhs.validity(), rhs.validity());
 
@@ -157,7 +157,7 @@ where
         .map(|(l, r)| op(*l, *r));
     let values = Buffer::from_trusted_len_iter(values);
 
-    Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
+    PrimitiveArray::<T>::from_data(data_type, values, validity)
 }
 
 /// Version of binary that checks for errors in the closure used to create the
@@ -195,13 +195,13 @@ pub fn binary_with_bitmap<T, D, F>(
     rhs: &PrimitiveArray<D>,
     data_type: DataType,
     op: F,
-) -> Result<(PrimitiveArray<T>, Bitmap)>
+) -> (PrimitiveArray<T>, Bitmap)
 where
     T: NativeType,
     D: NativeType,
     F: Fn(T, D) -> (T, bool),
 {
-    check_same_len(lhs, rhs)?;
+    check_same_len(lhs, rhs).unwrap();
 
     let validity = combine_validities(lhs.validity(), rhs.validity());
 
@@ -215,10 +215,10 @@ where
 
     let values = Buffer::from_trusted_len_iter(values);
 
-    Ok((
+    (
         PrimitiveArray::<T>::from_data(data_type, values, validity),
         mut_bitmap.into(),
-    ))
+    )
 }
 
 /// Version of binary that creates a mutable bitmap that is used to keep track
@@ -229,13 +229,13 @@ pub fn binary_checked<T, D, F>(
     rhs: &PrimitiveArray<D>,
     data_type: DataType,
     op: F,
-) -> Result<PrimitiveArray<T>>
+) -> PrimitiveArray<T>
 where
     T: NativeType,
     D: NativeType,
     F: Fn(T, D) -> Option<T>,
 {
-    check_same_len(lhs, rhs)?;
+    check_same_len(lhs, rhs).unwrap();
 
     let mut mut_bitmap = MutableBitmap::with_capacity(lhs.len());
 
@@ -265,5 +265,5 @@ where
     // as Null
     let validity = combine_validities(validity.as_ref(), Some(&bitmap));
 
-    Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
+    PrimitiveArray::<T>::from_data(data_type, values, validity)
 }

--- a/src/compute/bitwise.rs
+++ b/src/compute/bitwise.rs
@@ -2,41 +2,36 @@
 use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 use crate::array::{Array, PrimitiveArray};
-use crate::compute::arithmetics::basic::check_same_type;
 use crate::compute::arity::{binary, unary};
-use crate::error::Result;
 use crate::types::NativeType;
 
 /// Performs `OR` operation on two arrays.
-/// # Error
-/// This function errors when the arrays have different lengths or are different types.
-pub fn or<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+/// # Panic
+/// This function errors when the arrays have different lengths.
+pub fn or<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + BitOr<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
     binary(lhs, rhs, lhs.data_type().clone(), |a, b| a | b)
 }
 
 /// Performs `XOR` operation between two arrays.
-/// # Error
-/// This function errors when the arrays have different lengths or are different types.
-pub fn xor<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+/// # Panic
+/// This function errors when the arrays have different lengths.
+pub fn xor<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + BitXor<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
     binary(lhs, rhs, lhs.data_type().clone(), |a, b| a ^ b)
 }
 
 /// Performs `AND` operation on two arrays.
-/// # Error
-/// This function errors when the arrays have different lengths or are different types.
-pub fn and<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> Result<PrimitiveArray<T>>
+/// # Panic
+/// This function panics when the arrays have different lengths.
+pub fn and<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> PrimitiveArray<T>
 where
     T: NativeType + BitAnd<Output = T>,
 {
-    check_same_type(lhs, rhs)?;
     binary(lhs, rhs, lhs.data_type().clone(), |a, b| a & b)
 }
 

--- a/tests/it/compute/aggregate/sum.rs
+++ b/tests/it/compute/aggregate/sum.rs
@@ -46,7 +46,7 @@ fn test_primitive_array_sum_large_64() {
         .map(|i| if i % 3 == 0 { Some(0) } else { Some(i) })
         .collect();
     // create an array that actually has non-zero values at the invalid indices
-    let c = arithmetics::basic::add(&a, &b).unwrap();
+    let c = arithmetics::basic::add(&a, &b);
     assert_eq!(
         Some((1..=100).filter(|i| i % 3 == 0).sum()),
         sum_primitive(&c)

--- a/tests/it/compute/arithmetics/basic/add.rs
+++ b/tests/it/compute/arithmetics/basic/add.rs
@@ -6,24 +6,23 @@ use arrow2::compute::arithmetics::{
 };
 
 #[test]
+#[should_panic]
 fn test_add_mismatched_length() {
     let a = Int32Array::from_slice(&[5, 6]);
     let b = Int32Array::from_slice(&[5]);
-    add(&a, &b)
-        .err()
-        .expect("should have failed due to different lengths");
+    add(&a, &b);
 }
 
 #[test]
 fn test_add() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let result = add(&a, &b).unwrap();
+    let result = add(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(12)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.add(&b).unwrap();
+    let result = a.add(&b);
     assert_eq!(result, expected);
 }
 
@@ -32,25 +31,25 @@ fn test_add() {
 fn test_add_panic() {
     let a = Int8Array::from(&[Some(100i8)]);
     let b = Int8Array::from(&[Some(100i8)]);
-    let _ = add(&a, &b);
+    add(&a, &b);
 }
 
 #[test]
 fn test_add_checked() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let result = checked_add(&a, &b).unwrap();
+    let result = checked_add(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(12)]);
     assert_eq!(result, expected);
 
     let a = Int8Array::from(&[Some(100i8), Some(100i8), Some(100i8)]);
     let b = Int8Array::from(&[Some(0i8), Some(100i8), Some(0i8)]);
-    let result = checked_add(&a, &b).unwrap();
+    let result = checked_add(&a, &b);
     let expected = Int8Array::from(&[Some(100i8), None, Some(100i8)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.checked_add(&b).unwrap();
+    let result = a.checked_add(&b);
     assert_eq!(result, expected);
 }
 
@@ -58,18 +57,18 @@ fn test_add_checked() {
 fn test_add_saturating() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let result = saturating_add(&a, &b).unwrap();
+    let result = saturating_add(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(12)]);
     assert_eq!(result, expected);
 
     let a = Int8Array::from(&[Some(100i8)]);
     let b = Int8Array::from(&[Some(100i8)]);
-    let result = saturating_add(&a, &b).unwrap();
+    let result = saturating_add(&a, &b);
     let expected = Int8Array::from(&[Some(127)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.saturating_add(&b).unwrap();
+    let result = a.saturating_add(&b);
     assert_eq!(result, expected);
 }
 
@@ -77,20 +76,20 @@ fn test_add_saturating() {
 fn test_add_overflowing() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let (result, overflow) = overflowing_add(&a, &b).unwrap();
+    let (result, overflow) = overflowing_add(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(12)]);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, false, false, false]));
 
     let a = Int8Array::from(&[Some(1i8), Some(100i8)]);
     let b = Int8Array::from(&[Some(1i8), Some(100i8)]);
-    let (result, overflow) = overflowing_add(&a, &b).unwrap();
+    let (result, overflow) = overflowing_add(&a, &b);
     let expected = Int8Array::from(&[Some(2i8), Some(-56i8)]);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, true]));
 
     // Trait testing
-    let (result, overflow) = a.overflowing_add(&b).unwrap();
+    let (result, overflow) = a.overflowing_add(&b);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, true]));
 }
@@ -103,7 +102,7 @@ fn test_add_scalar() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.add(&1i32).unwrap();
+    let result = a.add(&1i32);
     assert_eq!(result, expected);
 }
 
@@ -120,7 +119,7 @@ fn test_add_scalar_checked() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.checked_add(&100i8).unwrap();
+    let result = a.checked_add(&100i8);
     assert_eq!(result, expected);
 }
 
@@ -137,7 +136,7 @@ fn test_add_scalar_saturating() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.saturating_add(&100i8).unwrap();
+    let result = a.saturating_add(&100i8);
     assert_eq!(result, expected);
 }
 
@@ -156,7 +155,7 @@ fn test_add_scalar_overflowing() {
     assert_eq!(overflow, Bitmap::from([false, true]));
 
     // Trait testing
-    let (result, overflow) = a.overflowing_add(&100i8).unwrap();
+    let (result, overflow) = a.overflowing_add(&100i8);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, true]));
 }

--- a/tests/it/compute/arithmetics/basic/div.rs
+++ b/tests/it/compute/arithmetics/basic/div.rs
@@ -3,24 +3,23 @@ use arrow2::compute::arithmetics::basic::*;
 use arrow2::compute::arithmetics::{ArrayCheckedDiv, ArrayDiv};
 
 #[test]
+#[should_panic]
 fn test_div_mismatched_length() {
     let a = Int32Array::from_slice(&[5, 6]);
     let b = Int32Array::from_slice(&[5]);
-    div(&a, &b)
-        .err()
-        .expect("should have failed due to different lengths");
+    div(&a, &b);
 }
 
 #[test]
 fn test_div() {
     let a = Int32Array::from(&[Some(5), Some(6)]);
     let b = Int32Array::from(&[Some(5), Some(6)]);
-    let result = div(&a, &b).unwrap();
+    let result = div(&a, &b);
     let expected = Int32Array::from(&[Some(1), Some(1)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.div(&b).unwrap();
+    let result = a.div(&b);
     assert_eq!(result, expected);
 }
 
@@ -36,18 +35,18 @@ fn test_div_panic() {
 fn test_div_checked() {
     let a = Int32Array::from(&[Some(5), None, Some(3), Some(6)]);
     let b = Int32Array::from(&[Some(5), Some(3), None, Some(6)]);
-    let result = checked_div(&a, &b).unwrap();
+    let result = checked_div(&a, &b);
     let expected = Int32Array::from(&[Some(1), None, None, Some(1)]);
     assert_eq!(result, expected);
 
     let a = Int32Array::from(&[Some(5), None, Some(3), Some(6)]);
     let b = Int32Array::from(&[Some(5), Some(0), Some(0), Some(6)]);
-    let result = checked_div(&a, &b).unwrap();
+    let result = checked_div(&a, &b);
     let expected = Int32Array::from(&[Some(1), None, None, Some(1)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.checked_div(&b).unwrap();
+    let result = a.checked_div(&b);
     assert_eq!(result, expected);
 }
 
@@ -59,7 +58,7 @@ fn test_div_scalar() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.div(&1i32).unwrap();
+    let result = a.div(&1i32);
     assert_eq!(result, expected);
 
     // check the strength reduced branches
@@ -97,6 +96,6 @@ fn test_div_scalar_checked() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.checked_div(&0).unwrap();
+    let result = a.checked_div(&0);
     assert_eq!(result, expected);
 }

--- a/tests/it/compute/arithmetics/basic/mul.rs
+++ b/tests/it/compute/arithmetics/basic/mul.rs
@@ -6,24 +6,23 @@ use arrow2::compute::arithmetics::{
 };
 
 #[test]
+#[should_panic]
 fn test_mul_mismatched_length() {
     let a = Int32Array::from_slice(&[5, 6]);
     let b = Int32Array::from_slice(&[5]);
-    mul(&a, &b)
-        .err()
-        .expect("should have failed due to different lengths");
+    mul(&a, &b);
 }
 
 #[test]
 fn test_mul() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let result = mul(&a, &b).unwrap();
+    let result = mul(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(36)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.mul(&b).unwrap();
+    let result = a.mul(&b);
     assert_eq!(result, expected);
 }
 
@@ -39,18 +38,18 @@ fn test_mul_panic() {
 fn test_mul_checked() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let result = checked_mul(&a, &b).unwrap();
+    let result = checked_mul(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(36)]);
     assert_eq!(result, expected);
 
     let a = Int8Array::from(&[Some(100i8), Some(100i8), Some(100i8)]);
     let b = Int8Array::from(&[Some(1i8), Some(100i8), Some(1i8)]);
-    let result = checked_mul(&a, &b).unwrap();
+    let result = checked_mul(&a, &b);
     let expected = Int8Array::from(&[Some(100i8), None, Some(100i8)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.checked_mul(&b).unwrap();
+    let result = a.checked_mul(&b);
     assert_eq!(result, expected);
 }
 
@@ -58,18 +57,18 @@ fn test_mul_checked() {
 fn test_mul_saturating() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let result = saturating_mul(&a, &b).unwrap();
+    let result = saturating_mul(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(36)]);
     assert_eq!(result, expected);
 
     let a = Int8Array::from(&[Some(-100i8)]);
     let b = Int8Array::from(&[Some(100i8)]);
-    let result = saturating_mul(&a, &b).unwrap();
+    let result = saturating_mul(&a, &b);
     let expected = Int8Array::from(&[Some(-128)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.saturating_mul(&b).unwrap();
+    let result = a.saturating_mul(&b);
     assert_eq!(result, expected);
 }
 
@@ -77,20 +76,20 @@ fn test_mul_saturating() {
 fn test_mul_overflowing() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let (result, overflow) = overflowing_mul(&a, &b).unwrap();
+    let (result, overflow) = overflowing_mul(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(36)]);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, false, false, false]));
 
     let a = Int8Array::from(&[Some(1i8), Some(-100i8)]);
     let b = Int8Array::from(&[Some(1i8), Some(100i8)]);
-    let (result, overflow) = overflowing_mul(&a, &b).unwrap();
+    let (result, overflow) = overflowing_mul(&a, &b);
     let expected = Int8Array::from(&[Some(1i8), Some(-16i8)]);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, true]));
 
     // Trait testing
-    let (result, overflow) = a.overflowing_mul(&b).unwrap();
+    let (result, overflow) = a.overflowing_mul(&b);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, true]));
 }
@@ -103,7 +102,7 @@ fn test_mul_scalar() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.mul(&1i32).unwrap();
+    let result = a.mul(&1i32);
     assert_eq!(result, expected);
 }
 
@@ -120,7 +119,7 @@ fn test_mul_scalar_checked() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.checked_mul(&100i8).unwrap();
+    let result = a.checked_mul(&100i8);
     assert_eq!(result, expected);
 }
 
@@ -137,7 +136,7 @@ fn test_mul_scalar_saturating() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.saturating_mul(&100i8).unwrap();
+    let result = a.saturating_mul(&100i8);
     assert_eq!(result, expected);
 }
 
@@ -156,7 +155,7 @@ fn test_mul_scalar_overflowing() {
     assert_eq!(overflow, Bitmap::from([false, true]));
 
     // Trait testing
-    let (result, overflow) = a.overflowing_mul(&100i8).unwrap();
+    let (result, overflow) = a.overflowing_mul(&100i8);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, true]));
 }

--- a/tests/it/compute/arithmetics/basic/rem.rs
+++ b/tests/it/compute/arithmetics/basic/rem.rs
@@ -3,24 +3,23 @@ use arrow2::compute::arithmetics::basic::*;
 use arrow2::compute::arithmetics::{ArrayCheckedRem, ArrayRem};
 
 #[test]
+#[should_panic]
 fn test_rem_mismatched_length() {
     let a = Int32Array::from_slice(&[5, 6]);
     let b = Int32Array::from_slice(&[5]);
-    rem(&a, &b)
-        .err()
-        .expect("should have failed due to different lengths");
+    rem(&a, &b);
 }
 
 #[test]
 fn test_rem() {
     let a = Int32Array::from(&[Some(5), Some(6)]);
     let b = Int32Array::from(&[Some(4), Some(4)]);
-    let result = rem(&a, &b).unwrap();
+    let result = rem(&a, &b);
     let expected = Int32Array::from(&[Some(1), Some(2)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.rem(&b).unwrap();
+    let result = a.rem(&b);
     assert_eq!(result, expected);
 }
 
@@ -36,18 +35,18 @@ fn test_rem_panic() {
 fn test_rem_checked() {
     let a = Int32Array::from(&[Some(5), None, Some(3), Some(6)]);
     let b = Int32Array::from(&[Some(5), Some(3), None, Some(5)]);
-    let result = checked_rem(&a, &b).unwrap();
+    let result = checked_rem(&a, &b);
     let expected = Int32Array::from(&[Some(0), None, None, Some(1)]);
     assert_eq!(result, expected);
 
     let a = Int32Array::from(&[Some(5), None, Some(3), Some(6)]);
     let b = Int32Array::from(&[Some(5), Some(0), Some(0), Some(5)]);
-    let result = checked_rem(&a, &b).unwrap();
+    let result = checked_rem(&a, &b);
     let expected = Int32Array::from(&[Some(0), None, None, Some(1)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.checked_rem(&b).unwrap();
+    let result = a.checked_rem(&b);
     assert_eq!(result, expected);
 }
 
@@ -59,7 +58,7 @@ fn test_rem_scalar() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.rem(&2i32).unwrap();
+    let result = a.rem(&2i32);
     assert_eq!(result, expected);
 
     // check the strength reduced branches
@@ -97,6 +96,6 @@ fn test_rem_scalar_checked() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.checked_rem(&0).unwrap();
+    let result = a.checked_rem(&0);
     assert_eq!(result, expected);
 }

--- a/tests/it/compute/arithmetics/basic/sub.rs
+++ b/tests/it/compute/arithmetics/basic/sub.rs
@@ -6,24 +6,23 @@ use arrow2::compute::arithmetics::{
 };
 
 #[test]
+#[should_panic]
 fn test_sub_mismatched_length() {
     let a = Int32Array::from_slice(&[5, 6]);
     let b = Int32Array::from_slice(&[5]);
-    sub(&a, &b)
-        .err()
-        .expect("should have failed due to different lengths");
+    sub(&a, &b);
 }
 
 #[test]
 fn test_sub() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let result = sub(&a, &b).unwrap();
+    let result = sub(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(0)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.sub(&b).unwrap();
+    let result = a.sub(&b);
     assert_eq!(result, expected);
 }
 
@@ -39,18 +38,18 @@ fn test_sub_panic() {
 fn test_sub_checked() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let result = checked_sub(&a, &b).unwrap();
+    let result = checked_sub(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(0)]);
     assert_eq!(result, expected);
 
     let a = Int8Array::from(&[Some(100i8), Some(-100i8), Some(100i8)]);
     let b = Int8Array::from(&[Some(1i8), Some(100i8), Some(0i8)]);
-    let result = checked_sub(&a, &b).unwrap();
+    let result = checked_sub(&a, &b);
     let expected = Int8Array::from(&[Some(99i8), None, Some(100i8)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.checked_sub(&b).unwrap();
+    let result = a.checked_sub(&b);
     assert_eq!(result, expected);
 }
 
@@ -58,18 +57,18 @@ fn test_sub_checked() {
 fn test_sub_saturating() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let result = saturating_sub(&a, &b).unwrap();
+    let result = saturating_sub(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(0)]);
     assert_eq!(result, expected);
 
     let a = Int8Array::from(&[Some(-100i8)]);
     let b = Int8Array::from(&[Some(100i8)]);
-    let result = saturating_sub(&a, &b).unwrap();
+    let result = saturating_sub(&a, &b);
     let expected = Int8Array::from(&[Some(-128)]);
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.saturating_sub(&b).unwrap();
+    let result = a.saturating_sub(&b);
     assert_eq!(result, expected);
 }
 
@@ -77,20 +76,20 @@ fn test_sub_saturating() {
 fn test_sub_overflowing() {
     let a = Int32Array::from(&[None, Some(6), None, Some(6)]);
     let b = Int32Array::from(&[Some(5), None, None, Some(6)]);
-    let (result, overflow) = overflowing_sub(&a, &b).unwrap();
+    let (result, overflow) = overflowing_sub(&a, &b);
     let expected = Int32Array::from(&[None, None, None, Some(0)]);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, false, false, false]));
 
     let a = Int8Array::from(&[Some(1i8), Some(-100i8)]);
     let b = Int8Array::from(&[Some(1i8), Some(100i8)]);
-    let (result, overflow) = overflowing_sub(&a, &b).unwrap();
+    let (result, overflow) = overflowing_sub(&a, &b);
     let expected = Int8Array::from(&[Some(0i8), Some(56i8)]);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, true]));
 
     // Trait testing
-    let (result, overflow) = a.overflowing_sub(&b).unwrap();
+    let (result, overflow) = a.overflowing_sub(&b);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, true]));
 }
@@ -103,7 +102,7 @@ fn test_sub_scalar() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.sub(&1i32).unwrap();
+    let result = a.sub(&1i32);
     assert_eq!(result, expected);
 }
 
@@ -120,7 +119,7 @@ fn test_sub_scalar_checked() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.checked_sub(&100i8).unwrap();
+    let result = a.checked_sub(&100i8);
     assert_eq!(result, expected);
 }
 
@@ -137,7 +136,7 @@ fn test_sub_scalar_saturating() {
     assert_eq!(result, expected);
 
     // Trait testing
-    let result = a.saturating_sub(&100i8).unwrap();
+    let result = a.saturating_sub(&100i8);
     assert_eq!(result, expected);
 }
 
@@ -156,7 +155,7 @@ fn test_sub_scalar_overflowing() {
     assert_eq!(overflow, Bitmap::from([false, true]));
 
     // Trait testing
-    let (result, overflow) = a.overflowing_sub(&100i8).unwrap();
+    let (result, overflow) = a.overflowing_sub(&100i8);
     assert_eq!(result, expected);
     assert_eq!(overflow, Bitmap::from([false, true]));
 }

--- a/tests/it/compute/arithmetics/decimal/add.rs
+++ b/tests/it/compute/arithmetics/decimal/add.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::zero_prefixed_literal, clippy::inconsistent_digit_grouping)]
 
 use arrow2::array::*;
-use arrow2::compute::arithmetics::decimal::add::*;
+use arrow2::compute::arithmetics::decimal::{adaptive_add, add, checked_add, saturating_add};
 use arrow2::compute::arithmetics::{ArrayAdd, ArrayCheckedAdd, ArraySaturatingAdd};
 use arrow2::datatypes::DataType;
 
@@ -13,26 +13,23 @@ fn test_add_normal() {
     let b = PrimitiveArray::from([Some(22222i128), Some(22200i128), None, Some(11100i128)])
         .to(DataType::Decimal(5, 2));
 
-    let result = add(&a, &b).unwrap();
+    let result = add(&a, &b);
     let expected = PrimitiveArray::from([Some(33333i128), Some(33300i128), None, Some(33300i128)])
         .to(DataType::Decimal(5, 2));
 
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.add(&b).unwrap();
+    let result = a.add(&b);
     assert_eq!(result, expected);
 }
 
 #[test]
+#[should_panic]
 fn test_add_decimal_wrong_precision() {
     let a = PrimitiveArray::from([None]).to(DataType::Decimal(5, 2));
     let b = PrimitiveArray::from([None]).to(DataType::Decimal(6, 2));
-    let result = add(&a, &b);
-
-    if result.is_ok() {
-        panic!("Should panic for different precision");
-    }
+    add(&a, &b);
 }
 
 #[test]
@@ -51,14 +48,14 @@ fn test_add_saturating() {
     let b = PrimitiveArray::from([Some(22222i128), Some(22200i128), None, Some(11100i128)])
         .to(DataType::Decimal(5, 2));
 
-    let result = saturating_add(&a, &b).unwrap();
+    let result = saturating_add(&a, &b);
     let expected = PrimitiveArray::from([Some(33333i128), Some(33300i128), None, Some(33300i128)])
         .to(DataType::Decimal(5, 2));
 
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.saturating_add(&b).unwrap();
+    let result = a.saturating_add(&b);
     assert_eq!(result, expected);
 }
 
@@ -79,7 +76,7 @@ fn test_add_saturating_overflow() {
     ])
     .to(DataType::Decimal(5, 2));
 
-    let result = saturating_add(&a, &b).unwrap();
+    let result = saturating_add(&a, &b);
 
     let expected = PrimitiveArray::from([
         Some(99999i128),
@@ -92,7 +89,7 @@ fn test_add_saturating_overflow() {
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.saturating_add(&b).unwrap();
+    let result = a.saturating_add(&b);
     assert_eq!(result, expected);
 }
 
@@ -104,14 +101,14 @@ fn test_add_checked() {
     let b = PrimitiveArray::from([Some(22222i128), Some(22200i128), None, Some(11100i128)])
         .to(DataType::Decimal(5, 2));
 
-    let result = checked_add(&a, &b).unwrap();
+    let result = checked_add(&a, &b);
     let expected = PrimitiveArray::from([Some(33333i128), Some(33300i128), None, Some(33300i128)])
         .to(DataType::Decimal(5, 2));
 
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.checked_add(&b).unwrap();
+    let result = a.checked_add(&b);
     assert_eq!(result, expected);
 }
 
@@ -119,12 +116,12 @@ fn test_add_checked() {
 fn test_add_checked_overflow() {
     let a = PrimitiveArray::from([Some(1i128), Some(99999i128)]).to(DataType::Decimal(5, 2));
     let b = PrimitiveArray::from([Some(1i128), Some(1i128)]).to(DataType::Decimal(5, 2));
-    let result = checked_add(&a, &b).unwrap();
+    let result = checked_add(&a, &b);
     let expected = PrimitiveArray::from([Some(2i128), None]).to(DataType::Decimal(5, 2));
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.checked_add(&b).unwrap();
+    let result = a.checked_add(&b);
     assert_eq!(result, expected);
 }
 

--- a/tests/it/compute/arithmetics/decimal/div.rs
+++ b/tests/it/compute/arithmetics/decimal/div.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::zero_prefixed_literal, clippy::inconsistent_digit_grouping)]
 
 use arrow2::array::*;
-use arrow2::compute::arithmetics::decimal::div::*;
+use arrow2::compute::arithmetics::decimal::{adaptive_div, checked_div, div, saturating_div};
 use arrow2::compute::arithmetics::{ArrayCheckedDiv, ArrayDiv};
 use arrow2::datatypes::DataType;
 
@@ -31,7 +31,7 @@ fn test_divide_normal() {
     ])
     .to(DataType::Decimal(7, 3));
 
-    let result = div(&a, &b).unwrap();
+    let result = div(&a, &b);
     let expected = PrimitiveArray::from([
         Some(1_800i128),
         Some(5_000i128),
@@ -45,19 +45,16 @@ fn test_divide_normal() {
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.div(&b).unwrap();
+    let result = a.div(&b);
     assert_eq!(result, expected);
 }
 
 #[test]
+#[should_panic]
 fn test_divide_decimal_wrong_precision() {
     let a = PrimitiveArray::from([None]).to(DataType::Decimal(5, 2));
     let b = PrimitiveArray::from([None]).to(DataType::Decimal(6, 2));
-    let result = div(&a, &b);
-
-    if result.is_ok() {
-        panic!("Should panic for different precision");
-    }
+    div(&a, &b);
 }
 
 #[test]
@@ -65,7 +62,7 @@ fn test_divide_decimal_wrong_precision() {
 fn test_divide_panic() {
     let a = PrimitiveArray::from([Some(99999i128)]).to(DataType::Decimal(5, 2));
     let b = PrimitiveArray::from([Some(000_01i128)]).to(DataType::Decimal(5, 2));
-    let _ = div(&a, &b);
+    div(&a, &b);
 }
 
 #[test]
@@ -90,7 +87,7 @@ fn test_divide_saturating() {
     ])
     .to(DataType::Decimal(7, 3));
 
-    let result = saturating_div(&a, &b).unwrap();
+    let result = saturating_div(&a, &b);
     let expected = PrimitiveArray::from([
         Some(1_800i128),
         Some(5_000i128),
@@ -123,7 +120,7 @@ fn test_divide_saturating_overflow() {
     ])
     .to(DataType::Decimal(5, 2));
 
-    let result = saturating_div(&a, &b).unwrap();
+    let result = saturating_div(&a, &b);
 
     let expected = PrimitiveArray::from([
         Some(-99999i128),
@@ -159,7 +156,7 @@ fn test_divide_checked() {
     ])
     .to(DataType::Decimal(7, 3));
 
-    let result = div(&a, &b).unwrap();
+    let result = div(&a, &b);
     let expected = PrimitiveArray::from([
         Some(1_800i128),
         Some(5_000i128),
@@ -180,13 +177,13 @@ fn test_divide_checked_overflow() {
     let b =
         PrimitiveArray::from([Some(000_00i128), None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 
-    let result = checked_div(&a, &b).unwrap();
+    let result = checked_div(&a, &b);
     let expected = PrimitiveArray::from([None, None, Some(3_00i128)]).to(DataType::Decimal(5, 2));
 
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.checked_div(&b).unwrap();
+    let result = a.checked_div(&b);
     assert_eq!(result, expected);
 }
 

--- a/tests/it/compute/arithmetics/decimal/mul.rs
+++ b/tests/it/compute/arithmetics/decimal/mul.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::zero_prefixed_literal, clippy::inconsistent_digit_grouping)]
 
 use arrow2::array::*;
-use arrow2::compute::arithmetics::decimal::mul::*;
+use arrow2::compute::arithmetics::decimal::{adaptive_mul, checked_mul, mul, saturating_mul};
 use arrow2::compute::arithmetics::{ArrayCheckedMul, ArrayMul, ArraySaturatingMul};
 use arrow2::datatypes::DataType;
 
@@ -31,7 +31,7 @@ fn test_multiply_normal() {
     ])
     .to(DataType::Decimal(7, 2));
 
-    let result = mul(&a, &b).unwrap();
+    let result = mul(&a, &b);
     let expected = PrimitiveArray::from([
         Some(24690_86i128),
         Some(20_00i128),
@@ -45,19 +45,16 @@ fn test_multiply_normal() {
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.mul(&b).unwrap();
+    let result = a.mul(&b);
     assert_eq!(result, expected);
 }
 
 #[test]
+#[should_panic]
 fn test_multiply_decimal_wrong_precision() {
     let a = PrimitiveArray::from([None]).to(DataType::Decimal(5, 2));
     let b = PrimitiveArray::from([None]).to(DataType::Decimal(6, 2));
-    let result = mul(&a, &b);
-
-    if result.is_ok() {
-        panic!("Should panic for different precision");
-    }
+    mul(&a, &b);
 }
 
 #[test]
@@ -90,7 +87,7 @@ fn test_multiply_saturating() {
     ])
     .to(DataType::Decimal(7, 2));
 
-    let result = saturating_mul(&a, &b).unwrap();
+    let result = saturating_mul(&a, &b);
     let expected = PrimitiveArray::from([
         Some(24690_86i128),
         Some(20_00i128),
@@ -104,7 +101,7 @@ fn test_multiply_saturating() {
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.saturating_mul(&b).unwrap();
+    let result = a.saturating_mul(&b);
     assert_eq!(result, expected);
 }
 
@@ -125,7 +122,7 @@ fn test_multiply_saturating_overflow() {
     ])
     .to(DataType::Decimal(5, 2));
 
-    let result = saturating_mul(&a, &b).unwrap();
+    let result = saturating_mul(&a, &b);
 
     let expected = PrimitiveArray::from([
         Some(-99999i128),
@@ -138,7 +135,7 @@ fn test_multiply_saturating_overflow() {
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.saturating_mul(&b).unwrap();
+    let result = a.saturating_mul(&b);
     assert_eq!(result, expected);
 }
 
@@ -164,7 +161,7 @@ fn test_multiply_checked() {
     ])
     .to(DataType::Decimal(7, 2));
 
-    let result = checked_mul(&a, &b).unwrap();
+    let result = checked_mul(&a, &b);
     let expected = PrimitiveArray::from([
         Some(24690_86i128),
         Some(20_00i128),
@@ -178,7 +175,7 @@ fn test_multiply_checked() {
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.checked_mul(&b).unwrap();
+    let result = a.checked_mul(&b);
     assert_eq!(result, expected);
 }
 
@@ -186,7 +183,7 @@ fn test_multiply_checked() {
 fn test_multiply_checked_overflow() {
     let a = PrimitiveArray::from([Some(99999i128), Some(1_00i128)]).to(DataType::Decimal(5, 2));
     let b = PrimitiveArray::from([Some(10000i128), Some(2_00i128)]).to(DataType::Decimal(5, 2));
-    let result = checked_mul(&a, &b).unwrap();
+    let result = checked_mul(&a, &b);
     let expected = PrimitiveArray::from([None, Some(2_00i128)]).to(DataType::Decimal(5, 2));
 
     assert_eq!(result, expected);

--- a/tests/it/compute/arithmetics/decimal/sub.rs
+++ b/tests/it/compute/arithmetics/decimal/sub.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::zero_prefixed_literal, clippy::inconsistent_digit_grouping)]
 
 use arrow2::array::*;
-use arrow2::compute::arithmetics::decimal::sub::*;
+use arrow2::compute::arithmetics::decimal::{adaptive_sub, checked_sub, saturating_sub, sub};
 use arrow2::compute::arithmetics::{ArrayCheckedSub, ArraySaturatingSub, ArraySub};
 use arrow2::datatypes::DataType;
 
@@ -13,26 +13,23 @@ fn test_subtract_normal() {
     let b = PrimitiveArray::from([Some(22222i128), Some(11100i128), None, Some(11100i128)])
         .to(DataType::Decimal(5, 2));
 
-    let result = sub(&a, &b).unwrap();
+    let result = sub(&a, &b);
     let expected = PrimitiveArray::from([Some(-11111i128), Some(11100i128), None, Some(28900i128)])
         .to(DataType::Decimal(5, 2));
 
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.sub(&b).unwrap();
+    let result = a.sub(&b);
     assert_eq!(result, expected);
 }
 
 #[test]
+#[should_panic]
 fn test_subtract_decimal_wrong_precision() {
     let a = PrimitiveArray::from([None]).to(DataType::Decimal(5, 2));
     let b = PrimitiveArray::from([None]).to(DataType::Decimal(6, 2));
-    let result = sub(&a, &b);
-
-    if result.is_ok() {
-        panic!("Should panic for different precision");
-    }
+    sub(&a, &b);
 }
 
 #[test]
@@ -51,14 +48,14 @@ fn test_subtract_saturating() {
     let b = PrimitiveArray::from([Some(22222i128), Some(11100i128), None, Some(11100i128)])
         .to(DataType::Decimal(5, 2));
 
-    let result = saturating_sub(&a, &b).unwrap();
+    let result = saturating_sub(&a, &b);
     let expected = PrimitiveArray::from([Some(-11111i128), Some(11100i128), None, Some(28900i128)])
         .to(DataType::Decimal(5, 2));
 
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.saturating_sub(&b).unwrap();
+    let result = a.saturating_sub(&b);
     assert_eq!(result, expected);
 }
 
@@ -79,7 +76,7 @@ fn test_subtract_saturating_overflow() {
     ])
     .to(DataType::Decimal(5, 2));
 
-    let result = saturating_sub(&a, &b).unwrap();
+    let result = saturating_sub(&a, &b);
 
     let expected = PrimitiveArray::from([
         Some(-99999i128),
@@ -92,7 +89,7 @@ fn test_subtract_saturating_overflow() {
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.saturating_sub(&b).unwrap();
+    let result = a.saturating_sub(&b);
     assert_eq!(result, expected);
 }
 
@@ -104,14 +101,14 @@ fn test_subtract_checked() {
     let b = PrimitiveArray::from([Some(22222i128), Some(11100i128), None, Some(11100i128)])
         .to(DataType::Decimal(5, 2));
 
-    let result = checked_sub(&a, &b).unwrap();
+    let result = checked_sub(&a, &b);
     let expected = PrimitiveArray::from([Some(-11111i128), Some(11100i128), None, Some(28900i128)])
         .to(DataType::Decimal(5, 2));
 
     assert_eq!(result, expected);
 
     // Testing trait
-    let result = a.checked_sub(&b).unwrap();
+    let result = a.checked_sub(&b);
     assert_eq!(result, expected);
 }
 
@@ -119,7 +116,7 @@ fn test_subtract_checked() {
 fn test_subtract_checked_overflow() {
     let a = PrimitiveArray::from([Some(4i128), Some(-99999i128)]).to(DataType::Decimal(5, 2));
     let b = PrimitiveArray::from([Some(2i128), Some(1i128)]).to(DataType::Decimal(5, 2));
-    let result = checked_sub(&a, &b).unwrap();
+    let result = checked_sub(&a, &b);
     let expected = PrimitiveArray::from([Some(2i128), None]).to(DataType::Decimal(5, 2));
     assert_eq!(result, expected);
 }

--- a/tests/it/compute/arithmetics/mod.rs
+++ b/tests/it/compute/arithmetics/mod.rs
@@ -3,7 +3,7 @@ mod decimal;
 mod time;
 
 use arrow2::array::new_empty_array;
-use arrow2::compute::arithmetics::{arithmetic, can_arithmetic, Operator};
+use arrow2::compute::arithmetics::*;
 use arrow2::datatypes::DataType::*;
 use arrow2::datatypes::{IntervalUnit, TimeUnit};
 
@@ -42,27 +42,26 @@ fn consistency() {
         Duration(TimeUnit::Nanosecond),
         Interval(IntervalUnit::MonthDayNano),
     ];
-    let operators = vec![
-        Operator::Add,
-        Operator::Divide,
-        Operator::Subtract,
-        Operator::Multiply,
-        Operator::Remainder,
-    ];
 
-    let cases = datatypes
-        .clone()
-        .into_iter()
-        .zip(operators.into_iter())
-        .zip(datatypes.into_iter());
+    let cases = datatypes.clone().into_iter().zip(datatypes.into_iter());
 
-    cases.for_each(|((lhs, op), rhs)| {
+    cases.for_each(|(lhs, rhs)| {
         let lhs_a = new_empty_array(lhs.clone());
         let rhs_a = new_empty_array(rhs.clone());
-        if can_arithmetic(&lhs, op, &rhs) {
-            assert!(arithmetic(lhs_a.as_ref(), op, rhs_a.as_ref()).is_ok());
-        } else {
-            assert!(arithmetic(lhs_a.as_ref(), op, rhs_a.as_ref()).is_err());
+        if can_add(&lhs, &rhs) {
+            add(lhs_a.as_ref(), rhs_a.as_ref());
+        }
+        if can_sub(&lhs, &rhs) {
+            sub(lhs_a.as_ref(), rhs_a.as_ref());
+        }
+        if can_mul(&lhs, &rhs) {
+            mul(lhs_a.as_ref(), rhs_a.as_ref());
+        }
+        if can_div(&lhs, &rhs) {
+            div(lhs_a.as_ref(), rhs_a.as_ref());
+        }
+        if can_rem(&lhs, &rhs) {
+            rem(lhs_a.as_ref(), rhs_a.as_ref());
         }
     });
 }

--- a/tests/it/compute/arithmetics/time.rs
+++ b/tests/it/compute/arithmetics/time.rs
@@ -12,7 +12,7 @@ fn test_adding_timestamp() {
     let duration = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)])
         .to(DataType::Duration(TimeUnit::Second));
 
-    let result = add_duration(&timestamp, &duration).unwrap();
+    let result = add_duration(&timestamp, &duration);
     let expected =
         PrimitiveArray::from([Some(100010i64), Some(200020i64), None, Some(300030i64)]).to(
             DataType::Timestamp(TimeUnit::Second, Some("America/New_York".to_string())),
@@ -36,7 +36,7 @@ fn test_adding_duration_different_scale() {
     let duration = PrimitiveArray::from([Some(10_000i64), Some(20_000i64), None, Some(30_000i64)])
         .to(DataType::Duration(TimeUnit::Millisecond));
 
-    let result = add_duration(&timestamp, &duration).unwrap();
+    let result = add_duration(&timestamp, &duration);
     assert_eq!(result, expected);
 
     // Testing duration in nanoseconds.
@@ -51,7 +51,7 @@ fn test_adding_duration_different_scale() {
     ])
     .to(DataType::Duration(TimeUnit::Nanosecond));
 
-    let result = add_duration(&timestamp, &duration).unwrap();
+    let result = add_duration(&timestamp, &duration);
     assert_eq!(result, expected);
 }
 
@@ -67,7 +67,7 @@ fn test_adding_subtract_timestamps_scale() {
         DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
     );
 
-    let result = add_duration(&timestamp, &duration).unwrap();
+    let result = add_duration(&timestamp, &duration);
     assert_eq!(result, expected);
 
     let timestamp = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)]).to(
@@ -87,7 +87,7 @@ fn test_adding_subtract_timestamps_scale() {
         Some("America/New_York".to_string()),
     ));
 
-    let result = add_duration(&timestamp, &duration).unwrap();
+    let result = add_duration(&timestamp, &duration);
     assert_eq!(result, expected);
 }
 
@@ -101,7 +101,7 @@ fn test_subtract_timestamp() {
     let duration = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)])
         .to(DataType::Duration(TimeUnit::Second));
 
-    let result = subtract_duration(&timestamp, &duration).unwrap();
+    let result = subtract_duration(&timestamp, &duration);
     let expected =
         PrimitiveArray::from([Some(99990i64), Some(199980i64), None, Some(299970i64)]).to(
             DataType::Timestamp(TimeUnit::Second, Some("America/New_York".to_string())),
@@ -125,7 +125,7 @@ fn test_subtracting_duration_different_scale() {
     let duration = PrimitiveArray::from([Some(10_000i64), Some(20_000i64), None, Some(30_000i64)])
         .to(DataType::Duration(TimeUnit::Millisecond));
 
-    let result = subtract_duration(&timestamp, &duration).unwrap();
+    let result = subtract_duration(&timestamp, &duration);
     assert_eq!(result, expected);
 
     // Testing duration in nanoseconds.
@@ -140,7 +140,7 @@ fn test_subtracting_duration_different_scale() {
     ])
     .to(DataType::Duration(TimeUnit::Nanosecond));
 
-    let result = subtract_duration(&timestamp, &duration).unwrap();
+    let result = subtract_duration(&timestamp, &duration);
     assert_eq!(result, expected);
 }
 
@@ -157,7 +157,7 @@ fn test_subtracting_subtract_timestamps_scale() {
             DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
         );
 
-    let result = subtract_duration(&timestamp, &duration).unwrap();
+    let result = subtract_duration(&timestamp, &duration);
     assert_eq!(result, expected);
 
     let timestamp = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)]).to(
@@ -177,7 +177,7 @@ fn test_subtracting_subtract_timestamps_scale() {
         Some("America/New_York".to_string()),
     ));
 
-    let result = subtract_duration(&timestamp, &duration).unwrap();
+    let result = subtract_duration(&timestamp, &duration);
     assert_eq!(result, expected);
 }
 
@@ -229,7 +229,7 @@ fn test_adding_to_time() {
     let time_32 = PrimitiveArray::from([Some(100000i32), Some(200000i32), None, Some(300000i32)])
         .to(DataType::Time32(TimeUnit::Second));
 
-    let result = add_duration(&time_32, &duration).unwrap();
+    let result = add_duration(&time_32, &duration);
     let expected = PrimitiveArray::from([Some(100010i32), Some(200020i32), None, Some(300030i32)])
         .to(DataType::Time32(TimeUnit::Second));
 
@@ -245,7 +245,7 @@ fn test_subtract_to_time() {
     let time_32 = PrimitiveArray::from([Some(100000i32), Some(200000i32), None, Some(300000i32)])
         .to(DataType::Time32(TimeUnit::Second));
 
-    let result = subtract_duration(&time_32, &duration).unwrap();
+    let result = subtract_duration(&time_32, &duration);
     let expected = PrimitiveArray::from([Some(99990i32), Some(199980i32), None, Some(299970i32)])
         .to(DataType::Time32(TimeUnit::Second));
 
@@ -266,14 +266,14 @@ fn test_date32() {
         PrimitiveArray::from([Some(100_000i32), Some(100_000i32), None, Some(100_000i32)])
             .to(DataType::Date32);
 
-    let result = add_duration(&date_32, &duration).unwrap();
+    let result = add_duration(&date_32, &duration);
     let expected =
         PrimitiveArray::from([Some(100_001i32), Some(100_010i32), None, Some(100_100i32)])
             .to(DataType::Date32);
 
     assert_eq!(result, expected);
 
-    let result = subtract_duration(&date_32, &duration).unwrap();
+    let result = subtract_duration(&date_32, &duration);
     let expected = PrimitiveArray::from([Some(99_999i32), Some(99_990i32), None, Some(99_900i32)])
         .to(DataType::Date32);
 
@@ -294,14 +294,14 @@ fn test_date64() {
         PrimitiveArray::from([Some(100_000i64), Some(100_000i64), None, Some(100_000i64)])
             .to(DataType::Date64);
 
-    let result = add_duration(&date_64, &duration).unwrap();
+    let result = add_duration(&date_64, &duration);
     let expected =
         PrimitiveArray::from([Some(100_010i64), Some(100_100i64), None, Some(101_000i64)])
             .to(DataType::Date64);
 
     assert_eq!(result, expected);
 
-    let result = subtract_duration(&date_64, &duration).unwrap();
+    let result = subtract_duration(&date_64, &duration);
     let expected = PrimitiveArray::from([Some(99_990i64), Some(99_900i64), None, Some(99_000i64)])
         .to(DataType::Date64);
 

--- a/tests/it/compute/bitwise.rs
+++ b/tests/it/compute/bitwise.rs
@@ -5,7 +5,7 @@ use arrow2::compute::bitwise::*;
 fn test_xor() {
     let a = Int32Array::from(&[Some(2), Some(4), Some(6), Some(7)]);
     let b = Int32Array::from(&[None, Some(6), Some(9), Some(7)]);
-    let result = xor(&a, &b).unwrap();
+    let result = xor(&a, &b);
     let expected = Int32Array::from(&[None, Some(2), Some(15), Some(0)]);
 
     assert_eq!(result, expected);
@@ -15,7 +15,7 @@ fn test_xor() {
 fn test_and() {
     let a = Int32Array::from(&[Some(1), Some(2), Some(15)]);
     let b = Int32Array::from(&[None, Some(2), Some(6)]);
-    let result = and(&a, &b).unwrap();
+    let result = and(&a, &b);
     let expected = Int32Array::from(&[None, Some(2), Some(6)]);
 
     assert_eq!(result, expected);
@@ -25,7 +25,7 @@ fn test_and() {
 fn test_or() {
     let a = Int32Array::from(&[Some(1), Some(2), Some(0)]);
     let b = Int32Array::from(&[None, Some(2), Some(0)]);
-    let result = or(&a, &b).unwrap();
+    let result = or(&a, &b);
     let expected = Int32Array::from(&[None, Some(2), Some(0)]);
 
     assert_eq!(result, expected);


### PR DESCRIPTION
Closes #527.

The functions are now offered based on the name instead of `Operator` (which was removed).

Also, the functions no longer error, and instead panic. As usual, `can_*` can be used to check if the operation is supported, and checking the `len` of the arrays is required.
