### PR TITLE
Improved performance in cast Primitive to Binary/String (2x)

### DIFF
--- a/benches/cast_kernels.rs
+++ b/benches/cast_kernels.rs
@@ -171,6 +171,10 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("cast utf8 to date64 512", |b| {
         b.iter(|| cast_array(&utf8_date_time_array, DataType::Date64))
     });
+
+    c.bench_function("cast int32 to binary 512", |b| {
+        b.iter(|| cast_array(&i32_array, DataType::Binary))
+    });
 }
 
 criterion_group!(benches, add_benchmark);

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -1,5 +1,6 @@
 use std::hash::Hash;
 
+use crate::error::Result;
 use crate::{
     array::*,
     bitmap::Bitmap,
@@ -8,10 +9,6 @@ use crate::{
     temporal_conversions::*,
     types::NativeType,
     util::lexical_to_bytes_mut,
-};
-use crate::{
-    error::Result,
-    util::{lexical_to_bytes, lexical_to_string},
 };
 
 use super::CastOptions;

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -7,6 +7,7 @@ use crate::{
     datatypes::{DataType, TimeUnit},
     temporal_conversions::*,
     types::NativeType,
+    util::lexical_to_bytes_mut,
 };
 use crate::{
     error::Result,
@@ -19,9 +20,21 @@ use super::CastOptions;
 pub fn primitive_to_binary<T: NativeType + lexical_core::ToLexical, O: Offset>(
     from: &PrimitiveArray<T>,
 ) -> BinaryArray<O> {
-    let iter = from.iter().map(|x| x.map(|x| lexical_to_bytes(*x)));
-
-    BinaryArray::from_trusted_len_iter(iter)
+    let mut buffer = vec![];
+    let builder = from.iter().fold(
+        MutableBinaryArray::<O>::with_capacity(from.len()),
+        |mut builder, x| {
+            match x {
+                Some(x) => {
+                    lexical_to_bytes_mut(*x, &mut buffer);
+                    builder.push(Some(buffer.as_slice()));
+                }
+                None => builder.push_null(),
+            }
+            builder
+        },
+    );
+    builder.into()
 }
 
 pub(super) fn primitive_to_binary_dyn<T, O>(from: &dyn Array) -> Result<Box<dyn Array>>
@@ -60,9 +73,23 @@ where
 pub fn primitive_to_utf8<T: NativeType + lexical_core::ToLexical, O: Offset>(
     from: &PrimitiveArray<T>,
 ) -> Utf8Array<O> {
-    let iter = from.iter().map(|x| x.map(|x| lexical_to_string(*x)));
-
-    Utf8Array::from_trusted_len_iter(iter)
+    let mut buffer = vec![];
+    let builder = from.iter().fold(
+        MutableUtf8Array::<O>::with_capacity(from.len()),
+        |mut builder, x| {
+            match x {
+                Some(x) => {
+                    lexical_to_bytes_mut(*x, &mut buffer);
+                    builder.push(Some(unsafe {
+                        std::str::from_utf8_unchecked(buffer.as_slice())
+                    }));
+                }
+                None => builder.push_null(),
+            }
+            builder
+        },
+    );
+    builder.into()
 }
 
 pub(super) fn primitive_to_utf8_dyn<T, O>(from: &dyn Array) -> Result<Box<dyn Array>>


### PR DESCRIPTION
Reuse the temp bytes buffer.

```
cast int32 to binary 512                                                                             
		time:   [10.650 us 10.761 us 10.885 us]
		change: [-47.175% -46.939% -46.649%] (p = 0.00 < 0.05)
		Performance has improved.

```