### PR TITLE
fix unescaped '"' in json writing

### DIFF
--- a/src/io/json/write/serialize.rs
+++ b/src/io/json/write/serialize.rs
@@ -1,5 +1,4 @@
 use lexical_core::ToLexical;
-use serde_json::Value;
 use streaming_iterator::StreamingIterator;
 
 use crate::bitmap::utils::zip_validity;
@@ -139,7 +138,7 @@ fn list_serializer<'a, O: Offset>(
 
 #[inline]
 fn utf8_serialize(value: &str, buf: &mut Vec<u8>) {
-    if value.as_bytes().is_ascii() {
+    if value.as_bytes().is_ascii() && !value.contains('"') {
         buf.reserve(value.len() + 2);
         buf.push(b'"');
         buf.extend_from_slice(value.as_bytes());
@@ -147,7 +146,7 @@ fn utf8_serialize(value: &str, buf: &mut Vec<u8>) {
     } else {
         // it may contain reserved keywords: perform roundtrip for
         // todo: avoid this roundtrip over serde_json
-        serde_json::to_writer(buf, &Value::String(value.to_string())).unwrap();
+        serde_json::to_writer(buf, value).unwrap();
     }
 }
 

--- a/src/io/json/write/serialize.rs
+++ b/src/io/json/write/serialize.rs
@@ -46,7 +46,7 @@ fn utf8_serializer<'a, O: Offset>(
         array.iter(),
         |x, buf| {
             if let Some(x) = x {
-                utf8_serialize(x, buf)
+                serde_json::to_writer(buf, x).unwrap();
             } else {
                 buf.extend_from_slice(b"null")
             }
@@ -136,20 +136,6 @@ fn list_serializer<'a, O: Offset>(
     ))
 }
 
-#[inline]
-fn utf8_serialize(value: &str, buf: &mut Vec<u8>) {
-    if value.as_bytes().is_ascii() && !value.contains('"') {
-        buf.reserve(value.len() + 2);
-        buf.push(b'"');
-        buf.extend_from_slice(value.as_bytes());
-        buf.push(b'"');
-    } else {
-        // it may contain reserved keywords: perform roundtrip for
-        // todo: avoid this roundtrip over serde_json
-        serde_json::to_writer(buf, value).unwrap();
-    }
-}
-
 fn new_serializer<'a>(
     array: &'a dyn Array,
 ) -> Box<dyn StreamingIterator<Item = [u8]> + 'a + Send + Sync> {
@@ -188,7 +174,7 @@ fn serialize_item<F: JsonFormat>(
             buffer.push(b',');
         }
         first_item = false;
-        utf8_serialize(key, buffer);
+        serde_json::to_writer(&mut *buffer, key).unwrap();
         buffer.push(b':');
         buffer.extend(*value);
     }

--- a/tests/it/io/json/write.rs
+++ b/tests/it/io/json/write.rs
@@ -301,7 +301,7 @@ fn write_escaped_utf8() -> Result<()> {
 
     assert_eq!(
         String::from_utf8(buf).unwrap().as_bytes(),
-        b"{\"c1\":\"a\na\"}\n{\"c1\":null}\n"
+        b"{\"c1\":\"a\\na\"}\n{\"c1\":null}\n"
     );
     Ok(())
 }

--- a/tests/it/io/json/write.rs
+++ b/tests/it/io/json/write.rs
@@ -305,3 +305,22 @@ fn write_escaped_utf8() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn write_quotation_marks_in_utf8() -> Result<()> {
+    let a = Utf8Array::<i32>::from(&vec![Some("a\"a"), None]);
+
+    let batch = Chunk::try_new(vec![&a as &dyn Array]).unwrap();
+
+    let buf = write_batch(
+        batch,
+        vec!["c1".to_string()],
+        json_write::LineDelimited::default(),
+    )?;
+
+    assert_eq!(
+        String::from_utf8(buf).unwrap().as_bytes(),
+        b"{\"c1\":\"a\\\"a\"}\n{\"c1\":null}\n"
+    );
+    Ok(())
+}


### PR DESCRIPTION
fixes #811.

This is a quick hack that also searches for `"` before branching.

However, the second branch first did an unnecessary heap convertion from `&str` -> `String`. I removed it and the tests still succeed. 

I think that we maybe should not branch at all now we don' do this heap allocation? Because we are now doing a double scan over the data determine which path we must take.