### PR TITLE
Made scalar arithmetics use Scalar API

### DIFF
--- a/src/compute/arithmetics/basic/mod.rs
+++ b/src/compute/arithmetics/basic/mod.rs
@@ -24,6 +24,7 @@ use num_traits::{CheckedNeg, WrappingNeg};
 
 use crate::{
     array::{Array, PrimitiveArray},
+    scalar::PrimitiveScalar,
     types::NativeType,
 };
 
@@ -45,7 +46,7 @@ impl NativeArithmetics for i64 {}
 impl NativeArithmetics for f32 {}
 impl NativeArithmetics for f64 {}
 
-/// Negates values from array.
+/// Negates the values of the [`PrimitiveArray<T>`] (validity is preserved)
 ///
 /// # Examples
 /// ```
@@ -101,4 +102,18 @@ where
     T: NativeType + WrappingNeg,
 {
     unary(array, |a| a.wrapping_neg(), array.data_type().clone())
+}
+
+#[inline]
+fn binary_scalar<T: NativeType, F: Fn(T, T) -> T>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveScalar<T>,
+    op: F,
+) -> PrimitiveArray<T> {
+    let rhs = if let Some(rhs) = rhs.value() {
+        rhs
+    } else {
+        return PrimitiveArray::<T>::new_null(lhs.data_type().clone(), lhs.len());
+    };
+    unary(lhs, |x| op(x, rhs), lhs.data_type().clone())
 }

--- a/src/compute/arithmetics/basic/mul.rs
+++ b/src/compute/arithmetics/basic/mul.rs
@@ -10,12 +10,12 @@ use crate::{
         arithmetics::{
             ArrayCheckedMul, ArrayMul, ArrayOverflowingMul, ArraySaturatingMul, ArrayWrappingMul,
         },
-        arity::{
-            binary, binary_checked, binary_with_bitmap, unary, unary_checked, unary_with_bitmap,
-        },
+        arity::{binary, binary_checked, binary_with_bitmap, unary_checked, unary_with_bitmap},
     },
+    scalar::PrimitiveScalar,
 };
 
+use super::binary_scalar;
 use super::NativeArithmetics;
 
 /// Multiplies two primitive arrays with the same type.
@@ -200,12 +200,11 @@ where
 /// let expected = Int32Array::from(&[None, Some(12), None, Some(12)]);
 /// assert_eq!(result, expected)
 /// ```
-pub fn mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
+pub fn mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveScalar<T>) -> PrimitiveArray<T>
 where
     T: NativeArithmetics + Mul<Output = T>,
 {
-    let rhs = *rhs;
-    unary(lhs, |a| a * rhs, lhs.data_type().clone())
+    binary_scalar(lhs, rhs, |a, b| a * b)
 }
 
 /// Wrapping multiplication of a scalar T to a [`PrimitiveArray`] of type T.
@@ -221,11 +220,14 @@ where
 /// let expected = Int8Array::from(&[None, Some(0)]);
 /// assert_eq!(result, expected);
 /// ```
-pub fn wrapping_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
+pub fn wrapping_mul_scalar<T>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveScalar<T>,
+) -> PrimitiveArray<T>
 where
     T: NativeArithmetics + WrappingMul<Output = T>,
 {
-    unary(lhs, |a| a.wrapping_mul(rhs), lhs.data_type().clone())
+    binary_scalar(lhs, rhs, |a, b| a.wrapping_mul(&b))
 }
 
 /// Checked multiplication of a scalar T to a primitive array of type T. If the
@@ -242,11 +244,15 @@ where
 /// let expected = Int8Array::from(&[None, None, None, None]);
 /// assert_eq!(result, expected);
 /// ```
-pub fn checked_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
+pub fn checked_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveScalar<T>) -> PrimitiveArray<T>
 where
     T: NativeArithmetics + CheckedMul<Output = T>,
 {
-    let rhs = *rhs;
+    let rhs = if let Some(rhs) = rhs.value() {
+        rhs
+    } else {
+        return PrimitiveArray::<T>::new_null(lhs.data_type().clone(), lhs.len());
+    };
     let op = move |a: T| a.checked_mul(&rhs);
 
     unary_checked(lhs, op, lhs.data_type().clone())
@@ -266,14 +272,14 @@ where
 /// let expected = Int8Array::from(&[Some(-128i8)]);
 /// assert_eq!(result, expected);
 /// ```
-pub fn saturating_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> PrimitiveArray<T>
+pub fn saturating_mul_scalar<T>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveScalar<T>,
+) -> PrimitiveArray<T>
 where
     T: NativeArithmetics + SaturatingMul<Output = T>,
 {
-    let rhs = *rhs;
-    let op = move |a: T| a.saturating_mul(&rhs);
-
-    unary(lhs, op, lhs.data_type().clone())
+    binary_scalar(lhs, rhs, |a, b| a.saturating_mul(&b))
 }
 
 /// Overflowing multiplication of a scalar T to a primitive array of type T. If
@@ -291,52 +297,62 @@ where
 /// let expected = Int8Array::from(&[Some(100i8), Some(16i8)]);
 /// assert_eq!(result, expected);
 /// ```
