### PR TITLE
Added support to deserialize JSON (!= NDJSON)

### DIFF
--- a/examples/json_read.rs
+++ b/examples/json_read.rs
@@ -3,37 +3,23 @@ use std::io::BufReader;
 use std::sync::Arc;
 
 use arrow2::array::Array;
-use arrow2::chunk::Chunk;
-use arrow2::error::Result;
+use arrow2::error::{ArrowError, Result};
 use arrow2::io::json::read;
 
-fn read_path(path: &str, projection: Option<Vec<&str>>) -> Result<Chunk<Arc<dyn Array>>> {
+fn read_path(path: &str) -> Result<Arc<dyn Array>> {
     // Example of reading a JSON file.
-    let mut reader = BufReader::new(File::open(path)?);
+    let reader = BufReader::new(File::open(path)?);
+    let data = serde_json::from_reader(reader)?;
 
-    let fields = read::infer_and_reset(&mut reader, None)?;
-
-    let fields = if let Some(projection) = projection {
-        fields
-            .into_iter()
-            .filter(|field| projection.contains(&field.name.as_ref()))
-            .collect()
+    let values = if let serde_json::Value::Array(values) = data {
+        Ok(values)
     } else {
-        fields
-    };
+        Err(ArrowError::InvalidArgumentError("".to_string()))
+    }?;
 
-    // at most 1024 rows. This container can be re-used across batches.
-    let mut rows = vec![String::default(); 1024];
+    let data_type = read::infer_rows(&values)?;
 
-    // Reads up to 1024 rows.
-    // this is IO-intensive and performs minimal CPU work. In particular,
-    // no deserialization is performed.
-    let read = read::read_rows(&mut reader, &mut rows)?;
-    let rows = &rows[..read];
-
-    // deserialize `rows` into `Chunk`. This is CPU-intensive, has no IO,
-    // and can be performed on a different thread pool via a channel.
-    read::deserialize(rows, &fields)
+    Ok(read::deserialize_json(&values, data_type))
 }
 
 fn main() -> Result<()> {
@@ -42,7 +28,7 @@ fn main() -> Result<()> {
 
     let file_path = &args[1];
 
-    let batch = read_path(file_path, None)?;
+    let batch = read_path(file_path)?;
     println!("{:#?}", batch);
     Ok(())
 }

--- a/examples/ndjson_read.rs
+++ b/examples/ndjson_read.rs
@@ -1,0 +1,48 @@
+use std::fs::File;
+use std::io::BufReader;
+use std::sync::Arc;
+
+use arrow2::array::Array;
+use arrow2::chunk::Chunk;
+use arrow2::error::Result;
+use arrow2::io::json::read;
+
+fn read_path(path: &str, projection: Option<Vec<&str>>) -> Result<Chunk<Arc<dyn Array>>> {
+    // Example of reading a NDJSON file.
+    let mut reader = BufReader::new(File::open(path)?);
+
+    let fields = read::infer_and_reset(&mut reader, None)?;
+
+    let fields = if let Some(projection) = projection {
+        fields
+            .into_iter()
+            .filter(|field| projection.contains(&field.name.as_ref()))
+            .collect()
+    } else {
+        fields
+    };
+
+    // at most 1024 rows. This container can be re-used across batches.
+    let mut rows = vec![String::default(); 1024];
+
+    // Reads up to 1024 rows.
+    // this is IO-intensive and performs minimal CPU work. In particular,
+    // no deserialization is performed.
+    let read = read::read_rows(&mut reader, &mut rows)?;
+    let rows = &rows[..read];
+
+    // deserialize `rows` into `Chunk`. This is CPU-intensive, has no IO,
+    // and can be performed on a different thread pool via a channel.
+    read::deserialize(rows, &fields)
+}
+
+fn main() -> Result<()> {
+    use std::env;
+    let args: Vec<String> = env::args().collect();
+
+    let file_path = &args[1];
+
+    let batch = read_path(file_path, None)?;
+    println!("{:#?}", batch);
+    Ok(())
+}

--- a/guide/src/io/README.md
+++ b/guide/src/io/README.md
@@ -5,7 +5,7 @@ This crate offers optional features that enable interoperability with different 
 * Arrow (`io_ipc`)
 * CSV (`io_csv`)
 * Parquet (`io_parquet`)
-* Json (`io_json`)
+* JSON and NDJSON (`io_json`)
 * Avro (`io_avro` and `io_avro_async`)
 
 In this section you can find a guide and examples for each one of them.

--- a/guide/src/io/json_read.md
+++ b/guide/src/io/json_read.md
@@ -1,10 +1,16 @@
 # JSON read
 
-When compiled with feature `io_json`, you can use this crate to read JSON files.
+When compiled with feature `io_json`, you can use this crate to read NDJSON files:
 
 ```rust
-{{#include ../../../examples/json_read.rs}}
+{{#include ../../../examples/ndjson_read.rs}}
 ```
 
 Note how deserialization can be performed on a separate thread pool to avoid
 blocking the runtime (see also [here](https://ryhl.io/blog/async-what-is-blocking/)).
+
+This crate also supports reading JSON, at the expense of being unable to read the file in chunks.
+
+```rust
+{{#include ../../../examples/json_read.rs}}
+```

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -271,3 +271,10 @@ pub fn deserialize<A: AsRef<str>>(
     let (_, columns, _) = deserialize_struct(&rows, data_type).into_data();
     Ok(Chunk::new(columns))
 }
+
+/// Deserializes a slice of [`Value`] to an Array of logical type [`DataType`].
+///
+/// This function allows consuming deserialized JSON to Arrow.
+pub fn deserialize_json(rows: &[Value], data_type: DataType) -> Arc<dyn Array> {
+    _deserialize(rows, data_type)
+}

--- a/src/io/json/read/mod.rs
+++ b/src/io/json/read/mod.rs
@@ -5,7 +5,7 @@ mod iterator;
 
 use crate::error::{ArrowError, Result};
 
-pub use deserialize::deserialize;
+pub use deserialize::{deserialize, deserialize_json};
 pub use infer_schema::*;
 
 /// Reads rows from `reader` into `rows`. Returns the number of read items.


### PR DESCRIPTION
So far the crate only supported reading NDJSON (by splitting the file with `\n` and reading it in chunks). This PR adds support to deserialize JSON.

It also adds an example demonstrating how to use it.

It also enables reading arrays with structs (missed by #750)

Closes  #712