### PR TITLE
Added support for pushdown projection in reading Avro

### DIFF
--- a/benches/avro_read.rs
+++ b/benches/avro_read.rs
@@ -52,6 +52,7 @@ fn read_batch(buffer: &[u8], size: usize) -> Result<()> {
         ),
         avro_schema,
         schema.fields,
+        None,
     );
 
     let mut rows = 0;

--- a/examples/avro_read.rs
+++ b/examples/avro_read.rs
@@ -20,6 +20,7 @@ fn main() -> Result<()> {
         read::Decompressor::new(read::BlockStreamIterator::new(file, file_marker), codec),
         avro_schema,
         schema.fields,
+        None,
     );
 
     for maybe_chunk in reader {

--- a/src/io/avro/read/mod.rs
+++ b/src/io/avro/read/mod.rs
@@ -17,7 +17,7 @@ mod schema;
 mod util;
 
 pub(super) use header::deserialize_header;
-pub(super) use schema::convert_schema;
+pub(super) use schema::infer_schema;
 
 use crate::array::Array;
 use crate::chunk::Chunk;
@@ -32,7 +32,7 @@ pub fn read_metadata<R: std::io::Read>(
     reader: &mut R,
 ) -> Result<(Vec<AvroSchema>, Schema, Option<Compression>, [u8; 16])> {
     let (avro_schema, codec, marker) = util::read_schema(reader)?;
-    let schema = convert_schema(&avro_schema)?;
+    let schema = infer_schema(&avro_schema)?;
 
     let avro_schema = if let AvroSchema::Record(Record { fields, .. }) = avro_schema {
         fields.into_iter().map(|x| x.schema).collect()

--- a/src/io/avro/read/mod.rs
+++ b/src/io/avro/read/mod.rs
@@ -48,15 +48,23 @@ pub struct Reader<R: Read> {
     iter: Decompressor<R>,
     avro_schemas: Vec<AvroSchema>,
     fields: Vec<Field>,
+    projection: Vec<bool>,
 }
 
 impl<R: Read> Reader<R> {
     /// Creates a new [`Reader`].
-    pub fn new(iter: Decompressor<R>, avro_schemas: Vec<AvroSchema>, fields: Vec<Field>) -> Self {
+    pub fn new(
+        iter: Decompressor<R>,
+        avro_schemas: Vec<AvroSchema>,
+        fields: Vec<Field>,
+        projection: Option<Vec<bool>>,
+    ) -> Self {
+        let projection = projection.unwrap_or_else(|| fields.iter().map(|_| true).collect());
         Self {
             iter,
             avro_schemas,
             fields,
+            projection,
         }
     }
 
@@ -72,10 +80,11 @@ impl<R: Read> Iterator for Reader<R> {
     fn next(&mut self) -> Option<Self::Item> {
         let fields = &self.fields[..];
         let avro_schemas = &self.avro_schemas;
+        let projection = &self.projection;
 
         self.iter
             .next()
             .transpose()
-            .map(|maybe_block| deserialize(maybe_block?, fields, avro_schemas))
+            .map(|maybe_block| deserialize(maybe_block?, fields, avro_schemas, projection))
     }
 }

--- a/src/io/avro/read/schema.rs
+++ b/src/io/avro/read/schema.rs
@@ -19,8 +19,9 @@ fn external_props(schema: &AvroSchema) -> Metadata {
     props
 }
 
-/// Maps an [`AvroSchema`] into a [`Schema`].
-pub fn convert_schema(schema: &AvroSchema) -> Result<Schema> {
+/// Infers an [`Schema`] from the root [`AvroSchema`].
+/// This
+pub fn infer_schema(schema: &AvroSchema) -> Result<Schema> {
     if let AvroSchema::Record(Record { fields, .. }) = schema {
         Ok(fields
             .iter()
@@ -35,7 +36,7 @@ pub fn convert_schema(schema: &AvroSchema) -> Result<Schema> {
             .into())
     } else {
         Err(ArrowError::OutOfSpec(
-            "An avro Schema must be of type Record".to_string(),
+            "The root AvroSchema must be of type Record".to_string(),
         ))
     }
 }

--- a/src/io/avro/read_async/metadata.rs
+++ b/src/io/avro/read_async/metadata.rs
@@ -8,8 +8,8 @@ use futures::AsyncReadExt;
 use crate::datatypes::Schema;
 use crate::error::{ArrowError, Result};
 
-use super::super::read::convert_schema;
 use super::super::read::deserialize_header;
+use super::super::read::infer_schema;
 use super::super::Compression;
 use super::super::{read_header, read_metadata};
 use super::utils::zigzag_i64;
@@ -28,7 +28,7 @@ pub async fn read_metadata<R: AsyncRead + Unpin + Send>(
     reader: &mut R,
 ) -> Result<(Vec<AvroSchema>, Schema, Option<Compression>, [u8; 16])> {
     let (avro_schema, codec, marker) = read_metadata_async(reader).await?;
-    let schema = convert_schema(&avro_schema)?;
+    let schema = infer_schema(&avro_schema)?;
 
     let avro_schema = if let AvroSchema::Record(Record { fields, .. }) = avro_schema {
         fields.into_iter().map(|x| x.schema).collect()

--- a/tests/it/io/avro/write.rs
+++ b/tests/it/io/avro/write.rs
@@ -117,7 +117,7 @@ fn roundtrip(compression: Option<write::Compression>) -> Result<()> {
 
     let data = write_avro(&expected, &expected_schema, compression)?;
 
-    let (result, read_schema) = read_avro(&data)?;
+    let (result, read_schema) = read_avro(&data, None)?;
 
     assert_eq!(expected_schema, read_schema);
     for (c1, c2) in result.columns().iter().zip(expected.columns().iter()) {

--- a/tests/it/io/avro/write_async.rs
+++ b/tests/it/io/avro/write_async.rs
@@ -32,7 +32,7 @@ async fn roundtrip(compression: Option<write::Compression>) -> Result<()> {
 
     let data = write_avro(&expected, &expected_schema, compression).await?;
 
-    let (result, read_schema) = read_avro(&data)?;
+    let (result, read_schema) = read_avro(&data, None)?;
 
     assert_eq!(expected_schema, read_schema);
     for (c1, c2) in result.columns().iter().zip(expected.columns().iter()) {


### PR DESCRIPTION
This allows skipping deserializing columns when they are not required.

The speedup is proportional to the number of columns that are not needed (times the average cost of deserializing a column type over all skipped columns).
