### PR TITLE
Fallible array initialization

### DIFF
--- a/benches/iter_list.rs
+++ b/benches/iter_list.rs
@@ -14,8 +14,8 @@ fn add_benchmark(c: &mut Criterion) {
     (10..=20).step_by(2).for_each(|log2_size| {
         let size = 2usize.pow(log2_size);
 
-        let values = Buffer::from_iter(0..size as i32);
-        let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+        let values = (0..size as i32).collect();
+        let values = PrimitiveArray::<i32>::from_vec(values);
 
         let mut offsets = (0..size as i32).step_by(2).collect::<Vec<_>>();
         offsets.push(size as i32);

--- a/guide/src/high_level.md
+++ b/guide/src/high_level.md
@@ -259,7 +259,7 @@ where
     let values = Buffer::from_trusted_len_iter(values);
 
     // create the new array, cloning its validity
-    PrimitiveArray::<O>::from_data(data_type.clone(), values, array.validity().cloned())
+    PrimitiveArray::<O>::new(data_type.clone(), values, array.validity().cloned())
 }
 ```
 

--- a/src/array/README.md
+++ b/src/array/README.md
@@ -22,11 +22,11 @@ This document describes the overall design of this module.
 
 * Every child array on the struct MUST be `Arc<dyn Array>`. This enables the struct to be clonable.
 
-* An array MUST implement `from_data(...) -> Self`. This method MUST panic iff:
+* An array MUST implement `try_new(...) -> Self`. This MUST error iff:
     * the data does not follow the arrow specification
-    * the arguments lead to unsound code (e.g. a Utf8 array MUST verify that its each item is valid `utf8`)
+    * the arguments lead to unsound code (e.g. a Utf8 array MUST verify that its each items is valid `utf8`)
 
-* An array MAY implement `unsafe from_data_unchecked` that skips the soundness validation. `from_data_unchecked` MUST panic if the specification is incorrect.
+* An array MAY implement `unsafe try_new_unchecked` that skips validation that is `O(N)`. `try_new_unchecked` MUST panic if the specification is incorrect.
 
 * An array MUST implement either `new_empty()` or `new_empty(DataType)` that returns a zero-len of `Self`.
 

--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -58,8 +58,6 @@ impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryArray<O> {
         let offsets = unsafe { array.buffer::<O>(1) }?;
         let values = unsafe { array.buffer::<u8>(2) }?;
 
-        Ok(Self::from_data_unchecked(
-            data_type, offsets, values, validity,
-        ))
+        Self::try_new_unchecked(data_type, offsets, values, validity)
     }
 }

--- a/src/array/dictionary/ffi.rs
+++ b/src/array/dictionary/ffi.rs
@@ -31,7 +31,7 @@ impl<K: DictionaryKey, A: ffi::ArrowArrayRef> FromFfi<A> for DictionaryArray<K> 
         let values = unsafe { array.buffer::<K>(1) }?;
 
         let data_type = K::PRIMITIVE.into();
-        let keys = PrimitiveArray::<K>::from_data(data_type, values, validity);
+        let keys = PrimitiveArray::<K>::try_new(data_type, values, validity)?;
         let values = array.dictionary()?.unwrap();
         let values = ffi::try_from(values)?.into();
 

--- a/src/array/growable/binary.rs
+++ b/src/array/growable/binary.rs
@@ -61,7 +61,9 @@ impl<'a, O: Offset> GrowableBinary<'a, O> {
         let offsets = std::mem::take(&mut self.offsets);
         let values = std::mem::take(&mut self.values);
 
-        BinaryArray::<O>::from_data(data_type, offsets.into(), values.into(), validity.into())
+        // todo: consider using the `_unchecked` variant here.
+        BinaryArray::<O>::try_new(data_type, offsets.into(), values.into(), validity.into())
+            .expect("All invariants to be uphold by construction")
     }
 }
 
@@ -99,11 +101,13 @@ impl<'a, O: Offset> Growable<'a> for GrowableBinary<'a, O> {
 
 impl<'a, O: Offset> From<GrowableBinary<'a, O>> for BinaryArray<O> {
     fn from(val: GrowableBinary<'a, O>) -> Self {
-        BinaryArray::<O>::from_data(
+        // todo: consider using the `_unchecked` variant here.
+        BinaryArray::<O>::try_new(
             val.data_type,
             val.offsets.into(),
             val.values.into(),
             val.validity.into(),
         )
+        .expect("All invariants to be uphold by construction")
     }
 }

--- a/src/array/growable/dictionary.rs
+++ b/src/array/growable/dictionary.rs
@@ -84,7 +84,8 @@ impl<'a, T: DictionaryKey> GrowableDictionary<'a, T> {
         let values = std::mem::take(&mut self.key_values);
 
         let data_type = T::PRIMITIVE.into();
-        let keys = PrimitiveArray::<T>::from_data(data_type, values.into(), validity.into());
+        let keys = PrimitiveArray::<T>::try_new(data_type, values.into(), validity.into())
+            .expect("All invariants to be uphold");
 
         DictionaryArray::<T>::from_data(keys, self.values.clone())
     }
@@ -127,11 +128,8 @@ impl<'a, T: DictionaryKey> From<GrowableDictionary<'a, T>> for DictionaryArray<T
     #[inline]
     fn from(val: GrowableDictionary<'a, T>) -> Self {
         let data_type = T::PRIMITIVE.into();
-        let keys = PrimitiveArray::<T>::from_data(
-            data_type,
-            val.key_values.into(),
-            val.key_validity.into(),
-        );
+        let keys =
+            PrimitiveArray::<T>::new(data_type, val.key_values.into(), val.key_validity.into());
 
         DictionaryArray::<T>::from_data(keys, val.values)
     }

--- a/src/array/growable/primitive.rs
+++ b/src/array/growable/primitive.rs
@@ -62,7 +62,8 @@ impl<'a, T: NativeType> GrowablePrimitive<'a, T> {
         let validity = std::mem::take(&mut self.validity);
         let values = std::mem::take(&mut self.values);
 
-        PrimitiveArray::<T>::from_data(self.data_type.clone(), values.into(), validity.into())
+        PrimitiveArray::<T>::try_new(self.data_type.clone(), values.into(), validity.into())
+            .expect("All invariants to be uphold")
     }
 }
 
@@ -96,6 +97,6 @@ impl<'a, T: NativeType> Growable<'a> for GrowablePrimitive<'a, T> {
 impl<'a, T: NativeType> From<GrowablePrimitive<'a, T>> for PrimitiveArray<T> {
     #[inline]
     fn from(val: GrowablePrimitive<'a, T>) -> Self {
-        PrimitiveArray::<T>::from_data(val.data_type, val.values.into(), val.validity.into())
+        PrimitiveArray::<T>::new(val.data_type, val.values.into(), val.validity.into())
     }
 }

--- a/src/array/growable/utf8.rs
+++ b/src/array/growable/utf8.rs
@@ -55,13 +55,16 @@ impl<'a, O: Offset> GrowableUtf8<'a, O> {
         let offsets = std::mem::take(&mut self.offsets);
         let values = std::mem::take(&mut self.values);
 
+        // Safety
+        // [`GrowableUtf8`] fulfills all invariants of [`Utf8Array`]
         unsafe {
-            Utf8Array::<O>::from_data_unchecked(
+            Utf8Array::<O>::try_new_unchecked(
                 self.arrays[0].data_type().clone(),
                 offsets.into(),
                 values.into(),
                 validity.into(),
             )
+            .expect("All invariants to be uphold by construction")
         }
     }
 }
@@ -100,13 +103,16 @@ impl<'a, O: Offset> Growable<'a> for GrowableUtf8<'a, O> {
 
 impl<'a, O: Offset> From<GrowableUtf8<'a, O>> for Utf8Array<O> {
     fn from(val: GrowableUtf8<'a, O>) -> Self {
+        // Safety
+        // [`GrowableUtf8`] fulfills all invariants of [`Utf8Array`]
         unsafe {
-            Utf8Array::<O>::from_data_unchecked(
+            Utf8Array::<O>::try_new_unchecked(
                 val.arrays[0].data_type().clone(),
                 val.offsets.into(),
                 val.values.into(),
                 val.validity.into(),
             )
         }
+        .expect("All invariants to be uphold by construction")
     }
 }

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -54,7 +54,7 @@ impl<O: Offset> ListArray<O> {
         values: Arc<dyn Array>,
         validity: Option<Bitmap>,
     ) -> Self {
-        check_offsets(&offsets, values.len());
+        check_offsets(&offsets, values.len()).unwrap();
 
         if let Some(ref validity) = validity {
             assert_eq!(offsets.len() - 1, validity.len());

--- a/src/array/map/mod.rs
+++ b/src/array/map/mod.rs
@@ -61,7 +61,7 @@ impl MapArray {
         field: Arc<dyn Array>,
         validity: Option<Bitmap>,
     ) -> Self {
-        check_offsets(&offsets, field.len());
+        check_offsets(&offsets, field.len()).unwrap();
 
         if let Some(ref validity) = validity {
             assert_eq!(offsets.len() - 1, validity.len());

--- a/src/array/primitive/ffi.rs
+++ b/src/array/primitive/ffi.rs
@@ -55,6 +55,6 @@ impl<T: NativeType, A: ffi::ArrowArrayRef> FromFfi<A> for PrimitiveArray<T> {
         let validity = unsafe { array.validity() }?;
         let values = unsafe { array.buffer::<T>(1) }?;
 
-        Ok(Self::from_data(data_type, values, validity))
+        Self::try_new(data_type, values, validity)
     }
 }

--- a/src/array/primitive/from_natural.rs
+++ b/src/array/primitive/from_natural.rs
@@ -21,24 +21,23 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// # Implementation
     /// This does not assume that the iterator has a known length.
     pub fn from_values<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        Self::from_data(T::PRIMITIVE.into(), Vec::<T>::from_iter(iter).into(), None)
+        Self::try_new(T::PRIMITIVE.into(), Vec::<T>::from_iter(iter).into(), None)
+            .expect("All invariants to be uphold")
     }
 
     /// Creates a (non-null) [`PrimitiveArray`] from a slice of values.
     /// # Implementation
     /// This is essentially a memcopy
     pub fn from_slice<P: AsRef<[T]>>(slice: P) -> Self {
-        Self::from_data(
-            T::PRIMITIVE.into(),
-            Vec::<T>::from(slice.as_ref()).into(),
-            None,
-        )
+        Self::try_new(T::PRIMITIVE.into(), slice.as_ref().to_vec().into(), None)
+            .expect("All invariants to be uphold")
     }
 
     /// Creates a (non-null) [`PrimitiveArray`] from a vector of values.
-    /// This does not have memcopy and is the fastest way to create a [`PrimitiveArray`].
-    pub fn from_vec(array: Vec<T>) -> Self {
-        Self::from_data(T::PRIMITIVE.into(), array.into(), None)
+    /// This is `O(1)`
+    pub fn from_vec(values: Vec<T>) -> Self {
+        Self::try_new(T::PRIMITIVE.into(), values.into(), None)
+            .expect("All invariants to be uphold")
     }
 }
 

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -91,9 +91,14 @@ impl<T: NativeType> PrimitiveArray<T> {
         })
     }
 
+    /// Returns a new [`PrimitiveArray`]
+    /// # Panic
+    /// This function panics iff:
+    /// * the validity's length is not equal to `offsets.len() - 1`.
+    /// * The `data_type`'s physical type is not valid for the generic
     #[inline]
-    pub(crate) fn new(data_type: DataType, values: Buffer<T>, validity: Option<Bitmap>) -> Self {
-        Self::try_new(data_type, values, validity).expect("Reached an internal error of arrow2.")
+    pub fn new(data_type: DataType, values: Buffer<T>, validity: Option<Bitmap>) -> Self {
+        Self::try_new(data_type, values, validity).expect("Invariants of PrimitiveArray violated")
     }
 
     /// Returns a slice of this [`PrimitiveArray`].

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -28,7 +28,7 @@ impl<T: NativeType> From<MutablePrimitiveArray<T>> for PrimitiveArray<T> {
             None
         };
 
-        PrimitiveArray::<T>::from_data(other.data_type, other.values.into(), validity)
+        PrimitiveArray::<T>::new(other.data_type, other.values.into(), validity)
     }
 }
 
@@ -352,7 +352,7 @@ impl<T: NativeType> MutableArray for MutablePrimitiveArray<T> {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(PrimitiveArray::from_data(
+        Box::new(PrimitiveArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.values).into(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
@@ -360,7 +360,7 @@ impl<T: NativeType> MutableArray for MutablePrimitiveArray<T> {
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(PrimitiveArray::from_data(
+        Arc::new(PrimitiveArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.values).into(),
             std::mem::take(&mut self.validity).map(|x| x.into()),

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -1,33 +1,48 @@
-use crate::types::Offset;
+use crate::{
+    error::{ArrowError, Result},
+    types::Offset,
+};
 
-pub fn check_offsets_minimal<O: Offset>(offsets: &[O], values_len: usize) -> usize {
-    assert!(
-        !offsets.is_empty(),
-        "The length of the offset buffer must be larger than 1"
-    );
+pub fn check_offsets_minimal<O: Offset>(offsets: &[O], values_len: usize) -> Result<usize> {
+    if offsets.is_empty() {
+        return Err(ArrowError::InvalidArgumentError(
+            "The offsets of a variable-sized array must contain at least one element (usually 0)"
+                .to_string(),
+        ));
+    }
     let len = offsets.len() - 1;
 
     let last_offset = offsets[len];
     let last_offset = last_offset.to_usize();
+    if last_offset > values_len {
+        return Err(ArrowError::InvalidArgumentError(
+            "The last offset of a variable-sized array is not equal to the length of the values"
+                .to_string(),
+        ));
+    }
 
-    assert_eq!(
-        values_len, last_offset,
-        "The length of the values must be equal to the last offset value"
-    );
-    len
+    Ok(len)
 }
 
-/// # Panics iff:
-/// * the `offsets` is not monotonically increasing, or
+/// # Errors iff:
+/// * `offsets` is empty
+/// * `offsets` is not monotonically increasing, or
 /// * any slice of `values` between two consecutive pairs from `offsets` is invalid `utf8`, or
 /// * any offset is larger or equal to `values_len`.
-pub fn check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) {
+pub fn check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) -> Result<()> {
     const SIMD_CHUNK_SIZE: usize = 64;
 
     if values.is_ascii() {
-        check_offsets(offsets, values.len());
+        check_offsets(offsets, values.len())
     } else {
-        offsets.windows(2).for_each(|window| {
+        if offsets.is_empty() {
+            return Err(ArrowError::InvalidArgumentError(
+                "The offsets of a variable-sized array must contain at least one element (usually 0)"
+                    .to_string(),
+            ));
+        }
+
+        offsets.windows(2).try_for_each(|window| {
             let start = window[0].to_usize();
             let end = window[1].to_usize();
             // assert monotonicity
@@ -37,30 +52,47 @@ pub fn check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) {
 
             // Fast ASCII check per item
             if slice.len() < SIMD_CHUNK_SIZE && slice.is_ascii() {
-                return;
+                return Ok(());
             }
 
             // assert utf8
-            simdutf8::basic::from_utf8(slice).expect("A non-utf8 string was passed.");
-        });
+            simdutf8::basic::from_utf8(slice).map(|_| ()).map_err(|_| {
+                ArrowError::InvalidArgumentError("A non-utf8 string was passed.".to_string())
+            })
+        })
     }
 }
 
-/// # Panics iff:
-/// * the `offsets` is not monotonically increasing, or
+/// # Errors
+/// Iff:
+/// * `offsets` is empty
+/// * `offsets` is not monotonically increasing, or
 /// * any offset is larger or equal to `values_len`.
-pub fn check_offsets<O: Offset>(offsets: &[O], values_len: usize) {
+pub fn check_offsets<O: Offset>(offsets: &[O], values_len: usize) -> Result<()> {
     if offsets.is_empty() {
-        return;
+        return Err(ArrowError::InvalidArgumentError(
+            "The offsets of a variable-sized array must contain at least one element (usually 0)"
+                .to_string(),
+        ));
     }
 
     let mut last = offsets[0];
-    // assert monotonicity
-    assert!(offsets.iter().skip(1).all(|&end| {
+    let are_monotone = offsets.iter().skip(1).all(|&end| {
         let monotone = last <= end;
         last = end;
         monotone
-    }));
+    });
+    if !are_monotone {
+        return Err(ArrowError::InvalidArgumentError(
+            "The offsets of a variable-sized array are not monotonically increasing".to_string(),
+        ));
+    }
     // assert bounds
-    assert!(last.to_usize() <= values_len);
+    if last.to_usize() > values_len {
+        return Err(ArrowError::InvalidArgumentError(
+            "The last offset of a variable-sized array is not equal to the length of the values"
+                .to_string(),
+        ));
+    }
+    Ok(())
 }

--- a/src/array/utf8/ffi.rs
+++ b/src/array/utf8/ffi.rs
@@ -56,8 +56,6 @@ impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for Utf8Array<O> {
         let offsets = unsafe { array.buffer::<O>(1) }?;
         let values = unsafe { array.buffer::<u8>(2)? };
 
-        Ok(Self::from_data_unchecked(
-            data_type, offsets, values, validity,
-        ))
+        Self::try_new_unchecked(data_type, offsets, values, validity)
     }
 }

--- a/src/compute/arithmetics/decimal/add.rs
+++ b/src/compute/arithmetics/decimal/add.rs
@@ -225,7 +225,7 @@ pub fn adaptive_add(
 
         let validity = combine_validities(lhs.validity(), rhs.validity());
 
-        Ok(PrimitiveArray::<i128>::from_data(
+        Ok(PrimitiveArray::<i128>::new(
             DataType::Decimal(res_p, res_s),
             values,
             validity,

--- a/src/compute/arithmetics/decimal/div.rs
+++ b/src/compute/arithmetics/decimal/div.rs
@@ -290,7 +290,7 @@ pub fn adaptive_div(
 
         let validity = combine_validities(lhs.validity(), rhs.validity());
 
-        Ok(PrimitiveArray::<i128>::from_data(
+        Ok(PrimitiveArray::<i128>::new(
             DataType::Decimal(res_p, res_s),
             values,
             validity,

--- a/src/compute/arithmetics/decimal/mul.rs
+++ b/src/compute/arithmetics/decimal/mul.rs
@@ -302,7 +302,7 @@ pub fn adaptive_mul(
 
         let validity = combine_validities(lhs.validity(), rhs.validity());
 
-        Ok(PrimitiveArray::<i128>::from_data(
+        Ok(PrimitiveArray::<i128>::new(
             DataType::Decimal(res_p, res_s),
             values,
             validity,

--- a/src/compute/arithmetics/decimal/sub.rs
+++ b/src/compute/arithmetics/decimal/sub.rs
@@ -225,7 +225,7 @@ pub fn adaptive_sub(
 
         let validity = combine_validities(lhs.validity(), rhs.validity());
 
-        Ok(PrimitiveArray::<i128>::from_data(
+        Ok(PrimitiveArray::<i128>::new(
             DataType::Decimal(res_p, res_s),
             values,
             validity,

--- a/src/compute/arity.rs
+++ b/src/compute/arity.rs
@@ -29,7 +29,7 @@ where
     let values = array.values().iter().map(|v| op(*v));
     let values = Buffer::from_trusted_len_iter(values);
 
-    PrimitiveArray::<O>::from_data(data_type, values, array.validity().cloned())
+    PrimitiveArray::<O>::new(data_type, values, array.validity().cloned())
 }
 
 /// Version of unary that checks for errors in the closure used to create the
@@ -47,7 +47,7 @@ where
     let values = array.values().iter().map(|v| op(*v));
     let values = Buffer::try_from_trusted_len_iter(values)?;
 
-    Ok(PrimitiveArray::<O>::from_data(
+    Ok(PrimitiveArray::<O>::new(
         data_type,
         values,
         array.validity().cloned(),
@@ -77,7 +77,7 @@ where
     let values = Buffer::from_trusted_len_iter(values);
 
     (
-        PrimitiveArray::<O>::from_data(data_type, values, array.validity().cloned()),
+        PrimitiveArray::<O>::new(data_type, values, array.validity().cloned()),
         mut_bitmap.into(),
     )
 }
@@ -117,7 +117,7 @@ where
     let bitmap: Bitmap = mut_bitmap.into();
     let validity = combine_validities(array.validity(), Some(&bitmap));
 
-    PrimitiveArray::<O>::from_data(data_type, values, validity)
+    PrimitiveArray::<O>::new(data_type, values, validity)
 }
 
 /// Applies a binary operations to two primitive arrays. This is the fastest
@@ -156,7 +156,7 @@ where
         .map(|(l, r)| op(*l, *r));
     let values = Buffer::from_trusted_len_iter(values);
 
-    PrimitiveArray::<T>::from_data(data_type, values, validity)
+    PrimitiveArray::<T>::new(data_type, values, validity)
 }
 
 /// Version of binary that checks for errors in the closure used to create the
@@ -184,7 +184,7 @@ where
 
     let values = Buffer::try_from_trusted_len_iter(values)?;
 
-    Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
+    Ok(PrimitiveArray::<T>::new(data_type, values, validity))
 }
 
 /// Version of binary that returns an array and bitmap. Used when working with
@@ -215,7 +215,7 @@ where
     let values = Buffer::from_trusted_len_iter(values);
 
     (
-        PrimitiveArray::<T>::from_data(data_type, values, validity),
+        PrimitiveArray::<T>::new(data_type, values, validity),
         mut_bitmap.into(),
     )
 }
@@ -264,5 +264,5 @@ where
     // as Null
     let validity = combine_validities(validity.as_ref(), Some(&bitmap));
 
-    PrimitiveArray::<T>::from_data(data_type, values, validity)
+    PrimitiveArray::<T>::new(data_type, values, validity)
 }

--- a/src/compute/cast/binary_to.rs
+++ b/src/compute/cast/binary_to.rs
@@ -10,7 +10,9 @@ pub fn binary_to_large_binary(from: &BinaryArray<i32>, to_data_type: DataType) -
     let values = from.values().clone();
     let offsets = from.offsets().iter().map(|x| *x as i64);
     let offsets = Buffer::from_trusted_len_iter(offsets);
-    BinaryArray::<i64>::from_data(to_data_type, offsets, values, from.validity().cloned())
+    // todo: using the `_unchecked` variant here.
+    BinaryArray::<i64>::try_new(to_data_type, offsets, values, from.validity().cloned())
+        .expect("All invariants to be uphold")
 }
 
 /// Conversion of binary
@@ -24,12 +26,7 @@ pub fn binary_large_to_binary(
 
     let offsets = from.offsets().iter().map(|x| *x as i32);
     let offsets = Buffer::from_trusted_len_iter(offsets);
-    Ok(BinaryArray::<i32>::from_data(
-        to_data_type,
-        offsets,
-        values,
-        from.validity().cloned(),
-    ))
+    BinaryArray::<i32>::try_new(to_data_type, offsets, values, from.validity().cloned())
 }
 
 /// Casts a [`BinaryArray`] to a [`PrimitiveArray`] at best-effort using `lexical_core::parse_partial`, making any uncastable value as zero.

--- a/src/compute/cast/boolean_to.rs
+++ b/src/compute/cast/boolean_to.rs
@@ -23,7 +23,7 @@ where
         .map(|x| if x { T::one() } else { T::default() });
     let values = Buffer::<T>::from_trusted_len_iter(iter);
 
-    PrimitiveArray::<T>::from_data(T::PRIMITIVE.into(), values, from.validity().cloned())
+    PrimitiveArray::<T>::new(T::PRIMITIVE.into(), values, from.validity().cloned())
 }
 
 /// Casts the [`BooleanArray`] to a [`Utf8Array`], casting trues to `"1"` and falses to `"0"`

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -37,12 +37,13 @@ pub fn primitive_to_binary<T: NativeType + lexical_core::ToLexical, O: Offset>(
         }
         values.set_len(offset);
         values.shrink_to_fit();
-        BinaryArray::<O>::from_data_unchecked(
+        BinaryArray::<O>::try_new_unchecked(
             BinaryArray::<O>::default_data_type(),
             offsets.into(),
             values.into(),
             from.validity().cloned(),
         )
+        .expect("Loop above to uphold all invariants")
     }
 }
 
@@ -103,12 +104,13 @@ pub fn primitive_to_utf8<T: NativeType + lexical_core::ToLexical, O: Offset>(
         }
         values.set_len(offset);
         values.shrink_to_fit();
-        Utf8Array::<O>::from_data_unchecked(
+        Utf8Array::<O>::try_new_unchecked(
             Utf8Array::<O>::default_data_type(),
             offsets.into(),
             values.into(),
             from.validity().cloned(),
         )
+        .expect("All invariants to be uphold by construction")
     }
 }
 

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -177,7 +177,7 @@ pub fn primitive_to_same_primitive<T>(
 where
     T: NativeType,
 {
-    PrimitiveArray::<T>::from_data(
+    PrimitiveArray::<T>::new(
         to_type.clone(),
         from.values().clone(),
         from.validity().cloned(),

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -148,9 +148,11 @@ pub fn utf8_to_large_utf8(from: &Utf8Array<i32>) -> Utf8Array<i64> {
     let values = from.values().clone();
     let offsets = from.offsets().iter().map(|x| *x as i64);
     let offsets = Buffer::from_trusted_len_iter(offsets);
+    // Safety: the invariants are upheld by construction
     unsafe {
-        Utf8Array::<i64>::from_data_unchecked(data_type, offsets, values, from.validity().cloned())
+        Utf8Array::<i64>::try_new_unchecked(data_type, offsets, values, from.validity().cloned())
     }
+    .expect("All invariants to be uphold by construction")
 }
 
 /// Conversion of utf8
@@ -162,7 +164,9 @@ pub fn utf8_large_to_utf8(from: &Utf8Array<i64>) -> Result<Utf8Array<i32>> {
 
     let offsets = from.offsets().iter().map(|x| *x as i32);
     let offsets = Buffer::from_trusted_len_iter(offsets);
+    // Safety: the invariants are upheld by construction
     Ok(unsafe {
-        Utf8Array::<i32>::from_data_unchecked(data_type, offsets, values, from.validity().cloned())
-    })
+        Utf8Array::<i32>::try_new_unchecked(data_type, offsets, values, from.validity().cloned())
+    }
+    .expect("All invariants to be uphold by construction"))
 }

--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -32,7 +32,7 @@ fn filter_nonnull_primitive<T: NativeType>(
                 new_validity.push_unchecked(is_valid);
             });
 
-        PrimitiveArray::<T>::from_data(
+        PrimitiveArray::<T>::new(
             array.data_type().clone(),
             buffer.into(),
             new_validity.into(),
@@ -46,7 +46,7 @@ fn filter_nonnull_primitive<T: NativeType>(
             .map(|x| x.0)
             .for_each(|item| buffer.push(*item));
 
-        PrimitiveArray::<T>::from_data(array.data_type().clone(), buffer.into(), None)
+        PrimitiveArray::<T>::new(array.data_type().clone(), buffer.into(), None)
     }
 }
 

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -38,7 +38,7 @@ pub fn hash_boolean(array: &BooleanArray) -> PrimitiveArray<u64> {
 
     let iter = array.values_iter().map(|x| u8::get_hash(&x, &state));
     let values = Buffer::from_trusted_len_iter(iter);
-    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().cloned())
+    PrimitiveArray::<u64>::new(DataType::UInt64, values, array.validity().cloned())
 }
 
 #[multiversion]
@@ -51,7 +51,7 @@ pub fn hash_utf8<O: Offset>(array: &Utf8Array<O>) -> PrimitiveArray<u64> {
         .values_iter()
         .map(|x| <[u8]>::get_hash(&x.as_bytes(), &state));
     let values = Buffer::from_trusted_len_iter(iter);
-    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().cloned())
+    PrimitiveArray::<u64>::new(DataType::UInt64, values, array.validity().cloned())
 }
 
 /// Element-wise hash of a [`BinaryArray`]. Validity is preserved.
@@ -59,7 +59,7 @@ pub fn hash_binary<O: Offset>(array: &BinaryArray<O>) -> PrimitiveArray<u64> {
     let state = new_state!();
     let iter = array.values_iter().map(|x| <[u8]>::get_hash(&x, &state));
     let values = Buffer::from_trusted_len_iter(iter);
-    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().cloned())
+    PrimitiveArray::<u64>::new(DataType::UInt64, values, array.validity().cloned())
 }
 
 macro_rules! with_match_primitive_type {(

--- a/src/compute/length.rs
+++ b/src/compute/length.rs
@@ -43,7 +43,7 @@ where
         DataType::Int32
     };
 
-    PrimitiveArray::<O>::from_data(data_type, values, array.validity().cloned())
+    PrimitiveArray::<O>::new(data_type, values, array.validity().cloned())
 }
 
 /// Returns an array of integers with the number of bytes on each string of the array.

--- a/src/compute/nullif.rs
+++ b/src/compute/nullif.rs
@@ -43,7 +43,7 @@ pub fn nullif_primitive<T: NativeType + Simd8>(
 
     let validity = combine_validities(lhs.validity(), equal.as_ref());
 
-    Ok(PrimitiveArray::<T>::from_data(
+    Ok(PrimitiveArray::<T>::new(
         lhs.data_type().clone(),
         lhs.values().clone(),
         validity,

--- a/src/compute/sort/boolean.rs
+++ b/src/compute/sort/boolean.rs
@@ -48,6 +48,5 @@ pub fn sort_boolean<I: Index>(
         values.shrink_to_fit();
     }
 
-    let data_type = I::PRIMITIVE.into();
-    PrimitiveArray::<I>::from_data(data_type, values.into(), None)
+    PrimitiveArray::<I>::from_vec(values)
 }

--- a/src/compute/sort/common.rs
+++ b/src/compute/sort/common.rs
@@ -161,6 +161,5 @@ where
         indices
     };
 
-    let data_type = I::PRIMITIVE.into();
-    PrimitiveArray::<I>::from_data(data_type, indices.into(), None)
+    PrimitiveArray::<I>::from_vec(indices)
 }

--- a/src/compute/sort/lex_sort.rs
+++ b/src/compute/sort/lex_sort.rs
@@ -179,10 +179,5 @@ pub fn lexsort_to_indices<I: Index>(
         values.sort_unstable_by(lex_comparator);
     }
 
-    let data_type = I::PRIMITIVE.into();
-    Ok(PrimitiveArray::<I>::from_data(
-        data_type,
-        values.into(),
-        None,
-    ))
+    Ok(PrimitiveArray::<I>::from_vec(values))
 }

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -357,8 +357,7 @@ where
 
     values.truncate(limit.unwrap_or_else(|| values.len()));
 
-    let data_type = I::PRIMITIVE.into();
-    PrimitiveArray::<I>::from_data(data_type, values.into(), None)
+    PrimitiveArray::<I>::from_vec(values)
 }
 
 /// Compare two `Array`s based on the ordering defined in [ord](crate::array::ord).

--- a/src/compute/sort/primitive/sort.rs
+++ b/src/compute/sort/primitive/sort.rs
@@ -146,7 +146,7 @@ where
     let values = array.values();
     let validity = array.validity();
 
-    let (buffer, validity) = if let Some(validity) = validity {
+    let (values, validity) = if let Some(validity) = validity {
         sort_nullable(values, validity, cmp, options, limit)
     } else {
         let mut buffer = Vec::<T>::new();
@@ -158,7 +158,7 @@ where
 
         (buffer.into(), None)
     };
-    PrimitiveArray::<T>::from_data(array.data_type().clone(), buffer, validity)
+    PrimitiveArray::<T>::new(array.data_type().clone(), values, validity)
 }
 
 #[cfg(test)]

--- a/src/compute/substring.rs
+++ b/src/compute/substring.rs
@@ -108,12 +108,14 @@ fn binary_substring<O: Offset>(
         new_values.extend_from_slice(&values[start..start + length]);
     });
 
-    BinaryArray::<O>::from_data(
+    // todo: consider using the `_unchecked` variant here.
+    BinaryArray::<O>::try_new(
         array.data_type().clone(),
         new_offsets.into(),
         new_values.into(),
         validity.cloned(),
     )
+    .expect("Invariants to be upheld by above implementation")
 }
 
 /// Returns an ArrayRef with a substring starting from `start` and with optional length `length` of each of the elements in `array`.

--- a/src/compute/take/binary.rs
+++ b/src/compute/take/binary.rs
@@ -37,5 +37,7 @@ pub fn take<O: Offset, I: Index>(
         (false, true) => take_indices_validity(values.offsets(), values.values(), indices),
         (true, true) => take_values_indices_validity(values, indices),
     };
-    BinaryArray::<O>::from_data(data_type, offsets, values, validity)
+    // todo: using the `_unchecked` variant here.
+    BinaryArray::<O>::try_new(data_type, offsets, values, validity)
+        .expect("Invariants to be upheld by implementation")
 }

--- a/src/compute/take/primitive.rs
+++ b/src/compute/take/primitive.rs
@@ -111,5 +111,5 @@ pub fn take<T: NativeType, I: Index>(
         (true, true) => take_values_indices_validity::<T, I>(values, indices),
     };
 
-    PrimitiveArray::<T>::from_data(values.data_type().clone(), buffer, validity)
+    PrimitiveArray::<T>::new(values.data_type().clone(), buffer, validity)
 }

--- a/src/compute/take/utf8.rs
+++ b/src/compute/take/utf8.rs
@@ -37,7 +37,11 @@ pub fn take<O: Offset, I: Index>(
         (false, true) => take_indices_validity(values.offsets(), values.values(), indices),
         (true, true) => take_values_indices_validity(values, indices),
     };
-    unsafe { Utf8Array::<O>::from_data_unchecked(data_type, offsets, values, validity) }
+    // Safety:
+    // * Each of the implementations above guarantees the offsets invariants
+    // * `values` comes from `Utf8Array`, so its values are valid utf8
+    unsafe { Utf8Array::<O>::try_new_unchecked(data_type, offsets, values, validity) }
+        .expect("All invariants to be uphold by construction")
 }
 
 #[cfg(test)]

--- a/src/io/ipc/read/array/binary.rs
+++ b/src/io/ipc/read/array/binary.rs
@@ -57,9 +57,7 @@ pub fn read_binary<O: Offset, R: Read + Seek>(
         compression,
     )?;
 
-    Ok(BinaryArray::<O>::from_data(
-        data_type, offsets, values, validity,
-    ))
+    BinaryArray::<O>::try_new(data_type, offsets, values, validity)
 }
 
 pub fn skip_binary(

--- a/src/io/ipc/read/array/primitive.rs
+++ b/src/io/ipc/read/array/primitive.rs
@@ -46,7 +46,7 @@ where
         is_little_endian,
         compression,
     )?;
-    Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
+    PrimitiveArray::<T>::try_new(data_type, values, validity)
 }
 
 pub fn skip_primitive(

--- a/src/io/ipc/read/array/utf8.rs
+++ b/src/io/ipc/read/array/utf8.rs
@@ -57,9 +57,7 @@ pub fn read_utf8<O: Offset, R: Read + Seek>(
         compression,
     )?;
 
-    Ok(Utf8Array::<O>::from_data(
-        data_type, offsets, values, validity,
-    ))
+    Utf8Array::<O>::try_new(data_type, offsets, values, validity)
 }
 
 pub fn skip_utf8(

--- a/src/io/json_integration/read/array.rs
+++ b/src/io/json_integration/read/array.rs
@@ -90,7 +90,7 @@ fn to_primitive_days_ms(
         .iter()
         .map(to_days_ms)
         .collect();
-    PrimitiveArray::<days_ms>::from_data(data_type, values, validity)
+    PrimitiveArray::<days_ms>::new(data_type, values, validity)
 }
 
 fn to_primitive_months_days_ns(
@@ -105,7 +105,7 @@ fn to_primitive_months_days_ns(
         .iter()
         .map(to_months_days_ns)
         .collect();
-    PrimitiveArray::<months_days_ns>::from_data(data_type, values, validity)
+    PrimitiveArray::<months_days_ns>::new(data_type, values, validity)
 }
 
 fn to_decimal(json_col: &ArrowJsonColumn, data_type: DataType) -> PrimitiveArray<i128> {
@@ -123,7 +123,7 @@ fn to_decimal(json_col: &ArrowJsonColumn, data_type: DataType) -> PrimitiveArray
         })
         .collect();
 
-    PrimitiveArray::<i128>::from_data(data_type, values, validity)
+    PrimitiveArray::<i128>::new(data_type, values, validity)
 }
 
 fn to_primitive<T: NativeType + NumCast>(
@@ -159,7 +159,7 @@ fn to_primitive<T: NativeType + NumCast>(
             .collect()
     };
 
-    PrimitiveArray::<T>::from_data(data_type, values, validity)
+    PrimitiveArray::<T>::new(data_type, values, validity)
 }
 
 fn to_binary<O: Offset>(json_col: &ArrowJsonColumn, data_type: DataType) -> Arc<dyn Array> {

--- a/src/io/json_integration/read/array.rs
+++ b/src/io/json_integration/read/array.rs
@@ -173,7 +173,10 @@ fn to_binary<O: Offset>(json_col: &ArrowJsonColumn, data_type: DataType) -> Arc<
         .map(|value| value.as_str().map(|x| hex::decode(x).unwrap()).unwrap())
         .flatten()
         .collect();
-    Arc::new(BinaryArray::from_data(data_type, offsets, values, validity))
+    Arc::new(
+        BinaryArray::try_new(data_type, offsets, values, validity)
+            .expect("JSON file to contain valid data"),
+    )
 }
 
 fn to_utf8<O: Offset>(json_col: &ArrowJsonColumn, data_type: DataType) -> Arc<dyn Array> {
@@ -187,7 +190,10 @@ fn to_utf8<O: Offset>(json_col: &ArrowJsonColumn, data_type: DataType) -> Arc<dy
         .map(|value| value.as_str().unwrap().as_bytes().to_vec())
         .flatten()
         .collect();
-    Arc::new(Utf8Array::from_data(data_type, offsets, values, validity))
+    Arc::new(
+        Utf8Array::try_new(data_type, offsets, values, validity)
+            .expect("JSON file to contain valid data"),
+    )
 }
 
 fn to_list<O: Offset>(

--- a/src/io/parquet/read/binary/dictionary.rs
+++ b/src/io/parquet/read/binary/dictionary.rs
@@ -152,7 +152,7 @@ where
         // the array is empty and thus we need to push the first offset ourselves.
         offsets.push(O::zero());
     };
-    let keys = PrimitiveArray::from_data(K::PRIMITIVE.into(), indices.into(), validity.into());
+    let keys = PrimitiveArray::try_new(K::PRIMITIVE.into(), indices.into(), validity.into())?;
     let data_type = DictionaryArray::<K>::get_child(&data_type).clone();
     let values = utils::finish_array(data_type, offsets, values, None)?.into();
     Ok(Box::new(DictionaryArray::<K>::from_data(keys, values)))

--- a/src/io/parquet/read/binary/dictionary.rs
+++ b/src/io/parquet/read/binary/dictionary.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use parquet2::{
     encoding::{hybrid_rle, Encoding},
     metadata::{ColumnChunkMetaData, ColumnDescriptor},
@@ -7,9 +5,9 @@ use parquet2::{
     FallibleStreamingIterator,
 };
 
-use super::super::utils as other_utils;
+use super::{super::utils as other_utils, utils};
 use crate::{
-    array::{Array, DictionaryArray, DictionaryKey, Offset, PrimitiveArray, Utf8Array},
+    array::{Array, DictionaryArray, DictionaryKey, Offset, PrimitiveArray},
     bitmap::{utils::BitmapIter, MutableBitmap},
     datatypes::DataType,
     error::{ArrowError, Result},
@@ -156,11 +154,6 @@ where
     };
     let keys = PrimitiveArray::from_data(K::PRIMITIVE.into(), indices.into(), validity.into());
     let data_type = DictionaryArray::<K>::get_child(&data_type).clone();
-    let values = Arc::new(Utf8Array::from_data(
-        data_type,
-        offsets.into(),
-        values.into(),
-        None,
-    ));
+    let values = utils::finish_array(data_type, offsets, values, None)?.into();
     Ok(Box::new(DictionaryArray::<K>::from_data(keys, values)))
 }

--- a/src/io/parquet/read/binary/mod.rs
+++ b/src/io/parquet/read/binary/mod.rs
@@ -60,7 +60,7 @@ where
             )?
         }
     }
-    Ok(utils::finish_array(data_type, offsets, values, validity))
+    utils::finish_array(data_type, offsets, values, Some(validity))
 }
 
 pub async fn stream_to_array<O, I, E>(
@@ -92,5 +92,5 @@ where
         )?
     }
 
-    Ok(finish_array(data_type.clone(), offsets, values, validity))
+    finish_array(data_type.clone(), offsets, values, Some(validity))
 }

--- a/src/io/parquet/read/binary/utils.rs
+++ b/src/io/parquet/read/binary/utils.rs
@@ -2,27 +2,30 @@ use crate::{
     array::{Array, BinaryArray, Offset, Utf8Array},
     bitmap::MutableBitmap,
     datatypes::DataType,
+    error::ArrowError,
 };
 
 pub(super) fn finish_array<O: Offset>(
     data_type: DataType,
     offsets: Vec<O>,
     values: Vec<u8>,
-    validity: MutableBitmap,
-) -> Box<dyn Array> {
+    validity: Option<MutableBitmap>,
+) -> Result<Box<dyn Array>, ArrowError> {
     match data_type {
-        DataType::LargeBinary | DataType::Binary => Box::new(BinaryArray::from_data(
+        DataType::LargeBinary | DataType::Binary => BinaryArray::try_new(
             data_type,
             offsets.into(),
             values.into(),
-            validity.into(),
-        )),
-        DataType::LargeUtf8 | DataType::Utf8 => Box::new(Utf8Array::from_data(
+            validity.map(|x| x.into()),
+        )
+        .map(|x| Box::new(x) as Box<dyn Array>),
+        DataType::LargeUtf8 | DataType::Utf8 => Utf8Array::try_new(
             data_type,
             offsets.into(),
             values.into(),
-            validity.into(),
-        )),
+            validity.map(|x| x.into()),
+        )
+        .map(|x| Box::new(x) as Box<dyn Array>),
         _ => unreachable!(),
     }
 }

--- a/src/io/parquet/read/primitive/dictionary.rs
+++ b/src/io/parquet/read/primitive/dictionary.rs
@@ -153,8 +153,8 @@ where
         )?
     }
 
-    let keys = PrimitiveArray::from_data(K::PRIMITIVE.into(), indices.into(), validity.into());
+    let keys = PrimitiveArray::new(K::PRIMITIVE.into(), indices.into(), validity.into());
     let data_type = DictionaryArray::<K>::get_child(&data_type).clone();
-    let values = Arc::new(PrimitiveArray::from_data(data_type, values.into(), None));
+    let values = Arc::new(PrimitiveArray::new(data_type, values.into(), None));
     Ok(Box::new(DictionaryArray::<K>::from_data(keys, values)))
 }

--- a/src/io/parquet/read/primitive/mod.rs
+++ b/src/io/parquet/read/primitive/mod.rs
@@ -53,11 +53,8 @@ where
         _ => data_type,
     };
 
-    Ok(Box::new(PrimitiveArray::from_data(
-        data_type,
-        values.into(),
-        validity.into(),
-    )))
+    PrimitiveArray::try_new(data_type, values.into(), validity.into())
+        .map(|x| Box::new(x) as Box<dyn Array>)
 }
 
 pub fn iter_to_array<T, A, I, E, F>(
@@ -104,9 +101,6 @@ where
         _ => data_type,
     };
 
-    Ok(Box::new(PrimitiveArray::from_data(
-        data_type,
-        values.into(),
-        validity.into(),
-    )))
+    PrimitiveArray::try_new(data_type, values.into(), validity.into())
+        .map(|x| Box::new(x) as Box<dyn Array>)
 }

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -285,20 +285,14 @@ pub fn array_to_page(
             if precision <= 9 {
                 let values = array.values().iter().map(|x| *x as i32);
                 let values = Buffer::from_trusted_len_iter(values);
-                let array = PrimitiveArray::<i32>::from_data(
-                    DataType::Int32,
-                    values,
-                    array.validity().cloned(),
-                );
+                let array =
+                    PrimitiveArray::<i32>::new(DataType::Int32, values, array.validity().cloned());
                 primitive::array_to_page::<i32, i32>(&array, options, descriptor)
             } else if precision <= 18 {
                 let values = array.values().iter().map(|x| *x as i64);
                 let values = Buffer::from_trusted_len_iter(values);
-                let array = PrimitiveArray::<i64>::from_data(
-                    DataType::Int64,
-                    values,
-                    array.validity().cloned(),
-                );
+                let array =
+                    PrimitiveArray::<i64>::new(DataType::Int64, values, array.validity().cloned());
                 primitive::array_to_page::<i64, i64>(&array, options, descriptor)
             } else {
                 let size = decimal_length_from_precision(precision);

--- a/tests/it/array/list/mod.rs
+++ b/tests/it/array/list/mod.rs
@@ -8,8 +8,7 @@ mod mutable;
 
 #[test]
 fn display() {
-    let values = Buffer::from_slice([1, 2, 3, 4, 5]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::from_vec(vec![1, 2, 3, 4, 5]);
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let array = ListArray::<i32>::from_data(
@@ -28,8 +27,7 @@ fn display() {
 #[test]
 #[should_panic(expected = "The child's datatype must match the inner type of the \'data_type\'")]
 fn test_nested_panic() {
-    let values = Buffer::from_slice([1, 2, 3, 4, 5]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::from_vec(vec![1, 2, 3, 4, 5]);
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let array = ListArray::<i32>::from_data(
@@ -51,8 +49,7 @@ fn test_nested_panic() {
 
 #[test]
 fn test_nested_display() {
-    let values = Buffer::from_slice([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::from_vec(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let array = ListArray::<i32>::from_data(

--- a/tests/it/array/primitive/mod.rs
+++ b/tests/it/array/primitive/mod.rs
@@ -28,7 +28,7 @@ fn basics() {
     assert!(!array.is_valid(1));
     assert!(array.is_valid(2));
 
-    let array2 = Int32Array::from_data(
+    let array2 = Int32Array::new(
         DataType::Int32,
         array.values().clone(),
         array.validity().cloned(),
@@ -298,8 +298,7 @@ fn months_days_ns() {
 }
 
 #[test]
-#[should_panic]
 fn wrong_data_type() {
     let values = Buffer::from_slice(b"abbb");
-    PrimitiveArray::from_data(DataType::Utf8, values, None);
+    assert!(PrimitiveArray::try_new(DataType::Utf8, values, None).is_err());
 }

--- a/tests/it/compute/take.rs
+++ b/tests/it/compute/take.rs
@@ -178,8 +178,7 @@ fn unsigned_take() {
 
 #[test]
 fn list_with_no_none() {
-    let values = Buffer::from_slice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::from_vec(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let array = ListArray::<i32>::from_data(
@@ -192,8 +191,7 @@ fn list_with_no_none() {
     let indices = PrimitiveArray::from([Some(4i32), Some(1), Some(3)]);
     let result = take(&array, &indices).unwrap();
 
-    let expected_values = Buffer::from_slice([9, 6, 7, 8]);
-    let expected_values = PrimitiveArray::<i32>::from_data(DataType::Int32, expected_values, None);
+    let expected_values = PrimitiveArray::<i32>::from_vec(vec![9, 6, 7, 8]);
     let expected_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let expected = ListArray::<i32>::from_data(
         expected_type,
@@ -207,8 +205,7 @@ fn list_with_no_none() {
 
 #[test]
 fn list_with_none() {
-    let values = Buffer::from_slice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::from_vec(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
     let validity_values = vec![true, false, true, true, true];
     let validity = Bitmap::from_trusted_len_iter(validity_values.into_iter());
@@ -269,8 +266,7 @@ fn list_both_validity() {
 
 #[test]
 fn test_nested() {
-    let values = Buffer::from_slice([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::from_vec(vec![1, 1, 2, 3, 4, 5, 6, 7, 8, 10]);
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let array = ListArray::<i32>::from_data(
@@ -292,8 +288,7 @@ fn test_nested() {
     let result = take(&nested, &indices).unwrap();
 
     // expected data
-    let expected_values = Buffer::from_slice([1, 2, 3, 4, 5, 6, 7, 8]);
-    let expected_values = PrimitiveArray::<i32>::from_data(DataType::Int32, expected_values, None);
+    let expected_values = PrimitiveArray::<i32>::from_vec(vec![1, 2, 3, 4, 5, 6, 7, 8]);
 
     let expected_data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let expected_array = ListArray::<i32>::from_data(


### PR DESCRIPTION
Currently `from_data` panics on invalid data. However, there are more defensive approaches to this problem, specially when the user is unsure whether the data is valid or not, recovering with an error message, etc.

This PR replaces `from_data` and `from_data_unchecked` by 
* `new` (panics)
* `try_new` (errors)
* `unsafe try_new_unchecked` (errors)

with the hopes of removing panics from this and this lib's consumers (panics are considered vulnerabilities as they can easily be abused to DOS a server).

This PR is not complete (only migrated Binary, Utf8 and Primitive)