### PR TITLE
Refactored `nullif`

### DIFF
--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -56,7 +56,10 @@ pub mod utf8;
 mod simd;
 pub use simd::{Simd8, Simd8Lanes, Simd8PartialEq, Simd8PartialOrd};
 
-pub(crate) use primitive::compare_values_op as primitive_compare_values_op;
+pub(crate) use primitive::{
+    compare_values_op as primitive_compare_values_op,
+    compare_values_op_scalar as primitive_compare_values_op_scalar,
+};
 
 macro_rules! match_eq_ord {(
     $key_type:expr, | $_:tt $T:ident | $($body:tt)*

--- a/src/compute/utils.rs
+++ b/src/compute/utils.rs
@@ -48,14 +48,3 @@ pub fn check_same_len(lhs: &dyn Array, rhs: &dyn Array) -> Result<()> {
     }
     Ok(())
 }
-
-// Errors iff the two arrays have a different data_type.
-#[inline]
-pub fn check_same_type(lhs: &dyn Array, rhs: &dyn Array) -> Result<()> {
-    if lhs.data_type() != rhs.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
-            "Arrays must have the same logical type".to_string(),
-        ));
-    }
-    Ok(())
-}


### PR DESCRIPTION
* Added `nullif` to remaining primitives
* Made `nullif` panic if invalid arguments (the user can check the compute's capability to know if the dynamic dispatch is available via `can_nullif`)
* Renamed `nullif_primitive` to `primitive_nullif` to align with the rest of the API
* Added support to scalar version, `nullif_scalar`
* Added `primitive_nullif_scalar`
