### PR TITLE
Allowed passing `None` as ipc_fields in flight API

### DIFF
--- a/integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -96,7 +96,7 @@ async fn upload_data(
 
     let options = write::WriteOptions { compression: None };
 
-    let mut schema = flight::serialize_schema(schema, fields);
+    let mut schema = flight::serialize_schema(schema, Some(fields));
     schema.flight_descriptor = Some(descriptor.clone());
     upload_tx.send(schema).await?;
 

--- a/integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -113,7 +113,7 @@ impl FlightService for FlightServiceImpl {
 
         let schema = std::iter::once(Ok(serialize_schema(
             &flight.schema,
-            &flight.ipc_schema.fields,
+            Some(&flight.ipc_schema.fields),
         )));
 
         let batches = flight
@@ -175,7 +175,7 @@ impl FlightService for FlightServiceImpl {
 
                 let total_records: usize = flight.chunks.iter().map(|chunk| chunk.len()).sum();
 
-                let schema = serialize_schema_to_info(&flight.schema, &flight.ipc_schema.fields)
+                let schema = serialize_schema_to_info(&flight.schema, Some(&flight.ipc_schema.fields))
                     .expect(
                         "Could not generate schema bytes from schema stored by a DoPut; \
                          this should be impossible",


### PR DESCRIPTION
This was a regression vs 0.8 - users should be allowed to pass `Option` to retain the previous behavior.