### PR TITLE
Bumped zstd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ hex = { version = "^0.4", optional = true }
 
 # for IPC compression
 lz4 = { version = "1.23.1", optional = true }
-zstd = { version = "0.9", optional = true }
+zstd = { version = "0.10", optional = true }
 
 rand = { version = "0.8", optional = true }
 


### PR DESCRIPTION
To align with `parquet2` and avoid an extra dependency.