### PR TITLE
Speed up boolean comparison kernels (~3x)

### DIFF
--- a/benches/comparison_kernels.rs
+++ b/benches/comparison_kernels.rs
@@ -1,17 +1,8 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
-use arrow2::array::*;
 use arrow2::scalar::*;
 use arrow2::util::bench_util::*;
 use arrow2::{compute::comparison::*, datatypes::DataType};
-
-fn bench_op(arr_a: &dyn Array, arr_b: &dyn Array, op: Operator) {
-    compare(black_box(arr_a), black_box(arr_b), op).unwrap();
-}
-
-fn bench_op_scalar(arr_a: &dyn Array, value_b: &dyn Scalar, op: Operator) {
-    compare_scalar(black_box(arr_a), black_box(value_b), op).unwrap();
-}
 
 fn add_benchmark(c: &mut Criterion) {
     (10..=20).step_by(2).for_each(|log2_size| {
@@ -21,36 +12,30 @@ fn add_benchmark(c: &mut Criterion) {
         let arr_b = create_primitive_array_with_seed::<f32>(size, DataType::Float32, 0.0, 43);
 
         c.bench_function(&format!("f32 2^{}", log2_size), |b| {
-            b.iter(|| bench_op(&arr_a, &arr_b, Operator::Eq))
+            b.iter(|| eq(&arr_a, &arr_b))
         });
         c.bench_function(&format!("f32 scalar 2^{}", log2_size), |b| {
-            b.iter(|| {
-                bench_op_scalar(
-                    &arr_a,
-                    &PrimitiveScalar::<f32>::from(Some(0.5)),
-                    Operator::Eq,
-                )
-            })
+            b.iter(|| eq_scalar(&arr_a, &PrimitiveScalar::<f32>::from(Some(0.5))))
         });
 
         let arr_a = create_boolean_array(size, 0.0, 0.1);
         let arr_b = create_boolean_array(size, 0.0, 0.2);
 
         c.bench_function(&format!("bool 2^{}", log2_size), |b| {
-            b.iter(|| bench_op(&arr_a, &arr_b, Operator::Eq))
+            b.iter(|| eq(&arr_a, &arr_b))
         });
         c.bench_function(&format!("bool scalar 2^{}", log2_size), |b| {
-            b.iter(|| bench_op_scalar(&arr_a, &BooleanScalar::from(Some(false)), Operator::Eq))
+            b.iter(|| eq_scalar(&arr_a, &BooleanScalar::from(Some(false))))
         });
 
         let arr_a = create_string_array::<i32>(size, 4, 0.1, 42);
         let arr_b = create_string_array::<i32>(size, 4, 0.1, 43);
         c.bench_function(&format!("utf8 2^{}", log2_size), |b| {
-            b.iter(|| bench_op(&arr_a, &arr_b, Operator::Eq))
+            b.iter(|| eq(&arr_a, &arr_b))
         });
 
         c.bench_function(&format!("utf8 2^{}", log2_size), |b| {
-            b.iter(|| bench_op_scalar(&arr_a, &Utf8Scalar::<i32>::from(Some("abc")), Operator::Eq))
+            b.iter(|| eq_scalar(&arr_a, &Utf8Scalar::<i32>::from(Some("abc"))))
         });
     })
 }

--- a/src/compute/comparison/boolean.rs
+++ b/src/compute/comparison/boolean.rs
@@ -18,7 +18,7 @@ where
 
     let values = binary(lhs.values(), rhs.values(), op);
 
-    BooleanArray::from_data(DataType::Boolean, values.into(), validity)
+    BooleanArray::from_data(DataType::Boolean, values, validity)
 }
 
 /// Evaluate `op(left, right)` for [`BooleanArray`] and scalar using

--- a/src/compute/comparison/boolean.rs
+++ b/src/compute/comparison/boolean.rs
@@ -1,44 +1,22 @@
 //! Comparison functions for [`BooleanArray`]
 use crate::{
     array::BooleanArray,
-    bitmap::{Bitmap, MutableBitmap},
-    buffer::MutableBuffer,
+    bitmap::{binary, unary, Bitmap},
     datatypes::DataType,
 };
 
 use super::super::utils::combine_validities;
 
