### PR TITLE
add unchecked versions

### DIFF
--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -1,7 +1,7 @@
 use std::hint::unreachable_unchecked;
 use std::iter::FromIterator;
 
-use crate::bitmap::utils::merge_reversed;
+use crate::bitmap::utils::{merge_reversed, set_bit_unchecked};
 use crate::trusted_len::TrustedLen;
 
 use super::utils::{count_zeros, fmt, get_bit, set, set_bit, BitmapIter};
@@ -207,6 +207,14 @@ impl MutableBitmap {
     #[inline]
     pub fn set(&mut self, index: usize, value: bool) {
         set_bit(self.buffer.as_mut_slice(), index, value)
+    }
+
+    /// Sets the position `index` to `value`
+    /// # Safety
+    /// Caller must ensure that `index < self.len()`
+    #[inline]
+    pub unsafe fn set_unchecked(&mut self, index: usize, value: bool) {
+        set_bit_unchecked(self.buffer.as_mut_slice(), index, value)
     }
 
     /// Shrinks the capacity of the [`MutableBitmap`] to fit its current length.

--- a/src/bitmap/utils/mod.rs
+++ b/src/bitmap/utils/mod.rs
@@ -43,9 +43,20 @@ pub fn set(byte: u8, i: usize, value: bool) -> u8 {
 }
 
 /// Sets bit at position `i` in `data`
+/// # Panics
+/// panics if `i >= data.len() / 8`
 #[inline]
 pub fn set_bit(data: &mut [u8], i: usize, value: bool) {
     data[i / 8] = set(data[i / 8], i % 8, value);
+}
+
+/// Sets bit at position `i` in `data` without doing bound checks
+/// # Safety
+/// caller must ensure that `i < data.len() / 8`
+#[inline]
+pub unsafe fn set_bit_unchecked(data: &mut [u8], i: usize, value: bool) {
+    let byte = data.get_unchecked_mut(i / 8);
+    *byte = set(*byte, i % 8, value);
 }
 
 /// Returns whether bit at position `i` in `data` is set or not


### PR DESCRIPTION
add unchecked versions of `set`
for `MutableBitmap` and `MutablePrimitiveArray`

The safe `set` now asserts the invariant and dispatches the the `unchecked` version. This elides a bound check because it was first done on the `values` buffer and the validity bitmap. Where it is the invariant of the struct that they have the same length.