### PR TITLE
Improved performance of filter performance via Simd selection [3x]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target-tarpaulin
 venv
 lcov.info
 Cargo.lock
+example.arrow
 fixtures
 settings.json
 dev/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,13 +249,15 @@ harness = false
 name = "comparison_kernels"
 harness = false
 
-[[bench]]
-name = "read_parquet"
-harness = false
+## disabled because we don't have the path of env `CARGO_MANIFEST_DIR`
 
-[[bench]]
-name = "write_parquet"
-harness = false
+# [[bench]]
+# name = "read_parquet"
+# harness = false
+
+# [[bench]]
+# name = "write_parquet"
+# harness = false
 
 [[bench]]
 name = "aggregate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,15 +249,14 @@ harness = false
 name = "comparison_kernels"
 harness = false
 
-## disabled because we don't have the path of env `CARGO_MANIFEST_DIR`
 
-# [[bench]]
-# name = "read_parquet"
-# harness = false
+[[bench]]
+name = "read_parquet"
+harness = false
 
-# [[bench]]
-# name = "write_parquet"
-# harness = false
+[[bench]]
+name = "write_parquet"
+harness = false
 
 [[bench]]
 name = "aggregate"

--- a/benches/filter_kernels.rs
+++ b/benches/filter_kernels.rs
@@ -94,12 +94,21 @@ fn add_benchmark(c: &mut Criterion) {
     });
 
     let data_array = create_primitive_array::<f32>(size, 0.5);
+    let data_array_nonull = create_primitive_array::<f32>(size, 0.0);
     c.bench_function("filter f32", |b| {
         b.iter(|| bench_filter(&data_array, &filter_array))
     });
     c.bench_function("filter f32 high selectivity", |b| {
         b.iter(|| bench_filter(&data_array, &dense_filter_array))
     });
+
+    c.bench_function("filter f32 nonull", |b| {
+        b.iter(|| bench_filter(&data_array_nonull, &filter_array))
+    });
+    c.bench_function("filter f32 nonull high selectivity", |b| {
+        b.iter(|| bench_filter(&data_array_nonull, &dense_filter_array))
+    });
+
     c.bench_function("filter context f32", |b| {
         b.iter(|| bench_built_filter(&filter, &data_array))
     });

--- a/src/types/bit_chunk.rs
+++ b/src/types/bit_chunk.rs
@@ -1,7 +1,9 @@
 use std::{
     fmt::Binary,
-    ops::{BitAnd, BitAndAssign, BitOr, Not, Shl, ShlAssign, ShrAssign},
+    ops::{BitAndAssign, Not, Shl, ShlAssign, ShrAssign},
 };
+
+use num_traits::PrimInt;
 
 use super::NativeType;
 
@@ -9,22 +11,16 @@ use super::NativeType;
 /// whose width is `1` bit. In `simd_packed` notation, this corresponds to `m1xY`.
 pub trait BitChunk:
     super::private::Sealed
+    + PrimInt
     + NativeType
     + Binary
-    + BitAnd<Output = Self>
     + ShlAssign
     + Not<Output = Self>
     + ShrAssign<usize>
     + ShlAssign<usize>
     + Shl<usize, Output = Self>
-    + Eq
     + BitAndAssign
