### PR TITLE
Fixed error in reading negative decimals from parquet

### DIFF
--- a/parquet_integration/write_parquet.py
+++ b/parquet_integration/write_parquet.py
@@ -50,7 +50,8 @@ def case_basic_nullable(size=1):
 
 
 def case_basic_required(size=1):
-    int64 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    int64 = [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8]
+    uint32 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     float64 = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
     string = ["Hello", "bbb", "aa", "", "bbb", "abc", "bbb", "bbb", "def", "aaa"]
     boolean = [True, True, False, False, False, True, True, True, True, True]
@@ -82,7 +83,7 @@ def case_basic_required(size=1):
             "string": string * size,
             "bool": boolean * size,
             "date": int64 * size,
-            "uint32": int64 * size,
+            "uint32": uint32 * size,
             "decimal_9": decimal * size,
             "decimal_18": decimal * size,
             "decimal_26": decimal * size,

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -399,6 +399,7 @@ pub fn pyarrow_nullable_statistics(column: usize) -> Option<Box<dyn Statistics>>
 // these values match the values in `integration`
 pub fn pyarrow_required(column: usize) -> Box<dyn Array> {
     let i64_values = &[
+        Some(-1),
         Some(0),
         Some(1),
         Some(2),
@@ -408,7 +409,6 @@ pub fn pyarrow_required(column: usize) -> Box<dyn Array> {
         Some(6),
         Some(7),
         Some(8),
-        Some(9),
     ];
 
     match column {


### PR DESCRIPTION
Fixes #676 .  On conversion from a FixedLenByteArray to i128, any extension bytes must be filled with the value of the MSB to correctly handle negative values.