### PR TITLE
Added support to compare intervals

### DIFF
--- a/src/compute/comparison/primitive.rs
+++ b/src/compute/comparison/primitive.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use super::super::utils::combine_validities;
-use super::simd::{Simd8, Simd8Lanes};
+use super::simd::{Simd8, Simd8Lanes, Simd8PartialEq, Simd8PartialOrd};
 
 pub(crate) fn compare_values_op<T, F>(lhs: &[T], rhs: &[T], op: F) -> MutableBitmap
 where
@@ -87,6 +87,7 @@ where
 pub fn eq<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialEq,
 {
     compare_op(lhs, rhs, |a, b| a.eq(b))
 }
@@ -95,6 +96,7 @@ where
 pub fn eq_scalar<T>(lhs: &PrimitiveArray<T>, rhs: T) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialEq,
 {
     compare_op_scalar(lhs, rhs, |a, b| a.eq(b))
 }
@@ -103,6 +105,7 @@ where
 pub fn neq<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialEq,
 {
     compare_op(lhs, rhs, |a, b| a.neq(b))
 }
@@ -111,6 +114,7 @@ where
 pub fn neq_scalar<T>(lhs: &PrimitiveArray<T>, rhs: T) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialEq,
 {
     compare_op_scalar(lhs, rhs, |a, b| a.neq(b))
 }
@@ -119,6 +123,7 @@ where
 pub fn lt<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialOrd,
 {
     compare_op(lhs, rhs, |a, b| a.lt(b))
 }
@@ -127,6 +132,7 @@ where
 pub fn lt_scalar<T>(lhs: &PrimitiveArray<T>, rhs: T) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialOrd,
 {
     compare_op_scalar(lhs, rhs, |a, b| a.lt(b))
 }
@@ -135,6 +141,7 @@ where
 pub fn lt_eq<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialOrd,
 {
     compare_op(lhs, rhs, |a, b| a.lt_eq(b))
 }
@@ -144,6 +151,7 @@ where
 pub fn lt_eq_scalar<T>(lhs: &PrimitiveArray<T>, rhs: T) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialOrd,
 {
     compare_op_scalar(lhs, rhs, |a, b| a.lt_eq(b))
 }
@@ -153,6 +161,7 @@ where
 pub fn gt<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialOrd,
 {
     compare_op(lhs, rhs, |a, b| a.gt(b))
 }
@@ -162,6 +171,7 @@ where
 pub fn gt_scalar<T>(lhs: &PrimitiveArray<T>, rhs: T) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialOrd,
 {
     compare_op_scalar(lhs, rhs, |a, b| a.gt(b))
 }
@@ -171,6 +181,7 @@ where
 pub fn gt_eq<T>(lhs: &PrimitiveArray<T>, rhs: &PrimitiveArray<T>) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialOrd,
 {
     compare_op(lhs, rhs, |a, b| a.gt_eq(b))
 }
@@ -180,6 +191,7 @@ where
 pub fn gt_eq_scalar<T>(lhs: &PrimitiveArray<T>, rhs: T) -> BooleanArray
 where
     T: NativeType + Simd8,
+    T::Simd: Simd8PartialOrd,
 {
     compare_op_scalar(lhs, rhs, |a, b| a.gt_eq(b))
 }

--- a/src/compute/comparison/simd/mod.rs
+++ b/src/compute/comparison/simd/mod.rs
@@ -12,10 +12,18 @@ pub trait Simd8Lanes<T>: Copy {
     fn from_chunk(v: &[T]) -> Self;
     /// loads an incomplete chunk, filling the remaining items with `remaining`.
     fn from_incomplete_chunk(v: &[T], remaining: T) -> Self;
+}
+
+/// Trait implemented by implementors of [`Simd8Lanes`] whose [`Simd8`] implements [PartialEq].
+pub trait Simd8PartialEq: Copy {
     /// Equal
     fn eq(self, other: Self) -> u8;
     /// Not equal
     fn neq(self, other: Self) -> u8;
+}
+
+/// Trait implemented by implementors of [`Simd8Lanes`] whose [`Simd8`] implements [PartialOrd].
+pub trait Simd8PartialOrd: Copy {
     /// Less than or equal to
     fn lt_eq(self, other: Self) -> u8;
     /// Less than
@@ -38,6 +46,7 @@ pub(super) fn set<T: Copy, F: Fn(T, T) -> bool>(lhs: [T; 8], rhs: [T; 8], op: F)
     byte
 }
 
