### PR TITLE
Improved performance of `SlicesIterator` (15%)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,3 +306,7 @@ harness = false
 [[bench]]
 name = "write_json"
 harness = false
+
+[[bench]]
+name = "slices_iterator"
+harness = false

--- a/benches/slices_iterator.rs
+++ b/benches/slices_iterator.rs
@@ -1,0 +1,25 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use arrow2::bitmap::{utils::SlicesIterator, Bitmap};
+
+fn bench_slices(lhs: &Bitmap) {
+    let set_count = lhs.len() - lhs.null_count();
+    let slices = SlicesIterator::new(lhs);
+
+    let count = slices.fold(0usize, |acc, v| acc + v.1);
+    assert_eq!(count, set_count);
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+
+        let bitmap: Bitmap = (0..size).into_iter().map(|x| x % 3 == 0).collect();
+        c.bench_function(&format!("bitmap slices 2^{}", log2_size), |b| {
+            b.iter(|| bench_slices(&bitmap))
+        });
+    });
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Some code simplification (10%) and inlining (5%).

```
bitmap slices 2^10      time:   [3.3655 us 3.3766 us 3.3875 us]                                
                        change: [-15.754% -15.343% -14.973%] (p = 0.00 < 0.05)

bitmap slices 2^20      time:   [3.3802 ms 3.3890 ms 3.3976 ms]                                
                        change: [-15.120% -14.776% -14.451%] (p = 0.00 < 0.05)

```