### PR TITLE
Made Avro read API use `Block` and `CompressedBlock`

### DIFF
--- a/src/io/avro/mod.rs
+++ b/src/io/avro/mod.rs
@@ -90,3 +90,41 @@ macro_rules! read_metadata {
 }
 
 pub(crate) use {avro_decode, read_header, read_metadata};
+
+/// A compressed Avro block.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CompressedBlock {
+    /// The number of rows
+    pub number_of_rows: usize,
+    /// The compressed data
+    pub data: Vec<u8>,
+}
+
+impl CompressedBlock {
+    /// Creates a new CompressedBlock
+    pub fn new(number_of_rows: usize, data: Vec<u8>) -> Self {
+        Self {
+            number_of_rows,
+            data,
+        }
+    }
+}
+
+/// An uncompressed Avro block.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Block {
+    /// The number of rows
+    pub number_of_rows: usize,
+    /// The uncompressed data
+    pub data: Vec<u8>,
+}
+
+impl Block {
+    /// Creates a new Block
+    pub fn new(number_of_rows: usize, data: Vec<u8>) -> Self {
+        Self {
+            number_of_rows,
+            data,
+        }
+    }
+}

--- a/src/io/avro/read/deserialize.rs
+++ b/src/io/avro/read/deserialize.rs
@@ -10,6 +10,7 @@ use crate::error::Result;
 use crate::record_batch::RecordBatch;
 use crate::types::months_days_ns;
 
+use super::super::Block;
 use super::nested::*;
 use super::util;
 
@@ -241,13 +242,15 @@ fn deserialize_value<'a>(
     Ok(block)
 }
 
-/// Deserializes an Avro block into a [`RecordBatch`].
+/// Deserializes a [`Block`] into a [`RecordBatch`].
 pub fn deserialize(
-    mut block: &[u8],
-    rows: usize,
+    block: &Block,
     schema: Arc<Schema>,
     avro_schemas: &[AvroSchema],
 ) -> Result<RecordBatch> {
+    let rows = block.number_of_rows;
+    let mut block = block.data.as_ref();
+
     // create mutables, one per field
     let mut arrays: Vec<Box<dyn MutableArray>> = schema
         .fields()

--- a/src/io/avro/read/mod.rs
+++ b/src/io/avro/read/mod.rs
@@ -1,4 +1,3 @@
-#![deny(missing_docs)]
 //! APIs to read from Avro format to arrow.
 use std::io::Read;
 use std::sync::Arc;
@@ -73,9 +72,9 @@ impl<R: Read> Iterator for Reader<R> {
         let schema = self.schema.clone();
         let avro_schemas = &self.avro_schemas;
 
-        self.iter.next().transpose().map(|x| {
-            let (data, rows) = x?;
-            deserialize(data, *rows, schema, avro_schemas)
-        })
+        self.iter
+            .next()
+            .transpose()
+            .map(|maybe_block| deserialize(maybe_block?, schema, avro_schemas))
     }
 }

--- a/src/io/avro/read_async/mod.rs
+++ b/src/io/avro/read_async/mod.rs
@@ -1,8 +1,9 @@
-//! Async Avro
+//! Async read Avro
 
 mod block;
 mod metadata;
 pub(self) mod utils;
 
+pub use super::{Block, CompressedBlock};
 pub use block::block_stream;
 pub use metadata::read_metadata;

--- a/src/io/avro/write/block.rs
+++ b/src/io/avro/write/block.rs
@@ -2,45 +2,8 @@ use std::io::Write;
 
 use crate::{error::Result, io::avro::Compression};
 
+use super::super::{Block, CompressedBlock};
 use super::{util::zigzag_encode, SYNC_NUMBER};
-
-/// A compressed Avro block.
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct CompressedBlock {
-    /// The number of rows
-    pub number_of_rows: usize,
-    /// The compressed data
-    pub data: Vec<u8>,
-}
-
-impl CompressedBlock {
-    /// Creates a new CompressedBlock
-    pub fn new(number_of_rows: usize, data: Vec<u8>) -> Self {
-        Self {
-            number_of_rows,
-            data,
-        }
-    }
-}
-
-/// An uncompressed Avro block.
-#[derive(Debug, Clone, Default, PartialEq)]
-pub struct Block {
-    /// The number of rows
-    pub number_of_rows: usize,
-    /// The uncompressed data
-    pub data: Vec<u8>,
-}
-
-impl Block {
-    /// Creates a new Block
-    pub fn new(number_of_rows: usize, data: Vec<u8>) -> Self {
-        Self {
-            number_of_rows,
-            data,
-        }
-    }
-}
 
 /// Writes a [`CompressedBlock`] to `writer`
 pub fn write_block<W: Write>(writer: &mut W, compressed_block: &CompressedBlock) -> Result<()> {

--- a/src/io/avro/write/mod.rs
+++ b/src/io/avro/write/mod.rs
@@ -17,6 +17,8 @@ mod block;
 pub use block::*;
 mod util;
 
+pub use super::{Block, CompressedBlock};
+
 const SYNC_NUMBER: [u8; 16] = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4];
 
 /// Writes Avro's metadata to `writer`.

--- a/tests/it/io/avro/read_async.rs
+++ b/tests/it/io/avro/read_async.rs
@@ -24,8 +24,8 @@ async fn test(codec: Codec) -> Result<()> {
     let blocks = block_stream(&mut reader, marker).await;
 
     pin_mut!(blocks);
-    while let Some((block, rows)) = blocks.next().await.transpose()? {
-        assert!(rows > 0 || block.is_empty())
+    while let Some(block) = blocks.next().await.transpose()? {
+        assert!(block.number_of_rows > 0 || block.data.is_empty())
     }
     Ok(())
 }


### PR DESCRIPTION
Cleans the public API to read from Avro by using the new `Block` and `CompressedBlock` API designed as part of #690 

See changes to the example to understand how to migrate.