### PR TITLE
Simplified `Schema` and `Field`

### DIFF
--- a/arrow-parquet-integration-testing/src/main.rs
+++ b/arrow-parquet-integration-testing/src/main.rs
@@ -116,7 +116,7 @@ fn main() -> Result<()> {
 
     let schema = if let Some(projection) = &projection {
         let fields = schema
-            .fields()
+            .fields
             .iter()
             .enumerate()
             .filter_map(|(i, f)| {
@@ -127,7 +127,7 @@ fn main() -> Result<()> {
                 }
             })
             .collect::<Vec<_>>();
-        Schema::new(fields)
+        Schema::from(fields)
     } else {
         schema
     };
@@ -168,7 +168,7 @@ fn main() -> Result<()> {
     };
 
     let encodings = schema
-        .fields()
+        .fields
         .iter()
         .map(|x| match x.data_type() {
             DataType::Dictionary(..) => Encoding::RleDictionary,

--- a/benches/avro_read.rs
+++ b/benches/avro_read.rs
@@ -51,7 +51,7 @@ fn read_batch(buffer: &[u8], size: usize) -> Result<()> {
             codec,
         ),
         avro_schema,
-        schema.fields().clone(),
+        schema.fields,
     );
 
     let mut rows = 0;

--- a/benches/filter_kernels.rs
+++ b/benches/filter_kernels.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -125,8 +123,9 @@ fn add_benchmark(c: &mut Criterion) {
 
     let data_array = create_primitive_array::<f32>(size, 0.0);
 
-    let columns = Chunk::try_new(vec![Arc::new(data_array) as ArrayRef]).unwrap();
-    c.bench_function("filter single record batch", |b| {
+    let columns = Chunk::try_new(vec![&data_array as &dyn Array]).unwrap();
+
+    c.bench_function("filter single chunk", |b| {
         b.iter(|| filter_chunk(&columns, &filter_array))
     });
 }

--- a/benches/write_ipc.rs
+++ b/benches/write_ipc.rs
@@ -3,14 +3,14 @@ use std::io::Cursor;
 
 use arrow2::array::*;
 use arrow2::chunk::Chunk;
-use arrow2::datatypes::{Field, Schema};
+use arrow2::datatypes::Field;
 use arrow2::error::Result;
 use arrow2::io::ipc::write::*;
 use arrow2::util::bench_util::{create_boolean_array, create_primitive_array, create_string_array};
 
 fn write(array: &dyn Array) -> Result<()> {
     let field = Field::new("c1", array.data_type().clone(), true);
-    let schema = Schema::new(vec![field]);
+    let schema = vec![field].into();
     let columns = Chunk::try_new(vec![clone(array).into()])?;
 
     let writer = Cursor::new(vec![]);

--- a/benches/write_parquet.rs
+++ b/benches/write_parquet.rs
@@ -1,11 +1,11 @@
 use std::io::Cursor;
 use std::sync::Arc;
 
-use arrow2::datatypes::{Field, Schema};
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use arrow2::array::{clone, Array};
 use arrow2::chunk::Chunk;
+use arrow2::datatypes::{Field, Schema};
 use arrow2::error::Result;
 use arrow2::io::parquet::write::*;
 use arrow2::util::bench_util::{create_boolean_array, create_primitive_array, create_string_array};
@@ -13,7 +13,7 @@ use arrow2::util::bench_util::{create_boolean_array, create_primitive_array, cre
 type ChunkArc = Chunk<Arc<dyn Array>>;
 
 fn write(array: &dyn Array, encoding: Encoding) -> Result<()> {
-    let schema = Schema::new(vec![Field::new("c1", array.data_type().clone(), true)]);
+    let schema = Schema::from(vec![Field::new("c1", array.data_type().clone(), true)]);
     let columns: ChunkArc = Chunk::new(vec![clone(array).into()]);
 
     let options = WriteOptions {

--- a/examples/avro_read_async.rs
+++ b/examples/avro_read_async.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
         let handle = tokio::task::spawn_blocking(move || {
             let mut decompressed = Block::new(0, vec![]);
             decompress_block(&mut block, &mut decompressed, compression)?;
-            deserialize(&decompressed, schema.fields(), &avro_schemas)
+            deserialize(&decompressed, &schema.fields, &avro_schemas)
         });
         let batch = handle.await.unwrap()?;
         assert!(!batch.is_empty());

--- a/examples/avro_write.rs
+++ b/examples/avro_write.rs
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
         Some(6),
     ]);
     let field = Field::new("c1", array.data_type().clone(), true);
-    let schema = Schema::new(vec![field]);
+    let schema = vec![field].into();
 
     let mut file = File::create(path)?;
     write_avro(&mut file, &[(&array) as &dyn Array], &schema, None)?;

--- a/examples/csv_read_async.rs
+++ b/examples/csv_read_async.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use tokio::fs::File;
 use tokio_util::compat::*;
 
@@ -17,18 +15,12 @@ async fn main() -> Result<()> {
 
     let mut reader = AsyncReaderBuilder::new().create_reader(file);
 
-    let schema = Arc::new(infer_schema(&mut reader, None, true, &infer).await?);
+    let fields = infer_schema(&mut reader, None, true, &infer).await?;
 
     let mut rows = vec![ByteRecord::default(); 100];
     let rows_read = read_rows(&mut reader, 0, &mut rows).await?;
 
-    let columns = deserialize_batch(
-        &rows[..rows_read],
-        schema.fields(),
-        None,
-        0,
-        deserialize_column,
-    )?;
+    let columns = deserialize_batch(&rows[..rows_read], &fields, None, 0, deserialize_column)?;
     println!("{:?}", columns.arrays()[0]);
     Ok(())
 }

--- a/examples/extension.rs
+++ b/examples/extension.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
 }
 
 fn write_ipc<W: Write + Seek>(writer: W, array: impl Array + 'static) -> Result<W> {
-    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), false)]);
+    let schema = vec![Field::new("a", array.data_type().clone(), false)].into();
 
     let options = write::WriteOptions { compression: None };
     let mut writer = write::FileWriter::try_new(writer, &schema, None, options)?;

--- a/examples/ipc_file_read.rs
+++ b/examples/ipc_file_read.rs
@@ -30,7 +30,7 @@ fn main() -> Result<()> {
     let file_path = &args[1];
 
     let (schema, batches) = read_batches(file_path)?;
-    let names = schema.fields().iter().map(|f| f.name()).collect::<Vec<_>>();
+    let names = schema.fields.iter().map(|f| &f.name).collect::<Vec<_>>();
     println!("{}", print::write(&batches, &names));
     Ok(())
 }

--- a/examples/ipc_file_write.rs
+++ b/examples/ipc_file_write.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
     let file_path = &args[1];
 
     // create a batch
-    let schema = Schema::new(vec![
+    let schema = Schema::from(vec![
         Field::new("a", DataType::Int32, false),
         Field::new("b", DataType::Utf8, false),
     ]);

--- a/examples/json_read.rs
+++ b/examples/json_read.rs
@@ -16,7 +16,7 @@ fn read_path(path: &str, projection: Option<Vec<&str>>) -> Result<Chunk<Arc<dyn 
     let fields = if let Some(projection) = projection {
         fields
             .into_iter()
-            .filter(|field| projection.contains(&field.name().as_ref()))
+            .filter(|field| projection.contains(&field.name.as_ref()))
             .collect()
     } else {
         fields

--- a/examples/metadata.rs
+++ b/examples/metadata.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use arrow2::datatypes::{DataType, Field, Metadata, Schema};
 
 fn main() {
@@ -20,17 +18,17 @@ fn main() {
     let field1 = field1.with_metadata(metadata);
 
     // a schema (a table)
-    let schema = Schema::new(vec![field1, field2]);
+    let schema = Schema::from(vec![field1, field2]);
 
-    assert_eq!(schema.fields().len(), 2);
+    assert_eq!(schema.fields.len(), 2);
 
     // which can also contain extra metadata:
-    let mut metadata = HashMap::new();
+    let mut metadata = Metadata::new();
     metadata.insert(
         "Office Space".to_string(),
         "Deals with real issues in the workplace.".to_string(),
     );
     let schema = schema.with_metadata(metadata);
 
-    assert_eq!(schema.fields().len(), 2);
+    assert_eq!(schema.fields.len(), 2);
 }

--- a/examples/parquet_read.rs
+++ b/examples/parquet_read.rs
@@ -22,7 +22,7 @@ fn read_field(path: &str, row_group: usize, field: usize) -> Result<Box<dyn Arra
     let columns = read::get_column_iterator(&mut file, &metadata, row_group, field, None, vec![]);
 
     // get the columns' field
-    let field = &arrow_schema.fields()[field];
+    let field = &arrow_schema.fields[field];
 
     // This is the actual work. In this case, pages are read and
     // decompressed, decoded and deserialized to arrow.

--- a/examples/parquet_read_parallel.rs
+++ b/examples/parquet_read_parallel.rs
@@ -65,7 +65,7 @@ fn parallel_read(path: &str, row_group: usize) -> Result<Chunk<Arc<dyn Array>>> 
                 let mut arrays = vec![];
                 while let Ok((field_i, parquet_field, column_chunks)) = rx_consumer.recv() {
                     let start = SystemTime::now();
-                    let field = &arrow_schema_consumer.fields()[field_i];
+                    let field = &arrow_schema_consumer.fields[field_i];
                     println!("consumer {} start - {}", i, field_i);
 
                     let columns = read::ReadColumnIterator::new(parquet_field, column_chunks);

--- a/examples/parquet_write.rs
+++ b/examples/parquet_write.rs
@@ -5,7 +5,7 @@ use arrow2::error::ArrowError;
 use arrow2::io::parquet::write::to_parquet_schema;
 use arrow2::{
     array::{Array, Int32Array},
-    datatypes::{Field, Schema},
+    datatypes::Field,
     error::Result,
     io::parquet::write::{
         array_to_pages, write_file, Compression, Compressor, DynIter, DynStreamingIterator,
@@ -14,7 +14,7 @@ use arrow2::{
 };
 
 fn write_single_array(path: &str, array: &dyn Array, field: Field) -> Result<()> {
-    let schema = Schema::new(vec![field]);
+    let schema = vec![field].into();
 
     let options = WriteOptions {
         write_statistics: true,

--- a/examples/parquet_write_record.rs
+++ b/examples/parquet_write_record.rs
@@ -50,7 +50,7 @@ fn main() -> Result<()> {
         Some(6),
     ]);
     let field = Field::new("c1", array.data_type().clone(), true);
-    let schema = Schema::new(vec![field]);
+    let schema = Schema::from(vec![field]);
     let columns = Chunk::new(vec![Arc::new(array) as Arc<dyn Array>]);
 
     write_batch("test.parquet", schema, columns)

--- a/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -95,7 +95,7 @@ fn arrow_to_json(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()>
         .schema
         .fields
         .iter()
-        .map(|f| f.name())
+        .map(|f| &f.name)
         .collect::<Vec<_>>();
 
     let schema = json_write::serialize_schema(&metadata.schema, &metadata.ipc_schema.fields);

--- a/integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -221,7 +221,7 @@ async fn consume_flight_location(
 
     for (counter, expected_batch) in expected_data.iter().enumerate() {
         let data =
-            receive_batch_flight_data(&mut resp, schema.fields(), ipc_schema, &mut dictionaries)
+            receive_batch_flight_data(&mut resp, &schema.fields, ipc_schema, &mut dictionaries)
                 .await
                 .unwrap_or_else(|| {
                     panic!(
@@ -234,7 +234,7 @@ async fn consume_flight_location(
         let metadata = counter.to_string().into_bytes();
         assert_eq!(metadata, data.app_metadata);
 
-        let actual_batch = deserialize_batch(&data, schema.fields(), ipc_schema, &dictionaries)
+        let actual_batch = deserialize_batch(&data, &schema.fields, ipc_schema, &dictionaries)
             .expect("Unable to convert flight data to Arrow batch");
 
         assert_eq!(expected_batch.columns().len(), actual_batch.columns().len());
@@ -245,8 +245,7 @@ async fn consume_flight_location(
             .zip(actual_batch.columns().iter())
             .enumerate()
         {
-            let field = schema.field(i);
-            let field_name = field.name();
+            let field_name = &schema.fields[i].name;
             assert_eq!(expected, actual, "Data for field {}", field_name);
         }
     }

--- a/integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -299,8 +299,7 @@ async fn record_batch_from_message(
         0,
     );
 
-    arrow_batch_result
-        .map_err(|e| Status::internal(format!("Could not convert to Chunk: {:?}", e)))
+    arrow_batch_result.map_err(|e| Status::internal(format!("Could not convert to Chunk: {:?}", e)))
 }
 
 async fn dictionary_from_message(
@@ -351,7 +350,7 @@ async fn save_uploaded_chunks(
                 let batch = record_batch_from_message(
                     message,
                     &data.data_body,
-                    schema.fields(),
+                    &schema.fields,
                     &ipc_schema,
                     &mut dictionaries,
                 )
@@ -363,7 +362,7 @@ async fn save_uploaded_chunks(
                 dictionary_from_message(
                     message,
                     &data.data_body,
-                    schema.fields(),
+                    &schema.fields,
                     &ipc_schema,
                     &mut dictionaries,
                 )

--- a/src/array/display.rs
+++ b/src/array/display.rs
@@ -184,7 +184,7 @@ pub fn get_value_display<'a>(array: &'a dyn Array) -> Box<dyn Fn(usize) -> Strin
             Box::new(move |row: usize| {
                 let mut string = displays
                     .iter()
-                    .zip(a.fields().iter().map(|f| f.name()))
+                    .zip(a.fields().iter().map(|f| &f.name))
                     .map(|(f, name)| (f(row), name))
                     .fold("{".to_string(), |mut acc, (v, name)| {
                         acc.push_str(&format!("{}: {}, ", name, v));

--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -218,7 +218,7 @@ impl std::fmt::Debug for StructArray {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "StructArray{{")?;
         for (field, column) in self.fields().iter().zip(self.values()) {
-            writeln!(f, "{}: {:?},", field.name(), column)?;
+            writeln!(f, "{}: {:?},", field.name, column)?;
         }
         write!(f, "}}")
     }

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -91,14 +91,14 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
         (Struct(_), _) => false,
         (_, Struct(_)) => false,
         (List(list_from), List(list_to)) => {
-            can_cast_types(list_from.data_type(), list_to.data_type())
+            can_cast_types(&list_from.data_type, &list_to.data_type)
         }
         (LargeList(list_from), LargeList(list_to)) => {
-            can_cast_types(list_from.data_type(), list_to.data_type())
+            can_cast_types(&list_from.data_type, &list_to.data_type)
         }
         (List(list_from), LargeList(list_to)) if list_from == list_to => true,
         (LargeList(list_from), List(list_to)) if list_from == list_to => true,
-        (_, List(list_to)) => can_cast_types(from_type, list_to.data_type()),
+        (_, List(list_to)) => can_cast_types(from_type, &list_to.data_type),
         (Dictionary(_, from_value_type, _), Dictionary(_, to_value_type, _)) => {
             can_cast_types(from_value_type, to_value_type)
         }
@@ -383,7 +383,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
 
         (_, List(to)) => {
             // cast primitive to list's primitive
-            let values = cast(array, to.data_type(), options)?.into();
+            let values = cast(array, &to.data_type, options)?.into();
             // create offsets, where if array.len() = 2, we have [0,1,2]
             let offsets =
                 unsafe { Buffer::from_trusted_len_iter_unchecked(0..=array.len() as i32) };

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -153,7 +153,7 @@ pub fn sort_to_indices<I: Index>(
         )),
         DataType::List(field) => {
             let (v, n) = partition_validity(values);
-            match field.data_type() {
+            match &field.data_type {
                 DataType::Int8 => Ok(sort_list::<I, i32, i8>(values, v, n, options, limit)),
                 DataType::Int16 => Ok(sort_list::<I, i32, i16>(values, v, n, options, limit)),
                 DataType::Int32 => Ok(sort_list::<I, i32, i32>(values, v, n, options, limit)),

--- a/src/datatypes/field.rs
+++ b/src/datatypes/field.rs
@@ -1,8 +1,13 @@
-use crate::error::{ArrowError, Result};
-
 use super::{DataType, Metadata};
 
-/// Represents the metadata of a "column".
+/// Represents Arrow's metadata of a "column".
+///
+/// A [`Field`] is the closest representation of the traditional "column": a logical type
+/// ([`DataType`]) with a name and nullability.
+/// A Field has optional [`Metadata`] that can be used to annotate the field with custom metadata.
+///
+/// Almost all IO in this crate uses [`Field`] to represent logical information about the data
+/// to be serialized.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Field {
     /// Its name
@@ -10,18 +15,18 @@ pub struct Field {
     /// Its logical [`DataType`]
     pub data_type: DataType,
     /// Its nullability
-    pub nullable: bool,
+    pub is_nullable: bool,
     /// Additional custom (opaque) metadata.
     pub metadata: Metadata,
 }
 
 impl Field {
     /// Creates a new [`Field`].
-    pub fn new<T: Into<String>>(name: T, data_type: DataType, nullable: bool) -> Self {
+    pub fn new<T: Into<String>>(name: T, data_type: DataType, is_nullable: bool) -> Self {
         Field {
             name: name.into(),
             data_type,
-            nullable,
+            is_nullable,
             metadata: Default::default(),
         }
     }
@@ -32,149 +37,14 @@ impl Field {
         Self {
             name: self.name,
             data_type: self.data_type,
-            nullable: self.nullable,
+            is_nullable: self.is_nullable,
             metadata,
         }
     }
 
-    /// Returns the [`Field`]'s metadata.
-    #[inline]
-    pub const fn metadata(&self) -> &Metadata {
-        &self.metadata
-    }
-
-    /// Returns the [`Field`]'s name.
-    #[inline]
-    pub const fn name(&self) -> &String {
-        &self.name
-    }
-
     /// Returns the [`Field`]'s [`DataType`].
     #[inline]
-    pub const fn data_type(&self) -> &DataType {
+    pub fn data_type(&self) -> &DataType {
         &self.data_type
-    }
-
-    /// Returns whether the [`Field`] should contain null values.
-    #[inline]
-    pub const fn is_nullable(&self) -> bool {
-        self.nullable
-    }
-
-    /// Merge field into self if it is compatible. Struct will be merged recursively.
-    /// NOTE: `self` may be updated to unexpected state in case of merge failure.
-    ///
-    /// Example:
-    ///
-    /// ```
-    /// use arrow2::datatypes::*;
-    ///
-    /// let mut field = Field::new("c1", DataType::Int64, false);
-    /// assert!(field.try_merge(&Field::new("c1", DataType::Int64, true)).is_ok());
-    /// assert!(field.is_nullable());
-    /// ```
-    pub fn try_merge(&mut self, from: &Field) -> Result<()> {
-        // merge metadata
-        for (key, from_value) in from.metadata() {
-            if let Some(self_value) = self.metadata.get(key) {
-                if self_value != from_value {
-                    return Err(ArrowError::InvalidArgumentError(format!(
-                        "Fail to merge field due to conflicting metadata data value for key {}",
-                        key
-                    )));
-                }
-            } else {
-                self.metadata.insert(key.clone(), from_value.clone());
-            }
-        }
-
-        match &mut self.data_type {
-            DataType::Struct(nested_fields) => match &from.data_type {
-                DataType::Struct(from_nested_fields) => {
-                    for from_field in from_nested_fields {
-                        let mut is_new_field = true;
-                        for self_field in nested_fields.iter_mut() {
-                            if self_field.name != from_field.name {
-                                continue;
-                            }
-                            is_new_field = false;
-                            self_field.try_merge(from_field)?;
-                        }
-                        if is_new_field {
-                            nested_fields.push(from_field.clone());
-                        }
-                    }
-                }
-                _ => {
-                    return Err(ArrowError::InvalidArgumentError(
-                        "Fail to merge schema Field due to conflicting datatype".to_string(),
-                    ));
-                }
-            },
-            DataType::Union(nested_fields, _, _) => match &from.data_type {
-                DataType::Union(from_nested_fields, _, _) => {
-                    for from_field in from_nested_fields {
-                        let mut is_new_field = true;
-                        for self_field in nested_fields.iter_mut() {
-                            if from_field == self_field {
-                                is_new_field = false;
-                                break;
-                            }
-                        }
-                        if is_new_field {
-                            nested_fields.push(from_field.clone());
-                        }
-                    }
-                }
-                _ => {
-                    return Err(ArrowError::InvalidArgumentError(
-                        "Fail to merge schema Field due to conflicting datatype".to_string(),
-                    ));
-                }
-            },
-            DataType::Null
-            | DataType::Boolean
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Float16
-            | DataType::Float32
-            | DataType::Float64
-            | DataType::Timestamp(_, _)
-            | DataType::Date32
-            | DataType::Date64
-            | DataType::Time32(_)
-            | DataType::Time64(_)
-            | DataType::Duration(_)
-            | DataType::Binary
-            | DataType::LargeBinary
-            | DataType::Interval(_)
-            | DataType::LargeList(_)
-            | DataType::List(_)
-            | DataType::Dictionary(_, _, _)
-            | DataType::FixedSizeList(_, _)
-            | DataType::FixedSizeBinary(_)
-            | DataType::Utf8
-            | DataType::LargeUtf8
-            | DataType::Extension(_, _, _)
-            | DataType::Map(_, _)
-            | DataType::Decimal(_, _) => {
-                if self.data_type != from.data_type {
-                    return Err(ArrowError::InvalidArgumentError(
-                        "Fail to merge schema Field due to conflicting datatype".to_string(),
-                    ));
-                }
-            }
-        }
-        if from.nullable {
-            self.nullable = from.nullable;
-        }
-
-        Ok(())
     }
 }

--- a/src/datatypes/schema.rs
+++ b/src/datatypes/schema.rs
@@ -1,196 +1,34 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+use super::{Field, Metadata};
 
-use std::collections::HashMap;
-
-use crate::error::{ArrowError, Result};
-
-use super::Field;
-
-/// An ordered sequence of [`Field`] with optional metadata.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// An ordered sequence of [`Field`]s with associated [`Metadata`].
+///
+/// [`Schema`] is an abstration used to read from, and write to, Arrow IPC format,
+/// Apache Parquet, and Apache Avro. All these formats have a concept of a schema
+/// with fields and metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct Schema {
     /// The fields composing this schema.
     pub fields: Vec<Field>,
-    /// A map of key-value pairs containing additional meta data.
-    pub metadata: HashMap<String, String>,
+    /// Optional metadata.
+    pub metadata: Metadata,
 }
 
 impl Schema {
-    /// Creates an empty [`Schema`].
-    pub fn empty() -> Self {
-        Self {
-            fields: vec![],
-            metadata: HashMap::new(),
-        }
-    }
-
-    /// Creates a new [`Schema`] from a sequence of [`Field`] values.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use arrow2::datatypes::{Field, DataType, Schema};
-    /// let field_a = Field::new("a", DataType::Int64, false);
-    /// let field_b = Field::new("b", DataType::Boolean, false);
-    ///
-    /// let schema = Schema::new(vec![field_a, field_b]);
-    /// ```
-    pub fn new(fields: Vec<Field>) -> Self {
-        Self::new_from(fields, HashMap::new())
-    }
-
-    /// Creates a new `Schema` from a sequence of `Field` values
-    /// and additional metadata.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use arrow2::datatypes::{Field, DataType, Schema};
-    /// # use std::collections::HashMap;
-    /// let field_a = Field::new("a", DataType::Int64, false);
-    /// let field_b = Field::new("b", DataType::Boolean, false);
-    ///
-    /// let mut metadata: HashMap<String, String> = HashMap::new();
-    /// metadata.insert("row_count".to_string(), "100".to_string());
-    ///
-    /// let schema = Schema::new_from(vec![field_a, field_b], metadata);
-    /// ```
+    /// Attaches a [`Metadata`] to [`Schema`]
     #[inline]
-    pub const fn new_from(fields: Vec<Field>, metadata: HashMap<String, String>) -> Self {
-        Self { fields, metadata }
-    }
-
-    /// Creates a new [`Field`] with metadata.
-    #[inline]
-    pub fn with_metadata(self, metadata: HashMap<String, String>) -> Self {
+    pub fn with_metadata(self, metadata: Metadata) -> Self {
         Self {
             fields: self.fields,
             metadata,
         }
     }
+}
 
-    /// Merge schema into self if it is compatible. Struct fields will be merged recursively.
-    ///
-    /// Example:
-    ///
-    /// ```
-    /// use arrow2::datatypes::*;
-    ///
-    /// let merged = Schema::try_merge(vec![
-    ///     Schema::new(vec![
-    ///         Field::new("c1", DataType::Int64, false),
-    ///         Field::new("c2", DataType::Utf8, false),
-    ///     ]),
-    ///     Schema::new(vec![
-    ///         Field::new("c1", DataType::Int64, true),
-    ///         Field::new("c2", DataType::Utf8, false),
-    ///         Field::new("c3", DataType::Utf8, false),
-    ///     ]),
-    /// ]).unwrap();
-    ///
-    /// assert_eq!(
-    ///     merged,
-    ///     Schema::new(vec![
-    ///         Field::new("c1", DataType::Int64, true),
-    ///         Field::new("c2", DataType::Utf8, false),
-    ///         Field::new("c3", DataType::Utf8, false),
-    ///     ]),
-    /// );
-    /// ```
-    pub fn try_merge(schemas: impl IntoIterator<Item = Self>) -> Result<Self> {
-        schemas
-            .into_iter()
-            .try_fold(Self::empty(), |mut merged, schema| {
-                let Schema { metadata, fields } = schema;
-                for (key, value) in metadata.into_iter() {
-                    // merge metadata
-                    if let Some(old_val) = merged.metadata.get(&key) {
-                        if old_val != &value {
-                            return Err(ArrowError::InvalidArgumentError(
-                                "Fail to merge schema due to conflicting metadata.".to_string(),
-                            ));
-                        }
-                    }
-                    merged.metadata.insert(key, value);
-                }
-                // merge fields
-                for field in fields.into_iter() {
-                    let mut new_field = true;
-                    for merged_field in &mut merged.fields {
-                        if field.name() != merged_field.name() {
-                            continue;
-                        }
-                        new_field = false;
-                        merged_field.try_merge(&field)?
-                    }
-                    // found a new field, add to field list
-                    if new_field {
-                        merged.fields.push(field);
-                    }
-                }
-                Ok(merged)
-            })
-    }
-
-    /// Returns all [`Field`]s in this schema.
-    #[inline]
-    pub const fn fields(&self) -> &Vec<Field> {
-        &self.fields
-    }
-
-    /// Returns the [`Field`] at position `i`.
-    /// # Panics
-    /// Panics iff `i` is larger than the number of fields in this [`Schema`].
-    pub fn field(&self, i: usize) -> &Field {
-        &self.fields[i]
-    }
-
-    /// Returns the first [`Field`] named `name`.
-    pub fn field_with_name(&self, name: &str) -> Result<&Field> {
-        Ok(&self.fields[self.index_of(name)?])
-    }
-
-    /// Find the index of the column with the given name.
-    pub fn index_of(&self, name: &str) -> Result<usize> {
-        for i in 0..self.fields.len() {
-            if self.fields[i].name() == name {
-                return Ok(i);
-            }
+impl From<Vec<Field>> for Schema {
+    fn from(fields: Vec<Field>) -> Self {
+        Self {
+            fields,
+            ..Default::default()
         }
-        let valid_fields: Vec<String> = self.fields.iter().map(|f| f.name().clone()).collect();
-        Err(ArrowError::InvalidArgumentError(format!(
-            "Unable to get field named \"{}\". Valid fields: {:?}",
-            name, valid_fields
-        )))
-    }
-
-    /// Returns an immutable reference to the Map of custom metadata key-value pairs.
-    #[inline]
-    pub const fn metadata(&self) -> &HashMap<String, String> {
-        &self.metadata
-    }
-
-    /// Look up a column by name and return a immutable reference to the column along with
-    /// its index.
-    pub fn column_with_name(&self, name: &str) -> Option<(usize, &Field)> {
-        self.fields
-            .iter()
-            .enumerate()
-            .find(|&(_, c)| c.name() == name)
     }
 }

--- a/src/doc/lib.md
+++ b/src/doc/lib.md
@@ -28,7 +28,7 @@ fn main() -> Result<()> {
     assert_eq!(c, b);
 
     // declare a schema with fields
-    let schema = Schema::new(vec![
+    let schema = Schema::from(vec![
         Field::new("c1", DataType::Int32, true),
         Field::new("c2", DataType::Int32, true),
     ]);

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -56,9 +56,9 @@ impl Ffi_ArrowSchema {
     /// creates a new [Ffi_ArrowSchema]
     pub(crate) fn new(field: &Field) -> Self {
         let format = to_format(field.data_type());
-        let name = field.name().clone();
+        let name = field.name.clone();
 
-        let mut flags = field.is_nullable() as i64 * 2;
+        let mut flags = field.is_nullable as i64 * 2;
 
         // allocate (and hold) the children
         let children_vec = match field.data_type() {
@@ -101,7 +101,7 @@ impl Ffi_ArrowSchema {
             None
         };
 
-        let metadata = field.metadata();
+        let metadata = &field.metadata;
 
         let metadata = if let DataType::Extension(name, _, extension_metadata) = field.data_type() {
             // append extension information.

--- a/src/io/avro/read/deserialize.rs
+++ b/src/io/avro/read/deserialize.rs
@@ -102,7 +102,7 @@ fn deserialize_value<'a>(
                 unreachable!()
             };
 
-            let is_nullable = inner.is_nullable();
+            let is_nullable = inner.is_nullable;
             let array = array
                 .as_mut_any()
                 .downcast_mut::<DynMutableListArray<i32>>()
@@ -268,7 +268,7 @@ pub fn deserialize(
             .zip(fields.iter())
             .zip(avro_schemas.iter())
         {
-            block = deserialize_item(array.as_mut(), field.is_nullable(), avro_field, block)?
+            block = deserialize_item(array.as_mut(), field.is_nullable, avro_field, block)?
         }
     }
     Chunk::try_new(arrays.iter_mut().map(|array| array.as_arc()).collect())

--- a/src/io/avro/read/schema.rs
+++ b/src/io/avro/read/schema.rs
@@ -75,7 +75,7 @@ pub fn convert_schema(schema: &AvroSchema) -> Result<Schema> {
             )))
         }
     };
-    Ok(Schema::new(schema_fields))
+    Ok(schema_fields.into())
 }
 
 fn schema_to_field(

--- a/src/io/avro/write/schema.rs
+++ b/src/io/avro/write/schema.rs
@@ -11,8 +11,8 @@ pub fn to_avro_schema(schema: &Schema) -> Result<Vec<AvroField>> {
 }
 
 fn field_to_field(field: &Field) -> Result<AvroField> {
-    let schema = type_to_schema(field.data_type(), field.is_nullable())?;
-    Ok(AvroField::new(field.name(), schema))
+    let schema = type_to_schema(field.data_type(), field.is_nullable)?;
+    Ok(AvroField::new(&field.name, schema))
 }
 
 fn type_to_schema(data_type: &DataType, is_nullable: bool) -> Result<AvroSchema> {
@@ -34,8 +34,8 @@ fn _type_to_schema(data_type: &DataType) -> Result<AvroSchema> {
         DataType::Binary => AvroSchema::Bytes(None),
         DataType::Utf8 => AvroSchema::String(None),
         DataType::List(inner) => AvroSchema::Array(Box::new(type_to_schema(
-            inner.data_type(),
-            inner.is_nullable(),
+            &inner.data_type,
+            inner.is_nullable,
         )?)),
         DataType::Date32 => AvroSchema::Int(Some(IntLogical::Date)),
         DataType::Time32(TimeUnit::Millisecond) => AvroSchema::Int(Some(IntLogical::Time)),

--- a/src/io/csv/read/infer_schema.rs
+++ b/src/io/csv/read/infer_schema.rs
@@ -3,20 +3,20 @@ use std::{
     io::{Read, Seek},
 };
 
-use crate::datatypes::{DataType, Schema};
+use crate::datatypes::{DataType, Field};
 use crate::error::Result;
 
 use super::super::utils::merge_schema;
 use super::{ByteRecord, Reader};
 
-/// Infers a [`Schema`] of a CSV file by reading through the first n records up to `max_rows`.
+/// Infers the [`Field`]s of a CSV file by reading through the first n records up to `max_rows`.
 /// Seeks back to the begining of the file _after_ the header
 pub fn infer_schema<R: Read + Seek, F: Fn(&[u8]) -> DataType>(
     reader: &mut Reader<R>,
     max_rows: Option<usize>,
     has_header: bool,
     infer: &F,
-) -> Result<Schema> {
+) -> Result<Vec<Field>> {
     // get or create header names
     // when has_header is false, creates default column names with column_ prefix
     let headers: Vec<String> = if has_header {
@@ -57,5 +57,5 @@ pub fn infer_schema<R: Read + Seek, F: Fn(&[u8]) -> DataType>(
     // return the reader seek back to the start
     reader.seek(position)?;
 
-    Ok(Schema::new(fields))
+    Ok(fields)
 }

--- a/src/io/csv/read_async/infer_schema.rs
+++ b/src/io/csv/read_async/infer_schema.rs
@@ -2,20 +2,20 @@ use std::collections::HashSet;
 
 use super::{AsyncReader, ByteRecord};
 
-use crate::datatypes::{DataType, Schema};
+use crate::datatypes::{DataType, Field};
 use crate::error::Result;
 use crate::io::csv::utils::merge_schema;
 
 use futures::{AsyncRead, AsyncSeek};
 
-/// Infers a [`Schema`] of a CSV file by reading through the first n records up to `max_rows`.
-/// Seeks back to the begining of the file _after_ the header.
+/// Infers the [`Field`]s of a CSV file by reading through the first n records up to `max_rows`.
+/// Seeks back to the begining of the file _after_ the header
 pub async fn infer_schema<R, F>(
     reader: &mut AsyncReader<R>,
     max_rows: Option<usize>,
     has_header: bool,
     infer: &F,
-) -> Result<Schema>
+) -> Result<Vec<Field>>
 where
     R: AsyncRead + AsyncSeek + Unpin + Send + Sync,
     F: Fn(&[u8]) -> DataType,
@@ -65,5 +65,5 @@ where
     // return the reader seek back to the start
     reader.seek(position).await?;
 
-    Ok(Schema::new(fields))
+    Ok(fields)
 }

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -41,7 +41,7 @@
 //! let mut file = File::create(&path)?;
 //! let x_coord = Field::new("x", DataType::Int32, false);
 //! let y_coord = Field::new("y", DataType::Int32, false);
-//! let schema = Schema::new(vec![x_coord, y_coord]);
+//! let schema = Schema::from(vec![x_coord, y_coord]);
 //! let options = WriteOptions {compression: None};
 //! let mut writer = FileWriter::try_new(file, &schema, None, options)?;
 //!

--- a/src/io/ipc/read/common.rs
+++ b/src/io/ipc/read/common.rs
@@ -118,7 +118,7 @@ pub fn read_record_batch<R: Read + Seek>(
                     version,
                 )?)),
                 ProjectionResult::NotSelected((field, _)) => {
-                    skip(&mut field_nodes, field.data_type(), &mut buffers)?;
+                    skip(&mut field_nodes, &field.data_type, &mut buffers)?;
                     Ok(None)
                 }
             })
@@ -223,7 +223,7 @@ pub fn read_dictionary<R: Read + Seek>(
     // As the dictionary batch does not contain the type of the
     // values array, we need to retrieve this from the schema.
     // Get an array representing this dictionary's values.
-    let dictionary_values: ArrayRef = match first_field.data_type() {
+    let dictionary_values: ArrayRef = match &first_field.data_type {
         DataType::Dictionary(_, ref value_type, _) => {
             // Make a fake schema for the dictionary batch.
             let fields = vec![Field::new("", value_type.as_ref().clone(), false)];

--- a/src/io/ipc/read/deserialize.rs
+++ b/src/io/ipc/read/deserialize.rs
@@ -30,7 +30,7 @@ pub fn read<R: Read + Seek>(
     version: MetadataVersion,
 ) -> Result<Arc<dyn Array>> {
     use PhysicalType::*;
-    let data_type = field.data_type().clone();
+    let data_type = field.data_type.clone();
 
     match data_type.to_physical_type() {
         Null => read_null(field_nodes, data_type).map(|x| Arc::new(x) as Arc<dyn Array>),

--- a/src/io/ipc/read/stream.rs
+++ b/src/io/ipc/read/stream.rs
@@ -155,7 +155,7 @@ fn read_next<R: Read>(
 
             read_record_batch(
                 batch,
-                metadata.schema.fields(),
+                &metadata.schema.fields,
                 &metadata.ipc_schema,
                 None,
                 dictionaries,
@@ -177,7 +177,7 @@ fn read_next<R: Read>(
 
             read_dictionary(
                 batch,
-                metadata.schema.fields(),
+                &metadata.schema.fields,
                 &metadata.ipc_schema,
                 dictionaries,
                 &mut dict_reader,

--- a/src/io/ipc/write/schema.rs
+++ b/src/io/ipc/write/schema.rs
@@ -38,14 +38,14 @@ pub fn schema_to_fb_offset<'a>(
     ipc_fields: &[IpcField],
 ) -> WIPOffset<ipc::Schema<'a>> {
     let fields = schema
-        .fields()
+        .fields
         .iter()
         .zip(ipc_fields.iter())
         .map(|(field, ipc_field)| build_field(fbb, field, ipc_field))
         .collect::<Vec<_>>();
 
     let mut custom_metadata = vec![];
-    for (k, v) in schema.metadata() {
+    for (k, v) in &schema.metadata {
         let fb_key_name = fbb.create_string(k.as_str());
         let fb_val_name = fbb.create_string(v.as_str());
 
@@ -126,8 +126,8 @@ pub(crate) fn build_field<'a>(
         write_extension(fbb, name, metadata, &mut kv_vec);
     }
 
-    let fb_field_name = fbb.create_string(field.name().as_str());
-    let field_type = get_fb_field_type(field.data_type(), ipc_field, field.is_nullable(), fbb);
+    let fb_field_name = fbb.create_string(field.name.as_str());
+    let field_type = get_fb_field_type(field.data_type(), ipc_field, field.is_nullable, fbb);
 
     let fb_dictionary =
         if let DataType::Dictionary(index_type, inner, is_ordered) = field.data_type() {
@@ -146,7 +146,7 @@ pub(crate) fn build_field<'a>(
             None
         };
 
-    write_metadata(fbb, field.metadata(), &mut kv_vec);
+    write_metadata(fbb, &field.metadata, &mut kv_vec);
 
     let fb_metadata = if !kv_vec.is_empty() {
         Some(fbb.create_vector(&kv_vec))
@@ -160,7 +160,7 @@ pub(crate) fn build_field<'a>(
         field_builder.add_dictionary(dictionary)
     }
     field_builder.add_type_type(field_type.type_type);
-    field_builder.add_nullable(field.is_nullable());
+    field_builder.add_nullable(field.is_nullable);
     match field_type.children {
         None => {}
         Some(children) => field_builder.add_children(children),

--- a/src/io/ipc/write/stream_async.rs
+++ b/src/io/ipc/write/stream_async.rs
@@ -45,7 +45,7 @@ impl<W: AsyncWrite + Unpin + Send> StreamWriter<W> {
                 arrow_data: vec![],
             }
         } else {
-            let ipc_fields = default_ipc_fields(schema.fields());
+            let ipc_fields = default_ipc_fields(&schema.fields);
             EncodedData {
                 ipc_message: schema_to_bytes(schema, &ipc_fields),
                 arrow_data: vec![],
@@ -77,7 +77,7 @@ impl<W: AsyncWrite + Unpin + Send> StreamWriter<W> {
                 &self.write_options,
             )?
         } else {
-            let ipc_fields = default_ipc_fields(schema.fields());
+            let ipc_fields = default_ipc_fields(&schema.fields);
             encode_chunk(
                 columns,
                 &ipc_fields,

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -54,7 +54,7 @@ impl<W: Write> FileWriter<W> {
         let ipc_fields = if let Some(ipc_fields) = ipc_fields {
             ipc_fields
         } else {
-            default_ipc_fields(schema.fields())
+            default_ipc_fields(&schema.fields)
         };
         let encoded_message = EncodedData {
             ipc_message: schema_to_bytes(schema, &ipc_fields),

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -144,7 +144,7 @@ fn deserialize_struct<A: Borrow<Value>>(rows: &[A], data_type: DataType) -> Stru
 
     let mut values = fields
         .iter()
-        .map(|f| (f.name(), (f.data_type(), vec![])))
+        .map(|f| (&f.name, (f.data_type(), vec![])))
         .collect::<HashMap<_, _>>();
 
     rows.iter().for_each(|row| {

--- a/src/io/json/write/serialize.rs
+++ b/src/io/json/write/serialize.rs
@@ -72,7 +72,7 @@ fn struct_serializer<'a>(
         .map(|x| x.as_ref())
         .map(new_serializer)
         .collect::<Vec<_>>();
-    let names = array.fields().iter().map(|f| f.name().as_str());
+    let names = array.fields().iter().map(|f| f.name.as_str());
 
     Box::new(BufStreamingIterator::new(
         zip_validity(0..array.len(), array.validity().map(|x| x.iter())),

--- a/src/io/json_integration/read/array.rs
+++ b/src/io/json_integration/read/array.rs
@@ -417,7 +417,7 @@ pub fn deserialize_chunk(
     json_dictionaries: &HashMap<i64, ArrowJsonDictionaryBatch>,
 ) -> Result<Chunk<Arc<dyn Array>>> {
     let arrays = schema
-        .fields()
+        .fields
         .iter()
         .zip(&json_batch.columns)
         .zip(ipc_fields.iter())

--- a/src/io/json_integration/write/schema.rs
+++ b/src/io/json_integration/write/schema.rs
@@ -108,7 +108,7 @@ fn serialize_field(field: &Field, ipc_field: &IpcField) -> ArrowJsonField {
         }
         _ => vec![],
     };
-    let metadata = serialize_metadata(field.metadata());
+    let metadata = serialize_metadata(&field.metadata);
 
     let dictionary = if let DataType::Dictionary(key_type, _, is_ordered) = field.data_type() {
         use crate::datatypes::IntegerType::*;
@@ -134,9 +134,9 @@ fn serialize_field(field: &Field, ipc_field: &IpcField) -> ArrowJsonField {
     };
 
     ArrowJsonField {
-        name: field.name().to_string(),
+        name: field.name.clone(),
         field_type: serialize_data_type(field.data_type()),
-        nullable: field.is_nullable(),
+        nullable: field.is_nullable,
         children,
         dictionary,
         metadata,

--- a/src/io/parquet/read/nested_utils.rs
+++ b/src/io/parquet/read/nested_utils.rs
@@ -213,7 +213,7 @@ pub fn extend_offsets<R, D>(
 }
 
 pub fn init_nested(field: &Field, capacity: usize, container: &mut Vec<Box<dyn Nested>>) {
-    let is_nullable = field.is_nullable();
+    let is_nullable = field.is_nullable;
 
     use crate::datatypes::PhysicalType::*;
     match field.data_type().to_physical_type() {

--- a/src/io/parquet/read/record_batch.rs
+++ b/src/io/parquet/read/record_batch.rs
@@ -111,7 +111,7 @@ impl<R: Read + Seek> Iterator for RecordReader<R> {
     type Item = Result<Chunk<Arc<dyn Array>>>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.schema.fields().is_empty() {
+        if self.schema.fields.is_empty() {
             return None;
         }
         if self.current_group == self.metadata.row_groups.len() {
@@ -138,8 +138,8 @@ impl<R: Read + Seek> Iterator for RecordReader<R> {
         let b1 = std::mem::take(&mut self.buffer);
         let b2 = std::mem::take(&mut self.decompress_buffer);
 
-        let a = schema.fields().iter().enumerate().try_fold(
-            (b1, b2, Vec::with_capacity(schema.fields().len())),
+        let a = schema.fields.iter().enumerate().try_fold(
+            (b1, b2, Vec::with_capacity(schema.fields.len())),
             |(b1, b2, mut columns), (field_index, field)| {
                 let field_index = self.indices[field_index]; // project into the original schema
                 let column_iter = get_column_iterator(

--- a/src/io/parquet/read/schema/convert.rs
+++ b/src/io/parquet/read/schema/convert.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 // Convert a parquet schema into Arrow schema
 use parquet2::{
     metadata::{KeyValue, SchemaDescriptor},
@@ -12,31 +10,26 @@ use parquet2::{
     },
 };
 
-use crate::datatypes::{DataType, Field, IntervalUnit, Schema, TimeUnit};
+use crate::datatypes::{DataType, Field, IntervalUnit, Metadata, Schema, TimeUnit};
 use crate::error::{ArrowError, Result};
 
-fn parse_key_value_metadata(
-    key_value_metadata: &Option<Vec<KeyValue>>,
-) -> Option<HashMap<String, String>> {
-    match key_value_metadata {
-        Some(key_values) => {
-            let map: HashMap<String, String> = key_values
-                .iter()
-                .filter_map(|kv| {
-                    kv.value
-                        .as_ref()
-                        .map(|value| (kv.key.clone(), value.clone()))
-                })
-                .collect();
+fn parse_key_value_metadata(key_value_metadata: &Option<Vec<KeyValue>>) -> Option<Metadata> {
+    key_value_metadata.as_ref().and_then(|key_values| {
+        let map: Metadata = key_values
+            .iter()
+            .filter_map(|kv| {
+                kv.value
+                    .as_ref()
+                    .map(|value| (kv.key.clone(), value.clone()))
+            })
+            .collect();
 
-            if map.is_empty() {
-                None
-            } else {
-                Some(map)
-            }
+        if map.is_empty() {
+            None
+        } else {
+            Some(map)
         }
-        None => None,
-    }
+    })
 }
 
 /// Convert parquet schema to arrow schema
@@ -52,7 +45,7 @@ pub fn parquet_to_arrow_schema(
         .map(to_field)
         .filter_map(|x| x.transpose())
         .collect::<Result<Vec<_>>>()
-        .map(|fields| Schema::new_from(fields, metadata))
+        .map(|fields| Schema { fields, metadata })
 }
 
 pub fn from_int32(
@@ -477,7 +470,7 @@ mod tests {
         let parquet_schema = SchemaDescriptor::try_from_message(message)?;
         let converted_arrow_schema = parquet_to_arrow_schema(&parquet_schema, &None)?;
 
-        assert_eq!(converted_arrow_schema.fields(), &expected);
+        assert_eq!(converted_arrow_schema.fields, expected);
         Ok(())
     }
 
@@ -497,7 +490,7 @@ mod tests {
         let parquet_schema = SchemaDescriptor::try_from_message(message)?;
         let converted_arrow_schema = parquet_to_arrow_schema(&parquet_schema, &None)?;
 
-        assert_eq!(converted_arrow_schema.fields(), &expected);
+        assert_eq!(converted_arrow_schema.fields, expected);
         Ok(())
     }
 
@@ -517,7 +510,7 @@ mod tests {
         let parquet_schema = SchemaDescriptor::try_from_message(message)?;
         let converted_arrow_schema = parquet_to_arrow_schema(&parquet_schema, &None)?;
 
-        assert_eq!(converted_arrow_schema.fields(), &expected);
+        assert_eq!(converted_arrow_schema.fields, expected);
         Ok(())
     }
 
@@ -716,12 +709,7 @@ mod tests {
         let parquet_schema = SchemaDescriptor::try_from_message(message_type)?;
         let converted_arrow_schema = parquet_to_arrow_schema(&parquet_schema, &None)?;
 
-        let converted_fields = converted_arrow_schema.fields();
-
-        assert_eq!(arrow_fields.len(), converted_fields.len());
-        for i in 0..arrow_fields.len() {
-            assert_eq!(arrow_fields[i], converted_fields[i]);
-        }
+        assert_eq!(arrow_fields, converted_arrow_schema.fields);
         Ok(())
     }
 
@@ -794,12 +782,7 @@ mod tests {
         let parquet_schema = SchemaDescriptor::try_from_message(message_type)?;
         let converted_arrow_schema = parquet_to_arrow_schema(&parquet_schema, &None)?;
 
-        let converted_fields = converted_arrow_schema.fields();
-
-        assert_eq!(arrow_fields.len(), converted_fields.len());
-        for i in 0..arrow_fields.len() {
-            assert_eq!(arrow_fields[i], converted_fields[i]);
-        }
+        assert_eq!(arrow_fields, converted_arrow_schema.fields);
         Ok(())
     }
 
@@ -831,12 +814,7 @@ mod tests {
         let parquet_schema = SchemaDescriptor::try_from_message(message_type)?;
         let converted_arrow_schema = parquet_to_arrow_schema(&parquet_schema, &None)?;
 
-        let converted_fields = converted_arrow_schema.fields();
-
-        assert_eq!(arrow_fields.len(), converted_fields.len());
-        for i in 0..arrow_fields.len() {
-            assert_eq!(arrow_fields[i], converted_fields[i]);
-        }
+        assert_eq!(arrow_fields, converted_arrow_schema.fields);
         Ok(())
     }
 
@@ -886,12 +864,7 @@ mod tests {
         let parquet_schema = SchemaDescriptor::try_from_message(message_type)?;
         let converted_arrow_schema = parquet_to_arrow_schema(&parquet_schema, &None)?;
 
-        let converted_fields = converted_arrow_schema.fields();
-
-        assert_eq!(arrow_fields.len(), converted_fields.len());
-        for i in 0..arrow_fields.len() {
-            assert_eq!(arrow_fields[i], converted_fields[i]);
-        }
+        assert_eq!(arrow_fields, converted_arrow_schema.fields);
         Ok(())
     }
 
@@ -959,12 +932,7 @@ mod tests {
         let parquet_schema = SchemaDescriptor::try_from_message(message_type)?;
         let converted_arrow_schema = parquet_to_arrow_schema(&parquet_schema, &None)?;
 
-        let converted_fields = converted_arrow_schema.fields();
-
-        assert_eq!(arrow_fields.len(), converted_fields.len());
-        for i in 0..arrow_fields.len() {
-            assert_eq!(arrow_fields[i], converted_fields[i]);
-        }
+        assert_eq!(arrow_fields, converted_arrow_schema.fields);
         Ok(())
     }
 
@@ -1059,12 +1027,7 @@ mod tests {
         let parquet_schema = SchemaDescriptor::try_from_message(message_type)?;
         let converted_arrow_schema = parquet_to_arrow_schema(&parquet_schema, &None)?;
 
-        let converted_fields = converted_arrow_schema.fields();
-
-        assert_eq!(arrow_fields.len(), converted_fields.len());
-        for i in 0..arrow_fields.len() {
-            assert_eq!(arrow_fields[i], converted_fields[i]);
-        }
+        assert_eq!(arrow_fields, converted_arrow_schema.fields);
         Ok(())
     }
 
@@ -1085,10 +1048,10 @@ mod tests {
         let converted_arrow_schema =
             parquet_to_arrow_schema(&parquet_schema, &Some(key_value_metadata))?;
 
-        let mut expected_metadata: HashMap<String, String> = HashMap::new();
+        let mut expected_metadata = Metadata::new();
         expected_metadata.insert("foo".to_owned(), "bar".to_owned());
 
-        assert_eq!(converted_arrow_schema.metadata(), &expected_metadata);
+        assert_eq!(converted_arrow_schema.metadata, expected_metadata);
         Ok(())
     }
 }

--- a/src/io/parquet/read/schema/metadata.rs
+++ b/src/io/parquet/read/schema/metadata.rs
@@ -111,9 +111,9 @@ mod tests {
         let schema = read_schema("fixtures/pyarrow3/v1/basic_nullable_10.parquet")?;
         let names = schema
             .unwrap()
-            .fields()
+            .fields
             .iter()
-            .map(|x| x.name().clone())
+            .map(|x| x.name.clone())
             .collect::<Vec<_>>();
         assert_eq!(
             names,

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -54,7 +54,7 @@ pub(self) fn decimal_length_from_precision(precision: usize) -> usize {
 /// Creates a parquet [`SchemaDescriptor`] from a [`Schema`].
 pub fn to_parquet_schema(schema: &Schema) -> Result<SchemaDescriptor> {
     let parquet_types = schema
-        .fields()
+        .fields
         .iter()
         .map(to_parquet_type)
         .collect::<Result<Vec<_>>>()?;

--- a/src/io/parquet/write/record_batch.rs
+++ b/src/io/parquet/write/record_batch.rs
@@ -30,7 +30,7 @@ impl<A: AsRef<dyn Array> + 'static, I: Iterator<Item = Result<Chunk<A>>>> RowGro
         options: WriteOptions,
         encodings: Vec<Encoding>,
     ) -> Result<Self> {
-        assert_eq!(schema.fields().len(), encodings.len());
+        assert_eq!(schema.fields.len(), encodings.len());
 
         let parquet_schema = to_parquet_schema(schema)?;
 

--- a/src/io/parquet/write/schema.rs
+++ b/src/io/parquet/write/schema.rs
@@ -20,7 +20,7 @@ use crate::{
 use super::super::ARROW_SCHEMA_META_KEY;
 
 pub fn schema_to_metadata_key(schema: &Schema) -> KeyValue {
-    let serialized_schema = schema_to_bytes(schema, &default_ipc_fields(schema.fields()));
+    let serialized_schema = schema_to_bytes(schema, &default_ipc_fields(&schema.fields));
 
     // manually prepending the length to the schema as arrow uses the legacy IPC format
     // TODO: change after addressing ARROW-9777
@@ -40,8 +40,8 @@ pub fn schema_to_metadata_key(schema: &Schema) -> KeyValue {
 
 /// Creates a [`ParquetType`] from a [`Field`].
 pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
-    let name = field.name().clone();
-    let repetition = if field.is_nullable() {
+    let name = field.name.clone();
+    let repetition = if field.is_nullable {
         Repetition::Optional
     } else {
         Repetition::Required
@@ -279,7 +279,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             )?)
         }
         DataType::Dictionary(_, value, _) => {
-            let dict_field = Field::new(name.as_str(), value.as_ref().clone(), field.is_nullable());
+            let dict_field = Field::new(name.as_str(), value.as_ref().clone(), field.is_nullable);
             to_parquet_type(&dict_field)
         }
         DataType::FixedSizeBinary(size) => Ok(ParquetType::try_from_primitive(

--- a/tests/it/io/avro/read.rs
+++ b/tests/it/io/avro/read.rs
@@ -45,7 +45,7 @@ pub(super) fn schema() -> (AvroSchema, Schema) {
     }
 "#;
 
-    let schema = Schema::new(vec![
+    let schema = Schema::from(vec![
         Field::new("a", DataType::Int64, false),
         Field::new("b", DataType::Utf8, false),
         Field::new("c", DataType::Int32, false),

--- a/tests/it/io/avro/write.rs
+++ b/tests/it/io/avro/write.rs
@@ -7,7 +7,7 @@ use arrow2::error::Result;
 use arrow2::io::avro::write;
 
 fn schema() -> Schema {
-    Schema::new(vec![
+    Schema::from(vec![
         Field::new("a", DataType::Int64, false),
         Field::new("b", DataType::Utf8, false),
         Field::new("c", DataType::Int32, false),

--- a/tests/it/io/csv/read.rs
+++ b/tests/it/io/csv/read.rs
@@ -27,18 +27,12 @@ fn read() -> Result<()> {
 "Aberdeen, Aberdeen City, UK",57.149651,-2.099075"#;
     let mut reader = ReaderBuilder::new().from_reader(Cursor::new(data));
 
-    let schema = Arc::new(infer_schema(&mut reader, None, true, &infer)?);
+    let fields = infer_schema(&mut reader, None, true, &infer)?;
 
     let mut rows = vec![ByteRecord::default(); 100];
     let rows_read = read_rows(&mut reader, 0, &mut rows)?;
 
-    let columns = deserialize_batch(
-        &rows[..rows_read],
-        schema.fields(),
-        None,
-        0,
-        deserialize_column,
-    )?;
+    let columns = deserialize_batch(&rows[..rows_read], &fields, None, 0, deserialize_column)?;
 
     assert_eq!(14, columns.len());
     assert_eq!(3, columns.arrays().len());
@@ -64,15 +58,15 @@ fn infer_basics() -> Result<()> {
     let file = Cursor::new("1,2,3\na,b,c\na,,c");
     let mut reader = ReaderBuilder::new().from_reader(file);
 
-    let schema = infer_schema(&mut reader, Some(10), false, &infer)?;
+    let fields = infer_schema(&mut reader, Some(10), false, &infer)?;
 
     assert_eq!(
-        schema,
-        Schema::new(vec![
+        fields,
+        vec![
             Field::new("column_1", DataType::Utf8, true),
             Field::new("column_2", DataType::Utf8, true),
             Field::new("column_3", DataType::Utf8, true),
-        ])
+        ]
     );
     Ok(())
 }
@@ -82,15 +76,15 @@ fn infer_ints() -> Result<()> {
     let file = Cursor::new("1,2,3\n1,a,5\n2,,4");
     let mut reader = ReaderBuilder::new().from_reader(file);
 
-    let schema = infer_schema(&mut reader, Some(10), false, &infer)?;
+    let fields = infer_schema(&mut reader, Some(10), false, &infer)?;
 
     assert_eq!(
-        schema,
-        Schema::new(vec![
+        fields,
+        vec![
             Field::new("column_1", DataType::Int64, true),
             Field::new("column_2", DataType::Utf8, true),
             Field::new("column_3", DataType::Int64, true),
-        ])
+        ]
     );
     Ok(())
 }

--- a/tests/it/io/csv/read_async.rs
+++ b/tests/it/io/csv/read_async.rs
@@ -23,18 +23,12 @@ async fn read() -> Result<()> {
 "Aberdeen, Aberdeen City, UK",57.149651,-2.099075"#;
     let mut reader = AsyncReaderBuilder::new().create_reader(Cursor::new(data.as_bytes()));
 
-    let schema = infer_schema(&mut reader, None, true, &infer).await?;
+    let fields = infer_schema(&mut reader, None, true, &infer).await?;
 
     let mut rows = vec![ByteRecord::default(); 100];
     let rows_read = read_rows(&mut reader, 0, &mut rows).await?;
 
-    let columns = deserialize_batch(
-        &rows[..rows_read],
-        schema.fields(),
-        None,
-        0,
-        deserialize_column,
-    )?;
+    let columns = deserialize_batch(&rows[..rows_read], &fields, None, 0, deserialize_column)?;
 
     assert_eq!(14, columns.len());
     assert_eq!(3, columns.arrays().len());

--- a/tests/it/io/ipc/read/file.rs
+++ b/tests/it/io/ipc/read/file.rs
@@ -165,7 +165,7 @@ fn test_projection(version: &str, file_name: &str, column: usize) -> Result<()> 
     let metadata = read_file_metadata(&mut file)?;
     let mut reader = FileReader::new(&mut file, metadata, Some(vec![column]));
 
-    assert_eq!(reader.schema().fields().len(), 1);
+    assert_eq!(reader.schema().fields.len(), 1);
 
     reader.try_for_each(|rhs| {
         assert_eq!(rhs?.arrays().len(), 1);

--- a/tests/it/io/ipc/write/file.rs
+++ b/tests/it/io/ipc/write/file.rs
@@ -338,7 +338,7 @@ fn write_boolean() -> Result<()> {
         None,
         Some(true),
     ])) as Arc<dyn Array>;
-    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
+    let schema = Schema::from(vec![Field::new("a", array.data_type().clone(), true)]);
     let columns = Chunk::try_new(vec![array])?;
     round_trip(columns, schema, None)
 }
@@ -348,7 +348,7 @@ fn write_boolean() -> Result<()> {
 fn write_sliced_utf8() -> Result<()> {
     use std::sync::Arc;
     let array = Arc::new(Utf8Array::<i32>::from_slice(["aa", "bb"]).slice(1, 1)) as Arc<dyn Array>;
-    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
+    let schema = Schema::from(vec![Field::new("a", array.data_type().clone(), true)]);
     let columns = Chunk::try_new(vec![array])?;
     round_trip(columns, schema, None)
 }
@@ -366,7 +366,7 @@ fn write_sliced_list() -> Result<()> {
     array.try_extend(data).unwrap();
     let array: Arc<dyn Array> = array.into_arc().slice(1, 2).into();
 
-    let schema = Schema::new(vec![Field::new("a", array.data_type().clone(), true)]);
+    let schema = Schema::from(vec![Field::new("a", array.data_type().clone(), true)]);
     let columns = Chunk::try_new(vec![array])?;
     round_trip(columns, schema, None)
 }

--- a/tests/it/io/json/mod.rs
+++ b/tests/it/io/json/mod.rs
@@ -43,7 +43,7 @@ fn round_trip(data: String) -> Result<()> {
 
     let buf = write_batch(
         columns.clone(),
-        fields.iter().map(|x| x.name().to_string()).collect(),
+        fields.iter().map(|x| x.name.clone()).collect(),
         json_write::LineDelimited::default(),
     )?;
 
@@ -72,7 +72,7 @@ fn case_list() -> (String, Schema, Vec<Box<dyn Array>>) {
             "#
     .to_string();
 
-    let schema = Schema::new(vec![
+    let schema = Schema::from(vec![
         Field::new("a", DataType::Int64, true),
         Field::new(
             "b",
@@ -133,7 +133,7 @@ fn case_dict() -> (String, Schema, Vec<Box<dyn Array>>) {
         true,
     )));
 
-    let schema = Schema::new(vec![Field::new("events", data_type, true)]);
+    let schema = Schema::from(vec![Field::new("events", data_type, true)]);
 
     type A = MutableDictionaryArray<u64, MutableUtf8Array<i32>>;
 
@@ -163,7 +163,7 @@ fn case_basics() -> (String, Schema, Vec<Box<dyn Array>>) {
     {"a":-10, "b":-3.5, "c":true, "d":null}
     {"a":100000000, "b":0.6, "d":"text"}"#
         .to_string();
-    let schema = Schema::new(vec![
+    let schema = Schema::from(vec![
         Field::new("a", DataType::Int64, true),
         Field::new("b", DataType::Float64, true),
         Field::new("c", DataType::Boolean, true),
@@ -183,7 +183,7 @@ fn case_basics_schema() -> (String, Schema, Vec<Box<dyn Array>>) {
     {"a":10, "b":-3.5, "c":true, "d":null, "e":"text"}
     {"a":100000000, "b":0.6, "d":"text"}"#
         .to_string();
-    let schema = Schema::new(vec![
+    let schema = Schema::from(vec![
         Field::new("a", DataType::UInt32, true),
         Field::new("b", DataType::Float32, true),
         Field::new("c", DataType::Boolean, true),
@@ -220,7 +220,7 @@ fn case_struct() -> (String, Schema, Vec<Box<dyn Array>>) {
         ]),
         true,
     );
-    let schema = Schema::new(vec![a_field]);
+    let schema = Schema::from(vec![a_field]);
 
     // build expected output
     let d = Utf8Array::<i32>::from(&vec![Some("text"), None, Some("text"), None]);

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -716,7 +716,7 @@ fn arrow_type() -> Result<()> {
     let dt1 = DataType::Duration(TimeUnit::Second);
     let array = PrimitiveArray::<i64>::from([Some(1), None, Some(2)]).to(dt1.clone());
     let array2 = Utf8Array::<i64>::from([Some("a"), None, Some("bb")]);
-    let schema = Schema::new(vec![
+    let schema = Schema::from(vec![
         Field::new("a1", dt1, true),
         Field::new("a2", array2.data_type().clone(), true),
     ]);

--- a/tests/it/io/parquet/write.rs
+++ b/tests/it/io/parquet/write.rs
@@ -32,7 +32,7 @@ fn round_trip(
     let array: Arc<dyn Array> = array.into();
 
     let field = Field::new("a1", array.data_type().clone(), nullable);
-    let schema = Schema::new(vec![field]);
+    let schema = Schema::from(vec![field]);
 
     let options = WriteOptions {
         write_statistics: true,


### PR DESCRIPTION
* `Schema` no longer has its accessors, since all its attributes are public.
* `Field` lost most of its accessors, since all its attributes are public.
* `merge_field`, `merge_datatypes`, `merge_schema` was removed, since whether two fields or schemas can be merged is highly context dependent and can't be easily decided here
