### PR TITLE
make Buffer::offset public

### DIFF
--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -121,8 +121,9 @@ impl<T: NativeType> Buffer<T> {
         self.data.ptr()
     }
 
-    /// Returns a offset of this buffer
-    pub(crate) fn offset(&self) -> usize {
+    /// Returns the offset of this buffer.
+    #[inline]
+    pub fn offset(&self) -> usize {
         self.offset
     }
 }


### PR DESCRIPTION
I want to know if a certain primitive array has been sliced. This seems easiest to me by checking if the backing buffer has got an offset.