### PR TITLE
remove superfluous assert

### DIFF
--- a/src/array/growable/mod.rs
+++ b/src/array/growable/mod.rs
@@ -73,7 +73,6 @@ pub fn make_growable<'a>(
 ) -> Box<dyn Growable<'a> + 'a> {
     assert!(!arrays.is_empty());
     let data_type = arrays[0].data_type();
-    assert!(arrays.iter().all(|&item| item.data_type() == data_type));
 
     use PhysicalType::*;
     match data_type.to_physical_type() {


### PR DESCRIPTION
I was looking at the concat kernel and saw we loop over the `&[& dyn Array]` array to check if the `DataTypes` are equal, then we dispatch to `make_growable` to do the same loop, but then we `assert` if they are not equal. Then we dispatch to the implementations where we `downcast` via `Any`, so yet another assert on the `DataType`.

This PR removes one of the loops where we `assert`.

For a future PR I am thinking about splitting it in a fallible and one that only asserts at the downcast. I have quite a few cases where I create a very large number of small arrays of the same `DataType` in polars. Those loops then need to loop a large number of elements.