### PR TITLE
Simplified `ArrowError`

### DIFF
--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -410,8 +410,8 @@ impl<O: Offset, T: AsRef<[u8]>> TryPush<Option<T>> for MutableBinaryArray<O> {
             Some(value) => {
                 let bytes = value.as_ref();
 
-                let size = O::from_usize(self.values.len() + bytes.len())
-                    .ok_or(ArrowError::KeyOverflowError)?;
+                let size =
+                    O::from_usize(self.values.len() + bytes.len()).ok_or(ArrowError::Overflow)?;
 
                 self.values.extend_from_slice(bytes);
 

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -70,7 +70,7 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
                 Ok(false)
             }
             None => {
-                let key = K::from_usize(self.map.len()).ok_or(ArrowError::KeyOverflowError)?;
+                let key = K::from_usize(self.map.len()).ok_or(ArrowError::Overflow)?;
                 self.map.insert(hash, key);
                 self.keys.push(Some(key));
                 Ok(true)

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -58,7 +58,7 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
     #[inline]
     fn try_push_valid(&mut self) -> Result<()> {
         if self.values.len() % self.size != 0 {
-            return Err(ArrowError::KeyOverflowError);
+            return Err(ArrowError::Overflow);
         };
         if let Some(validity) = &mut self.validity {
             validity.push(true)

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -130,7 +130,7 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
     /// This is a relatively low level function, prefer `try_push` when you can.
     pub fn try_push_valid(&mut self) -> Result<()> {
         let size = self.values.len();
-        let size = O::from_usize(size).ok_or(ArrowError::KeyOverflowError)?; // todo: make this error
+        let size = O::from_usize(size).ok_or(ArrowError::Overflow)?;
         assert!(size >= *self.offsets.last().unwrap());
 
         self.offsets.push(size);

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -448,7 +448,7 @@ impl<O: Offset, T: AsRef<str>> TryPush<Option<T>> for MutableUtf8Array<O> {
                 let bytes = value.as_ref().as_bytes();
                 self.values.extend_from_slice(bytes);
 
-                let size = O::from_usize(self.values.len()).ok_or(ArrowError::KeyOverflowError)?;
+                let size = O::from_usize(self.values.len()).ok_or(ArrowError::Overflow)?;
 
                 self.offsets.push(size);
 

--- a/src/compute/cast/dictionary_to.rs
+++ b/src/compute/cast/dictionary_to.rs
@@ -13,7 +13,7 @@ macro_rules! key_cast {
         // Failure to cast keys (because they don't fit in the
         // target type) results in NULL values;
         if cast_keys.null_count() > $keys.null_count() {
-            return Err(ArrowError::KeyOverflowError);
+            return Err(ArrowError::Overflow);
         }
         Ok(Box::new(DictionaryArray::<$to_type>::from_data(
             cast_keys, $values,
@@ -74,7 +74,7 @@ where
     let casted_keys = primitive_to_primitive::<K1, K2>(keys, &K2::DATA_TYPE);
 
     if casted_keys.null_count() > keys.null_count() {
-        Err(ArrowError::KeyOverflowError)
+        Err(ArrowError::Overflow)
     } else {
         Ok(DictionaryArray::from_data(casted_keys, values.clone()))
     }
@@ -94,7 +94,7 @@ where
     let casted_keys = primitive_as_primitive::<K1, K2>(keys, &K2::DATA_TYPE);
 
     if casted_keys.null_count() > keys.null_count() {
-        Err(ArrowError::KeyOverflowError)
+        Err(ArrowError::Overflow)
     } else {
         Ok(DictionaryArray::from_data(casted_keys, values.clone()))
     }

--- a/src/datatypes/field.rs
+++ b/src/datatypes/field.rs
@@ -177,7 +177,7 @@ impl Field {
                 for (key, from_value) in from_metadata {
                     if let Some(self_value) = self_metadata.get(key) {
                         if self_value != from_value {
-                            return Err(ArrowError::Schema(format!(
+                            return Err(ArrowError::InvalidArgumentError(format!(
                                 "Fail to merge field due to conflicting metadata data value for key {}", key),
                             ));
                         }
@@ -193,12 +193,12 @@ impl Field {
             _ => {}
         }
         if from.dict_id != self.dict_id {
-            return Err(ArrowError::Schema(
+            return Err(ArrowError::InvalidArgumentError(
                 "Fail to merge schema Field due to conflicting dict_id".to_string(),
             ));
         }
         if from.dict_is_ordered != self.dict_is_ordered {
-            return Err(ArrowError::Schema(
+            return Err(ArrowError::InvalidArgumentError(
                 "Fail to merge schema Field due to conflicting dict_is_ordered".to_string(),
             ));
         }
@@ -220,7 +220,7 @@ impl Field {
                     }
                 }
                 _ => {
-                    return Err(ArrowError::Schema(
+                    return Err(ArrowError::InvalidArgumentError(
                         "Fail to merge schema Field due to conflicting datatype".to_string(),
                     ));
                 }
@@ -241,7 +241,7 @@ impl Field {
                     }
                 }
                 _ => {
-                    return Err(ArrowError::Schema(
+                    return Err(ArrowError::InvalidArgumentError(
                         "Fail to merge schema Field due to conflicting datatype".to_string(),
                     ));
                 }
@@ -279,7 +279,7 @@ impl Field {
             | DataType::Map(_, _)
             | DataType::Decimal(_, _) => {
                 if self.data_type != from.data_type {
-                    return Err(ArrowError::Schema(
+                    return Err(ArrowError::InvalidArgumentError(
                         "Fail to merge schema Field due to conflicting datatype".to_string(),
                     ));
                 }

--- a/src/datatypes/schema.rs
+++ b/src/datatypes/schema.rs
@@ -120,7 +120,7 @@ impl Schema {
                     // merge metadata
                     if let Some(old_val) = merged.metadata.get(&key) {
                         if old_val != &value {
-                            return Err(ArrowError::Schema(
+                            return Err(ArrowError::InvalidArgumentError(
                                 "Fail to merge schema due to conflicting metadata.".to_string(),
                             ));
                         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,31 +5,23 @@ use std::error::Error;
 
 /// Enum with all errors in this crate.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ArrowError {
     /// Returned when functionality is not yet available.
     NotYetImplemented(String),
-    /// Triggered by an external error, such as CSV, serde, chrono.
+    /// Wrapper for an error triggered by a dependency
     External(String, Box<dyn Error + Send + Sync>),
-    /// Error associated with incompatible schemas.
-    Schema(String),
-    /// Errors associated with IO
+    /// Wrapper for IO errors
     Io(std::io::Error),
     /// When an invalid argument is passed to a function.
     InvalidArgumentError(String),
-    /// Error during import or export to/from C Data Interface
-    Ffi(String),
-    /// Error during import or export to/from IPC
-    Ipc(String),
     /// Error during import or export to/from a format
     ExternalFormat(String),
     /// Whenever pushing to a container fails because it does not support more entries.
-    /// (e.g. maximum size of the keys of a dictionary overflowed)
-    KeyOverflowError,
-    /// Error during arithmetic operation. Normally returned
-    /// during checked operations
-    ArithmeticError(String),
-    /// Any other error.
-    Other(String),
+    /// The solution is usually to use a higher-capacity container-backing type.
+    Overflow,
+    /// Whenever incoming data from the C data interface, IPC or Flight does not fulfil the Arrow specification.
+    OutOfSpec(String),
 }
 
 impl ArrowError {
@@ -66,27 +58,17 @@ impl Display for ArrowError {
             ArrowError::External(message, source) => {
                 write!(f, "External error{}: {}", message, &source)
             }
-            ArrowError::Schema(desc) => write!(f, "Schema error: {}", desc),
             ArrowError::Io(desc) => write!(f, "Io error: {}", desc),
             ArrowError::InvalidArgumentError(desc) => {
                 write!(f, "Invalid argument error: {}", desc)
             }
-            ArrowError::Ffi(desc) => {
-                write!(f, "FFI error: {}", desc)
-            }
-            ArrowError::Ipc(desc) => {
-                write!(f, "IPC error: {}", desc)
-            }
             ArrowError::ExternalFormat(desc) => {
                 write!(f, "External format error: {}", desc)
             }
-            ArrowError::KeyOverflowError => {
-                write!(f, "Dictionary key bigger than the key type")
+            ArrowError::Overflow => {
+                write!(f, "Operation overflew the backing container.")
             }
-            ArrowError::ArithmeticError(desc) => {
-                write!(f, "Arithmetic error: {}", desc)
-            }
-            ArrowError::Other(message) => {
+            ArrowError::OutOfSpec(message) => {
                 write!(f, "{}", message)
             }
         }

--- a/src/ffi/ffi.rs
+++ b/src/ffi/ffi.rs
@@ -184,7 +184,9 @@ unsafe fn create_buffer<T: NativeType>(
     index: usize,
 ) -> Result<Buffer<T>> {
     if array.buffers.is_null() {
-        return Err(ArrowError::Ffi("The array buffers are null".to_string()));
+        return Err(ArrowError::OutOfSpec(
+            "The array buffers are null".to_string(),
+        ));
     }
 
     let buffers = array.buffers as *mut *const u8;
@@ -197,7 +199,9 @@ unsafe fn create_buffer<T: NativeType>(
     let offset = buffer_offset(array, data_type, index);
     let bytes = ptr
         .map(|ptr| Bytes::new(ptr, len, deallocation))
-        .ok_or_else(|| ArrowError::Ffi(format!("The buffer at position {} is null", index)))?;
+        .ok_or_else(|| {
+            ArrowError::OutOfSpec(format!("The buffer at position {} is null", index))
+        })?;
 
     Ok(Buffer::from_bytes(bytes).slice(offset, len - offset))
 }
@@ -215,7 +219,9 @@ unsafe fn create_bitmap(
     index: usize,
 ) -> Result<Bitmap> {
     if array.buffers.is_null() {
-        return Err(ArrowError::Ffi("The array buffers are null".to_string()));
+        return Err(ArrowError::OutOfSpec(
+            "The array buffers are null".to_string(),
+        ));
     }
     let len = array.length as usize;
     let offset = array.offset as usize;
@@ -229,7 +235,7 @@ unsafe fn create_bitmap(
     let bytes = ptr
         .map(|ptr| Bytes::new(ptr, bytes_len, deallocation))
         .ok_or_else(|| {
-            ArrowError::Ffi(format!(
+            ArrowError::OutOfSpec(format!(
                 "The buffer {} is a null pointer and cannot be interpreted as a bitmap",
                 index
             ))

--- a/src/io/avro/read/decompress.rs
+++ b/src/io/avro/read/decompress.rs
@@ -30,12 +30,12 @@ fn decompress_block(
         #[cfg(feature = "io_avro_compression")]
         Some(Compression::Snappy) => {
             let len = snap::raw::decompress_len(&block[..block.len() - 4])
-                .map_err(|_| ArrowError::Other("Failed to decompress snap".to_string()))?;
+                .map_err(|_| ArrowError::ExternalFormat("Failed to decompress snap".to_string()))?;
             decompress.clear();
             decompress.resize(len, 0);
             snap::raw::Decoder::new()
                 .decompress(&block[..block.len() - 4], decompress)
-                .map_err(|_| ArrowError::Other("Failed to decompress snap".to_string()))?;
+                .map_err(|_| ArrowError::ExternalFormat("Failed to decompress snap".to_string()))?;
             Ok(false)
         }
         #[cfg(not(feature = "io_avro_compression"))]

--- a/src/io/avro/read/nested.rs
+++ b/src/io/avro/read/nested.rs
@@ -43,7 +43,7 @@ impl<O: Offset> DynMutableListArray<O> {
     #[inline]
     pub fn try_push_valid(&mut self) -> Result<()> {
         let size = self.values.len();
-        let size = O::from_usize(size).ok_or(ArrowError::KeyOverflowError)?; // todo: make this error
+        let size = O::from_usize(size).ok_or(ArrowError::Overflow)?;
         assert!(size >= *self.offsets.last().unwrap());
 
         self.offsets.push(size);

--- a/src/io/ipc/compression.rs
+++ b/src/io/ipc/compression.rs
@@ -19,13 +19,13 @@ pub fn decompress_zstd(input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
 #[cfg(not(feature = "io_ipc_compression"))]
 pub fn decompress_lz4(_input_buf: &[u8], _output_buf: &mut [u8]) -> Result<()> {
     use crate::error::ArrowError;
-    Err(ArrowError::Ipc("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
+    Err(ArrowError::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
 }
 
 #[cfg(not(feature = "io_ipc_compression"))]
 pub fn decompress_zstd(_input_buf: &[u8], _output_buf: &mut [u8]) -> Result<()> {
     use crate::error::ArrowError;
-    Err(ArrowError::Ipc("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
+    Err(ArrowError::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
 }
 
 #[cfg(feature = "io_ipc_compression")]
@@ -48,13 +48,13 @@ pub fn compress_zstd(input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
 #[cfg(not(feature = "io_ipc_compression"))]
 pub fn compress_lz4(_input_buf: &[u8], _output_buf: &mut Vec<u8>) -> Result<()> {
     use crate::error::ArrowError;
-    Err(ArrowError::Ipc("The crate was compiled without IPC compression. Use `io_ipc_compression` to write compressed IPC.".to_string()))
+    Err(ArrowError::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to write compressed IPC.".to_string()))
 }
 
 #[cfg(not(feature = "io_ipc_compression"))]
 pub fn compress_zstd(_input_buf: &[u8], _output_buf: &mut Vec<u8>) -> Result<()> {
     use crate::error::ArrowError;
-    Err(ArrowError::Ipc("The crate was compiled without IPC compression. Use `io_ipc_compression` to write compressed IPC.".to_string()))
+    Err(ArrowError::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to write compressed IPC.".to_string()))
 }
 
 #[cfg(test)]

--- a/src/io/ipc/read/array/dictionary.rs
+++ b/src/io/ipc/read/array/dictionary.rs
@@ -31,7 +31,7 @@ where
         .get(&id)
         .ok_or_else(|| {
             let valid_ids = dictionaries.keys().collect::<HashSet<_>>();
-            ArrowError::Ipc(format!(
+            ArrowError::OutOfSpec(format!(
                 "Dictionary id {} not found. Valid ids: {:?}",
                 id, valid_ids
             ))

--- a/src/io/ipc/read/common.rs
+++ b/src/io/ipc/read/common.rs
@@ -103,12 +103,12 @@ pub fn read_record_batch<R: Read + Seek>(
     reader: &mut R,
     block_offset: u64,
 ) -> Result<RecordBatch> {
-    let buffers = batch
-        .buffers()
-        .ok_or_else(|| ArrowError::Ipc("Unable to get buffers from IPC RecordBatch".to_string()))?;
+    let buffers = batch.buffers().ok_or_else(|| {
+        ArrowError::OutOfSpec("Unable to get buffers from IPC RecordBatch".to_string())
+    })?;
     let mut buffers: VecDeque<&ipc::Schema::Buffer> = buffers.iter().collect();
     let field_nodes = batch.nodes().ok_or_else(|| {
-        ArrowError::Ipc("Unable to get field nodes from IPC RecordBatch".to_string())
+        ArrowError::OutOfSpec("Unable to get field nodes from IPC RecordBatch".to_string())
     })?;
 
     let mut field_nodes = field_nodes.iter().collect::<VecDeque<_>>();
@@ -205,7 +205,7 @@ fn first_dict_field(id: usize, fields: &[Field]) -> Result<&Field> {
             return Ok(field);
         }
     }
-    Err(ArrowError::Schema(format!(
+    Err(ArrowError::OutOfSpec(format!(
         "dictionary id {} not found in schema",
         id
     )))

--- a/src/io/ipc/read/read_basic.rs
+++ b/src/io/ipc/read/read_basic.rs
@@ -52,7 +52,7 @@ fn read_uncompressed_buffer<T: NativeType, R: Read + Seek>(
 ) -> Result<MutableBuffer<T>> {
     let bytes = length * std::mem::size_of::<T>();
     if bytes > buffer_length {
-        return Err(ArrowError::Ipc(
+        return Err(ArrowError::OutOfSpec(
             format!("The slots of the array times the physical size must \
             be smaller or equal to the length of the IPC buffer. \
             However, this array reports {} slots, which, for physical type \"{}\", corresponds to {} bytes, \

--- a/src/io/ipc/write/common_async.rs
+++ b/src/io/ipc/write/common_async.rs
@@ -1,7 +1,7 @@
 use futures::AsyncWrite;
 use futures::AsyncWriteExt;
 
-use crate::error::{ArrowError, Result};
+use crate::error::Result;
 
 use super::super::CONTINUATION_MARKER;
 use super::common::pad_to_8;
@@ -13,9 +13,7 @@ pub async fn write_message<W: AsyncWrite + Unpin + Send>(
     encoded: EncodedData,
 ) -> Result<(usize, usize)> {
     let arrow_data_len = encoded.arrow_data.len();
-    if arrow_data_len % 8 != 0 {
-        return Err(ArrowError::Ipc("Arrow data not aligned".to_string()));
-    }
+    assert_eq!(arrow_data_len % 8, 0, "Arrow data not aligned");
 
     let a = 8 - 1;
     let buffer = encoded.ipc_message;

--- a/src/io/ipc/write/common_sync.rs
+++ b/src/io/ipc/write/common_sync.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use crate::error::{ArrowError, Result};
+use crate::error::Result;
 
 use super::super::CONTINUATION_MARKER;
 use super::common::pad_to_8;
@@ -9,9 +9,7 @@ use super::common::EncodedData;
 /// Write a message's IPC data and buffers, returning metadata and buffer data lengths written
 pub fn write_message<W: Write>(writer: &mut W, encoded: EncodedData) -> Result<(usize, usize)> {
     let arrow_data_len = encoded.arrow_data.len();
-    if arrow_data_len % 8 != 0 {
-        return Err(ArrowError::Ipc("Arrow data not aligned".to_string()));
-    }
+    assert_eq!(arrow_data_len % 8, 0, "Arrow data not aligned");
 
     let a = 8 - 1;
     let buffer = encoded.ipc_message;

--- a/src/io/ipc/write/stream.rs
+++ b/src/io/ipc/write/stream.rs
@@ -41,7 +41,7 @@ pub struct StreamWriter<W: Write> {
     writer: W,
     /// IPC write options
     write_options: WriteOptions,
-    /// Whether the writer footer has been written, and the writer is finished
+    /// Whether the stream has been finished
     finished: bool,
     /// Keeps track of dictionaries that have been written
     dictionary_tracker: DictionaryTracker,
@@ -67,9 +67,10 @@ impl<W: Write> StreamWriter<W> {
     /// Write a record batch to the stream
     pub fn write(&mut self, batch: &RecordBatch) -> Result<()> {
         if self.finished {
-            return Err(ArrowError::Ipc(
-                "Cannot write record batch to stream writer as it is closed".to_string(),
-            ));
+            return Err(ArrowError::Io(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "Cannot write to a finished stream".to_string(),
+            )));
         }
 
         let (encoded_dictionaries, encoded_message) =

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -89,9 +89,10 @@ impl<W: Write> FileWriter<W> {
     /// Write a record batch to the file
     pub fn write(&mut self, batch: &RecordBatch) -> Result<()> {
         if self.finished {
-            return Err(ArrowError::Ipc(
-                "Cannot write record batch to file writer as it is closed".to_string(),
-            ));
+            return Err(ArrowError::Io(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "Cannot write to a finished file".to_string(),
+            )));
         }
 
         let (encoded_dictionaries, encoded_message) =

--- a/src/io/json/read/infer_schema.rs
+++ b/src/io/json/read/infer_schema.rs
@@ -236,7 +236,7 @@ where
                 }
             }
             value => {
-                return Err(ArrowError::Other(format!(
+                return Err(ArrowError::ExternalFormat(format!(
                     "Expected JSON record to be an object, found {:?}",
                     value
                 )));

--- a/src/io/json/read/reader.rs
+++ b/src/io/json/read/reader.rs
@@ -84,7 +84,7 @@ impl Decoder {
                 let v = value?;
                 match v {
                     Value::Object(_) => Ok(v),
-                    _ => Err(ArrowError::Other(format!(
+                    _ => Err(ArrowError::ExternalFormat(format!(
                         "Row needs to be of type object, got: {:?}",
                         v
                     ))),

--- a/src/io/json_integration/read.rs
+++ b/src/io/json_integration/read.rs
@@ -255,9 +255,9 @@ fn to_dictionary<K: DictionaryKey>(
     dictionaries: &HashMap<i64, ArrowJsonDictionaryBatch>,
 ) -> Result<Arc<dyn Array>> {
     // find dictionary
-    let dictionary = dictionaries
-        .get(&dict_id)
-        .ok_or_else(|| ArrowError::Ipc(format!("Unable to find any dictionary id {}", dict_id)))?;
+    let dictionary = dictionaries.get(&dict_id).ok_or_else(|| {
+        ArrowError::OutOfSpec(format!("Unable to find any dictionary id {}", dict_id))
+    })?;
 
     let keys = to_primitive(json_col, K::DATA_TYPE);
 

--- a/src/io/parquet/read/schema/metadata.rs
+++ b/src/io/parquet/read/schema/metadata.rs
@@ -38,10 +38,12 @@ fn get_arrow_schema_from_metadata(encoded_meta: &str) -> Result<Schema> {
                     .header_as_schema()
                     .map(fb_to_schema)
                     .map(|x| x.0)
-                    .ok_or_else(|| ArrowError::Ipc("the message is not Arrow Schema".to_string())),
+                    .ok_or_else(|| {
+                        ArrowError::OutOfSpec("the message is not Arrow Schema".to_string())
+                    }),
                 Err(err) => {
                     // The flatbuffers implementation returns an error on verification error.
-                    Err(ArrowError::Ipc(format!(
+                    Err(ArrowError::OutOfSpec(format!(
                         "Unable to get root as message stored in {}: {:?}",
                         ARROW_SCHEMA_META_KEY, err
                     )))

--- a/src/io/parquet/read/statistics/fixlen.rs
+++ b/src/io/parquet/read/statistics/fixlen.rs
@@ -53,8 +53,8 @@ impl TryFrom<(&ParquetFixedLenStatistics, DataType)> for PrimitiveStatistics<i12
             _ => unreachable!(),
         };
         if byte_lens > 16 {
-            Err(ArrowError::Other(format!(
-                "Can't deserialize i128 from Fixed Len Byte array with lengtg {:?}",
+            Err(ArrowError::ExternalFormat(format!(
+                "Can't deserialize i128 from Fixed Len Byte array with length {:?}",
                 byte_lens
             )))
         } else {

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -211,7 +211,7 @@ fn row_type_validation() {
     let re = builder.build(Cursor::new(content));
     assert_eq!(
         re.err().unwrap().to_string(),
-        r#"Expected JSON record to be an object, found Array([Number(1), String("hello")])"#,
+        r#"External format error: Expected JSON record to be an object, found Array([Number(1), String("hello")])"#,
     );
 }
 


### PR DESCRIPTION
* Removed some errors that were not used or could be replaced by more expressive ones
* Added new `OutOfSpec` error that covers many of the variants
* Added `#[non_exhaustive]` to `ArrowError` to signal that new variants may emerge

