### PR TITLE
Improved flexibility of reading parquet

### DIFF
--- a/examples/parquet_read_async.rs
+++ b/examples/parquet_read_async.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
         // A row group is consumed in two steps: the first step is to read the (compressed)
         // columns into memory, which is IO-bounded.
         let column_chunks =
-            read::read_columns_async(factory, row_group, schema.fields.clone(), None).await?;
+            read::read_columns_many_async(factory, row_group, schema.fields.clone(), None).await?;
 
         // the second step is to iterate over the columns in chunks.
         // this operation is CPU-bounded and should be sent to a separate thread pool (e.g. `tokio_rayon`) to not block

--- a/src/io/parquet/read/file.rs
+++ b/src/io/parquet/read/file.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::array::Array;
 use crate::chunk::Chunk;
 use crate::datatypes::Schema;
-use crate::io::parquet::read::read_columns;
+use crate::io::parquet::read::read_columns_many;
 use crate::{
     datatypes::Field,
     error::{ArrowError, Result},
@@ -233,7 +233,7 @@ impl<R: Read + Seek> RowGroupReader<R> {
         }
         self.current_group += 1;
 
-        let column_chunks = read_columns(
+        let column_chunks = read_columns_many(
             &mut self.reader,
             row_group,
             self.schema.fields.clone(),


### PR DESCRIPTION
This exposes an API to read parquet in different ways:

* read (IO-bounded) columns in parallel (!= concurrently)
* read and deserialize columns one by one (reduce memory pressure for column-based execution engines)

This allows the both of the two worlds: allow reading both multiple fields and distributed/concurrent work over individual fields.
