### PR TITLE
make `Bytes<T>` wrap `Vec<T>`

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 pub(self) mod physical_binary;
 
 /// A trait representing an immutable Arrow array. Arrow arrays are trait objects
-/// that are infalibly downcasted to concrete types according to the [`Array::data_type`].
+/// that are infallibly downcasted to concrete types according to the [`Array::data_type`].
 pub trait Array: Send + Sync {
     /// Convert to trait object.
     fn as_any(&self) -> &dyn Any;

--- a/src/buffer/bytes.rs
+++ b/src/buffer/bytes.rs
@@ -1,7 +1,7 @@
 //! This module contains an implementation of a contiguous immutable memory region that knows
 //! how to de-allocate itself, [`Bytes`].
 
-use std::slice;
+use std::mem::ManuallyDrop;
 use std::{fmt::Debug, fmt::Formatter};
 use std::{ptr::NonNull, sync::Arc};
 
@@ -11,7 +11,7 @@ use crate::types::NativeType;
 /// Mode of deallocating memory regions
 pub enum Deallocation {
     /// Native deallocation, using Rust deallocator with Arrow-specific memory aligment
-    Native(usize),
+    Native,
     // Foreign interface, via a callback
     Foreign(Arc<ffi::ArrowArray>),
 }
@@ -19,8 +19,8 @@ pub enum Deallocation {
 impl Debug for Deallocation {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            Deallocation::Native(capacity) => {
-                write!(f, "Deallocation::Native {{ capacity: {} }}", capacity)
+            Deallocation::Native => {
+                write!(f, "Deallocation::Native")
             }
             Deallocation::Foreign(_) => {
                 write!(f, "Deallocation::Foreign {{ capacity: unknown }}")
@@ -36,12 +36,8 @@ impl Debug for Deallocation {
 /// When the region is allocated by a foreign allocator, [Deallocation::Foreign], this calls the
 /// foreign deallocator to deallocate the region when it is no longer needed.
 pub struct Bytes<T: NativeType> {
-    /// The raw pointer to be begining of the region
-    ptr: NonNull<T>,
-
-    /// The number of bytes visible to this region. This is always smaller than its capacity (when avaliable).
-    len: usize,
-
+    /// inner data
+    data: Vec<T>,
     /// how to deallocate this region
     deallocation: Deallocation,
 }
@@ -59,13 +55,20 @@ impl<T: NativeType> Bytes<T> {
     ///
     /// This function is unsafe as there is no guarantee that the given pointer is valid for `len`
     /// bytes. If the `ptr` and `capacity` come from a `Buffer`, then this is guaranteed.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the give deallocation not is `Deallocation::Foreign`
     #[inline]
-    pub unsafe fn new(ptr: std::ptr::NonNull<T>, len: usize, deallocation: Deallocation) -> Self {
-        Self {
-            ptr,
-            len,
-            deallocation,
-        }
+    pub unsafe fn from_ffi(
+        ptr: std::ptr::NonNull<T>,
+        len: usize,
+        deallocation: Deallocation,
+    ) -> Self {
+        let data = Vec::from_raw_parts(ptr.as_ptr(), len, len);
+        assert!(matches!(deallocation, Deallocation::Foreign(_)));
+
+        Self { data, deallocation }
     }
 
     #[inline]
@@ -75,12 +78,13 @@ impl<T: NativeType> Bytes<T> {
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.len
+        self.data.len()
     }
 
     #[inline]
     pub fn ptr(&self) -> NonNull<T> {
-        self.ptr
+        debug_assert!(!self.data.as_ptr().is_null());
+        unsafe { NonNull::new_unchecked(self.data.as_ptr() as *mut T) }
     }
 }
 
@@ -88,11 +92,13 @@ impl<T: NativeType> Drop for Bytes<T> {
     #[inline]
     fn drop(&mut self) {
         match &self.deallocation {
-            Deallocation::Native(capacity) => unsafe {
-                let _ = Vec::from_raw_parts(self.ptr.as_ptr(), self.len, *capacity);
-            },
+            // the Vec may be dropped
+            Deallocation::Native => {}
             // foreign interface knows how to deallocate itself.
-            Deallocation::Foreign(_) => (),
+            Deallocation::Foreign(_) => {
+                let data = std::mem::take(&mut self.data);
+                let _ = ManuallyDrop::new(data);
+            }
         }
     }
 }
@@ -101,7 +107,7 @@ impl<T: NativeType> std::ops::Deref for Bytes<T> {
     type Target = [T];
 
     fn deref(&self) -> &[T] {
-        unsafe { slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
+        &self.data
     }
 }
 
@@ -113,7 +119,12 @@ impl<T: NativeType> PartialEq for Bytes<T> {
 
 impl<T: NativeType> Debug for Bytes<T> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "Bytes {{ ptr: {:?}, len: {}, data: ", self.ptr, self.len,)?;
+        write!(
+            f,
+            "Bytes {{ ptr: {:?}, len: {}, data: ",
+            self.data.as_ptr(),
+            self.len(),
+        )?;
 
         f.debug_list().entries(self.iter()).finish()?;
 
@@ -123,15 +134,11 @@ impl<T: NativeType> Debug for Bytes<T> {
 
 impl<T: NativeType> From<Vec<T>> for Bytes<T> {
     #[inline]
-    fn from(mut data: Vec<T>) -> Self {
-        let ptr = NonNull::new(data.as_mut_ptr()).unwrap();
-        let len = data.len();
-        let capacity = data.capacity();
-
-        let result = unsafe { Bytes::new(ptr, len, Deallocation::Native(capacity)) };
-        // so that the memory region is not deallocated.
-        std::mem::forget(data);
-        result
+    fn from(data: Vec<T>) -> Self {
+        Self {
+            data,
+            deallocation: Deallocation::Native,
+        }
     }
 }
 

--- a/src/ffi/ffi.rs
+++ b/src/ffi/ffi.rs
@@ -205,7 +205,7 @@ unsafe fn create_buffer<T: NativeType>(
     let len = buffer_len(array, data_type, index)?;
     let offset = buffer_offset(array, data_type, index);
     let bytes = ptr
-        .map(|ptr| Bytes::new(ptr, len, deallocation))
+        .map(|ptr| Bytes::from_ffi(ptr, len, deallocation))
         .ok_or_else(|| {
             ArrowError::OutOfSpec(format!("The buffer at position {} is null", index))
         })?;
@@ -240,7 +240,7 @@ unsafe fn create_bitmap(
     let bytes_len = bytes_for(offset + len);
     let ptr = NonNull::new(ptr as *mut u8);
     let bytes = ptr
-        .map(|ptr| Bytes::new(ptr, bytes_len, deallocation))
+        .map(|ptr| Bytes::from_ffi(ptr, bytes_len, deallocation))
         .ok_or_else(|| {
             ArrowError::OutOfSpec(format!(
                 "The buffer {} is a null pointer and cannot be interpreted as a bitmap",


### PR DESCRIPTION
Given that we would have natively allocated memory, this should make it easier to move in and out of `arrow` memory.