+/// Types that implement Simd8
 macro_rules! simd8_native {
     ($type:ty) => {
         impl Simd8 for $type {
@@ -56,7 +65,14 @@ macro_rules! simd8_native {
                 a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
                 a
             }
+        }
+    };
+}
 
+/// Types that implement PartialEq
+macro_rules! simd8_native_partial_eq {
+    ($type:ty) => {
+        impl Simd8PartialEq for [$type; 8] {
             #[inline]
             fn eq(self, other: Self) -> u8 {
                 set(self, other, |x, y| x == y)
@@ -67,7 +83,14 @@ macro_rules! simd8_native {
                 #[allow(clippy::float_cmp)]
                 set(self, other, |x, y| x != y)
             }
+        }
+    };
+}
 
+/// Types that implement PartialOrd
+macro_rules! simd8_native_partial_ord {
+    ($type:ty) => {
+        impl Simd8PartialOrd for [$type; 8] {
             #[inline]
             fn lt_eq(self, other: Self) -> u8 {
                 set(self, other, |x, y| x <= y)
@@ -88,6 +111,15 @@ macro_rules! simd8_native {
                 set(self, other, |x, y| x > y)
             }
         }
+    };
+}
+
+/// Types that implement simd8, PartialEq and PartialOrd
+macro_rules! simd8_native_all {
+    ($type:ty) => {
+        simd8_native! {$type}
+        simd8_native_partial_eq! {$type}
+        simd8_native_partial_ord! {$type}
     };
 }
 

--- a/src/compute/comparison/simd/native.rs
+++ b/src/compute/comparison/simd/native.rs
@@ -1,15 +1,20 @@
 use std::convert::TryInto;
 
-use super::{set, Simd8, Simd8Lanes};
+use super::{set, Simd8, Simd8Lanes, Simd8PartialEq, Simd8PartialOrd};
+use crate::types::{days_ms, months_days_ns};
 
-simd8_native!(u8);
-simd8_native!(u16);
-simd8_native!(u32);
-simd8_native!(u64);
-simd8_native!(i8);
-simd8_native!(i16);
-simd8_native!(i32);
-simd8_native!(i128);
-simd8_native!(i64);
-simd8_native!(f32);
-simd8_native!(f64);
+simd8_native_all!(u8);
+simd8_native_all!(u16);
+simd8_native_all!(u32);
+simd8_native_all!(u64);
+simd8_native_all!(i8);
+simd8_native_all!(i16);
+simd8_native_all!(i32);
+simd8_native_all!(i128);
+simd8_native_all!(i64);
+simd8_native_all!(f32);
+simd8_native_all!(f64);
+simd8_native!(days_ms);
+simd8_native_partial_eq!(days_ms);
+simd8_native!(months_days_ns);
+simd8_native_partial_eq!(months_days_ns);

--- a/src/compute/comparison/simd/packed.rs
+++ b/src/compute/comparison/simd/packed.rs
@@ -1,8 +1,10 @@
 use std::convert::TryInto;
 
-use super::{set, Simd8, Simd8Lanes};
-
 use packed_simd::*;
+
+use crate::types::{days_ms, months_days_ns};
+
+use super::*;
 
 macro_rules! simd8 {
     ($type:ty, $md:ty) => {
@@ -22,7 +24,9 @@ macro_rules! simd8 {
                 a.iter_mut().zip(v.iter()).for_each(|(a, b)| *a = *b);
                 Self::from_chunk(a.as_ref())
             }
+        }
 
+        impl Simd8PartialEq for $md {
             #[inline]
             fn eq(self, other: Self) -> u8 {
                 self.eq(other).bitmask()
@@ -32,7 +36,9 @@ macro_rules! simd8 {
             fn neq(self, other: Self) -> u8 {
                 self.ne(other).bitmask()
             }
+        }
 
+        impl Simd8PartialOrd for $md {
             #[inline]
             fn lt_eq(self, other: Self) -> u8 {
                 self.le(other).bitmask()
@@ -64,6 +70,10 @@ simd8!(i8, i8x8);
 simd8!(i16, i16x8);
 simd8!(i32, i32x8);
 simd8!(i64, i64x8);
-simd8_native!(i128);
+simd8_native_all!(i128);
 simd8!(f32, f32x8);
 simd8!(f64, f64x8);
+simd8_native!(days_ms);
+simd8_native_partial_eq!(days_ms);
+simd8_native!(months_days_ns);
+simd8_native_partial_eq!(months_days_ns);

--- a/src/compute/nullif.rs
+++ b/src/compute/nullif.rs
@@ -1,7 +1,7 @@
 //! Contains the operator [`nullif`].
 use crate::array::PrimitiveArray;
 use crate::bitmap::Bitmap;
-use crate::compute::comparison::{primitive_compare_values_op, Simd8, Simd8Lanes};
+use crate::compute::comparison::{primitive_compare_values_op, Simd8, Simd8PartialEq};
 use crate::compute::utils::check_same_type;
 use crate::datatypes::DataType;
 use crate::error::{ArrowError, Result};
@@ -32,10 +32,14 @@ use super::utils::combine_validities;
 /// This function errors iff
 /// * The arguments do not have the same logical type
 /// * The arguments do not have the same length
-pub fn nullif_primitive<T: NativeType + Simd8>(
+pub fn nullif_primitive<T>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<T>,
-) -> Result<PrimitiveArray<T>> {
+) -> Result<PrimitiveArray<T>>
+where
+    T: NativeType + Simd8,
+    T::Simd: Simd8PartialEq,
+{
     check_same_type(lhs, rhs)?;
 
     let equal = primitive_compare_values_op(lhs.values(), rhs.values(), |lhs, rhs| lhs.neq(rhs));

--- a/tests/it/compute/comparison.rs
+++ b/tests/it/compute/comparison.rs
@@ -1,7 +1,7 @@
 use arrow2::array::*;
 use arrow2::compute::comparison::boolean::*;
-use arrow2::datatypes::DataType::*;
 use arrow2::datatypes::TimeUnit;
+use arrow2::datatypes::{DataType::*, IntervalUnit};
 use arrow2::scalar::new_scalar;
 
 #[test]
@@ -20,6 +20,9 @@ fn consistency() {
         Int64,
         Float32,
         Float64,
+        Interval(IntervalUnit::YearMonth),
+        Interval(IntervalUnit::MonthDayNano),
+        Interval(IntervalUnit::DayTime),
         Timestamp(TimeUnit::Second, None),
         Timestamp(TimeUnit::Millisecond, None),
         Timestamp(TimeUnit::Microsecond, None),
@@ -46,6 +49,9 @@ fn consistency() {
         if can_eq(&d1) {
             eq(array.as_ref(), array.as_ref());
         }
+        if can_lt_eq(&d1) {
+            lt_eq(array.as_ref(), array.as_ref());
+        }
     });
 
     // array <> scalar
@@ -54,6 +60,9 @@ fn consistency() {
         let scalar = new_scalar(array.as_ref(), 0);
         if can_eq(&d1) {
             eq_scalar(array.as_ref(), scalar.as_ref());
+        }
+        if can_lt_eq(&d1) {
+            lt_eq(array.as_ref(), array.as_ref());
         }
     });
 }


### PR DESCRIPTION
This PR adds support to compare `months_days_nano` and `days_ms` intervals.

Note that these types do not implement `partialOrd` (since there is no constraints over how many days are represented in `ms` or months in `days`). Thus, the implementation can only exist for `eq` and `neq`, which is what this PR does.

For this to happen, I had to split the trait `Simd8Lanes` in 3, so that we can describe the different constraints above in traits.

The rest is just boilerplate to keep the code tidy and small.