### PR TITLE
Removed unneeded trait.

### DIFF
--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -25,7 +25,7 @@ use arrow_format::ipc::flatbuffers::VerifierOptions;
 use crate::array::*;
 use crate::datatypes::Schema;
 use crate::error::{ArrowError, Result};
-use crate::record_batch::{RecordBatch, RecordBatchReader};
+use crate::record_batch::RecordBatch;
 
 use super::super::convert;
 use super::super::{ARROW_MAGIC, CONTINUATION_MARKER};
@@ -316,11 +316,5 @@ impl<R: Read + Seek> Iterator for FileReader<R> {
         } else {
             None
         }
-    }
-}
-
-impl<R: Read + Seek> RecordBatchReader for FileReader<R> {
-    fn schema(&self) -> &Schema {
-        self.schema().as_ref()
     }
 }

--- a/src/record_batch.rs
+++ b/src/record_batch.rs
@@ -332,21 +332,3 @@ impl From<RecordBatch> for StructArray {
         StructArray::from_data(DataType::Struct(fields), values, None)
     }
 }
-
-/// Trait for types that can read `RecordBatch`'s.
-pub trait RecordBatchReader: Iterator<Item = Result<RecordBatch>> {
-    /// Returns the schema of this `RecordBatchReader`.
-    ///
-    /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
-    /// reader should have the same schema as returned from this method.
-    fn schema(&self) -> &Schema;
-
-    /// Reads the next `RecordBatch`.
-    #[deprecated(
-        since = "2.0.0",
-        note = "This method is deprecated in favour of `next` from the trait Iterator."
-    )]
-    fn next_batch(&mut self) -> Result<Option<RecordBatch>> {
-        self.next().transpose()
-    }
-}


### PR DESCRIPTION
Removes a trait that was only used once and did not offer sufficient benefits to justify its existence.

This is backward incompatible since the trait no longer exists. No migration path: the struct that implemented it already had the same method.