### PR TITLE
Sealed 2 traits to forbid downstream implementations

### DIFF
--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -4,11 +4,15 @@ use num_traits::Num;
 
 use crate::types::Index;
 
-/// Trait describing types that can be used as offsets as per Arrow specification.
-/// This trait is only implemented for `i32` and `i64`, the two sizes part of the specification.
-/// # Safety
-/// Do not implement.
-pub unsafe trait Offset: Index + Num + Ord + num_traits::CheckedAdd {
+mod private {
+    pub trait Sealed {}
+
+    impl Sealed for i32 {}
+    impl Sealed for i64 {}
+}
+
+/// Sealed trait describing types that can be used as offsets in Arrow (`i32` and `i64`).
+pub trait Offset: private::Sealed + Index + Num + Ord + num_traits::CheckedAdd {
     /// Whether it is `i32` or `i64`
     fn is_large() -> bool;
 
@@ -19,7 +23,7 @@ pub unsafe trait Offset: Index + Num + Ord + num_traits::CheckedAdd {
     fn from_isize(value: isize) -> Option<Self>;
 }
 
-unsafe impl Offset for i32 {
+impl Offset for i32 {
     #[inline]
     fn is_large() -> bool {
         false
@@ -36,7 +40,7 @@ unsafe impl Offset for i32 {
     }
 }
 
-unsafe impl Offset for i64 {
+impl Offset for i64 {
     #[inline]
     fn is_large() -> bool {
         true

--- a/src/io/parquet/write/levels.rs
+++ b/src/io/parquet/write/levels.rs
@@ -148,7 +148,7 @@ impl<O: Offset> Iterator for DefLevelsIter<'_, O> {
 
 #[derive(Debug)]
 pub struct NestedInfo<'a, O: Offset> {
-    is_optional: bool,
+    _is_optional: bool,
     offsets: &'a [O],
     validity: Option<&'a Bitmap>,
 }
@@ -156,7 +156,7 @@ pub struct NestedInfo<'a, O: Offset> {
 impl<'a, O: Offset> NestedInfo<'a, O> {
     pub fn new(offsets: &'a [O], validity: Option<&'a Bitmap>, is_optional: bool) -> Self {
         Self {
-            is_optional,
+            _is_optional: is_optional,
             offsets,
             validity,
         }


### PR DESCRIPTION
Also removed the `unsafe` from them, since they are now sealed (since it was just a way to avoid others from implementing).