### PR TITLE
Moved is_ordered from `Field` to `DataType::Dictionary`

### DIFF
--- a/arrow-parquet-integration-testing/src/main.rs
+++ b/arrow-parquet-integration-testing/src/main.rs
@@ -165,7 +165,7 @@ fn main() -> Result<()> {
         .fields()
         .iter()
         .map(|x| match x.data_type() {
-            DataType::Dictionary(_, _) => Encoding::RleDictionary,
+            DataType::Dictionary(..) => Encoding::RleDictionary,
             DataType::Utf8 | DataType::LargeUtf8 => {
                 if utf8_encoding == "delta" {
                     Encoding::DeltaLengthByteArray

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -79,7 +79,8 @@ impl<K: DictionaryKey> DictionaryArray<K> {
 
     /// The canonical method to create a new [`DictionaryArray`].
     pub fn from_data(keys: PrimitiveArray<K>, values: Arc<dyn Array>) -> Self {
-        let data_type = DataType::Dictionary(K::KEY_TYPE, Box::new(values.data_type().clone()));
+        let data_type =
+            DataType::Dictionary(K::KEY_TYPE, Box::new(values.data_type().clone()), false);
 
         Self {
             data_type,
@@ -165,7 +166,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
 impl<K: DictionaryKey> DictionaryArray<K> {
     pub(crate) fn get_child(data_type: &DataType) -> &DataType {
         match data_type {
-            DataType::Dictionary(_, values) => values.as_ref(),
+            DataType::Dictionary(_, values, _) => values.as_ref(),
             DataType::Extension(_, inner, _) => Self::get_child(inner),
             _ => panic!("DictionaryArray must be initialized with DataType::Dictionary"),
         }

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -31,7 +31,11 @@ impl<K: DictionaryKey, M: MutableArray> From<MutableDictionaryArray<K, M>> for D
 impl<K: DictionaryKey, M: MutableArray> From<M> for MutableDictionaryArray<K, M> {
     fn from(values: M) -> Self {
         Self {
-            data_type: DataType::Dictionary(K::KEY_TYPE, Box::new(values.data_type().clone())),
+            data_type: DataType::Dictionary(
+                K::KEY_TYPE,
+                Box::new(values.data_type().clone()),
+                false,
+            ),
             keys: MutablePrimitiveArray::<K>::new(),
             map: HashedMap::default(),
             values,
@@ -44,7 +48,11 @@ impl<K: DictionaryKey, M: MutableArray + Default> MutableDictionaryArray<K, M> {
     pub fn new() -> Self {
         let values = M::default();
         Self {
-            data_type: DataType::Dictionary(K::KEY_TYPE, Box::new(values.data_type().clone())),
+            data_type: DataType::Dictionary(
+                K::KEY_TYPE,
+                Box::new(values.data_type().clone()),
+                false,
+            ),
             keys: MutablePrimitiveArray::<K>::new(),
             map: HashedMap::default(),
             values,

--- a/src/array/display.rs
+++ b/src/array/display.rs
@@ -158,7 +158,7 @@ pub fn get_value_display<'a>(array: &'a dyn Array) -> Box<dyn Fn(usize) -> Strin
             };
             dyn_display!(array, ListArray<i64>, f)
         }
-        Dictionary(key_type, _) => match_integer_type!(key_type, |$T| {
+        Dictionary(key_type, ..) => match_integer_type!(key_type, |$T| {
             let a = array
                 .as_any()
                 .downcast_ref::<DictionaryArray<$T>>()

--- a/src/array/ord.rs
+++ b/src/array/ord.rs
@@ -215,7 +215,7 @@ pub fn build_compare(left: &dyn Array, right: &dyn Array) -> Result<DynComparato
         (LargeUtf8, LargeUtf8) => compare_string::<i64>(left, right),
         (Binary, Binary) => compare_binary::<i32>(left, right),
         (LargeBinary, LargeBinary) => compare_binary::<i64>(left, right),
-        (Dictionary(key_type_lhs, _), Dictionary(key_type_rhs, _)) => {
+        (Dictionary(key_type_lhs, ..), Dictionary(key_type_rhs, ..)) => {
             match (key_type_lhs, key_type_rhs) {
                 (IntegerType::UInt8, IntegerType::UInt8) => dyn_dict!(u8, left, right),
                 (IntegerType::UInt16, IntegerType::UInt16) => dyn_dict!(u16, left, right),

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -447,7 +447,7 @@ pub fn neg(array: &dyn Array) -> Box<dyn Array> {
 
 /// Whether [`neg`] is supported for a given [`DataType`]
 pub fn can_neg(data_type: &DataType) -> bool {
-    if let DataType::Dictionary(_, values) = data_type.to_logical_type() {
+    if let DataType::Dictionary(_, values, _) = data_type.to_logical_type() {
         return can_neg(values.as_ref());
     }
 

--- a/src/compute/cast/dictionary_to.rs
+++ b/src/compute/cast/dictionary_to.rs
@@ -110,7 +110,7 @@ pub(super) fn dictionary_cast_dyn<K: DictionaryKey>(
     let values = array.values();
 
     match to_type {
-        DataType::Dictionary(to_keys_type, to_values_type) => {
+        DataType::Dictionary(to_keys_type, to_values_type, _) => {
             let values = cast(values.as_ref(), to_values_type, options)?.into();
 
             // create the appropriate array type

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -80,40 +80,12 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
     match (from_type, to_type) {
         (
             Null,
-            Boolean
-            | Int8
-            | UInt8
-            | Int16
-            | UInt16
-            | Int32
-            | UInt32
-            | Float32
-            | Date32
-            | Time32(_)
-            | Int64
-            | UInt64
-            | Float64
-            | Date64
-            | List(_)
-            | Dictionary(_, _),
+            Boolean | Int8 | UInt8 | Int16 | UInt16 | Int32 | UInt32 | Float32 | Date32 | Time32(_)
+            | Int64 | UInt64 | Float64 | Date64 | List(_) | Dictionary(..),
         )
         | (
-            Boolean
-            | Int8
-            | UInt8
-            | Int16
-            | UInt16
-            | Int32
-            | UInt32
-            | Float32
-            | Date32
-            | Time32(_)
-            | Int64
-            | UInt64
-            | Float64
-            | Date64
-            | List(_)
-            | Dictionary(_, _),
+            Boolean | Int8 | UInt8 | Int16 | UInt16 | Int32 | UInt32 | Float32 | Date32 | Time32(_)
+            | Int64 | UInt64 | Float64 | Date64 | List(_) | Dictionary(..),
             Null,
         ) => true,
         (Struct(_), _) => false,
@@ -127,11 +99,11 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         (List(list_from), LargeList(list_to)) if list_from == list_to => true,
         (LargeList(list_from), List(list_to)) if list_from == list_to => true,
         (_, List(list_to)) => can_cast_types(from_type, list_to.data_type()),
-        (Dictionary(_, from_value_type), Dictionary(_, to_value_type)) => {
+        (Dictionary(_, from_value_type, _), Dictionary(_, to_value_type, _)) => {
             can_cast_types(from_value_type, to_value_type)
         }
-        (Dictionary(_, value_type), _) => can_cast_types(value_type, to_type),
-        (_, Dictionary(_, value_type)) => can_cast_types(from_type, value_type),
+        (Dictionary(_, value_type, _), _) => can_cast_types(value_type, to_type),
+        (_, Dictionary(_, value_type, _)) => can_cast_types(from_type, value_type),
 
         (_, Boolean) => is_numeric(from_type),
         (Boolean, _) => {
@@ -376,40 +348,12 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
     match (from_type, to_type) {
         (
             Null,
-            Boolean
-            | Int8
-            | UInt8
-            | Int16
-            | UInt16
-            | Int32
-            | UInt32
-            | Float32
-            | Date32
-            | Time32(_)
-            | Int64
-            | UInt64
-            | Float64
-            | Date64
-            | List(_)
-            | Dictionary(_, _),
+            Boolean | Int8 | UInt8 | Int16 | UInt16 | Int32 | UInt32 | Float32 | Date32 | Time32(_)
+            | Int64 | UInt64 | Float64 | Date64 | List(_) | Dictionary(..),
         )
         | (
-            Boolean
-            | Int8
-            | UInt8
-            | Int16
-            | UInt16
-            | Int32
-            | UInt32
-            | Float32
-            | Date32
-            | Time32(_)
-            | Int64
-            | UInt64
-            | Float64
-            | Date64
-            | List(_)
-            | Dictionary(_, _),
+            Boolean | Int8 | UInt8 | Int16 | UInt16 | Int32 | UInt32 | Float32 | Date32 | Time32(_)
+            | Int64 | UInt64 | Float64 | Date64 | List(_) | Dictionary(..),
             Null,
         ) => Ok(new_null_array(to_type.clone(), array.len())),
         (Struct(_), _) => Err(ArrowError::NotYetImplemented(
@@ -449,10 +393,10 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             Ok(Box::new(list_array))
         }
 
-        (Dictionary(index_type, _), _) => match_integer_type!(index_type, |$T| {
+        (Dictionary(index_type, ..), _) => match_integer_type!(index_type, |$T| {
             dictionary_cast_dyn::<$T>(array, to_type, options)
         }),
-        (_, Dictionary(index_type, value_type)) => match_integer_type!(index_type, |$T| {
+        (_, Dictionary(index_type, value_type, _)) => match_integer_type!(index_type, |$T| {
             cast_to_dictionary::<$T>(array, value_type, options)
         }),
         (_, Boolean) => match from_type {

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -202,7 +202,7 @@ pub fn sort_to_indices<I: Index>(
                 ))),
             }
         }
-        DataType::Dictionary(key_type, value_type) => match value_type.as_ref() {
+        DataType::Dictionary(key_type, value_type, _) => match value_type.as_ref() {
             DataType::Utf8 => Ok(sort_dict::<I, i32>(values, key_type, options, limit)),
             DataType::LargeUtf8 => Ok(sort_dict::<I, i64>(values, key_type, options, limit)),
             t => Err(ArrowError::NotYetImplemented(format!(
@@ -282,7 +282,7 @@ pub fn can_sort(data_type: &DataType) -> bool {
                     | DataType::UInt64
             )
         }
-        DataType::Dictionary(_, value_type) => {
+        DataType::Dictionary(_, value_type, _) => {
             matches!(*value_type.as_ref(), DataType::Utf8 | DataType::LargeUtf8)
         }
         _ => false,

--- a/src/compute/take/mod.rs
+++ b/src/compute/take/mod.rs
@@ -133,6 +133,6 @@ pub fn can_take(data_type: &DataType) -> bool {
             | DataType::Struct(_)
             | DataType::List(_)
             | DataType::LargeList(_)
-            | DataType::Dictionary(_, _)
+            | DataType::Dictionary(..)
     )
 }

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -128,7 +128,7 @@ pub enum DataType {
     ///
     /// This type mostly used to represent low cardinality string
     /// arrays or a limited set of primitive types as integers.
-    Dictionary(IntegerType, Box<DataType>),
+    Dictionary(IntegerType, Box<DataType>, bool),
     /// Decimal value with precision and scale
     /// precision is the number of digits in the number and
     /// scale is the number of decimal places.
@@ -261,7 +261,7 @@ impl DataType {
             Struct(_) => PhysicalType::Struct,
             Union(_, _, _) => PhysicalType::Union,
             Map(_, _) => PhysicalType::Map,
-            Dictionary(key, _) => PhysicalType::Dictionary(*key),
+            Dictionary(key, _, _) => PhysicalType::Dictionary(*key),
             Extension(_, key, _) => key.to_physical_type(),
         }
     }

--- a/src/ffi/ffi.rs
+++ b/src/ffi/ffi.rs
@@ -331,7 +331,7 @@ fn create_dictionary(
     field: &Field,
     parent: Arc<ArrowArray>,
 ) -> Result<Option<ArrowArrayChild<'static>>> {
-    if let DataType::Dictionary(_, values) = field.data_type() {
+    if let DataType::Dictionary(_, values, _) = field.data_type() {
         let field = Field::new("", values.as_ref().clone(), true);
         assert!(!array.dictionary.is_null());
         let array = unsafe { &*array.dictionary };

--- a/src/io/avro/read/nested.rs
+++ b/src/io/avro/read/nested.rs
@@ -138,6 +138,7 @@ impl FixedItemsUtf8Dictionary {
             data_type: DataType::Dictionary(
                 IntegerType::Int32,
                 Box::new(values.data_type().clone()),
+                false,
             ),
             keys: MutablePrimitiveArray::<i32>::with_capacity(capacity),
             values,

--- a/src/io/avro/read/schema.rs
+++ b/src/io/avro/read/schema.rs
@@ -182,7 +182,7 @@ fn schema_to_field(
         AvroSchema::Enum { .. } => {
             return Ok(Field::new(
                 name.unwrap_or_default(),
-                DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Utf8)),
+                DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Utf8), false),
                 false,
             ))
         }

--- a/src/io/csv/write/serialize.rs
+++ b/src/io/csv/write/serialize.rs
@@ -383,7 +383,7 @@ pub fn new_serializer<'a>(
                 vec![],
             ))
         }
-        DataType::Dictionary(keys_dt, values_dt) => match &**values_dt {
+        DataType::Dictionary(keys_dt, values_dt, _) => match &**values_dt {
             DataType::LargeUtf8 => match *keys_dt {
                 IntegerType::UInt32 => serialize_utf8_dict::<u32, i64>(array.as_any()),
                 IntegerType::UInt64 => serialize_utf8_dict::<u64, i64>(array.as_any()),

--- a/src/io/ipc/read/common.rs
+++ b/src/io/ipc/read/common.rs
@@ -165,7 +165,7 @@ pub fn read_record_batch<R: Read + Seek>(
 fn find_first_dict_field_d(id: usize, data_type: &DataType) -> Option<&Field> {
     use DataType::*;
     match data_type {
-        Dictionary(_, inner) => find_first_dict_field_d(id, inner.as_ref()),
+        Dictionary(_, inner, _) => find_first_dict_field_d(id, inner.as_ref()),
         Map(field, _) => find_first_dict_field(id, field.as_ref()),
         List(field) => find_first_dict_field(id, field.as_ref()),
         LargeList(field) => find_first_dict_field(id, field.as_ref()),
@@ -191,7 +191,7 @@ fn find_first_dict_field_d(id: usize, data_type: &DataType) -> Option<&Field> {
 }
 
 fn find_first_dict_field(id: usize, field: &Field) -> Option<&Field> {
-    if let DataType::Dictionary(_, _) = &field.data_type {
+    if let DataType::Dictionary(_, _, _) = &field.data_type {
         if field.dict_id as usize == id {
             return Some(field);
         }
@@ -234,7 +234,7 @@ pub fn read_dictionary<R: Read + Seek>(
     // values array, we need to retrieve this from the schema.
     // Get an array representing this dictionary's values.
     let dictionary_values: ArrayRef = match first_field.data_type() {
-        DataType::Dictionary(_, ref value_type) => {
+        DataType::Dictionary(_, ref value_type, _) => {
             // Make a fake schema for the dictionary batch.
             let schema = Arc::new(Schema {
                 fields: vec![Field::new("", value_type.as_ref().clone(), false)],

--- a/src/io/ipc/write/common.rs
+++ b/src/io/ipc/write/common.rs
@@ -381,7 +381,7 @@ impl DictionaryTracker {
     ///   inserted.
     pub fn insert(&mut self, dict_id: i64, array: &Arc<dyn Array>) -> Result<bool> {
         let values = match array.data_type() {
-            DataType::Dictionary(key_type, _) => {
+            DataType::Dictionary(key_type, _, _) => {
                 match_integer_type!(key_type, |$T| {
                     let array = array
                         .as_any()

--- a/src/io/ipc/write/serialize.rs
+++ b/src/io/ipc/write/serialize.rs
@@ -470,7 +470,7 @@ pub fn write_dictionary(
     write_keys: bool,
 ) -> usize {
     match array.data_type() {
-        DataType::Dictionary(key_type, _) => {
+        DataType::Dictionary(key_type, _, _) => {
             match_integer_type!(key_type, |$T| {
                 _write_dictionary::<$T>(
                     array,

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -238,7 +238,7 @@ fn _deserialize<A: Borrow<Value>>(rows: &[A], data_type: DataType) -> Arc<dyn Ar
         DataType::Binary => Arc::new(deserialize_binary::<i32, _>(rows)),
         DataType::LargeBinary => Arc::new(deserialize_binary::<i64, _>(rows)),
         DataType::Struct(_) => Arc::new(deserialize_struct(rows, data_type)),
-        DataType::Dictionary(key_type, _) => {
+        DataType::Dictionary(key_type, _, _) => {
             match_integer_type!(key_type, |$T| {
                 Arc::new(deserialize_dictionary::<$T, _>(rows, data_type))
             })

--- a/src/io/json_integration/mod.rs
+++ b/src/io/json_integration/mod.rs
@@ -83,7 +83,7 @@ impl From<&Field> for ArrowJsonField {
             _ => None,
         };
 
-        let dictionary = if let DataType::Dictionary(key_type, _) = &field.data_type {
+        let dictionary = if let DataType::Dictionary(key_type, _, is_ordered) = &field.data_type {
             use crate::datatypes::IntegerType::*;
             Some(ArrowJsonFieldDictionary {
                 id: field.dict_id,
@@ -100,7 +100,7 @@ impl From<&Field> for ArrowJsonField {
                         UInt8 | UInt16 | UInt32 | UInt64 => false,
                     },
                 },
-                is_ordered: field.dict_is_ordered,
+                is_ordered: *is_ordered,
             })
         } else {
             None

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -98,7 +98,7 @@ fn dict_read<
     data_type: DataType,
 ) -> Result<Box<dyn Array>> {
     use DataType::*;
-    let values_data_type = if let Dictionary(_, v) = &data_type {
+    let values_data_type = if let Dictionary(_, v, _) = &data_type {
         v.as_ref()
     } else {
         panic!()
@@ -372,7 +372,7 @@ fn page_iter_to_array<I: FallibleStreamingIterator<Item = DataPage, Error = Parq
             binary::iter_to_array::<i64, _, _>(iter, metadata, data_type, nested)
         }
 
-        Dictionary(key_type, _) => match_integer_type!(key_type, |$T| {
+        Dictionary(key_type, _, _) => match_integer_type!(key_type, |$T| {
             dict_read::<$T, _>(iter, metadata, data_type)
         }),
 

--- a/src/io/parquet/read/primitive/mod.rs
+++ b/src/io/parquet/read/primitive/mod.rs
@@ -49,7 +49,7 @@ where
     }
 
     let data_type = match data_type {
-        DataType::Dictionary(_, values) => values.as_ref().clone(),
+        DataType::Dictionary(_, values, _) => values.as_ref().clone(),
         _ => data_type,
     };
 
@@ -100,7 +100,7 @@ where
     }
 
     let data_type = match data_type {
-        DataType::Dictionary(_, values) => values.as_ref().clone(),
+        DataType::Dictionary(_, values, _) => values.as_ref().clone(),
         _ => data_type,
     };
 

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -103,8 +103,8 @@ pub fn can_encode(data_type: &DataType, encoding: Encoding) -> bool {
                 Encoding::DeltaLengthByteArray,
                 DataType::Binary | DataType::LargeBinary | DataType::Utf8 | DataType::LargeUtf8,
             )
-            | (Encoding::RleDictionary, DataType::Dictionary(_, _))
-            | (Encoding::PlainDictionary, DataType::Dictionary(_, _))
+            | (Encoding::RleDictionary, DataType::Dictionary(_, _, _))
+            | (Encoding::PlainDictionary, DataType::Dictionary(_, _, _))
     )
 }
 
@@ -116,7 +116,7 @@ pub fn array_to_pages(
     encoding: Encoding,
 ) -> Result<DynIter<'static, Result<EncodedPage>>> {
     match array.data_type() {
-        DataType::Dictionary(key_type, _) => {
+        DataType::Dictionary(key_type, _, _) => {
             match_integer_type!(key_type, |$T| {
                 dictionary::array_to_pages::<$T>(
                     array.as_any().downcast_ref().unwrap(),

--- a/src/io/parquet/write/schema.rs
+++ b/src/io/parquet/write/schema.rs
@@ -277,7 +277,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
                 name, repetition, None, None, fields, None,
             )?)
         }
-        DataType::Dictionary(_, value) => {
+        DataType::Dictionary(_, value, _) => {
             let dict_field = Field::new(name.as_str(), value.as_ref().clone(), field.is_nullable());
             to_parquet_type(&dict_field)
         }

--- a/src/scalar/equal.rs
+++ b/src/scalar/equal.rs
@@ -125,7 +125,7 @@ fn equal(lhs: &dyn Scalar, rhs: &dyn Scalar) -> bool {
             let rhs = rhs.as_any().downcast_ref::<ListScalar<i64>>().unwrap();
             lhs == rhs
         }
-        DataType::Dictionary(key_type, _) => match_integer_type!(key_type, |$T| {
+        DataType::Dictionary(key_type, _, _) => match_integer_type!(key_type, |$T| {
             let lhs = lhs.as_any().downcast_ref::<DictionaryScalar<$T>>().unwrap();
             let rhs = rhs.as_any().downcast_ref::<DictionaryScalar<$T>>().unwrap();
             lhs == rhs

--- a/tests/it/compute/cast.rs
+++ b/tests/it/compute/cast.rs
@@ -483,7 +483,7 @@ fn utf8_to_dict() {
     let array = Utf8Array::<i32>::from(&[Some("one"), None, Some("three"), Some("one")]);
 
     // Cast to a dictionary (same value type, Utf8)
-    let cast_type = DataType::Dictionary(u8::KEY_TYPE, Box::new(DataType::Utf8));
+    let cast_type = DataType::Dictionary(u8::KEY_TYPE, Box::new(DataType::Utf8), false);
     let result = cast(&array, &cast_type, CastOptions::default()).expect("cast failed");
 
     let mut expected = MutableDictionaryArray::<u8, MutableUtf8Array<i32>>::new();
@@ -514,7 +514,7 @@ fn i32_to_dict() {
     let array = Int32Array::from(&[Some(1), None, Some(3), Some(1)]);
 
     // Cast to a dictionary (same value type, Utf8)
-    let cast_type = DataType::Dictionary(u8::KEY_TYPE, Box::new(DataType::Int32));
+    let cast_type = DataType::Dictionary(u8::KEY_TYPE, Box::new(DataType::Int32), false);
     let result = cast(&array, &cast_type, CastOptions::default()).expect("cast failed");
 
     let mut expected = MutableDictionaryArray::<u8, MutablePrimitiveArray<i32>>::new();

--- a/tests/it/ffi.rs
+++ b/tests/it/ffi.rs
@@ -196,7 +196,7 @@ fn schema() -> Result<()> {
 
     let field = Field::new(
         "a",
-        DataType::Dictionary(u32::KEY_TYPE, Box::new(DataType::Utf8)),
+        DataType::Dictionary(u32::KEY_TYPE, Box::new(DataType::Utf8), false),
         true,
     );
     test_round_trip_schema(field)?;

--- a/tests/it/io/avro/read.rs
+++ b/tests/it/io/avro/read.rs
@@ -61,7 +61,7 @@ pub(super) fn schema() -> (AvroSchema, Schema) {
         ),
         Field::new(
             "enum",
-            DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::Utf8)),
+            DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::Utf8), false),
             false,
         ),
     ]);

--- a/tests/it/io/json/mod.rs
+++ b/tests/it/io/json/mod.rs
@@ -130,7 +130,7 @@ fn case_dict() -> (String, Schema, Vec<Box<dyn Array>>) {
 
     let data_type = DataType::List(Box::new(Field::new(
         "item",
-        DataType::Dictionary(u64::KEY_TYPE, Box::new(DataType::Utf8)),
+        DataType::Dictionary(u64::KEY_TYPE, Box::new(DataType::Utf8), false),
         true,
     )));
 

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -637,7 +637,7 @@ fn integration_write(schema: &Schema, batches: &[RecordBatch]) -> Result<Vec<u8>
             .iter()
             .zip(descritors.clone())
             .map(|(array, descriptor)| {
-                let encoding = if let DataType::Dictionary(_, _) = array.data_type() {
+                let encoding = if let DataType::Dictionary(..) = array.data_type() {
                     Encoding::RleDictionary
                 } else {
                     Encoding::Plain

--- a/tests/it/io/print.rs
+++ b/tests/it/io/print.rs
@@ -87,7 +87,7 @@ fn write_null() -> Result<()> {
 #[test]
 fn write_dictionary() -> Result<()> {
     // define a schema.
-    let field_type = DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::Utf8));
+    let field_type = DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::Utf8), false);
     let schema = Arc::new(Schema::new(vec![Field::new("d1", field_type, true)]));
 
     let mut array = MutableDictionaryArray::<i32, MutableUtf8Array<i32>>::new();
@@ -119,7 +119,7 @@ fn write_dictionary() -> Result<()> {
 #[test]
 fn dictionary_validities() -> Result<()> {
     // define a schema.
-    let field_type = DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::Int32));
+    let field_type = DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::Int32), false);
     let schema = Arc::new(Schema::new(vec![Field::new("d1", field_type, true)]));
 
     let keys = PrimitiveArray::<i32>::from([Some(1), None, Some(0)]);


### PR DESCRIPTION
This allows users of `DictionaryArray` to check the boolean in its `data_type`, to specialize sorting of the values by taking the boolean into account.