-pub fn overflowing_mul_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &T) -> (PrimitiveArray<T>, Bitmap)
+pub fn overflowing_mul_scalar<T>(
+    lhs: &PrimitiveArray<T>,
+    rhs: &PrimitiveScalar<T>,
+) -> (PrimitiveArray<T>, Bitmap)
 where
     T: NativeArithmetics + OverflowingMul<Output = T>,
 {
-    let rhs = *rhs;
+    let rhs = if let Some(rhs) = rhs.value() {
+        rhs
+    } else {
+        return (
+            PrimitiveArray::<T>::new_null(lhs.data_type().clone(), lhs.len()),
+            Bitmap::new_zeroed(lhs.len()),
+        );
+    };
     let op = move |a: T| a.overflowing_mul(&rhs);
 
     unary_with_bitmap(lhs, op, lhs.data_type().clone())
 }
 
 // Implementation of ArrayMul trait for PrimitiveArrays with a scalar
-impl<T> ArrayMul<T> for PrimitiveArray<T>
+impl<T> ArrayMul<PrimitiveScalar<T>> for PrimitiveArray<T>
 where
-    T: NativeArithmetics + Mul<Output = T> + NativeArithmetics,
+    T: NativeArithmetics + Mul<Output = T>,
 {
-    fn mul(&self, rhs: &T) -> Self {
+    fn mul(&self, rhs: &PrimitiveScalar<T>) -> Self {
         mul_scalar(self, rhs)
     }
 }
 
 // Implementation of ArrayCheckedMul trait for PrimitiveArrays with a scalar
-impl<T> ArrayCheckedMul<T> for PrimitiveArray<T>
+impl<T> ArrayCheckedMul<PrimitiveScalar<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + CheckedMul<Output = T>,
 {
-    fn checked_mul(&self, rhs: &T) -> Self {
+    fn checked_mul(&self, rhs: &PrimitiveScalar<T>) -> Self {
         checked_mul_scalar(self, rhs)
     }
 }
 
 // Implementation of ArraySaturatingMul trait for PrimitiveArrays with a scalar
-impl<T> ArraySaturatingMul<T> for PrimitiveArray<T>
+impl<T> ArraySaturatingMul<PrimitiveScalar<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + SaturatingMul<Output = T>,
 {
-    fn saturating_mul(&self, rhs: &T) -> Self {
+    fn saturating_mul(&self, rhs: &PrimitiveScalar<T>) -> Self {
         saturating_mul_scalar(self, rhs)
     }
 }
 
 // Implementation of ArraySaturatingMul trait for PrimitiveArrays with a scalar
-impl<T> ArrayOverflowingMul<T> for PrimitiveArray<T>
+impl<T> ArrayOverflowingMul<PrimitiveScalar<T>> for PrimitiveArray<T>
 where
     T: NativeArithmetics + OverflowingMul<Output = T>,
 {
-    fn overflowing_mul(&self, rhs: &T) -> (Self, Bitmap) {
+    fn overflowing_mul(&self, rhs: &PrimitiveScalar<T>) -> (Self, Bitmap) {
         overflowing_mul_scalar(self, rhs)
     }
 }

--- a/src/compute/arithmetics/basic/pow.rs
+++ b/src/compute/arithmetics/basic/pow.rs
@@ -3,9 +3,11 @@ use num_traits::{checked_pow, CheckedMul, One, Pow, Zero};
 
 use crate::{
     array::{Array, PrimitiveArray},
-    compute::arity::{unary, unary_checked},
+    compute::arity::unary_checked,
+    scalar::PrimitiveScalar,
 };
 
+use super::binary_scalar;
 use super::NativeArithmetics;
 
 /// Raises an array of primitives to the power of exponent. Panics if one of
@@ -14,18 +16,20 @@ use super::NativeArithmetics;
 /// # Examples
 /// ```
 /// use arrow2::compute::arithmetics::basic::powf_scalar;
-/// use arrow2::array::Float32Array;
+/// use arrow2::array::PrimitiveArray;
+/// use arrow2::array::PrimitiveScalar;
 ///
-/// let a = Float32Array::from(&[Some(2f32), None]);
-/// let actual = powf_scalar(&a, 2.0);
+/// let a = PrimitiveArray::<f32>::from(&[Some(2f32), None]);
+/// let b = PrimitiveScalar::<f32>::from(Some(2.0f32));
+/// let actual = powf_scalar(&a, &b);
 /// let expected = Float32Array::from(&[Some(4f32), None]);
 /// assert_eq!(expected, actual);
 /// ```
-pub fn powf_scalar<T>(array: &PrimitiveArray<T>, exponent: T) -> PrimitiveArray<T>
+pub fn powf_scalar<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveScalar<T>) -> PrimitiveArray<T>
 where
     T: NativeArithmetics + Pow<T, Output = T>,
 {
-    unary(array, |x| x.pow(exponent), array.data_type().clone())
+    binary_scalar(lhs, rhs, |a, b| a.pow(b))
 }
 
 /// Checked operation of raising an array of primitives to the power of


### PR DESCRIPTION
So that we can carry the `DataType` information to the operators. Closed #659 