### PR TITLE
add to conversion to fixedsizebinary

### DIFF
--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -136,6 +136,18 @@ impl FixedSizeBinaryArray {
             .get_unchecked(i * self.size..(i + 1) * self.size)
     }
 
+    /// Returns a new [`FixedSizeBinary`] with a different logical type.
+    /// This is `O(1)`.
+    #[inline]
+    pub fn to(self, data_type: DataType) -> Self {
+        Self {
+            size: self.size,
+            data_type,
+            values: self.values,
+            validity: self.validity,
+        }
+    }
+
     /// Returns the size
     pub fn size(&self) -> usize {
         self.size

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -138,8 +138,19 @@ impl FixedSizeBinaryArray {
 
     /// Returns a new [`FixedSizeBinary`] with a different logical type.
     /// This is `O(1)`.
+    /// # Panics
+    /// Panics iff the data_type is not supported for the physical type.
     #[inline]
     pub fn to(self, data_type: DataType) -> Self {
+        match (
+            data_type.to_logical_type(),
+            self.data_type().to_logical_type(),
+        ) {
+            (DataType::FixedSizeBinary(size_a), DataType::FixedSizeBinary(size_b))
+                if size_a == size_b => {}
+            _ => panic!("Wrong DataType"),
+        }
+
         Self {
             size: self.size,
             data_type,


### PR DESCRIPTION
This adds `fn to` conversion for `FixedSizeBinary`. This makes converting to another logical type consistent with primitive arrays. 

I could add it to the other arrays as well.