### PR TITLE
Simplified API for FFI

### DIFF
--- a/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/arrow-pyarrow-integration-testing/src/lib.rs
@@ -66,7 +66,8 @@ fn to_rust_array(ob: PyObject, py: Python) -> PyResult<Arc<dyn Array>> {
     )?;
 
     let field = unsafe { ffi::import_field_from_c(schema.as_ref()).map_err(PyO3ArrowError::from)? };
-    let array = unsafe { ffi::import_array_from_c(array, &field).map_err(PyO3ArrowError::from)? };
+    let array =
+        unsafe { ffi::import_array_from_c(array, field.data_type).map_err(PyO3ArrowError::from)? };
 
     Ok(array.into())
 }

--- a/examples/ffi.rs
+++ b/examples/ffi.rs
@@ -19,7 +19,7 @@ unsafe fn import(
     schema: &ffi::Ffi_ArrowSchema,
 ) -> Result<Box<dyn Array>> {
     let field = ffi::import_field_from_c(schema)?;
-    ffi::import_array_from_c(array, &field)
+    ffi::import_array_from_c(array, field.data_type)
 }
 
 fn main() -> Result<()> {

--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -52,7 +52,7 @@ unsafe impl<O: Offset> ToFfi for BinaryArray<O> {
 
 impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryArray<O> {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field().data_type().clone();
+        let data_type = array.data_type().clone();
 
         let validity = unsafe { array.validity() }?;
         let offsets = unsafe { array.buffer::<O>(1) }?;

--- a/src/array/boolean/ffi.rs
+++ b/src/array/boolean/ffi.rs
@@ -50,7 +50,7 @@ unsafe impl ToFfi for BooleanArray {
 
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for BooleanArray {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field().data_type().clone();
+        let data_type = array.data_type().clone();
         let validity = unsafe { array.validity() }?;
         let values = unsafe { array.bitmap(1) }?;
         Ok(Self::from_data(data_type, values, validity))

--- a/src/array/fixed_size_binary/ffi.rs
+++ b/src/array/fixed_size_binary/ffi.rs
@@ -50,7 +50,7 @@ unsafe impl ToFfi for FixedSizeBinaryArray {
 
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for FixedSizeBinaryArray {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field().data_type().clone();
+        let data_type = array.data_type().clone();
         let validity = unsafe { array.validity() }?;
         let values = unsafe { array.buffer::<u8>(1) }?;
 

--- a/src/array/fixed_size_list/ffi.rs
+++ b/src/array/fixed_size_list/ffi.rs
@@ -35,7 +35,7 @@ unsafe impl ToFfi for FixedSizeListArray {
 
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for FixedSizeListArray {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field().data_type().clone();
+        let data_type = array.data_type().clone();
         let validity = unsafe { array.validity() }?;
         let child = unsafe { array.child(0)? };
         let values = ffi::try_from(child)?.into();

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -52,7 +52,7 @@ unsafe impl<O: Offset> ToFfi for ListArray<O> {
 
 impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for ListArray<O> {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field().data_type().clone();
+        let data_type = array.data_type().clone();
         let validity = unsafe { array.validity() }?;
         let offsets = unsafe { array.buffer::<O>(1) }?;
         let child = unsafe { array.child(0)? };

--- a/src/array/map/ffi.rs
+++ b/src/array/map/ffi.rs
@@ -52,7 +52,7 @@ unsafe impl ToFfi for MapArray {
 
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for MapArray {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field().data_type().clone();
+        let data_type = array.data_type().clone();
         let validity = unsafe { array.validity() }?;
         let offsets = unsafe { array.buffer::<i32>(1) }?;
         let child = array.child(0)?;

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -96,7 +96,7 @@ unsafe impl ToFfi for NullArray {
 
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for NullArray {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field().data_type().clone();
+        let data_type = array.data_type().clone();
         Ok(Self::from_data(data_type, array.array().len()))
     }
 }

--- a/src/array/primitive/ffi.rs
+++ b/src/array/primitive/ffi.rs
@@ -51,7 +51,7 @@ unsafe impl<T: NativeType> ToFfi for PrimitiveArray<T> {
 
 impl<T: NativeType, A: ffi::ArrowArrayRef> FromFfi<A> for PrimitiveArray<T> {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field().data_type().clone();
+        let data_type = array.data_type().clone();
         let validity = unsafe { array.validity() }?;
         let values = unsafe { array.buffer::<T>(1) }?;
 

--- a/src/array/struct_/ffi.rs
+++ b/src/array/struct_/ffi.rs
@@ -29,7 +29,7 @@ unsafe impl ToFfi for StructArray {
 
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for StructArray {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field().data_type().clone();
+        let data_type = array.data_type().clone();
         let fields = Self::get_fields(&data_type);
 
         let validity = unsafe { array.validity() }?;

--- a/src/array/union/ffi.rs
+++ b/src/array/union/ffi.rs
@@ -32,9 +32,8 @@ unsafe impl ToFfi for UnionArray {
 
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for UnionArray {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let field = array.field();
-        let data_type = field.data_type().clone();
-        let fields = Self::get_fields(field.data_type());
+        let data_type = array.data_type().clone();
+        let fields = Self::get_fields(&data_type);
 
         let mut types = unsafe { array.buffer::<i8>(0) }?;
         let offsets = if Self::is_sparse(&data_type) {

--- a/src/array/utf8/ffi.rs
+++ b/src/array/utf8/ffi.rs
@@ -51,7 +51,7 @@ unsafe impl<O: Offset> ToFfi for Utf8Array<O> {
 
 impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for Utf8Array<O> {
     unsafe fn try_from_ffi(array: A) -> Result<Self> {
-        let data_type = array.field().data_type().clone();
+        let data_type = array.data_type().clone();
         let validity = unsafe { array.validity() }?;
         let offsets = unsafe { array.buffer::<O>(1) }?;
         let values = unsafe { array.buffer::<u8>(2)? };

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -11,7 +11,7 @@ use crate::{array::*, datatypes::PhysicalType};
 /// * the interface is not valid (e.g. a null pointer)
 pub unsafe fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
     use PhysicalType::*;
-    Ok(match array.field().data_type().to_physical_type() {
+    Ok(match array.data_type().to_physical_type() {
         Null => Box::new(NullArray::try_from_ffi(array)?),
         Boolean => Box::new(BooleanArray::try_from_ffi(array)?),
         Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -12,7 +12,7 @@ pub(crate) use ffi::{ArrowArray, ArrowArrayRef};
 use std::sync::Arc;
 
 use crate::array::Array;
-use crate::datatypes::Field;
+use crate::datatypes::{DataType, Field};
 use crate::error::Result;
 
 pub use ffi::Ffi_ArrowArray;
@@ -50,7 +50,7 @@ pub unsafe fn import_field_from_c(field: &Ffi_ArrowSchema) -> Result<Field> {
 /// valid according to the [C data interface](https://arrow.apache.org/docs/format/CDataInterface.html) (FFI).
 pub unsafe fn import_array_from_c(
     array: Box<Ffi_ArrowArray>,
-    field: &Field,
+    data_type: DataType,
 ) -> Result<Box<dyn Array>> {
-    try_from(Arc::new(ArrowArray::new(array, field.clone())))
+    try_from(Arc::new(ArrowArray::new(array, data_type)))
 }

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -455,14 +455,14 @@ fn to_format(data_type: &DataType) -> String {
     }
 }
 
-pub(super) fn get_field_child(field: &Field, index: usize) -> Result<Field> {
-    match (index, field.data_type()) {
-        (0, DataType::List(field)) => Ok(field.as_ref().clone()),
-        (0, DataType::FixedSizeList(field, _)) => Ok(field.as_ref().clone()),
-        (0, DataType::LargeList(field)) => Ok(field.as_ref().clone()),
-        (0, DataType::Map(field, _)) => Ok(field.as_ref().clone()),
-        (index, DataType::Struct(fields)) => Ok(fields[index].clone()),
-        (index, DataType::Union(fields, _, _)) => Ok(fields[index].clone()),
+pub(super) fn get_child(data_type: &DataType, index: usize) -> Result<DataType> {
+    match (index, data_type) {
+        (0, DataType::List(field)) => Ok(field.data_type().clone()),
+        (0, DataType::FixedSizeList(field, _)) => Ok(field.data_type().clone()),
+        (0, DataType::LargeList(field)) => Ok(field.data_type().clone()),
+        (0, DataType::Map(field, _)) => Ok(field.data_type().clone()),
+        (index, DataType::Struct(fields)) => Ok(fields[index].data_type().clone()),
+        (index, DataType::Union(fields, _, _)) => Ok(fields[index].data_type().clone()),
         (child, data_type) => Err(ArrowError::OutOfSpec(format!(
             "Requested child {} to type {:?} that has no such child",
             child, data_type

--- a/tests/it/ffi.rs
+++ b/tests/it/ffi.rs
@@ -24,7 +24,8 @@ fn _test_round_trip(array: Arc<dyn Array>, expected: Box<dyn Array>) -> Result<(
 
     // import references
     let result_field = unsafe { ffi::import_field_from_c(schema_ptr.as_ref())? };
-    let result_array = unsafe { ffi::import_array_from_c(array_ptr, &result_field)? };
+    let result_array =
+        unsafe { ffi::import_array_from_c(array_ptr, result_field.data_type.clone())? };
 
     assert_eq!(&result_array, &expected);
     assert_eq!(result_field, field);


### PR DESCRIPTION
Inspired by [this observation](https://github.com/jorgecarleitao/arrow2/issues/673#issuecomment-1044788231) from @[multimeric](https://github.com/multimeric), I just realized that we do not really need a `Field` to read an array - the `DataType` is sufficient.

This PR leverages this observation to simplify the API a bit further. The updated examples show the idea.