### PR TITLE
Replaced `Display` by `Debug` for `Array`

### DIFF
--- a/examples/csv_read_async.rs
+++ b/examples/csv_read_async.rs
@@ -29,6 +29,6 @@ async fn main() -> Result<()> {
         0,
         deserialize_column,
     )?;
-    println!("{}", batch.column(0));
+    println!("{:?}", batch.column(0));
     Ok(())
 }

--- a/examples/parquet_read.rs
+++ b/examples/parquet_read.rs
@@ -41,6 +41,6 @@ fn main() -> Result<()> {
     let row_group = args[3].parse::<usize>().unwrap();
 
     let array = read_field(file_path, row_group, field)?;
-    println!("{}", array);
+    println!("{:?}", array);
     Ok(())
 }

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -15,7 +15,7 @@ pub use mutable::*;
 
 /// The Arrow's equivalent to an immutable `Vec<Option<bool>>`, but with `1/16` of its size.
 /// Cloning and slicing this struct is `O(1)`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct BooleanArray {
     data_type: DataType,
     values: Bitmap,
@@ -168,7 +168,7 @@ impl Array for BooleanArray {
     }
 }
 
-impl std::fmt::Display for BooleanArray {
+impl std::fmt::Debug for BooleanArray {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         display_fmt(self.iter(), "BooleanArray", f, false)
     }

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -208,7 +208,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let display = get_value_display(self);
         let new_lines = false;
-        let head = &format!("{}", self.data_type());
+        let head = &format!("{:?}", self.data_type());
         let iter = self.iter().enumerate().map(|(i, x)| x.map(|_| display(i)));
         display_fmt(iter, head, f, new_lines)
     }

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -9,7 +9,7 @@ pub use mutable::*;
 
 /// The Arrow's equivalent to an immutable `Vec<Option<[u8; size]>>`.
 /// Cloning and slicing this struct is `O(1)`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct FixedSizeBinaryArray {
     size: usize, // this is redundant with `data_type`, but useful to not have to deconstruct the data_type.
     data_type: DataType,
@@ -205,7 +205,7 @@ impl Array for FixedSizeBinaryArray {
     }
 }
 
-impl std::fmt::Display for FixedSizeBinaryArray {
+impl std::fmt::Debug for FixedSizeBinaryArray {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let iter = self.iter().map(|x| x.map(|x| format!("{:?}", x)));
         display_fmt(iter, "FixedSizeBinaryArray", f, false)

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     datatypes::{DataType, Field},
 };
 
-use super::{display_fmt, new_empty_array, new_null_array, Array};
+use super::{debug_fmt, new_empty_array, new_null_array, Array};
 
 mod ffi;
 mod iterator;
@@ -15,7 +15,7 @@ pub use mutable::*;
 
 /// The Arrow's equivalent to an immutable `Vec<Option<[T; size]>>` where `T` is an Arrow type.
 /// Cloning and slicing this struct is `O(1)`.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct FixedSizeListArray {
     size: usize, // this is redundant with `data_type`, but useful to not have to deconstruct the data_type.
     data_type: DataType,
@@ -196,8 +196,8 @@ impl Array for FixedSizeListArray {
     }
 }
 
-impl std::fmt::Display for FixedSizeListArray {
+impl std::fmt::Debug for FixedSizeListArray {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        display_fmt(self.iter(), "FixedSizeListArray", f, true)
+        debug_fmt(self.iter(), "FixedSizeListArray", f, true)
     }
 }

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use super::{
-    display_fmt, new_empty_array,
+    debug_fmt, new_empty_array,
     specification::{check_offsets, Offset},
     Array,
 };
@@ -19,7 +19,7 @@ mod mutable;
 pub use mutable::*;
 
 /// An [`Array`] semantically equivalent to `Vec<Option<Vec<Option<T>>>>` with Arrow's in-memory.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ListArray<O: Offset> {
     data_type: DataType,
     offsets: Buffer<O>,
