### PR TITLE
Allow to create primitive array by vec without extra memcopy

### DIFF
--- a/examples/growable.rs
+++ b/examples/growable.rs
@@ -3,8 +3,8 @@ use arrow2::array::PrimitiveArray;
 
 fn main() {
     // say we have two sorted arrays
-    let array0 = PrimitiveArray::<i64>::from_slice(&[1, 2, 5]);
-    let array1 = PrimitiveArray::<i64>::from_slice(&[3, 4, 6]);
+    let array0 = PrimitiveArray::<i64>::from_vec(vec![1, 2, 5]);
+    let array1 = PrimitiveArray::<i64>::from_vec(vec![3, 4, 6]);
 
     // and we found a way to compute the slices that sort them:
     // (array_index, start of the slice, length of the slice)
@@ -33,6 +33,6 @@ fn main() {
     // finally, convert it to the array (this is `O(1)`)
     let result: PrimitiveArray<i64> = growable.into();
 
-    let expected = PrimitiveArray::<i64>::from_slice(&[1, 2, 3, 4, 5, 6]);
+    let expected = PrimitiveArray::<i64>::from_vec(vec![1, 2, 3, 4, 5, 6]);
     assert_eq!(result, expected);
 }

--- a/src/array/primitive/from_natural.rs
+++ b/src/array/primitive/from_natural.rs
@@ -26,13 +26,19 @@ impl<T: NativeType> PrimitiveArray<T> {
 
     /// Creates a (non-null) [`PrimitiveArray`] from a slice of values.
     /// # Implementation
-    /// This is essentially a memcopy and is the fastest way to create a [`PrimitiveArray`].
+    /// This is essentially a memcopy
     pub fn from_slice<P: AsRef<[T]>>(slice: P) -> Self {
         Self::from_data(
             T::PRIMITIVE.into(),
             Vec::<T>::from(slice.as_ref()).into(),
             None,
         )
+    }
+
+    /// Creates a (non-null) [`PrimitiveArray`] from a vector of values.
+    /// This does not have memcopy and is the fastest way to create a [`PrimitiveArray`].
+    pub fn from_vec(array: Vec<T>) -> Self {
+        Self::from_data(T::PRIMITIVE.into(), array.into(), None)
     }
 }
 

--- a/src/util/bench_util.rs
+++ b/src/util/bench_util.rs
@@ -3,7 +3,6 @@
 use rand::distributions::{Alphanumeric, Distribution, Standard};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
-use crate::types::NaturalDataType;
 use crate::{array::*, types::NativeType};
 
 /// Returns fixed seedable RNG
@@ -14,7 +13,7 @@ pub fn seedable_rng() -> StdRng {
 /// Creates an random (but fixed-seeded) array of a given size and null density
 pub fn create_primitive_array<T>(size: usize, null_density: f32) -> PrimitiveArray<T>
 where
-    T: NativeType + NaturalDataType,
+    T: NativeType,
     Standard: Distribution<T>,
 {
     let mut rng = seedable_rng();
@@ -37,7 +36,7 @@ pub fn create_primitive_array_with_seed<T>(
     seed: u64,
 ) -> PrimitiveArray<T>
 where
-    T: NativeType + NaturalDataType,
+    T: NativeType,
     Standard: Distribution<T>,
 {
     let mut rng = StdRng::seed_from_u64(seed);

--- a/tests/it/io/csv/write.rs
+++ b/tests/it/io/csv/write.rs
@@ -14,7 +14,7 @@ fn data() -> RecordBatch {
     let c4 = BooleanArray::from(&[Some(true), Some(false), None]);
     let c5 = PrimitiveArray::<i64>::from([None, Some(1555584887378), Some(1555555555555)])
         .to(DataType::Timestamp(TimeUnit::Millisecond, None));
-    let c6 = PrimitiveArray::<i32>::from_slice(&[1234, 24680, 85563])
+    let c6 = PrimitiveArray::<i32>::from_vec(vec![1234, 24680, 85563])
         .to(DataType::Time32(TimeUnit::Second));
     let keys = UInt32Array::from_slice(&[2, 0, 1]);
     let c7 = DictionaryArray::from_data(keys, Arc::new(c1.clone()));
@@ -122,7 +122,7 @@ fn data_array(column: usize) -> (RecordBatch, Vec<&'static str>) {
             vec!["3", "2", "1"],
         ),
         9 => {
-            let array = PrimitiveArray::<i32>::from_slice(&[1_234_001, 24_680_001, 85_563_001])
+            let array = PrimitiveArray::<i32>::from_vec(vec![1_234_001, 24_680_001, 85_563_001])
                 .to(DataType::Time32(TimeUnit::Millisecond));
             (
                 Arc::new(array) as Arc<dyn Array>,
@@ -130,16 +130,19 @@ fn data_array(column: usize) -> (RecordBatch, Vec<&'static str>) {
             )
         }
         10 => {
-            let array =
-                PrimitiveArray::<i64>::from_slice(&[1_234_000_001, 24_680_000_001, 85_563_000_001])
-                    .to(DataType::Time64(TimeUnit::Microsecond));
+            let array = PrimitiveArray::<i64>::from_vec(vec![
+                1_234_000_001,
+                24_680_000_001,
+                85_563_000_001,
+            ])
+            .to(DataType::Time64(TimeUnit::Microsecond));
             (
                 Arc::new(array) as Arc<dyn Array>,
                 vec!["00:20:34.000001", "06:51:20.000001", "23:46:03.000001"],
             )
         }
         11 => {
-            let array = PrimitiveArray::<i64>::from_slice(&[
+            let array = PrimitiveArray::<i64>::from_vec(vec![
                 1_234_000_000_001,
                 24_680_000_000_001,
                 85_563_000_000_001,


### PR DESCRIPTION
`from_vec` is a faster way to create `primitive array` than `from_slice`.