-fn compare_values_op<F>(lhs: &Bitmap, rhs: &Bitmap, op: F) -> MutableBitmap
-where
-    F: Fn(u8, u8) -> u8,
-{
-    assert_eq!(lhs.len(), rhs.len());
-    let lhs_iter = lhs.chunks();
-    let rhs_iter = rhs.chunks();
-    let lhs_remainder = lhs_iter.remainder();
-    let rhs_remainder = rhs_iter.remainder();
-
-    let mut values = MutableBuffer::with_capacity((lhs.len() + 7) / 8);
-    let iter = lhs_iter.zip(rhs_iter).map(|(x, y)| op(x, y));
-    values.extend_from_trusted_len_iter(iter);
-
-    if lhs.len() % 8 != 0 {
-        values.push(op(lhs_remainder, rhs_remainder))
-    };
-
-    MutableBitmap::from_buffer(values, lhs.len())
-}
-
 /// Evaluate `op(lhs, rhs)` for [`BooleanArray`]s using a specified
 /// comparison function.
 fn compare_op<F>(lhs: &BooleanArray, rhs: &BooleanArray, op: F) -> BooleanArray
 where
-    F: Fn(u8, u8) -> u8,
+    F: Fn(u64, u64) -> u64,
 {
     assert_eq!(lhs.len(), rhs.len());
     let validity = combine_validities(lhs.validity(), rhs.validity());
 
-    let values = compare_values_op(lhs.values(), rhs.values(), op);
+    let values = binary(lhs.values(), rhs.values(), op);
 
     BooleanArray::from_data(DataType::Boolean, values.into(), validity)
 }
@@ -47,20 +25,11 @@ where
 /// a specified comparison function.
 pub fn compare_op_scalar<F>(lhs: &BooleanArray, rhs: bool, op: F) -> BooleanArray
 where
-    F: Fn(u8, u8) -> u8,
+    F: Fn(u64, u64) -> u64,
 {
-    let lhs_iter = lhs.values().chunks();
-    let lhs_remainder = lhs_iter.remainder();
     let rhs = if rhs { 0b11111111 } else { 0 };
 
-    let mut values = MutableBuffer::with_capacity((lhs.len() + 7) / 8);
-    let iter = lhs_iter.map(|x| op(x, rhs));
-    values.extend_from_trusted_len_iter(iter);
-
-    if lhs.len() % 8 != 0 {
-        values.push(op(lhs_remainder, rhs))
-    };
-    let values = MutableBitmap::from_buffer(values, lhs.len()).into();
+    let values = unary(lhs.values(), |x| op(x, rhs));
     BooleanArray::from_data(DataType::Boolean, values, lhs.validity().cloned())
 }
 


### PR DESCRIPTION
* Reuse `binary` and `unary` functions to do computation on `u64` elements and cleanup code.
* Restore comparison benchmark

Outcome:

```
bool 2^10               time:   [311.72 ns 312.34 ns 313.03 ns]
                        change: [-50.796% -50.519% -50.257%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

Benchmarking bool scalar 2^10: Collecting 100 samples in estimated 5.0002 s (36M                                                                                bool scalar 2^10        time:   [134.00 ns 134.44 ns 134.93 ns]
                        change: [-29.129% -28.672% -28.185%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe

Benchmarking bool 2^12: Collecting 100 samples in estimated 5.0011 s (7.5M itera                                                                                bool 2^12               time:   [682.72 ns 690.96 ns 698.70 ns]
                        change: [-67.207% -66.954% -66.710%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

Benchmarking bool scalar 2^12: Collecting 100 samples in estimated 5.0010 s (25M                                                                                bool scalar 2^12        time:   [194.41 ns 197.01 ns 200.69 ns]
                        change: [-51.596% -51.032% -50.249%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) high mild
  7 (7.00%) high severe

Benchmarking bool 2^14: Collecting 100 samples in estimated 5.0098 s (2.2M itera                                                                                bool 2^14               time:   [2.2481 us 2.2573 us 2.2680 us]
                        change: [-71.747% -71.515% -71.308%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild

Benchmarking bool scalar 2^14: Collecting 100 samples in estimated 5.0003 s (11M                                                                                bool scalar 2^14        time:   [449.36 ns 450.69 ns 452.27 ns]
                        change: [-66.059% -65.853% -65.645%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

Benchmarking bool 2^16: Collecting 100 samples in estimated 5.0003 s (616k itera                                                                                bool 2^16               time:   [8.1296 us 8.1497 us 8.1684 us]
                        change: [-75.072% -74.346% -73.690%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe

Benchmarking bool scalar 2^16: Collecting 100 samples in estimated 5.0012 s (3.8                                                                                bool scalar 2^16        time:   [1.2945 us 1.2995 us 1.3050 us]
                        change: [-72.611% -72.412% -72.226%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
```