@@ -241,13 +241,13 @@ impl<O: Offset> Array for ListArray<O> {
     }
 }
 
-impl<O: Offset> std::fmt::Display for ListArray<O> {
+impl<O: Offset> std::fmt::Debug for ListArray<O> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let head = if O::is_large() {
             "LargeListArray"
         } else {
             "ListArray"
         };
-        display_fmt(self.iter(), head, f, true)
+        debug_fmt(self.iter(), head, f, true)
     }
 }

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// The concrete [`Array`] of [`DataType::Null`].
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct NullArray {
     data_type: DataType,
     length: usize,
@@ -74,7 +74,7 @@ impl Array for NullArray {
     }
 }
 
-impl std::fmt::Display for NullArray {
+impl std::fmt::Debug for NullArray {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "NullArray({})", self.len())
     }

--- a/src/array/primitive/display.rs
+++ b/src/array/primitive/display.rs
@@ -1,14 +1,14 @@
 use crate::types::NativeType;
 
 use super::super::display::get_value_display;
-use super::super::{display_fmt, Array};
+use super::super::display_fmt;
 use super::PrimitiveArray;
 
-impl<T: NativeType> std::fmt::Display for PrimitiveArray<T> {
+impl<T: NativeType> std::fmt::Debug for PrimitiveArray<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let display = get_value_display(self);
         let new_lines = false;
-        let head = &format!("{}", self.data_type());
+        let head = &format!("{:?}", self.data_type());
         let iter = self.iter().enumerate().map(|(i, x)| x.map(|_| display(i)));
         display_fmt(iter, head, f, new_lines)
     }

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -30,7 +30,7 @@ pub use mutable::*;
 /// assert_eq!(array.validity(), Some(&Bitmap::from([true, false, true])));
 /// # }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PrimitiveArray<T: NativeType> {
     data_type: DataType,
     values: Buffer<T>,
