### PR TITLE
Improved error message for missing feature in compressed parquet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ futures = { version = "0.3", optional = true }
 ahash = { version = "0.7", optional = true }
 
 # parquet support
-parquet2 = { version = "0.7", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { version = "0.8", optional = true, default_features = false, features = ["stream"] }
 
 # avro
 avro-rs = { version = "0.13", optional = true, default_features = false }

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -8,7 +8,15 @@ const ARROW_SCHEMA_META_KEY: &str = "ARROW:schema";
 
 impl From<parquet2::error::ParquetError> for ArrowError {
     fn from(error: parquet2::error::ParquetError) -> Self {
-        ArrowError::External("".to_string(), Box::new(error))
+        match error {
+            parquet2::error::ParquetError::FeatureNotActive(_, _) => {
+                let message = "Failed to read a compressed parquet file. \
+                    Use the cargo feature \"io_parquet_compression\" to read compressed parquet files."
+                    .to_string();
+                ArrowError::ExternalFormat(message)
+            }
+            _ => ArrowError::ExternalFormat(error.to_string()),
+        }
     }
 }
 


### PR DESCRIPTION
Also bumps `parquet2`. Closes #626.