### PR TITLE
Supporting `LargeUtf8` and `LargeBinary` for avro schema

### DIFF
--- a/src/io/avro/write/schema.rs
+++ b/src/io/avro/write/schema.rs
@@ -32,7 +32,9 @@ fn _type_to_schema(data_type: &DataType) -> Result<AvroSchema> {
         DataType::Float32 => AvroSchema::Float,
         DataType::Float64 => AvroSchema::Double,
         DataType::Binary => AvroSchema::Bytes(None),
+        DataType::LargeBinary => AvroSchema::Bytes(None),
         DataType::Utf8 => AvroSchema::String(None),
+        DataType::LargeUtf8 => AvroSchema::String(None),
         DataType::List(inner) => AvroSchema::Array(Box::new(type_to_schema(
             &inner.data_type,
             inner.is_nullable,

--- a/tests/it/io/avro/write.rs
+++ b/tests/it/io/avro/write.rs
@@ -1,5 +1,3 @@
-use std::fmt::Binary;
-
 use arrow2::array::*;
 use arrow2::chunk::Chunk;
 use arrow2::datatypes::*;


### PR DESCRIPTION
- convert `LargeUtf8` and `LargeBinary` schema to `avro::String` and `avro::Bytes` when converting from datatype to avro schema.
- adding a test for `LargeUtf8` and `LargeBinary` io