### PR TITLE
Simplified `Utf8Scalar` and `BinaryScalar`

### DIFF
--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -297,12 +297,12 @@ macro_rules! compare_scalar {
             Utf8 => {
                 let lhs = lhs.as_any().downcast_ref().unwrap();
                 let rhs = rhs.as_any().downcast_ref::<Utf8Scalar<i32>>().unwrap();
-                utf8::$op::<i32>(lhs, rhs.value())
+                utf8::$op::<i32>(lhs, rhs.value().unwrap())
             }
             LargeUtf8 => {
                 let lhs = lhs.as_any().downcast_ref().unwrap();
                 let rhs = rhs.as_any().downcast_ref::<Utf8Scalar<i64>>().unwrap();
-                utf8::$op::<i64>(lhs, rhs.value())
+                utf8::$op::<i64>(lhs, rhs.value().unwrap())
             }
             Decimal(_, _) => {
                 let lhs = lhs.as_any().downcast_ref().unwrap();
@@ -315,12 +315,12 @@ macro_rules! compare_scalar {
             Binary => {
                 let lhs = lhs.as_any().downcast_ref().unwrap();
                 let rhs = rhs.as_any().downcast_ref::<BinaryScalar<i32>>().unwrap();
-                binary::$op::<i32>(lhs, rhs.value())
+                binary::$op::<i32>(lhs, rhs.value().unwrap())
             }
             LargeBinary => {
                 let lhs = lhs.as_any().downcast_ref().unwrap();
                 let rhs = rhs.as_any().downcast_ref::<BinaryScalar<i64>>().unwrap();
-                binary::$op::<i64>(lhs, rhs.value())
+                binary::$op::<i64>(lhs, rhs.value().unwrap())
             }
             _ => todo!("Comparisons of {:?} are not yet supported", data_type),
         }

--- a/tests/it/scalar/binary.rs
+++ b/tests/it/scalar/binary.rs
@@ -20,7 +20,7 @@ fn equal() {
 fn basics() {
     let a = BinaryScalar::<i32>::from(Some("a"));
 
-    assert_eq!(a.value(), b"a");
+    assert_eq!(a.value(), Some(b"a".as_ref()));
     assert_eq!(a.data_type(), &DataType::Binary);
     assert!(a.is_valid());
 

--- a/tests/it/scalar/utf8.rs
+++ b/tests/it/scalar/utf8.rs
@@ -20,7 +20,7 @@ fn equal() {
 fn basics() {
     let a = Utf8Scalar::<i32>::from(Some("a"));
 
-    assert_eq!(a.value(), "a");
+    assert_eq!(a.value(), Some("a"));
     assert_eq!(a.data_type(), &DataType::Utf8);
     assert!(a.is_valid());
 


### PR DESCRIPTION
Made both to use `Option<String>` and `Option<Vec<u8>>` respectively. One less `unsafe` ^_^
