### PR TITLE
Support parquet read from dictionary-encoded nonoptional pages

### DIFF
--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -314,6 +314,11 @@ fn v2_decimal_9_required() -> Result<()> {
 }
 
 #[test]
+fn v2_decimal_9_required_dict() -> Result<()> {
+    test_pyarrow_integration(6, 2, "basic", true, true, None)
+}
+
+#[test]
 fn v2_decimal_18_nullable() -> Result<()> {
     test_pyarrow_integration(8, 2, "basic", false, false, None)
 }
@@ -324,6 +329,11 @@ fn v2_decimal_18_required() -> Result<()> {
 }
 
 #[test]
+fn v2_decimal_18_required_dict() -> Result<()> {
+    test_pyarrow_integration(7, 2, "basic", true, true, None)
+}
+
+#[test]
 fn v2_decimal_26_nullable() -> Result<()> {
     test_pyarrow_integration(9, 2, "basic", false, false, None)
 }
@@ -331,6 +341,11 @@ fn v2_decimal_26_nullable() -> Result<()> {
 #[test]
 fn v2_decimal_26_required() -> Result<()> {
     test_pyarrow_integration(8, 2, "basic", false, true, None)
+}
+
+#[test]
+fn v2_decimal_26_required_dict() -> Result<()> {
+    test_pyarrow_integration(8, 2, "basic", true, true, None)
 }
 
 #[test]


### PR DESCRIPTION
Addresses  #668 .