### PR TITLE
Made `dyn Array` and `Scalar` usable in `#[derive(PartialEq)]`

### DIFF
--- a/src/array/equal/mod.rs
+++ b/src/array/equal/mod.rs
@@ -15,9 +15,21 @@ mod struct_;
 mod union;
 mod utf8;
 
-impl PartialEq for dyn Array {
-    fn eq(&self, other: &Self) -> bool {
-        equal(self, other)
+impl PartialEq for dyn Array + '_ {
+    fn eq(&self, that: &dyn Array) -> bool {
+        equal(self, that)
+    }
+}
+
+impl PartialEq<dyn Array> for Arc<dyn Array + '_> {
+    fn eq(&self, that: &dyn Array) -> bool {
+        equal(&**self, that)
+    }
+}
+
+impl PartialEq<dyn Array> for Box<dyn Array + '_> {
+    fn eq(&self, that: &dyn Array) -> bool {
+        equal(&**self, that)
     }
 }
 

--- a/src/scalar/equal.rs
+++ b/src/scalar/equal.rs
@@ -1,9 +1,23 @@
+use std::sync::Arc;
+
 use super::*;
 use crate::types::days_ms;
 
-impl PartialEq for dyn Scalar {
-    fn eq(&self, other: &Self) -> bool {
-        equal(self, other)
+impl PartialEq for dyn Scalar + '_ {
+    fn eq(&self, that: &dyn Scalar) -> bool {
+        equal(self, that)
+    }
+}
+
+impl PartialEq<dyn Scalar> for Arc<dyn Scalar + '_> {
+    fn eq(&self, that: &dyn Scalar) -> bool {
+        equal(&**self, that)
+    }
+}
+
+impl PartialEq<dyn Scalar> for Box<dyn Scalar + '_> {
+    fn eq(&self, that: &dyn Scalar) -> bool {
+        equal(&**self, that)
     }
 }
 

--- a/tests/it/array/mod.rs
+++ b/tests/it/array/mod.rs
@@ -97,3 +97,9 @@ fn test_with_validity() {
     let expected = PrimitiveArray::from(&[Some(1i32), None, Some(3)]);
     assert_eq!(arr_ref, &expected);
 }
+
+// check that `PartialEq` can be derived
+#[derive(PartialEq)]
+struct A {
+    array: std::sync::Arc<dyn Array>,
+}

--- a/tests/it/scalar/mod.rs
+++ b/tests/it/scalar/mod.rs
@@ -5,3 +5,9 @@ mod null;
 mod primitive;
 mod struct_;
 mod utf8;
+
+// check that `PartialEq` can be derived
+#[derive(PartialEq)]
+struct A {
+    array: std::sync::Arc<dyn arrow2::scalar::Scalar>,
+}


### PR DESCRIPTION
A small quality of life, as people can use these in structs and enums and still leverage the partial equality we offer in this crate.