### PR TITLE
Made API to create field accept `String`

### DIFF
--- a/src/datatypes/field.rs
+++ b/src/datatypes/field.rs
@@ -60,10 +60,10 @@ impl PartialEq for Field {
 }
 
 impl Field {
-    /// Creates a new field
-    pub fn new(name: &str, data_type: DataType, nullable: bool) -> Self {
+    /// Creates a new [`Field`].
+    pub fn new<T: Into<String>>(name: T, data_type: DataType, nullable: bool) -> Self {
         Field {
-            name: name.to_string(),
+            name: name.into(),
             data_type,
             nullable,
             dict_id: 0,
@@ -73,15 +73,15 @@ impl Field {
     }
 
     /// Creates a new field
-    pub fn new_dict(
-        name: &str,
+    pub fn new_dict<T: Into<String>>(
+        name: T,
         data_type: DataType,
         nullable: bool,
         dict_id: i64,
         dict_is_ordered: bool,
     ) -> Self {
         Field {
-            name: name.to_string(),
+            name: name.into(),
             data_type,
             nullable,
             dict_id,

--- a/src/datatypes/schema.rs
+++ b/src/datatypes/schema.rs
@@ -24,9 +24,10 @@ use super::Field;
 /// An ordered sequence of [`Field`] with optional metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Schema {
-    pub(crate) fields: Vec<Field>,
+    /// The fields composing this schema.
+    pub fields: Vec<Field>,
     /// A map of key-value pairs containing additional meta data.
-    pub(crate) metadata: HashMap<String, String>,
+    pub metadata: HashMap<String, String>,
 }
 
 impl Schema {


### PR DESCRIPTION
When we already own the string, we should not need an extra allocation to create the field. This PR does this.