### PR TITLE
Fixed performance regression of CSV reading

### DIFF
--- a/src/io/csv/read/deserialize.rs
+++ b/src/io/csv/read/deserialize.rs
@@ -15,6 +15,7 @@ use super::super::read_utils::{
 };
 
 impl ByteRecordGeneric for ByteRecord {
+    #[inline]
     fn get(&self, index: usize) -> Option<&[u8]> {
         self.get(index)
     }

--- a/src/io/csv/read_async/deserialize.rs
+++ b/src/io/csv/read_async/deserialize.rs
@@ -15,6 +15,7 @@ use super::super::read_utils::{
 };
 
 impl ByteRecordGeneric for ByteRecord {
+    #[inline]
     fn get(&self, index: usize) -> Option<&[u8]> {
         self.get(index)
     }


### PR DESCRIPTION
This was a performance regression introduced to downstream dependencies caused by poor inlining by Rust after the introduction of the async csv reading.