### PR TITLE
Fixed filter of predicate with validity

### DIFF
--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -111,8 +111,10 @@ pub fn build_filter(filter: &BooleanArray) -> Result<Filter> {
 }
 
 /// Filters an [Array], returning elements matching the filter (i.e. where the values are true).
-/// WARNING: the nulls of `filter` are ignored and the value on its slot is considered.
-/// Therefore, it is considered undefined behavior to pass `filter` with null values.
+///
+/// Note that the nulls of `filter` are interpreted as `false` will lead to these elements being
+/// masked out.
+///
 /// # Example
 /// ```rust
 /// # use arrow2::array::{Int32Array, PrimitiveArray, BooleanArray};

--- a/tests/it/compute/filter.rs
+++ b/tests/it/compute/filter.rs
@@ -1,4 +1,5 @@
 use arrow2::array::*;
+use arrow2::bitmap::Bitmap;
 use arrow2::compute::filter::*;
 
 #[test]
@@ -110,6 +111,21 @@ fn binary_array_with_null() {
     assert_eq!(b"hello", d.value(0));
     assert!(!d.is_null(0));
     assert!(d.is_null(1));
+}
+
+#[test]
+fn masked_true_values() {
+    let a = Int32Array::from_slice(&[1, 2, 3]);
+    let b = BooleanArray::from_slice(&[true, false, true]);
+    let validity = Bitmap::from(&[true, false, false]);
+
+    let b = b.with_validity(Some(validity));
+
+    let c = filter(&a, &b).unwrap();
+
+    let expected = Int32Array::from_slice(&[1]);
+
+    assert_eq!(expected, c.as_ref());
 }
 
 /*


### PR DESCRIPTION
The filter kernel took the values bitmap of the `mask/filter`, this works in most cases, as it often contains `false/unset` bits, but it doesn't have to.

This PR fixes the behavior and in case of null values it make sure that we first `mask & validities` before we filter.