### PR TITLE
Parquet: add as_any and null_count to dyn Statistics

### DIFF
--- a/src/io/parquet/read/statistics/binary.rs
+++ b/src/io/parquet/read/statistics/binary.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::convert::TryFrom;
 
 use crate::datatypes::DataType;
@@ -19,6 +20,14 @@ pub struct BinaryStatistics {
 impl Statistics for BinaryStatistics {
     fn data_type(&self) -> &DataType {
         &DataType::Binary
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn null_count(&self) -> Option<i64> {
+        self.null_count
     }
 }
 
@@ -44,6 +53,14 @@ pub struct Utf8Statistics {
 impl Statistics for Utf8Statistics {
     fn data_type(&self) -> &DataType {
         &DataType::Utf8
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn null_count(&self) -> Option<i64> {
+        self.null_count
     }
 }
 

--- a/src/io/parquet/read/statistics/boolean.rs
+++ b/src/io/parquet/read/statistics/boolean.rs
@@ -1,5 +1,6 @@
 use crate::datatypes::DataType;
 use parquet2::statistics::BooleanStatistics as ParquetBooleanStatistics;
+use std::any::Any;
 
 use super::Statistics;
 
@@ -14,6 +15,14 @@ pub struct BooleanStatistics {
 impl Statistics for BooleanStatistics {
     fn data_type(&self) -> &DataType {
         &DataType::Boolean
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn null_count(&self) -> Option<i64> {
+        self.null_count
     }
 }
 

--- a/src/io/parquet/read/statistics/fixlen.rs
+++ b/src/io/parquet/read/statistics/fixlen.rs
@@ -1,3 +1,4 @@
+use std::any::Any;
 use std::convert::{TryFrom, TryInto};
 
 use super::super::schema;
@@ -26,6 +27,14 @@ pub struct FixedLenStatistics {
 impl Statistics for FixedLenStatistics {
     fn data_type(&self) -> &DataType {
         &self.data_type
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn null_count(&self) -> Option<i64> {
+        self.null_count
     }
 }
 

--- a/src/io/parquet/read/statistics/mod.rs
+++ b/src/io/parquet/read/statistics/mod.rs
@@ -4,6 +4,7 @@ use crate::error::ArrowError;
 use parquet2::schema::types::PhysicalType;
 use parquet2::statistics::PrimitiveStatistics as ParquetPrimitiveStatistics;
 use parquet2::statistics::Statistics as ParquetStatistics;
+use std::any::Any;
 
 use crate::error::Result;
 
@@ -20,6 +21,12 @@ pub use fixlen::*;
 pub trait Statistics: std::fmt::Debug {
     /// returns the [`DataType`] of the statistics.
     fn data_type(&self) -> &DataType;
+
+    /// Returns `dyn Any` can used to downcast to a physical type.
+    fn as_any(&self) -> &dyn Any;
+
+    /// Return the null count statistic
+    fn null_count(&self) -> Option<i64>;
 }
 
 impl PartialEq for &dyn Statistics {

--- a/src/io/parquet/read/statistics/primitive.rs
+++ b/src/io/parquet/read/statistics/primitive.rs
@@ -2,6 +2,7 @@ use crate::{datatypes::DataType, types::NativeType};
 use parquet2::schema::types::ParquetType;
 use parquet2::statistics::PrimitiveStatistics as ParquetPrimitiveStatistics;
 use parquet2::types::NativeType as ParquetNativeType;
+use std::any::Any;
 
 use super::super::schema;
 use super::Statistics;
@@ -19,6 +20,14 @@ pub struct PrimitiveStatistics<T: NativeType> {
 impl<T: NativeType> Statistics for PrimitiveStatistics<T> {
     fn data_type(&self) -> &DataType {
         &self.data_type
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn null_count(&self) -> Option<i64> {
+        self.null_count
     }
 }
 


### PR DESCRIPTION
This adds the `as_any` method on `dyn Statistics` for parquet reading. I also added `null_count` similar to how `dyn Statistics` is defined in `parquet2`. 

I think the `distinct_count` would also be valuable on this trait.