### PR TITLE
Add extend_from_iter into growable trait

### DIFF
--- a/benches/growable.rs
+++ b/benches/growable.rs
@@ -19,6 +19,16 @@ fn add_benchmark(c: &mut Criterion) {
         })
     });
 
+    c.bench_function("growable::dyn_primitive::non_null::non_null", |b| {
+        b.iter(|| {
+            let mut a: Box<dyn Growable> =
+                Box::new(GrowablePrimitive::new(vec![&i32_array], false, 1026 * 10));
+
+            let iter = values.clone().into_iter().map(|start| (0, start, 10));
+            a.extend_from_iter(Box::new(iter));
+        })
+    });
+
     let i32_array = create_primitive_array::<i32>(1026 * 10, 0.0);
     c.bench_function("growable::primitive::non_null::null", |b| {
         b.iter(|| {

--- a/src/array/growable/mod.rs
+++ b/src/array/growable/mod.rs
@@ -40,6 +40,13 @@ pub trait Growable<'a> {
     /// Extends this [`Growable`] with null elements, disregarding the bound arrays
     fn extend_validity(&mut self, additional: usize);
 
+    /// Extends this [`Growable`] by iterator.
+    fn extend_from_iter(&mut self, iter: Box<dyn Iterator<Item = (usize, usize, usize)>>) {
+        for (index, start, len) in iter {
+            self.extend(index, start, len);
+        }
+    }
+
     /// Converts this [`Growable`] to an [`Arc<dyn Array>`], thereby finishing the mutation.
     /// Self will be empty after such operation.
     fn as_arc(&mut self) -> std::sync::Arc<dyn Array> {


### PR DESCRIPTION
Did not achieve expected performance.
```
growable::primitive::non_null::non_null                                                                             
                        time:   [2.5629 us 2.5658 us 2.5692 us]

growable::dyn_primitive::non_null::non_null                                                                             
                        time:   [6.3092 us 6.3195 us 6.3328 us]
			
			
After:

growable::dyn_primitive::non_null::non_null                                                                             
                        time:   [6.0020 us 6.0147 us 6.0300 us]


```

We can't make `extend_from_iter` accept generic iterator, it'll make this trait none object-safety.


Fixes #772 