@@ -61,7 +61,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     pub fn from_data(data_type: DataType, values: Buffer<T>, validity: Option<Bitmap>) -> Self {
         if !T::is_valid(&data_type) {
             Err(ArrowError::InvalidArgumentError(format!(
-                "Type {} does not support logical type {}",
+                "Type {} does not support logical type {:?}",
                 std::any::type_name::<T>(),
                 data_type
             )))
@@ -135,6 +135,11 @@ impl<T: NativeType> PrimitiveArray<T> {
         self.validity.as_ref()
     }
 
+    #[inline]
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
     /// The values [`Buffer`].
     /// Values on null slots are undetermined (they can be anything).
     #[inline]
@@ -166,7 +171,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     pub fn to(self, data_type: DataType) -> Self {
         if !T::is_valid(&data_type) {
             Err(ArrowError::InvalidArgumentError(format!(
-                "Type {} does not support logical type {}",
+                "Type {} does not support logical type {:?}",
                 std::any::type_name::<T>(),
                 data_type
             )))
@@ -193,7 +198,7 @@ impl<T: NativeType> Array for PrimitiveArray<T> {
 
     #[inline]
     fn data_type(&self) -> &DataType {
-        &self.data_type
+        self.data_type()
     }
 
     fn validity(&self) -> Option<&Bitmap> {

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -62,7 +62,7 @@ impl<T: NativeType + NaturalDataType> MutablePrimitiveArray<T> {
     ) -> Self {
         if !T::is_valid(&data_type) {
             Err(ArrowError::InvalidArgumentError(format!(
-                "Type {} does not support logical type {}",
+                "Type {} does not support logical type {:?}",
                 std::any::type_name::<T>(),
                 data_type
             )))

--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -27,7 +27,7 @@ mod iterator;
 ///
 /// let array = StructArray::from_data(DataType::Struct(fields), vec![boolean, int], None);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct StructArray {
     data_type: DataType,
     values: Vec<Arc<dyn Array>>,
@@ -214,11 +214,11 @@ impl Array for StructArray {
     }
 }
 
-impl std::fmt::Display for StructArray {
+impl std::fmt::Debug for StructArray {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "StructArray{{")?;
         for (field, column) in self.fields().iter().zip(self.values()) {
-            writeln!(f, "{}: {},", field.name(), column)?;
+            writeln!(f, "{}: {:?},", field.name(), column)?;
         }
         write!(f, "}}")
     }

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -23,7 +23,7 @@ type FieldEntry = (usize, Arc<dyn Array>);
 // let field = field.as_any().downcast to correct type;
 // let value = field.value(offset);
 // ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct UnionArray {
     types: Buffer<i8>,
     // None represents when there is no typeid
@@ -274,7 +274,7 @@ impl UnionArray {
     }
 }
 
-impl std::fmt::Display for UnionArray {
+impl std::fmt::Debug for UnionArray {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let display = get_value_display(self);
         let new_lines = false;

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -261,7 +261,7 @@ impl<O: Offset> Array for Utf8Array<O> {
 
 impl<O: Offset> std::fmt::Display for Utf8Array<O> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        display_fmt(self.iter(), &format!("{}", self.data_type()), f, false)
+        display_fmt(self.iter(), &format!("{:?}", self.data_type()), f, false)
     }
 }
 

--- a/src/compute/aggregate/min_max.rs
+++ b/src/compute/aggregate/min_max.rs
@@ -394,7 +394,7 @@ pub fn max(array: &dyn Array) -> Result<Box<dyn Scalar>> {
         }
         _ => {
             return Err(ArrowError::InvalidArgumentError(format!(
-                "The `max` operator does not support type `{}`",
+                "The `max` operator does not support type `{:?}`",
                 array.data_type(),
             )))
         }
@@ -435,7 +435,7 @@ pub fn min(array: &dyn Array) -> Result<Box<dyn Scalar>> {
         }
         _ => {
             return Err(ArrowError::InvalidArgumentError(format!(
-                "The `max` operator does not support type `{}`",
+                "The `max` operator does not support type `{:?}`",
                 array.data_type(),
             )))
         }

--- a/src/compute/aggregate/sum.rs
+++ b/src/compute/aggregate/sum.rs
@@ -168,7 +168,7 @@ pub fn sum(array: &dyn Array) -> Result<Box<dyn Scalar>> {
         DataType::Float64 => dyn_sum!(f64, array),
         _ => {
             return Err(ArrowError::InvalidArgumentError(format!(
-                "The `sum` operator does not support type `{}`",
+                "The `sum` operator does not support type `{:?}`",
                 array.data_type(),
             )))
         }

--- a/src/compute/if_then_else.rs
+++ b/src/compute/if_then_else.rs
@@ -30,7 +30,7 @@ pub fn if_then_else(
 ) -> Result<Box<dyn Array>> {
     if lhs.data_type() != rhs.data_type() {
         return Err(ArrowError::InvalidArgumentError(format!(
-            "If then else requires the arguments to have the same datatypes ({} != {})",
+            "If then else requires the arguments to have the same datatypes ({:?} != {:?})",
             lhs.data_type(),
             rhs.data_type()
         )));

--- a/src/compute/nullif.rs
+++ b/src/compute/nullif.rs
@@ -165,7 +165,7 @@ pub fn nullif(lhs: &dyn Array, rhs: &dyn Array) -> Result<Box<dyn Array>> {
         )
         .map(|x| Box::new(x) as Box<dyn Array>),
         other => Err(ArrowError::NotYetImplemented(format!(
-            "Nullif is not implemented for logical datatype {}",
+            "Nullif is not implemented for logical datatype {:?}",
             other
         ))),
     }

--- a/src/datatypes/field.rs
+++ b/src/datatypes/field.rs
@@ -292,9 +292,3 @@ impl Field {
         Ok(())
     }
 }
-
-impl std::fmt::Display for Field {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -138,12 +138,6 @@ pub enum DataType {
     Extension(String, Box<DataType>, Option<String>),
 }
 
-impl std::fmt::Display for DataType {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
 /// Mode of [`DataType::Union`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum UnionMode {

--- a/src/datatypes/schema.rs
+++ b/src/datatypes/schema.rs
@@ -194,16 +194,3 @@ impl Schema {
             .find(|&(_, c)| c.name() == name)
     }
 }
-
-impl std::fmt::Display for Schema {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str(
-            &self
-                .fields
-                .iter()
-                .map(|c| c.to_string())
-                .collect::<Vec<String>>()
-                .join(", "),
-        )
-    }
-}

--- a/src/io/csv/write/serialize.rs
+++ b/src/io/csv/write/serialize.rs
@@ -398,7 +398,7 @@ pub fn new_serializer<'a>(
                 panic!("only dictionary with string values are supported by csv writer")
             }
         },
-        dt => panic!("data type: {} not supported by csv writer", dt),
+        dt => panic!("data type: {:?} not supported by csv writer", dt),
     })
 }
 

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -123,10 +123,7 @@ pub fn array_to_pages<K: DictionaryKey>(
     descriptor: ColumnDescriptor,
     options: WriteOptions,
     encoding: Encoding,
-) -> Result<DynIter<'static, Result<EncodedPage>>>
-where
-    PrimitiveArray<K>: std::fmt::Display,
-{
+) -> Result<DynIter<'static, Result<EncodedPage>>> {
     match encoding {
         Encoding::PlainDictionary | Encoding::RleDictionary => {
             // write DictPage

--- a/src/scalar/equal.rs
+++ b/src/scalar/equal.rs
@@ -135,6 +135,6 @@ fn equal(lhs: &dyn Scalar, rhs: &dyn Scalar) -> bool {
             let rhs = rhs.as_any().downcast_ref::<StructScalar>().unwrap();
             lhs == rhs
         }
-        other => unimplemented!("{}", other),
+        other => unimplemented!("{:?}", other),
     }
 }

--- a/src/scalar/primitive.rs
+++ b/src/scalar/primitive.rs
@@ -20,7 +20,7 @@ impl<T: NativeType> PrimitiveScalar<T> {
     pub fn new(data_type: DataType, value: Option<T>) -> Self {
         if !T::is_valid(&data_type) {
             Err(ArrowError::InvalidArgumentError(format!(
-                "Type {} does not support logical type {}",
+                "Type {} does not support logical type {:?}",
                 std::any::type_name::<T>(),
                 data_type
             )))

--- a/tests/it/array/boolean/mod.rs
+++ b/tests/it/array/boolean/mod.rs
@@ -47,7 +47,7 @@ fn with_validity() {
 #[test]
 fn display() {
     let array = BooleanArray::from([Some(true), None, Some(false)]);
-    assert_eq!(format!("{}", array), "BooleanArray[true, , false]");
+    assert_eq!(format!("{:?}", array), "BooleanArray[true, None, false]");
 }
 
 #[test]

--- a/tests/it/array/fixed_size_binary/mod.rs
+++ b/tests/it/array/fixed_size_binary/mod.rs
@@ -37,7 +37,10 @@ fn display() {
         values,
         Some(Bitmap::from([true, false, true])),
     );
-    assert_eq!(format!("{}", a), "FixedSizeBinaryArray[[1, 2], , [5, 6]]");
+    assert_eq!(
+        format!("{:?}", a),
+        "FixedSizeBinaryArray[[1, 2], None, [5, 6]]"
+    );
 }
 
 #[test]

--- a/tests/it/array/list/mod.rs
+++ b/tests/it/array/list/mod.rs
@@ -20,7 +20,7 @@ fn display() {
     );
 
     assert_eq!(
-        format!("{}", array),
+        format!("{:?}", array),
         "ListArray[\nInt32[1, 2],\nInt32[],\nInt32[3],\nInt32[4, 5]\n]"
     );
 }
@@ -62,5 +62,5 @@ fn test_nested_display() {
         ListArray::<i32>::from_data(data_type, Buffer::from([0, 2, 5, 6]), Arc::new(array), None);
 
     let expected = "ListArray[\nListArray[\nInt32[1, 2],\nInt32[3, 4]\n],\nListArray[\nInt32[5, 6, 7],\nInt32[],\nInt32[8]\n],\nListArray[\nInt32[9, 10]\n]\n]";
-    assert_eq!(format!("{}", nested), expected);
+    assert_eq!(format!("{:?}", nested), expected);
 }

--- a/tests/it/array/primitive/mod.rs
+++ b/tests/it/array/primitive/mod.rs
@@ -78,19 +78,25 @@ fn from() {
 #[test]
 fn display_int32() {
     let array = Int32Array::from(&[Some(1), None, Some(2)]);
-    assert_eq!(format!("{}", array), "Int32[1, , 2]");
+    assert_eq!(format!("{:?}", array), "Int32[1, None, 2]");
 }
 
 #[test]
 fn display_date32() {
     let array = Int32Array::from(&[Some(1), None, Some(2)]).to(DataType::Date32);
-    assert_eq!(format!("{}", array), "Date32[1970-01-02, , 1970-01-03]");
+    assert_eq!(
+        format!("{:?}", array),
+        "Date32[1970-01-02, None, 1970-01-03]"
+    );
 }
 
 #[test]
 fn display_time32s() {
     let array = Int32Array::from(&[Some(1), None, Some(2)]).to(DataType::Time32(TimeUnit::Second));
-    assert_eq!(format!("{}", array), "Time32(Second)[00:00:01, , 00:00:02]");
+    assert_eq!(
+        format!("{:?}", array),
+        "Time32(Second)[00:00:01, None, 00:00:02]"
+    );
 }
 
 #[test]
@@ -98,8 +104,8 @@ fn display_time32ms() {
     let array =
         Int32Array::from(&[Some(1), None, Some(2)]).to(DataType::Time32(TimeUnit::Millisecond));
     assert_eq!(
-        format!("{}", array),
-        "Time32(Millisecond)[00:00:00.001, , 00:00:00.002]"
+        format!("{:?}", array),
+        "Time32(Millisecond)[00:00:00.001, None, 00:00:00.002]"
     );
 }
 
@@ -107,19 +113,22 @@ fn display_time32ms() {
 fn display_interval_d() {
     let array =
         Int32Array::from(&[Some(1), None, Some(2)]).to(DataType::Interval(IntervalUnit::YearMonth));
-    assert_eq!(format!("{}", array), "Interval(YearMonth)[1m, , 2m]");
+    assert_eq!(format!("{:?}", array), "Interval(YearMonth)[1m, None, 2m]");
 }
 
 #[test]
 fn display_int64() {
     let array = Int64Array::from(&[Some(1), None, Some(2)]).to(DataType::Int64);
-    assert_eq!(format!("{}", array), "Int64[1, , 2]");
+    assert_eq!(format!("{:?}", array), "Int64[1, None, 2]");
 }
 
 #[test]
 fn display_date64() {
     let array = Int64Array::from(&[Some(1), None, Some(86400000)]).to(DataType::Date64);
-    assert_eq!(format!("{}", array), "Date64[1970-01-01, , 1970-01-02]");
+    assert_eq!(
+        format!("{:?}", array),
+        "Date64[1970-01-01, None, 1970-01-02]"
+    );
 }
 
 #[test]
@@ -127,8 +136,8 @@ fn display_time64us() {
     let array =
         Int64Array::from(&[Some(1), None, Some(2)]).to(DataType::Time64(TimeUnit::Microsecond));
     assert_eq!(
-        format!("{}", array),
-        "Time64(Microsecond)[00:00:00.000001, , 00:00:00.000002]"
+        format!("{:?}", array),
+        "Time64(Microsecond)[00:00:00.000001, None, 00:00:00.000002]"
     );
 }
 
@@ -137,8 +146,8 @@ fn display_time64ns() {
     let array =
         Int64Array::from(&[Some(1), None, Some(2)]).to(DataType::Time64(TimeUnit::Nanosecond));
     assert_eq!(
-        format!("{}", array),
-        "Time64(Nanosecond)[00:00:00.000000001, , 00:00:00.000000002]"
+        format!("{:?}", array),
+        "Time64(Nanosecond)[00:00:00.000000001, None, 00:00:00.000000002]"
     );
 }
 
@@ -147,8 +156,8 @@ fn display_timestamp_s() {
     let array =
         Int64Array::from(&[Some(1), None, Some(2)]).to(DataType::Timestamp(TimeUnit::Second, None));
     assert_eq!(
-        format!("{}", array),
-        "Timestamp(Second, None)[1970-01-01 00:00:01, , 1970-01-01 00:00:02]"
+        format!("{:?}", array),
+        "Timestamp(Second, None)[1970-01-01 00:00:01, None, 1970-01-01 00:00:02]"
     );
 }
 
@@ -157,8 +166,8 @@ fn display_timestamp_ms() {
     let array = Int64Array::from(&[Some(1), None, Some(2)])
         .to(DataType::Timestamp(TimeUnit::Millisecond, None));
     assert_eq!(
-        format!("{}", array),
-        "Timestamp(Millisecond, None)[1970-01-01 00:00:00.001, , 1970-01-01 00:00:00.002]"
+        format!("{:?}", array),
+        "Timestamp(Millisecond, None)[1970-01-01 00:00:00.001, None, 1970-01-01 00:00:00.002]"
     );
 }
 
@@ -167,8 +176,8 @@ fn display_timestamp_us() {
     let array = Int64Array::from(&[Some(1), None, Some(2)])
         .to(DataType::Timestamp(TimeUnit::Microsecond, None));
     assert_eq!(
-        format!("{}", array),
-        "Timestamp(Microsecond, None)[1970-01-01 00:00:00.000001, , 1970-01-01 00:00:00.000002]"
+        format!("{:?}", array),
+        "Timestamp(Microsecond, None)[1970-01-01 00:00:00.000001, None, 1970-01-01 00:00:00.000002]"
     );
 }
 
@@ -177,8 +186,8 @@ fn display_timestamp_ns() {
     let array = Int64Array::from(&[Some(1), None, Some(2)])
         .to(DataType::Timestamp(TimeUnit::Nanosecond, None));
     assert_eq!(
-        format!("{}", array),
-        "Timestamp(Nanosecond, None)[1970-01-01 00:00:00.000000001, , 1970-01-01 00:00:00.000000002]"
+        format!("{:?}", array),
+        "Timestamp(Nanosecond, None)[1970-01-01 00:00:00.000000001, None, 1970-01-01 00:00:00.000000002]"
     );
 }
 
@@ -189,8 +198,8 @@ fn display_timestamp_tz_ns() {
         Some("+02:00".to_string()),
     ));
     assert_eq!(
-        format!("{}", array),
-        "Timestamp(Nanosecond, Some(\"+02:00\"))[1970-01-01 02:00:00.000000001 +02:00, , 1970-01-01 02:00:00.000000002 +02:00]"
+        format!("{:?}", array),
+        "Timestamp(Nanosecond, Some(\"+02:00\"))[1970-01-01 02:00:00.000000001 +02:00, None, 1970-01-01 02:00:00.000000002 +02:00]"
     );
 }
 
@@ -198,50 +207,68 @@ fn display_timestamp_tz_ns() {
 fn display_duration_ms() {
     let array =
         Int64Array::from(&[Some(1), None, Some(2)]).to(DataType::Duration(TimeUnit::Millisecond));
-    assert_eq!(format!("{}", array), "Duration(Millisecond)[1ms, , 2ms]");
+    assert_eq!(
+        format!("{:?}", array),
+        "Duration(Millisecond)[1ms, None, 2ms]"
+    );
 }
 
 #[test]
 fn display_duration_s() {
     let array =
         Int64Array::from(&[Some(1), None, Some(2)]).to(DataType::Duration(TimeUnit::Second));
-    assert_eq!(format!("{}", array), "Duration(Second)[1s, , 2s]");
+    assert_eq!(format!("{:?}", array), "Duration(Second)[1s, None, 2s]");
 }
 
 #[test]
 fn display_duration_us() {
     let array =
         Int64Array::from(&[Some(1), None, Some(2)]).to(DataType::Duration(TimeUnit::Microsecond));
-    assert_eq!(format!("{}", array), "Duration(Microsecond)[1us, , 2us]");
+    assert_eq!(
+        format!("{:?}", array),
+        "Duration(Microsecond)[1us, None, 2us]"
+    );
 }
 
 #[test]
 fn display_duration_ns() {
     let array =
         Int64Array::from(&[Some(1), None, Some(2)]).to(DataType::Duration(TimeUnit::Nanosecond));
-    assert_eq!(format!("{}", array), "Duration(Nanosecond)[1ns, , 2ns]");
+    assert_eq!(
+        format!("{:?}", array),
+        "Duration(Nanosecond)[1ns, None, 2ns]"
+    );
 }
 
 #[test]
 fn display_decimal() {
     let array = Int128Array::from(&[Some(12345), None, Some(23456)]).to(DataType::Decimal(5, 2));
-    assert_eq!(format!("{}", array), "Decimal(5, 2)[123.45, , 234.56]");
+    assert_eq!(
+        format!("{:?}", array),
+        "Decimal(5, 2)[123.45, None, 234.56]"
+    );
 }
 
 #[test]
 fn display_decimal1() {
     let array = Int128Array::from(&[Some(12345), None, Some(23456)]).to(DataType::Decimal(5, 1));
-    assert_eq!(format!("{}", array), "Decimal(5, 1)[1234.5, , 2345.6]");
+    assert_eq!(
+        format!("{:?}", array),
+        "Decimal(5, 1)[1234.5, None, 2345.6]"
+    );
 }
 
 #[test]
 fn display_interval_days_ms() {
     let array = DaysMsArray::from(&[Some(days_ms::new(1, 1)), None, Some(days_ms::new(2, 2))]);
-    assert_eq!(format!("{}", array), "Interval(DayTime)[1d1ms, , 2d2ms]");
+    assert_eq!(
+        format!("{:?}", array),
+        "Interval(DayTime)[1d1ms, None, 2d2ms]"
+    );
 }
 
 #[test]
-fn display_months_days_ns() {
+fn debug_months_days_ns() {
     let data = &[
         Some(months_days_ns::new(1, 1, 2)),
         None,
@@ -251,8 +278,8 @@ fn display_months_days_ns() {
     let array = MonthsDaysNsArray::from(&data);
 
     assert_eq!(
-        format!("{}", array),
-        "Interval(MonthDayNano)[1m1d2ns, , 2m3d3ns]"
+        format!("{:?}", array),
+        "Interval(MonthDayNano)[1m1d2ns, None, 2m3d3ns]"
     );
 }
 

--- a/tests/it/array/union.rs
+++ b/tests/it/array/union.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use arrow2::{array::*, buffer::Buffer, datatypes::*, error::Result};
 
 #[test]
-fn display() -> Result<()> {
+fn debug() -> Result<()> {
     let fields = vec![
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
@@ -17,7 +17,7 @@ fn display() -> Result<()> {
 
     let array = UnionArray::from_data(data_type, types, fields, None);
 
-    assert_eq!(format!("{}", array), "UnionArray[1, , c]");
+    assert_eq!(format!("{:?}", array), "UnionArray[1, None, c]");
 
     Ok(())
 }

--- a/tests/it/temporal_conversions.rs
+++ b/tests/it/temporal_conversions.rs
@@ -5,7 +5,7 @@ use arrow2::types::months_days_ns;
 
 #[test]
 fn naive() {
-    let expected = "Timestamp(Nanosecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, ]";
+    let expected = "Timestamp(Nanosecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S:z";
     let array = Utf8Array::<i32>::from_slice(&[
         "1996-12-19T16:39:57-02:00",
@@ -13,7 +13,7 @@ fn naive() {
         "1996-12-19 13:39:57-03:00", // missing T
     ]);
     let r = temporal_conversions::utf8_to_naive_timestamp_ns(&array, fmt);
-    assert_eq!(format!("{}", r), expected);
+    assert_eq!(format!("{:?}", r), expected);
 
     let fmt = "%Y-%m-%dT%H:%M:%S"; // no tz info
     let array = Utf8Array::<i32>::from_slice(&[
@@ -22,12 +22,12 @@ fn naive() {
         "1996-12-19 13:39:57-03:00", // missing T
     ]);
     let r = temporal_conversions::utf8_to_naive_timestamp_ns(&array, fmt);
-    assert_eq!(format!("{}", r), expected);
+    assert_eq!(format!("{:?}", r), expected);
 }
 
 #[test]
 fn naive_no_tz() {
-    let expected = "Timestamp(Nanosecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, ]";
+    let expected = "Timestamp(Nanosecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S"; // no tz info
     let array = Utf8Array::<i32>::from_slice(&[
         "1996-12-19T16:39:57",
@@ -35,14 +35,14 @@ fn naive_no_tz() {
         "1996-12-19 13:39:57", // missing T
     ]);
     let r = temporal_conversions::utf8_to_naive_timestamp_ns(&array, fmt);
-    assert_eq!(format!("{}", r), expected);
+    assert_eq!(format!("{:?}", r), expected);
 }
 
 #[test]
 fn tz_aware() {
     let tz = "-02:00".to_string();
     let expected =
-        "Timestamp(Nanosecond, Some(\"-02:00\"))[1996-12-19 16:39:57 -02:00, 1996-12-19 17:39:57 -02:00, ]";
+        "Timestamp(Nanosecond, Some(\"-02:00\"))[1996-12-19 16:39:57 -02:00, 1996-12-19 17:39:57 -02:00, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S%.f%:z";
     let array = Utf8Array::<i32>::from_slice(&[
         "1996-12-19T16:39:57.0-02:00",
@@ -50,13 +50,13 @@ fn tz_aware() {
         "1996-12-19 13:39:57.0-03:00",
     ]);
     let r = temporal_conversions::utf8_to_timestamp_ns(&array, fmt, tz).unwrap();
-    assert_eq!(format!("{}", r), expected);
+    assert_eq!(format!("{:?}", r), expected);
 }
 
 #[test]
 fn tz_aware_no_timezone() {
     let tz = "-02:00".to_string();
-    let expected = "Timestamp(Nanosecond, Some(\"-02:00\"))[, , ]";
+    let expected = "Timestamp(Nanosecond, Some(\"-02:00\"))[None, None, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S%.f";
     let array = Utf8Array::<i32>::from_slice(&[
         "1996-12-19T16:39:57.0",
@@ -64,7 +64,7 @@ fn tz_aware_no_timezone() {
         "1996-12-19 13:39:57.0",
     ]);
     let r = temporal_conversions::utf8_to_timestamp_ns(&array, fmt, tz).unwrap();
-    assert_eq!(format!("{}", r), expected);
+    assert_eq!(format!("{:?}", r), expected);
 }
 
 #[test]


### PR DESCRIPTION
Currently representing arrays in `Debug` is a bit verbose. This was useful to iterate over the struct definitions, but as the API stabilizes, we can move to less verbose representations.

This PR goes in this direction by removing the `impl Display` of the Array and by making the `Debug` one equal to the current `Display` one. This allows users to impl `Debug` on structs that contain arrays and have an easier to read string representation.

This follows the same design used by `std::Vec`, which does not present the struct details to the users.

This also removes the `Display` implementation to the datatypes, since it was equal to `Debug` (and there is no natural Display for them in Arrow).