-    + BitOr<Output = Self>
 {
-    /// A value with a single bit set at the most right position.
-    fn one() -> Self;
-    /// A value with no bits set.
-    fn zero() -> Self;
     /// convert itself into bytes.
     fn to_ne_bytes(self) -> Self::Bytes;
     /// convert itself from bytes.
@@ -35,11 +31,6 @@ macro_rules! bit_chunk {
     ($ty:ty) => {
         impl BitChunk for $ty {
             #[inline(always)]
-            fn zero() -> Self {
-                0
-            }
-
-            #[inline(always)]
             fn to_ne_bytes(self) -> Self::Bytes {
                 self.to_ne_bytes()
             }
@@ -47,11 +38,6 @@ macro_rules! bit_chunk {
             #[inline(always)]
             fn from_ne_bytes(v: Self::Bytes) -> Self {
                 Self::from_ne_bytes(v)
-            }
-
-            #[inline(always)]
-            fn one() -> Self {
-                1
             }
         }
     };
@@ -113,6 +99,54 @@ impl<T: BitChunk> Iterator for BitChunkIter<T> {
     }
 }
 
+/// An [`Iterator<Item=usize>`] over a [`BitChunk`].
+/// This iterator returns the postion of bit set.
+/// Refer: https://lemire.me/blog/2018/03/08/iterating-over-set-bits-quickly-simd-edition/
+/// # Example
+/// ```
+/// use arrow2::types::BitChunkOnes;
+/// let a = 0b00010000u8;
+/// let iter = BitChunkOnes::new(a);
+/// let r = iter.collect::<Vec<_>>();
+/// assert_eq!(r, vec![4]);
+/// ```
+pub struct BitChunkOnes<T: BitChunk> {
+    value: T,
+    remaining: usize,
+}
+
+impl<T: BitChunk> BitChunkOnes<T> {
+    /// Creates a new [`BitChunkOnes`] with `len` bits.
+    #[inline]
+    pub fn new(value: T) -> Self {
+        Self {
+            value,
+            remaining: value.count_ones() as usize,
+        }
+    }
+}
+
+impl<T: BitChunk> Iterator for BitChunkOnes<T> {
+    type Item = usize;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let v = self.value.trailing_zeros() as usize;
+        self.value &= self.value - T::one();
+
+        self.remaining -= 1;
+        Some(v)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -124,5 +158,14 @@ mod tests {
         let iter = BitChunkIter::new(a, 16);
         let r = iter.collect::<Vec<_>>();
         assert_eq!(r, (0..16).map(|x| x == 0 || x == 12).collect::<Vec<_>>(),);
+    }
+
+    #[test]
+    fn test_ones() {
+        let a = [0b00000001, 0b00010000]; // 0th and 13th entry
+        let a = u16::from_ne_bytes(a);
+        let mut iter = BitChunkOnes::new(a);
+        assert_eq!(iter.next(), Some(0));
+        assert_eq!(iter.next(), Some(12));
     }
 }

--- a/src/types/bit_chunk.rs
+++ b/src/types/bit_chunk.rs
@@ -99,6 +99,10 @@ impl<T: BitChunk> Iterator for BitChunkIter<T> {
     }
 }
 
+// # Safety
+// a mathematical invariant of this iterator
+unsafe impl<T: BitChunk> crate::trusted_len::TrustedLen for BitChunkIter<T> {}
+
 /// An [`Iterator<Item=usize>`] over a [`BitChunk`].
 /// This iterator returns the postion of bit set.
 /// Refer: https://lemire.me/blog/2018/03/08/iterating-over-set-bits-quickly-simd-edition/
@@ -147,6 +151,10 @@ impl<T: BitChunk> Iterator for BitChunkOnes<T> {
     }
 }
 
+// # Safety
+// a mathematical invariant of this iterator
+unsafe impl<T: BitChunk> crate::trusted_len::TrustedLen for BitChunkOnes<T> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -165,6 +173,7 @@ mod tests {
         let a = [0b00000001, 0b00010000]; // 0th and 13th entry
         let a = u16::from_ne_bytes(a);
         let mut iter = BitChunkOnes::new(a);
+        assert_eq!(iter.size_hint(), (2, Some(2)));
         assert_eq!(iter.next(), Some(0));
         assert_eq!(iter.next(), Some(12));
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -21,7 +21,7 @@
 //! for SIMD, at [`mod@simd`].
 
 mod bit_chunk;
-pub use bit_chunk::{BitChunk, BitChunkIter};
+pub use bit_chunk::{BitChunk, BitChunkIter, BitChunkOnes};
 mod index;
 pub mod simd;
 pub use index::*;


### PR DESCRIPTION
Benchmarks:

Before:

```rust
filter f32              time:   [269.62 us 269.88 us 270.12 us]                       
filter f32 high selectivity                                                                            
                        time:   [243.83 us 244.41 us 244.95 us]
filter f32 nonull       time:   [108.89 us 108.95 us 109.03 us]                              
filter f32 nonull high selectivity                                                                             
                        time:   [18.886 us 18.909 us 18.933 us]
 
```

Now:

``` 
filter f32            time:   [180.22 us 180.34 us 180.45 us]                       
filter f32 high selectivity                                                                            
                        time:   [94.458 us 94.495 us 94.540 us]
			
filter f32 nonull       time:   [58.747 us 58.775 us 58.809 us]                              
filter f32 nonull high selectivity                                                                             
                        time:   [10.456 us 10.477 us 10.494 us]
```