### PR TITLE
Migrated from `avro-rs` to `avro-schema`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ ahash = { version = "0.7", optional = true }
 # parquet support
 parquet2 = { version = "0.8", optional = true, default_features = false, features = ["stream"] }
 
-# avro
-avro-rs = { version = "0.13", optional = true, default_features = false }
+# avro support
+avro-schema = { version = "0.2", optional = true }
 # compression of avro
 libflate = { version = "1.1.1", optional = true }
 snap = { version = "1", optional = true }
@@ -138,7 +138,7 @@ io_parquet_compression = [
     "parquet2/lz4",
     "parquet2/brotli",
 ]
-io_avro = ["avro-rs", "fallible-streaming-iterator", "serde_json"]
+io_avro = ["avro-schema", "fallible-streaming-iterator", "serde_json"]
 io_avro_compression = [
     "libflate",
     "snap",

--- a/src/io/avro/mod.rs
+++ b/src/io/avro/mod.rs
@@ -6,14 +6,6 @@ pub mod read;
 #[cfg_attr(docsrs, doc(cfg(feature = "io_avro_async")))]
 pub mod read_async;
 
-use crate::error::ArrowError;
-
-impl From<avro_rs::Error> for ArrowError {
-    fn from(error: avro_rs::Error) -> Self {
-        ArrowError::External("".to_string(), Box::new(error))
-    }
-}
-
 // macros that can operate in sync and async code.
 macro_rules! avro_decode {
     ($reader:ident $($_await:tt)*) => {

--- a/src/io/avro/read/deserialize.rs
+++ b/src/io/avro/read/deserialize.rs
@@ -1,7 +1,7 @@
 use std::convert::TryInto;
 use std::sync::Arc;
 
-use avro_rs::Schema as AvroSchema;
+use avro_schema::{Enum, Schema as AvroSchema};
 
 use crate::array::*;
 use crate::datatypes::*;
@@ -33,7 +33,7 @@ fn make_mutable(
             Box::new(MutableUtf8Array::<i32>::with_capacity(capacity)) as Box<dyn MutableArray>
         }
         PhysicalType::Dictionary(_) => {
-            if let Some(AvroSchema::Enum { symbols, .. }) = avro_schema {
+            if let Some(AvroSchema::Enum(Enum { symbols, .. })) = avro_schema {
                 let values = Utf8Array::<i32>::from_slice(symbols);
                 Box::new(FixedItemsUtf8Dictionary::with_capacity(values, capacity))
                     as Box<dyn MutableArray>
@@ -64,7 +64,7 @@ fn make_mutable(
 
 fn is_union_null_first(avro_field: &AvroSchema) -> bool {
     if let AvroSchema::Union(schemas) = avro_field {
-        schemas.variants()[0] == AvroSchema::Null
+        schemas[0] == AvroSchema::Null
     } else {
         unreachable!()
     }

--- a/src/io/avro/read/header.rs
+++ b/src/io/avro/read/header.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use avro_rs::{Error, Schema};
+use avro_schema::Schema;
 use serde_json;
 
-use crate::error::Result;
+use crate::error::{ArrowError, Result};
 
 use super::Compression;
 
@@ -11,11 +11,13 @@ use super::Compression;
 pub(crate) fn deserialize_header(
     header: HashMap<String, Vec<u8>>,
 ) -> Result<(Schema, Option<Compression>)> {
-    let json = header
+    let schema = header
         .get("avro.schema")
-        .and_then(|bytes| serde_json::from_slice(bytes.as_ref()).ok())
-        .ok_or(Error::GetAvroSchemaFromMap)?;
-    let schema = Schema::parse(&json)?;
+        .ok_or_else(|| ArrowError::ExternalFormat("Avro schema must be present".to_string()))
+        .and_then(|bytes| {
+            serde_json::from_slice(bytes.as_ref())
+                .map_err(|e| ArrowError::ExternalFormat(e.to_string()))
+        })?;
 
     let compression = header.get("avro.codec").and_then(|bytes| {
         let bytes: &[u8] = bytes.as_ref();

--- a/src/io/avro/read/mod.rs
+++ b/src/io/avro/read/mod.rs
@@ -3,7 +3,7 @@
 use std::io::Read;
 use std::sync::Arc;
 
-use avro_rs::Schema as AvroSchema;
+use avro_schema::{Record, Schema as AvroSchema};
 use fallible_streaming_iterator::FallibleStreamingIterator;
 
 mod block;
@@ -41,7 +41,7 @@ pub fn read_metadata<R: std::io::Read>(
     let (avro_schema, codec, marker) = util::read_schema(reader)?;
     let schema = schema::convert_schema(&avro_schema)?;
 
-    let avro_schema = if let AvroSchema::Record { fields, .. } = avro_schema {
+    let avro_schema = if let AvroSchema::Record(Record { fields, .. }) = avro_schema {
         fields.into_iter().map(|x| x.schema).collect()
     } else {
         panic!()

--- a/src/io/avro/read/util.rs
+++ b/src/io/avro/read/util.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io::Read;
 
-use avro_rs::Schema;
+use avro_schema::Schema;
 
 use crate::error::{ArrowError, Result};
 

--- a/src/io/avro/read_async/metadata.rs
+++ b/src/io/avro/read_async/metadata.rs
@@ -1,7 +1,7 @@
 //! Async Avro
 use std::collections::HashMap;
 
-use avro_rs::Schema as AvroSchema;
+use avro_schema::{Record, Schema as AvroSchema};
 use futures::AsyncRead;
 use futures::AsyncReadExt;
 
@@ -30,7 +30,7 @@ pub async fn read_metadata<R: AsyncRead + Unpin + Send>(
     let (avro_schema, codec, marker) = read_metadata_async(reader).await?;
     let schema = convert_schema(&avro_schema)?;
 
-    let avro_schema = if let AvroSchema::Record { fields, .. } = avro_schema {
+    let avro_schema = if let AvroSchema::Record(Record { fields, .. }) = avro_schema {
         fields.into_iter().map(|x| x.schema).collect()
     } else {
         panic!()


### PR DESCRIPTION
This PR replaces `avro-rs` by `avro-schema` (authored by me).

# Background

While working on reading from Avro some months ago, and now on #690, I noticed 4 issues with `avro-rs`, some of which are blocking:

1. I was unable to create a `Schema::Union` since both its properties and the constructor are private :/
2. I identified a bug which was causing `avro-rs` to write schemas incorrectly
3. `avro-rs` drags dependencies and code to deserialize from Avro, but we do not use it since we implement deserializers directly to arrow
4. `avro-rs` is unmaintained ([its new home](https://github.com/apache/avro/tree/master/lang/rust) seems so as well), and some of my PRs there are not being merged or dragged upstream

# This PR

Given the above, I wrote a new crate, `avro-schema`, containing the declaration of the Avro schema (as per spec) in Rust. This hopefully offers more flexibility and unblocks #690

The other added bonus are:
1. The create only depends on `serde` and `serde_json`
2. The crate is quite small (<800 LOC) and `#![forbid(unsafe_code)]`
3. addresses all the issues mentioned above
