### PR TITLE
Fix parquet binary dict page reading

### DIFF
--- a/src/io/parquet/read/binary/basic.rs
+++ b/src/io/parquet/read/binary/basic.rs
@@ -105,8 +105,6 @@ fn read_delta_optional<O: Offset>(
     values: &mut Binary<O>,
     validity: &mut MutableBitmap,
 ) {
-    let length = values.len() + additional;
-
     let Binary {
         offsets,
         values,
@@ -126,7 +124,7 @@ fn read_delta_optional<O: Offset>(
     extend_from_decoder(
         validity,
         &mut validity_iterator,
-        length,
+        additional,
         &mut Offsets::<O>(offsets),
         offsets_iterator,
     );
@@ -143,8 +141,6 @@ fn read_plain_optional<O: Offset>(
     values: &mut Binary<O>,
     validity: &mut MutableBitmap,
 ) {
-    let length = values.len() + additional;
-
     // values_buffer: first 4 bytes are len, remaining is values
     let values_iterator = utils::BinaryIter::new(values_buffer);
 
@@ -153,7 +149,7 @@ fn read_plain_optional<O: Offset>(
     extend_from_decoder(
         validity,
         &mut validity_iterator,
-        length,
+        additional,
         values,
         values_iterator,
     )

--- a/src/io/parquet/read/binary/basic.rs
+++ b/src/io/parquet/read/binary/basic.rs
@@ -189,7 +189,7 @@ pub(super) fn extend_from_page<O: Offset>(
 
     let (_, validity_buffer, values_buffer, version) = utils::split_buffer(page, descriptor);
 
-    match dbg!((&page.encoding(), page.dictionary_page(), is_optional)) {
+    match (&page.encoding(), page.dictionary_page(), is_optional) {
         (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true) => {
             read_dict_buffer::<O>(
                 validity_buffer,

--- a/src/io/parquet/read/binary/basic.rs
+++ b/src/io/parquet/read/binary/basic.rs
@@ -67,12 +67,11 @@ fn read_dict_required<O: Offset>(
     values: &mut Binary<O>,
     validity: &mut MutableBitmap,
 ) {
+    debug_assert_eq!(0, validity.len());
     let values_iterator = values_iter(indices_buffer, dict, additional);
-
     for value in values_iterator {
         values.push(value);
     }
-    validity.extend_constant(additional, true);
 }
 
 struct Offsets<'a, O: Offset>(pub &'a mut Vec<O>);
@@ -190,7 +189,7 @@ pub(super) fn extend_from_page<O: Offset>(
 
     let (_, validity_buffer, values_buffer, version) = utils::split_buffer(page, descriptor);
 
-    match (&page.encoding(), page.dictionary_page(), is_optional) {
+    match dbg!((&page.encoding(), page.dictionary_page(), is_optional)) {
         (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true) => {
             read_dict_buffer::<O>(
                 validity_buffer,

--- a/src/io/parquet/read/binary/basic.rs
+++ b/src/io/parquet/read/binary/basic.rs
@@ -46,8 +46,6 @@ fn read_dict_buffer<O: Offset>(
     values: &mut Binary<O>,
     validity: &mut MutableBitmap,
 ) {
-    let length = values.len() + additional;
-
     let values_iterator = values_iter(indices_buffer, dict, additional);
 
     let mut validity_iterator = hybrid_rle::Decoder::new(validity_buffer, 1);
@@ -55,7 +53,7 @@ fn read_dict_buffer<O: Offset>(
     extend_from_decoder(
         validity,
         &mut validity_iterator,
-        length,
+        additional,
         values,
         values_iterator,
     );

--- a/src/io/parquet/read/binary/mod.rs
+++ b/src/io/parquet/read/binary/mod.rs
@@ -31,11 +31,10 @@ where
     ArrowError: From<E>,
     I: FallibleStreamingIterator<Item = DataPage, Error = E>,
 {
+    let is_nullable = nested.pop().unwrap().is_nullable();
     let capacity = metadata.num_values() as usize;
     let mut values = Binary::<O>::with_capacity(capacity);
-    let mut validity = MutableBitmap::with_capacity(capacity);
-
-    let is_nullable = nested.pop().unwrap().is_nullable();
+    let mut validity = MutableBitmap::with_capacity(capacity * usize::from(is_nullable));
 
     if nested.is_empty() {
         while let Some(page) = iter.next()? {
@@ -53,8 +52,8 @@ where
             )?
         }
     }
-    debug_assert_eq!(validity.len(), capacity);
     debug_assert_eq!(values.len(), capacity);
+    debug_assert_eq!(validity.len(), capacity * usize::from(is_nullable));
     Ok(utils::finish_array(data_type, values, validity))
 }
 

--- a/src/io/parquet/read/binary/mod.rs
+++ b/src/io/parquet/read/binary/mod.rs
@@ -40,6 +40,8 @@ where
         while let Some(page) = iter.next()? {
             basic::extend_from_page(page, metadata.descriptor(), &mut values, &mut validity)?
         }
+        debug_assert_eq!(values.len(), capacity);
+        debug_assert_eq!(validity.len(), capacity * usize::from(is_nullable));
     } else {
         while let Some(page) = iter.next()? {
             nested::extend_from_page(
@@ -52,8 +54,6 @@ where
             )?
         }
     }
-    debug_assert_eq!(values.len(), capacity);
-    debug_assert_eq!(validity.len(), capacity * usize::from(is_nullable));
     Ok(utils::finish_array(data_type, values, validity))
 }
 

--- a/src/io/parquet/read/binary/mod.rs
+++ b/src/io/parquet/read/binary/mod.rs
@@ -53,6 +53,8 @@ where
             )?
         }
     }
+    debug_assert_eq!(validity.len(), capacity);
+    debug_assert_eq!(values.len(), capacity);
     Ok(utils::finish_array(data_type, values, validity))
 }
 

--- a/src/io/parquet/read/boolean/mod.rs
+++ b/src/io/parquet/read/boolean/mod.rs
@@ -33,6 +33,8 @@ where
         while let Some(page) = iter.next()? {
             basic::extend_from_page(page, metadata.descriptor(), &mut values, &mut validity)?
         }
+        debug_assert_eq!(values.len(), capacity);
+        debug_assert_eq!(validity.len(), capacity * usize::from(is_nullable));
     } else {
         while let Some(page) = iter.next()? {
             nested::extend_from_page(
@@ -45,8 +47,6 @@ where
             )?
         }
     }
-    debug_assert_eq!(values.len(), capacity);
-    debug_assert_eq!(validity.len(), capacity * usize::from(is_nullable));
 
     Ok(Box::new(BooleanArray::from_data(
         data_type,

--- a/src/io/parquet/read/fixed_size_binary/utils.rs
+++ b/src/io/parquet/read/fixed_size_binary/utils.rs
@@ -26,6 +26,11 @@ impl FixedSizeBinary {
         self.values
             .resize(self.values.len() + additional * self.size, 0);
     }
+
+    #[inline]
+    pub fn len(&mut self) -> usize {
+        self.values.len() / self.size
+    }
 }
 
 impl Pushable<&[u8]> for FixedSizeBinary {

--- a/src/io/parquet/read/primitive/basic.rs
+++ b/src/io/parquet/read/primitive/basic.rs
@@ -71,11 +71,9 @@ fn read_dict_buffer_required<T, A, F>(
     A: ArrowNativeType,
     F: Fn(T) -> A,
 {
+    debug_assert_eq!(0, validity.len());
     let values_iterator = values_iter(indices_buffer, dict.values(), additional, op);
-
     values.extend(values_iterator);
-
-    validity.extend_constant(additional, true);
 }
 
 fn read_nullable<T, A, F>(

--- a/src/io/parquet/read/primitive/basic.rs
+++ b/src/io/parquet/read/primitive/basic.rs
@@ -46,8 +46,6 @@ fn read_dict_buffer_optional<T, A, F>(
     A: ArrowNativeType,
     F: Fn(T) -> A,
 {
-    let length = additional + values.len();
-
     let values_iterator = values_iter(indices_buffer, dict.values(), additional, op);
 
     let mut validity_iterator = hybrid_rle::Decoder::new(validity_buffer, 1);
@@ -55,10 +53,10 @@ fn read_dict_buffer_optional<T, A, F>(
     extend_from_decoder(
         validity,
         &mut validity_iterator,
-        length,
+        additional,
         values,
         values_iterator,
-    )
+    );
 }
 
 fn read_dict_buffer_required<T, A, F>(

--- a/src/io/parquet/read/primitive/mod.rs
+++ b/src/io/parquet/read/primitive/mod.rs
@@ -84,6 +84,8 @@ where
         while let Some(page) = iter.next()? {
             basic::extend_from_page(page, metadata.descriptor(), &mut values, &mut validity, op)?
         }
+        debug_assert_eq!(values.len(), capacity);
+        debug_assert_eq!(validity.len(), capacity * usize::from(is_nullable));
     } else {
         while let Some(page) = iter.next()? {
             nested::extend_from_page(
@@ -97,8 +99,6 @@ where
             )?
         }
     }
-    debug_assert_eq!(values.len(), capacity);
-    debug_assert_eq!(validity.len(), capacity * usize::from(is_nullable));
 
     let data_type = match data_type {
         DataType::Dictionary(_, values, _) => values.as_ref().clone(),


### PR DESCRIPTION
As described in #790, there is a bug in parquet binary dict page decoding whereby too many values are yielded due to a mixup in the length arguments passed to various decoding functions, ultimately leading to extra bitpacked values being included in the output array.  This PR fixes the bug, and adds some `debug_assert!`s in key places to ensure that tests would catch the issue in the future.  I went ahead and added similar debug asserts to the other page type read functions, which exposed a few places where validity buffers are being allocated for non-nullable columns.

Unfortunately these new debug asserts are firing for nested page type tests, but I don't currently understand how the encoding works for these page types (it looks significantly more complicated than RLE & bitpack).  I suspect that these test failures are a true positive, but I can't be sure without understanding how nested encoding works.