### PR TITLE
Added `try_new` and `new` to all arrays

### DIFF
--- a/src/array/README.md
+++ b/src/array/README.md
@@ -16,17 +16,16 @@ This document describes the overall design of this module.
 
 * An array with a null bitmap MUST implement it as `Option<Bitmap>`
 
-* An array MUST be `#[derive(Debug, Clone)]`
+* An array MUST be `#[derive(Clone)]`
 
 * The trait `Array` MUST only be implemented by structs in this module.
 
 * Every child array on the struct MUST be `Arc<dyn Array>`. This enables the struct to be clonable.
 
-* An array MUST implement `from_data(...) -> Self`. This method MUST panic iff:
-    * the data does not follow the arrow specification
-    * the arguments lead to unsound code (e.g. a Utf8 array MUST verify that its each item is valid `utf8`)
+* An array MUST implement `try_new(...) -> Self`. This method MUST error iff
+  the data does not follow the arrow specification, including any sentinel types such as utf8.
 
-* An array MAY implement `unsafe from_data_unchecked` that skips the soundness validation. `from_data_unchecked` MUST panic if the specification is incorrect.
+* An array MAY implement `unsafe try_new_unchecked` that skips validation steps that are `O(N)`.
 
 * An array MUST implement either `new_empty()` or `new_empty(DataType)` that returns a zero-len of `Self`.
 
@@ -36,7 +35,7 @@ This document describes the overall design of this module.
 
 * functions to create new arrays from native Rust SHOULD be named as follows:
     * `from`: from a slice of optional values (e.g. `AsRef<[Option<bool>]` for `BooleanArray`)
-    * `from_slice`: from a slice of values (e.g. `AsRef<[bool]` for `BooleanArray`)
+    * `from_slice`: from a slice of values (e.g. `AsRef<[bool]>` for `BooleanArray`)
     * `from_trusted_len_iter` from an iterator of trusted len of optional values
     * `from_trusted_len_values_iter` from an iterator of trusted len of values
     * `try_from_trusted_len_iter` from an fallible iterator of trusted len of optional values

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -4,9 +4,10 @@ use crate::{
     bitmap::Bitmap,
     buffer::Buffer,
     datatypes::{DataType, Field},
+    error::ArrowError,
 };
 
-use super::{new_empty_array, specification::check_offsets, Array, Offset};
+use super::{new_empty_array, specification::try_check_offsets, Array, Offset};
 
 mod ffi;
 pub(super) mod fmt;
