### PR TITLE
Made IPC ZSTD-compressed consumable by pyarrow

### DIFF
--- a/src/io/ipc/compression.rs
+++ b/src/io/ipc/compression.rs
@@ -41,7 +41,7 @@ pub fn compress_lz4(input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
 #[cfg_attr(docsrs, doc(cfg(feature = "io_ipc_compression")))]
 pub fn compress_zstd(input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
     use std::io::Write;
-    let mut encoder = zstd::Encoder::new(output_buf, 17)?.auto_finish();
+    let mut encoder = zstd::Encoder::new(output_buf, 0)?.auto_finish();
     encoder.write_all(input_buf).map_err(|e| e.into())
 }
 


### PR DESCRIPTION
I do not understand why the level must be zstd's default to work, but it works. This is either a bug on zstd's crate or on pyarrow's ZSTD's compressor :/