@@ -25,58 +26,96 @@ pub struct ListArray<O: Offset> {
 }
 
 impl<O: Offset> ListArray<O> {
-    /// Returns a new empty [`ListArray`].
-    pub fn new_empty(data_type: DataType) -> Self {
-        let values = new_empty_array(Self::get_child_type(&data_type).clone()).into();
-        Self::from_data(data_type, Buffer::from(vec![O::zero()]), values, None)
-    }
+    /// Creates a new [`ListArray`].
+    ///
+    /// # Errors
+    /// This function returns an error iff:
+    /// * the offsets are not monotonically increasing
+    /// * The last offset is not equal to the values' length.
+    /// * the validity's length is not equal to `offsets.len() - 1`.
+    /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either [`crate::datatypes::PhysicalType::List`] or [`crate::datatypes::PhysicalType::LargeList`].
+    /// * The `data_type`'s inner field's data type is not equal to `values.data_type`.
+    pub fn try_new(
+        data_type: DataType,
+        offsets: Buffer<O>,
+        values: Arc<dyn Array>,
+        validity: Option<Bitmap>,
+    ) -> Result<Self, ArrowError> {
+        try_check_offsets(&offsets, values.len())?;
 
-    /// Returns a new null [`ListArray`].
-    #[inline]
-    pub fn new_null(data_type: DataType, length: usize) -> Self {
-        let child = Self::get_child_type(&data_type).clone();
-        Self::from_data(
+        if validity
+            .as_ref()
+            .map_or(false, |validity| validity.len() != offsets.len() - 1)
+        {
+            return Err(ArrowError::oos(
+                "validity mask length must match the number of values",
+            ));
+        }
+
+        let child_data_type = Self::try_get_child(&data_type)?.data_type();
+        let values_data_type = values.data_type();
+        if child_data_type != values_data_type {
+            return Err(ArrowError::oos(
+                format!("ListArray's child's DataType must match. However, the expected DataType is {child_data_type:?} while it got {values_data_type:?}."),
+            ));
+        }
+
+        Ok(Self {
             data_type,
-            Buffer::new_zeroed(length + 1),
-            new_empty_array(child).into(),
-            Some(Bitmap::new_zeroed(length)),
-        )
+            offsets,
+            values,
+            validity,
+        })
     }
 
-    /// Returns a new [`ListArray`].
-    /// # Panic
+    /// Creates a new [`ListArray`].
+    ///
+    /// # Panics
     /// This function panics iff:
-    /// * The `data_type`'s physical type is not consistent with the offset `O`.
-    /// * The `offsets` and `values` are inconsistent
-    /// * The validity is not `None` and its length is different from `offsets.len() - 1`.
+    /// * the offsets are not monotonically increasing
+    /// * The last offset is not equal to the values' length.
+    /// * the validity's length is not equal to `offsets.len() - 1`.
+    /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either [`crate::datatypes::PhysicalType::List`] or [`crate::datatypes::PhysicalType::LargeList`].
+    /// * The `data_type`'s inner field's data type is not equal to `values.data_type`.
+    pub fn new(
+        data_type: DataType,
+        offsets: Buffer<O>,
+        values: Arc<dyn Array>,
+        validity: Option<Bitmap>,
+    ) -> Self {
+        Self::try_new(data_type, offsets, values, validity).unwrap()
+    }
+
+    /// Alias of `new`
     pub fn from_data(
         data_type: DataType,
         offsets: Buffer<O>,
         values: Arc<dyn Array>,
         validity: Option<Bitmap>,
     ) -> Self {
-        check_offsets(&offsets, values.len());
-
-        if let Some(ref validity) = validity {
-            assert_eq!(offsets.len() - 1, validity.len());
-        }
-
-        // validate data_type
-        let child_data_type = Self::get_child_type(&data_type);
-        assert_eq!(
-            child_data_type,
-            values.data_type(),
-            "The child's datatype must match the inner type of the \'data_type\'"
-        );
-
-        Self {
-            data_type,
-            offsets,
-            values,
-            validity,
-        }
+        Self::new(data_type, offsets, values, validity)
     }
 
+    /// Returns a new empty [`ListArray`].
+    pub fn new_empty(data_type: DataType) -> Self {
+        let values = new_empty_array(Self::get_child_type(&data_type).clone()).into();
+        Self::new(data_type, Buffer::from(vec![O::zero()]), values, None)
+    }
+
+    /// Returns a new null [`ListArray`].
+    #[inline]
+    pub fn new_null(data_type: DataType, length: usize) -> Self {
+        let child = Self::get_child_type(&data_type).clone();
+        Self::new(
+            data_type,
+            Buffer::new_zeroed(length + 1),
+            new_empty_array(child).into(),
+            Some(Bitmap::new_zeroed(length)),
+        )
+    }
+}
+
+impl<O: Offset> ListArray<O> {
     /// Returns a slice of this [`ListArray`].
     /// # Panics
     /// panics iff `offset + length >= self.len()`
@@ -185,15 +224,24 @@ impl<O: Offset> ListArray<O> {
     /// # Panics
     /// Panics iff the logical type is not consistent with this struct.
     pub fn get_child_field(data_type: &DataType) -> &Field {
+        Self::try_get_child(data_type).unwrap()
+    }
+
+    /// Returns a the inner [`Field`]
+    /// # Errors
+    /// Panics iff the logical type is not consistent with this struct.
+    fn try_get_child(data_type: &DataType) -> Result<&Field, ArrowError> {
         if O::is_large() {
             match data_type.to_logical_type() {
-                DataType::LargeList(child) => child.as_ref(),
-                _ => panic!("ListArray<i64> expects DataType::List or DataType::LargeList"),
+                DataType::LargeList(child) => Ok(child.as_ref()),
+                _ => Err(ArrowError::oos(
+                    "ListArray<i64> expects DataType::LargeList",
+                )),
             }
         } else {
             match data_type.to_logical_type() {
-                DataType::List(child) => child.as_ref(),
-                _ => panic!("ListArray<i32> expects DataType::List or DataType::List"),
+                DataType::List(child) => Ok(child.as_ref()),
+                _ => Err(ArrowError::oos("ListArray<i32> expects DataType::List")),
             }
         }
     }

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -2,7 +2,8 @@ use crate::{bitmap::Bitmap, datatypes::DataType};
 
 use crate::{
     array::{Array, FromFfi, ToFfi},
-    error::Result,
+    datatypes::PhysicalType,
+    error::ArrowError,
     ffi,
 };
 
@@ -14,6 +15,33 @@ pub struct NullArray {
 }
 
 impl NullArray {
+    /// Returns a new [`NullArray`].
+    /// # Errors
+    /// This function errors iff:
+    /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to [`crate::datatypes::PhysicalType::Null`].
+    pub fn try_new(data_type: DataType, length: usize) -> Result<Self, ArrowError> {
+        if data_type.to_physical_type() != PhysicalType::Null {
+            return Err(ArrowError::oos(
+                "BooleanArray can only be initialized with a DataType whose physical type is Boolean",
+            ));
+        }
+
+        Ok(Self { data_type, length })
+    }
+
+    /// Returns a new [`NullArray`].
+    /// # Panics
+    /// This function errors iff:
+    /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to [`crate::datatypes::PhysicalType::Null`].
+    pub fn new(data_type: DataType, length: usize) -> Self {
+        Self::try_new(data_type, length).unwrap()
+    }
+
+    /// Alias for `new`
+    pub fn from_data(data_type: DataType, length: usize) -> Self {
+        Self::new(data_type, length)
+    }
+
     /// Returns a new empty [`NullArray`].
     pub fn new_empty(data_type: DataType) -> Self {
         Self::from_data(data_type, 0)
@@ -23,12 +51,9 @@ impl NullArray {
     pub fn new_null(data_type: DataType, length: usize) -> Self {
         Self::from_data(data_type, length)
     }
+}
 
-    /// Returns a new [`NullArray`].
-    pub fn from_data(data_type: DataType, length: usize) -> Self {
-        Self { data_type, length }
-    }
-
+impl NullArray {
     /// Returns a slice of the [`NullArray`].
     pub fn slice(&self, _offset: usize, length: usize) -> Self {
         Self {
@@ -66,9 +91,11 @@ impl Array for NullArray {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
+
     unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
+
     fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {
         panic!("cannot set validity of a null array")
     }
@@ -95,7 +122,7 @@ unsafe impl ToFfi for NullArray {
 }
 
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for NullArray {
-    unsafe fn try_from_ffi(array: A) -> Result<Self> {
+    unsafe fn try_from_ffi(array: A) -> Result<Self, ArrowError> {
         let data_type = array.data_type().clone();
         Ok(Self::from_data(data_type, array.array().len()))
     }

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -58,9 +58,9 @@ impl<T: NativeType> PrimitiveArray<T> {
             ));
         }
 
-        if data_type.to_physical_type() != PhysicalType::Boolean {
+        if data_type.to_physical_type() != PhysicalType::Primitive(T::PRIMITIVE) {
             return Err(ArrowError::oos(
-                "BooleanArray can only be initialized with a DataType whose physical type is Boolean",
+                "BooleanArray can only be initialized with a DataType whose physical type is Primitive",
             ));
         }
 

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -1,6 +1,18 @@
 use crate::error::{ArrowError, Result};
 use crate::types::Offset;
 
+pub fn try_check_offsets_bounds<O: Offset>(offsets: &[O], values_len: usize) -> Result<usize> {
+    if let Some(last_offset) = offsets.last() {
+        if last_offset.to_usize() > values_len {
+            Err(ArrowError::oos("offsets must not exceed the values length"))
+        } else {
+            Ok(last_offset.to_usize())
+        }
+    } else {
+        Err(ArrowError::oos("offsets must have at least one element"))
+    }
+}
+
 pub fn check_offsets_minimal<O: Offset>(offsets: &[O], values_len: usize) -> usize {
     assert!(
         !offsets.is_empty(),

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -58,9 +58,11 @@ pub fn try_check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) -> Re
         // check bounds
         if offsets
             .last()
-            .map_or(false, |last| last.to_usize() > values.len())
+            .map_or(true, |last| last.to_usize() > values.len())
         {
-            return Err(ArrowError::oos("offsets must not exceed values length"));
+            return Err(ArrowError::oos(
+                "offsets must have at least one element and must not exceed values length",
+            ));
         };
 
         Ok(())
@@ -81,9 +83,11 @@ pub fn try_check_offsets<O: Offset>(offsets: &[O], values_len: usize) -> Result<
         Err(ArrowError::oos("offsets must be monotonically increasing"))
     } else if offsets
         .last()
-        .map_or(false, |last| last.to_usize() > values_len)
+        .map_or(true, |last| last.to_usize() > values_len)
     {
-        Err(ArrowError::oos("offsets must not exceed values length"))
+        Err(ArrowError::oos(
+            "offsets must have at least one element and must not exceed values length",
+        ))
     } else {
         Ok(())
     }

--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, Field},
+    error::ArrowError,
 };
 
 use super::{new_empty_array, new_null_array, Array};
@@ -26,7 +27,7 @@ mod iterator;
 ///     Field::new("c", DataType::Int32, false),
 /// ];
 ///
-/// let array = StructArray::from_data(DataType::Struct(fields), vec![boolean, int], None);
+/// let array = StructArray::new(DataType::Struct(fields), vec![boolean, int], None);
 /// ```
 #[derive(Clone)]
 pub struct StructArray {
@@ -36,6 +37,101 @@ pub struct StructArray {
 }
 
 impl StructArray {
+    /// Returns a new [`StructArray`].
+    /// # Errors
+    /// This function errors iff:
+    /// * `data_type`'s physical type is not [`crate::datatypes::PhysicalType::Struct`].
+    /// * the children of `data_type` are empty
+    /// * the values's len is different from children's length
+    /// * any of the values's data type is different from its corresponding children' data type
+    /// * any element of values has a different length than the first element
+    /// * the validity's length is not equal to the length of the first element
+    pub fn try_new(
+        data_type: DataType,
+        values: Vec<Arc<dyn Array>>,
+        validity: Option<Bitmap>,
+    ) -> Result<Self, ArrowError> {
+        let fields = Self::try_get_fields(&data_type)?;
+        if fields.is_empty() {
+            return Err(ArrowError::oos(
+                "A StructArray must contain at least one field",
+            ));
+        }
+        if fields.len() != values.len() {
+            return Err(ArrowError::oos(
+                "A StructArray must a number of fields in its DataType equal to the number of child values",
+            ));
+        }
+
+        fields
+            .iter().map(|a| &a.data_type)
+            .zip(values.iter().map(|a| a.data_type()))
+            .enumerate()
+            .try_for_each(|(index, (data_type, child))| {
+                if data_type != child {
+                    Err(ArrowError::oos(format!(
+                        "The children DataTypes of a StructArray must equal the children data types. 
+                         However, the field {index} has data type {data_type:?} but the value has data type {child:?}"
+                    )))
+                } else {
+                    Ok(())
+                }
+            })?;
+
+        let len = values[0].len();
+        values
+            .iter()
+            .map(|a| a.len())
+            .enumerate()
+            .try_for_each(|(index, a_len)| {
+                if a_len != len {
+                    Err(ArrowError::oos(format!(
+                        "The children DataTypes of a StructArray must equal the children data types.
+                         However, the values {index} has a length of {a_len}, which is different from values 0, {len}."
+                    )))
+                } else {
+                    Ok(())
+                }
+            })?;
+
+        if validity
+            .as_ref()
+            .map_or(false, |validity| validity.len() != len)
+        {
+            return Err(ArrowError::oos(
+                "The validity length of a StructArray must match its number of elements",
+            ));
+        }
+
+        Ok(Self {
+            data_type,
+            values,
+            validity,
+        })
+    }
+
+    /// Returns a new [`StructArray`]
+    /// # Panics
+    /// This function panics iff:
+    /// * `data_type`'s physical type is not [`crate::datatypes::PhysicalType::Struct`].
+    /// * the children of `data_type` are empty
+    /// * the values's len is different from children's length
+    /// * any of the values's data type is different from its corresponding children' data type
+    /// * any element of values has a different length than the first element
+    /// * the validity's length is not equal to the length of the first element
+    pub fn new(data_type: DataType, values: Vec<Arc<dyn Array>>, validity: Option<Bitmap>) -> Self {
+        Self::try_new(data_type, values, validity).unwrap()
+    }
+
+    /// Alias for `new`
+    pub fn from_data(
+        data_type: DataType,
+        values: Vec<Arc<dyn Array>>,
+        validity: Option<Bitmap>,
+    ) -> Self {
+        Self::new(data_type, values, validity)
+    }
+
     /// Creates an empty [`StructArray`].
     pub fn new_empty(data_type: DataType) -> Self {
         if let DataType::Struct(fields) = &data_type {
@@ -43,7 +139,7 @@ impl StructArray {
                 .iter()
                 .map(|field| new_empty_array(field.data_type().clone()).into())
                 .collect();
-            Self::from_data(data_type, values, None)
+            Self::new(data_type, values, None)
         } else {
             panic!("StructArray must be initialized with DataType::Struct");
         }
@@ -56,44 +152,17 @@ impl StructArray {
                 .iter()
                 .map(|field| new_null_array(field.data_type().clone(), length).into())
                 .collect();
-            Self::from_data(data_type, values, Some(Bitmap::new_zeroed(length)))
+            Self::new(data_type, values, Some(Bitmap::new_zeroed(length)))
         } else {
             panic!("StructArray must be initialized with DataType::Struct");
         }
     }
+}
 
-    /// Canonical method to create a [`StructArray`].
-    /// # Panics
-    /// * fields are empty
-    /// * values's len is different from Fields' length.
-    /// * any element of values has a different length than the first element.
-    pub fn from_data(
-        data_type: DataType,
-        values: Vec<Arc<dyn Array>>,
-        validity: Option<Bitmap>,
-    ) -> Self {
-        let fields = Self::get_fields(&data_type);
-        assert!(!fields.is_empty());
-        assert_eq!(fields.len(), values.len());
-        assert!(
-            fields
-                .iter()
-                .map(|f| f.data_type())
-                .eq(values.iter().map(|a| a.data_type())),
-            "The fields' datatypes must equal the values datatypes"
-        );
-        assert!(values.iter().all(|x| x.len() == values[0].len()));
-        if let Some(ref validity) = validity {
-            assert_eq!(values[0].len(), validity.len());
-        }
-        Self {
-            data_type,
-            values,
-            validity,
-        }
-    }
-
+// must use
+impl StructArray {
     /// Deconstructs the [`StructArray`] into its individual components.
+    #[must_use]
     pub fn into_data(self) -> (Vec<Field>, Vec<Arc<dyn Array>>, Option<Bitmap>) {
         let Self {
             data_type,
@@ -113,6 +182,7 @@ impl StructArray {
     /// * `offset + length` must be smaller than `self.len()`.
     /// # Implementation
     /// This operation is `O(F)` where `F` is the number of fields.
+    #[must_use]
     pub fn slice(&self, offset: usize, length: usize) -> Self {
         assert!(
             offset + length <= self.len(),
@@ -126,6 +196,7 @@ impl StructArray {
     /// This operation is `O(F)` where `F` is the number of fields.
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
+    #[must_use]
     pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
         let validity = self
             .validity
@@ -145,6 +216,7 @@ impl StructArray {
     /// Sets the validity bitmap on this [`StructArray`].
     /// # Panic
     /// This function panics iff `validity.len() != self.len()`.
+    #[must_use]
     pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
         if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
             panic!("validity should be as least as large as the array")
@@ -181,12 +253,18 @@ impl StructArray {
 
 impl StructArray {
     /// Returns the fields the `DataType::Struct`.
-    pub fn get_fields(data_type: &DataType) -> &[Field] {
-        match data_type {
-            DataType::Struct(fields) => fields,
-            DataType::Extension(_, inner, _) => Self::get_fields(inner),
-            _ => panic!("Wrong datatype passed to Struct."),
+    pub(crate) fn try_get_fields(data_type: &DataType) -> Result<&[Field], ArrowError> {
+        match data_type.to_logical_type() {
+            DataType::Struct(fields) => Ok(fields),
+            _ => Err(ArrowError::oos(
+                "Struct array must be created with a DataType whose physical type is Struct",
+            )),
         }
+    }
+
+    /// Returns the fields the `DataType::Struct`.
+    pub fn get_fields(data_type: &DataType) -> &[Field] {
+        Self::try_get_fields(data_type).unwrap()
     }
 }
 

--- a/tests/it/array/list/mod.rs
+++ b/tests/it/array/list/mod.rs
@@ -23,7 +23,7 @@ fn debug() {
 }
 
 #[test]
-#[should_panic(expected = "The child's datatype must match the inner type of the \'data_type\'")]
+#[should_panic]
 fn test_nested_panic() {
     let values = Buffer::from_slice([1, 2, 3, 4, 5]);
     let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);


### PR DESCRIPTION
This PR introduces the functions `try_new -> Result<Self>` and `new -> Self` to every array.

# Background

The function named `from_data` is currently used to initialize arrays. This name comes from the original arrow-rs implementation, where there is a concept of `ArrowData`. This concept is not used here, but the name "from_data" remained. Furthermore, this array currently panics, which means that it can only be used on trusted data.

# This PR

* adds two new functions, `try_new` and `new` that align with most of Rust's ecosystem.
* adds `try_new_unchecked` and `new_unchecked` for arrays whose validation is `O(N)` (e.g. variable length, utf8).
* adds better error messages to the validation

I have also (re-)audited all the invariants of every array to make sure they align with arrow's spec (they do).

# Next steps

* replace `from_data` throughout the code base by either `try_new` or `new` accordingly (depending on whether we expect the invariant to be held)
* deprecate `from_data`?