### PR TITLE
Made IPC IO use `try_new`

### DIFF
--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -25,7 +25,7 @@ pub struct MutableBinaryArray<O: Offset> {
 
 impl<O: Offset> From<MutableBinaryArray<O>> for BinaryArray<O> {
     fn from(other: MutableBinaryArray<O>) -> Self {
-        BinaryArray::<O>::from_data(
+        BinaryArray::<O>::new(
             other.data_type,
             other.offsets.into(),
             other.values.into(),
@@ -179,7 +179,7 @@ impl<O: Offset> MutableArray for MutableBinaryArray<O> {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(BinaryArray::from_data(
+        Box::new(BinaryArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.offsets).into(),
             std::mem::take(&mut self.values).into(),
@@ -188,7 +188,7 @@ impl<O: Offset> MutableArray for MutableBinaryArray<O> {
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(BinaryArray::from_data(
+        Arc::new(BinaryArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.offsets).into(),
             std::mem::take(&mut self.values).into(),

--- a/src/array/boolean/ffi.rs
+++ b/src/array/boolean/ffi.rs
@@ -53,6 +53,6 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for BooleanArray {
         let data_type = array.data_type().clone();
         let validity = unsafe { array.validity() }?;
         let values = unsafe { array.bitmap(1) }?;
-        Ok(Self::from_data(data_type, values, validity))
+        Self::try_new(data_type, values, validity)
     }
 }

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -74,13 +74,13 @@ impl BooleanArray {
 
     /// Returns a new empty [`BooleanArray`].
     pub fn new_empty(data_type: DataType) -> Self {
-        Self::from_data(data_type, Bitmap::new(), None)
+        Self::new(data_type, Bitmap::new(), None)
     }
 
     /// Returns a new [`BooleanArray`] whose all slots are null / `None`.
     pub fn new_null(data_type: DataType, length: usize) -> Self {
         let bitmap = Bitmap::new_zeroed(length);
-        Self::from_data(data_type, bitmap.clone(), Some(bitmap))
+        Self::new(data_type, bitmap.clone(), Some(bitmap))
     }
 }
 
@@ -139,13 +139,9 @@ impl BooleanArray {
 
         if let Some(bitmap) = self.validity {
             match bitmap.into_mut() {
-                Left(bitmap) => Left(BooleanArray::from_data(
-                    self.data_type,
-                    self.values,
-                    Some(bitmap),
-                )),
+                Left(bitmap) => Left(BooleanArray::new(self.data_type, self.values, Some(bitmap))),
                 Right(mutable_bitmap) => match self.values.into_mut() {
-                    Left(immutable) => Left(BooleanArray::from_data(
+                    Left(immutable) => Left(BooleanArray::new(
                         self.data_type,
                         immutable,
                         Some(mutable_bitmap.into()),
@@ -159,7 +155,7 @@ impl BooleanArray {
             }
         } else {
             match self.values.into_mut() {
-                Left(immutable) => Left(BooleanArray::from_data(self.data_type, immutable, None)),
+                Left(immutable) => Left(BooleanArray::new(self.data_type, immutable, None)),
                 Right(mutable) => Right(MutableBooleanArray::from_data(
                     self.data_type,
                     mutable,

--- a/src/array/boolean/mutable.rs
+++ b/src/array/boolean/mutable.rs
@@ -24,7 +24,7 @@ pub struct MutableBooleanArray {
 
 impl From<MutableBooleanArray> for BooleanArray {
     fn from(other: MutableBooleanArray) -> Self {
-        BooleanArray::from_data(
+        BooleanArray::new(
             other.data_type,
             other.values.into(),
             other.validity.map(|x| x.into()),

--- a/src/array/dictionary/ffi.rs
+++ b/src/array/dictionary/ffi.rs
@@ -31,7 +31,7 @@ impl<K: DictionaryKey, A: ffi::ArrowArrayRef> FromFfi<A> for DictionaryArray<K> 
         let values = unsafe { array.buffer::<K>(1) }?;
 
         let data_type = K::PRIMITIVE.into();
-        let keys = PrimitiveArray::<K>::from_data(data_type, values, validity);
+        let keys = PrimitiveArray::<K>::try_new(data_type, values, validity)?;
         let values = array.dictionary()?.unwrap();
         let values = ffi::try_from(values)?.into();
 

--- a/src/array/fixed_size_binary/ffi.rs
+++ b/src/array/fixed_size_binary/ffi.rs
@@ -54,6 +54,6 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for FixedSizeBinaryArray {
         let validity = unsafe { array.validity() }?;
         let values = unsafe { array.buffer::<u8>(1) }?;
 
-        Ok(Self::from_data(data_type, values, validity))
+        Self::try_new(data_type, values, validity)
     }
 }

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -76,12 +76,12 @@ impl FixedSizeBinaryArray {
 
     /// Returns a new empty [`FixedSizeBinaryArray`].
     pub fn new_empty(data_type: DataType) -> Self {
-        Self::from_data(data_type, Buffer::new(), None)
+        Self::new(data_type, Buffer::new(), None)
     }
 
     /// Returns a new null [`FixedSizeBinaryArray`].
     pub fn new_null(data_type: DataType, length: usize) -> Self {
-        Self::from_data(
+        Self::new(
             data_type,
             Buffer::new_zeroed(length),
             Some(Bitmap::new_zeroed(length)),

--- a/src/array/fixed_size_binary/mutable.rs
+++ b/src/array/fixed_size_binary/mutable.rs
@@ -23,7 +23,7 @@ pub struct MutableFixedSizeBinaryArray {
 
 impl From<MutableFixedSizeBinaryArray> for FixedSizeBinaryArray {
     fn from(other: MutableFixedSizeBinaryArray) -> Self {
-        FixedSizeBinaryArray::from_data(
+        FixedSizeBinaryArray::new(
             other.data_type,
             other.values.into(),
             other.validity.map(|x| x.into()),
@@ -187,7 +187,7 @@ impl MutableArray for MutableFixedSizeBinaryArray {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(FixedSizeBinaryArray::from_data(
+        Box::new(FixedSizeBinaryArray::new(
             DataType::FixedSizeBinary(self.size),
             std::mem::take(&mut self.values).into(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
@@ -195,7 +195,7 @@ impl MutableArray for MutableFixedSizeBinaryArray {
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(FixedSizeBinaryArray::from_data(
+        Arc::new(FixedSizeBinaryArray::new(
             DataType::FixedSizeBinary(self.size),
             std::mem::take(&mut self.values).into(),
             std::mem::take(&mut self.validity).map(|x| x.into()),

--- a/src/array/fixed_size_list/ffi.rs
+++ b/src/array/fixed_size_list/ffi.rs
@@ -40,6 +40,6 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for FixedSizeListArray {
         let child = unsafe { array.child(0)? };
         let values = ffi::try_from(child)?.into();
 
-        Ok(Self::from_data(data_type, values, validity))
+        Self::try_new(data_type, values, validity)
     }
 }

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -99,7 +99,7 @@ impl FixedSizeListArray {
     pub fn new_empty(data_type: DataType) -> Self {
         let values =
             new_empty_array(Self::get_child_and_size(&data_type).0.data_type().clone()).into();
-        Self::from_data(data_type, values, None)
+        Self::new(data_type, values, None)
     }
 
     /// Returns a new null [`FixedSizeListArray`].
@@ -109,7 +109,7 @@ impl FixedSizeListArray {
             length,
         )
         .into();
-        Self::from_data(data_type, values, Some(Bitmap::new_zeroed(length)))
+        Self::new(data_type, values, Some(Bitmap::new_zeroed(length)))
     }
 }
 

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -20,7 +20,7 @@ pub struct MutableFixedSizeListArray<M: MutableArray> {
 
 impl<M: MutableArray> From<MutableFixedSizeListArray<M>> for FixedSizeListArray {
     fn from(mut other: MutableFixedSizeListArray<M>) -> Self {
-        FixedSizeListArray::from_data(
+        FixedSizeListArray::new(
             other.data_type,
             other.values.as_arc(),
             other.validity.map(|x| x.into()),
@@ -93,7 +93,7 @@ impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(FixedSizeListArray::from_data(
+        Box::new(FixedSizeListArray::new(
             self.data_type.clone(),
             self.values.as_arc(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
@@ -101,7 +101,7 @@ impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(FixedSizeListArray::from_data(
+        Arc::new(FixedSizeListArray::new(
             self.data_type.clone(),
             self.values.as_arc(),
             std::mem::take(&mut self.validity).map(|x| x.into()),

--- a/src/array/growable/binary.rs
+++ b/src/array/growable/binary.rs
@@ -61,7 +61,7 @@ impl<'a, O: Offset> GrowableBinary<'a, O> {
         let offsets = std::mem::take(&mut self.offsets);
         let values = std::mem::take(&mut self.values);
 
-        BinaryArray::<O>::from_data(data_type, offsets.into(), values.into(), validity.into())
+        BinaryArray::<O>::new(data_type, offsets.into(), values.into(), validity.into())
     }
 }
 
@@ -99,7 +99,7 @@ impl<'a, O: Offset> Growable<'a> for GrowableBinary<'a, O> {
 
 impl<'a, O: Offset> From<GrowableBinary<'a, O>> for BinaryArray<O> {
     fn from(val: GrowableBinary<'a, O>) -> Self {
-        BinaryArray::<O>::from_data(
+        BinaryArray::<O>::new(
             val.data_type,
             val.offsets.into(),
             val.values.into(),

--- a/src/array/growable/boolean.rs
+++ b/src/array/growable/boolean.rs
@@ -51,7 +51,7 @@ impl<'a> GrowableBoolean<'a> {
         let validity = std::mem::take(&mut self.validity);
         let values = std::mem::take(&mut self.values);
 
-        BooleanArray::from_data(self.data_type.clone(), values.into(), validity.into())
+        BooleanArray::new(self.data_type.clone(), values.into(), validity.into())
     }
 }
 
@@ -82,6 +82,6 @@ impl<'a> Growable<'a> for GrowableBoolean<'a> {
 
 impl<'a> From<GrowableBoolean<'a>> for BooleanArray {
     fn from(val: GrowableBoolean<'a>) -> Self {
-        BooleanArray::from_data(val.data_type, val.values.into(), val.validity.into())
+        BooleanArray::new(val.data_type, val.values.into(), val.validity.into())
     }
 }

--- a/src/array/growable/fixed_binary.rs
+++ b/src/array/growable/fixed_binary.rs
@@ -53,7 +53,7 @@ impl<'a> GrowableFixedSizeBinary<'a> {
         let validity = std::mem::take(&mut self.validity);
         let values = std::mem::take(&mut self.values);
 
-        FixedSizeBinaryArray::from_data(
+        FixedSizeBinaryArray::new(
             self.arrays[0].data_type().clone(),
             values.into(),
             validity.into(),
@@ -89,7 +89,7 @@ impl<'a> Growable<'a> for GrowableFixedSizeBinary<'a> {
 
 impl<'a> From<GrowableFixedSizeBinary<'a>> for FixedSizeBinaryArray {
     fn from(val: GrowableFixedSizeBinary<'a>) -> Self {
-        FixedSizeBinaryArray::from_data(
+        FixedSizeBinaryArray::new(
             val.arrays[0].data_type().clone(),
             val.values.into(),
             val.validity.into(),

--- a/src/array/growable/fixed_size_list.rs
+++ b/src/array/growable/fixed_size_list.rs
@@ -69,7 +69,7 @@ impl<'a> GrowableFixedSizeList<'a> {
         let validity = std::mem::take(&mut self.validity);
         let values = self.values.as_arc();
 
-        FixedSizeListArray::from_data(self.arrays[0].data_type().clone(), values, validity.into())
+        FixedSizeListArray::new(self.arrays[0].data_type().clone(), values, validity.into())
     }
 }
 
@@ -99,7 +99,7 @@ impl<'a> From<GrowableFixedSizeList<'a>> for FixedSizeListArray {
         let mut values = val.values;
         let values = values.as_arc();
 
-        Self::from_data(
+        Self::new(
             val.arrays[0].data_type().clone(),
             values,
             val.validity.into(),

--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -104,7 +104,7 @@ impl<'a, O: Offset> GrowableList<'a, O> {
         let offsets = std::mem::take(&mut self.offsets);
         let values = self.values.as_arc();
 
-        ListArray::<O>::from_data(
+        ListArray::<O>::new(
             self.arrays[0].data_type().clone(),
             offsets.into(),
             values,
@@ -139,7 +139,7 @@ impl<'a, O: Offset> From<GrowableList<'a, O>> for ListArray<O> {
         let mut values = val.values;
         let values = values.as_arc();
 
-        ListArray::<O>::from_data(
+        ListArray::<O>::new(
             val.arrays[0].data_type().clone(),
             val.offsets.into(),
             values,

--- a/src/array/growable/null.rs
+++ b/src/array/growable/null.rs
@@ -39,16 +39,16 @@ impl<'a> Growable<'a> for GrowableNull {
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(NullArray::from_data(self.data_type.clone(), self.length))
+        Arc::new(NullArray::new(self.data_type.clone(), self.length))
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(NullArray::from_data(self.data_type.clone(), self.length))
+        Box::new(NullArray::new(self.data_type.clone(), self.length))
     }
 }
 
 impl From<GrowableNull> for NullArray {
     fn from(val: GrowableNull) -> Self {
-        NullArray::from_data(val.data_type, val.length)
+        NullArray::new(val.data_type, val.length)
     }
 }

--- a/src/array/growable/primitive.rs
+++ b/src/array/growable/primitive.rs
@@ -62,7 +62,7 @@ impl<'a, T: NativeType> GrowablePrimitive<'a, T> {
         let validity = std::mem::take(&mut self.validity);
         let values = std::mem::take(&mut self.values);
 
-        PrimitiveArray::<T>::from_data(self.data_type.clone(), values.into(), validity.into())
+        PrimitiveArray::<T>::new(self.data_type.clone(), values.into(), validity.into())
     }
 }
 
@@ -96,6 +96,6 @@ impl<'a, T: NativeType> Growable<'a> for GrowablePrimitive<'a, T> {
 impl<'a, T: NativeType> From<GrowablePrimitive<'a, T>> for PrimitiveArray<T> {
     #[inline]
     fn from(val: GrowablePrimitive<'a, T>) -> Self {
-        PrimitiveArray::<T>::from_data(val.data_type, val.values.into(), val.validity.into())
+        PrimitiveArray::<T>::new(val.data_type, val.values.into(), val.validity.into())
     }
 }

--- a/src/array/growable/structure.rs
+++ b/src/array/growable/structure.rs
@@ -68,7 +68,7 @@ impl<'a> GrowableStruct<'a> {
         let values = std::mem::take(&mut self.values);
         let values = values.into_iter().map(|mut x| x.as_arc()).collect();
 
-        StructArray::from_data(
+        StructArray::new(
             DataType::Struct(self.arrays[0].fields().to_vec()),
             values,
             validity.into(),
@@ -120,7 +120,7 @@ impl<'a> From<GrowableStruct<'a>> for StructArray {
     fn from(val: GrowableStruct<'a>) -> Self {
         let values = val.values.into_iter().map(|mut x| x.as_arc()).collect();
 
-        StructArray::from_data(
+        StructArray::new(
             DataType::Struct(val.arrays[0].fields().to_vec()),
             values,
             val.validity.into(),

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -50,7 +50,7 @@ impl<O: Offset, M: MutableArray + Default> Default for MutableListArray<O, M> {
 
 impl<O: Offset, M: MutableArray> From<MutableListArray<O, M>> for ListArray<O> {
     fn from(mut other: MutableListArray<O, M>) -> Self {
-        ListArray::from_data(
+        ListArray::new(
             other.data_type,
             other.offsets.into(),
             other.values.as_arc(),
@@ -209,7 +209,7 @@ impl<O: Offset, M: MutableArray + Default + 'static> MutableArray for MutableLis
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(ListArray::from_data(
+        Box::new(ListArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.offsets).into(),
             self.values.as_arc(),
@@ -218,7 +218,7 @@ impl<O: Offset, M: MutableArray + Default + 'static> MutableArray for MutableLis
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(ListArray::from_data(
+        Arc::new(ListArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.offsets).into(),
             self.values.as_arc(),

--- a/src/array/map/ffi.rs
+++ b/src/array/map/ffi.rs
@@ -58,6 +58,6 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for MapArray {
         let child = array.child(0)?;
         let values = ffi::try_from(child)?.into();
 
-        Ok(Self::from_data(data_type, offsets, values, validity))
+        Self::try_new(data_type, offsets, values, validity)
     }
 }

--- a/src/array/map/mod.rs
+++ b/src/array/map/mod.rs
@@ -104,7 +104,7 @@ impl MapArray {
     /// Returns a new null [`MapArray`] of `length`.
     pub fn new_null(data_type: DataType, length: usize) -> Self {
         let field = new_empty_array(Self::get_field(&data_type).data_type().clone()).into();
-        Self::from_data(
+        Self::new(
             data_type,
             Buffer::new_zeroed(length + 1),
             field,
@@ -115,7 +115,7 @@ impl MapArray {
     /// Returns a new empty [`MapArray`].
     pub fn new_empty(data_type: DataType) -> Self {
         let field = new_empty_array(Self::get_field(&data_type).data_type().clone()).into();
-        Self::from_data(data_type, Buffer::from(vec![0i32]), field, None)
+        Self::new(data_type, Buffer::from(vec![0i32]), field, None)
     }
 }
 

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -44,12 +44,12 @@ impl NullArray {
 
     /// Returns a new empty [`NullArray`].
     pub fn new_empty(data_type: DataType) -> Self {
-        Self::from_data(data_type, 0)
+        Self::new(data_type, 0)
     }
 
     /// Returns a new [`NullArray`].
     pub fn new_null(data_type: DataType, length: usize) -> Self {
-        Self::from_data(data_type, length)
+        Self::new(data_type, length)
     }
 }
 
@@ -124,6 +124,6 @@ unsafe impl ToFfi for NullArray {
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for NullArray {
     unsafe fn try_from_ffi(array: A) -> Result<Self, ArrowError> {
         let data_type = array.data_type().clone();
-        Ok(Self::from_data(data_type, array.array().len()))
+        Self::try_new(data_type, array.array().len())
     }
 }

--- a/src/array/primitive/ffi.rs
+++ b/src/array/primitive/ffi.rs
@@ -55,6 +55,6 @@ impl<T: NativeType, A: ffi::ArrowArrayRef> FromFfi<A> for PrimitiveArray<T> {
         let validity = unsafe { array.validity() }?;
         let values = unsafe { array.buffer::<T>(1) }?;
 
-        Ok(Self::from_data(data_type, values, validity))
+        Self::try_new(data_type, values, validity)
     }
 }

--- a/src/array/primitive/from_natural.rs
+++ b/src/array/primitive/from_natural.rs
@@ -21,14 +21,14 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// # Implementation
     /// This does not assume that the iterator has a known length.
     pub fn from_values<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        Self::from_data(T::PRIMITIVE.into(), Vec::<T>::from_iter(iter).into(), None)
+        Self::new(T::PRIMITIVE.into(), Vec::<T>::from_iter(iter).into(), None)
     }
 
     /// Creates a (non-null) [`PrimitiveArray`] from a slice of values.
     /// # Implementation
     /// This is essentially a memcopy
     pub fn from_slice<P: AsRef<[T]>>(slice: P) -> Self {
-        Self::from_data(
+        Self::new(
             T::PRIMITIVE.into(),
             Vec::<T>::from(slice.as_ref()).into(),
             None,
@@ -38,7 +38,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// Creates a (non-null) [`PrimitiveArray`] from a vector of values.
     /// This does not have memcopy and is the fastest way to create a [`PrimitiveArray`].
     pub fn from_vec(array: Vec<T>) -> Self {
-        Self::from_data(T::PRIMITIVE.into(), array.into(), None)
+        Self::new(T::PRIMITIVE.into(), array.into(), None)
     }
 }
 

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -28,7 +28,7 @@ impl<T: NativeType> From<MutablePrimitiveArray<T>> for PrimitiveArray<T> {
             None
         };
 
-        PrimitiveArray::<T>::from_data(other.data_type, other.values.into(), validity)
+        PrimitiveArray::<T>::new(other.data_type, other.values.into(), validity)
     }
 }
 
@@ -364,7 +364,7 @@ impl<T: NativeType> MutableArray for MutablePrimitiveArray<T> {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(PrimitiveArray::from_data(
+        Box::new(PrimitiveArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.values).into(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
@@ -372,7 +372,7 @@ impl<T: NativeType> MutableArray for MutablePrimitiveArray<T> {
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(PrimitiveArray::from_data(
+        Arc::new(PrimitiveArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.values).into(),
             std::mem::take(&mut self.validity).map(|x| x.into()),

--- a/src/array/struct_/ffi.rs
+++ b/src/array/struct_/ffi.rs
@@ -40,6 +40,6 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for StructArray {
             })
             .collect::<Result<Vec<Arc<dyn Array>>>>()?;
 
-        Ok(Self::from_data(data_type, values, validity))
+        Self::try_new(data_type, values, validity)
     }
 }

--- a/src/array/union/ffi.rs
+++ b/src/array/union/ffi.rs
@@ -55,6 +55,6 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for UnionArray {
             types = types.slice(offset, length);
         };
 
-        Ok(Self::from_data(data_type, types, fields, offsets))
+        Self::try_new(data_type, types, fields, offsets)
     }
 }

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -144,7 +144,7 @@ impl UnionArray {
             // all from the same field
             let types = Buffer::new_zeroed(length);
 
-            Self::from_data(data_type, types, fields, offsets)
+            Self::new(data_type, types, fields, offsets)
         } else {
             panic!("Union struct must be created with the corresponding Union DataType")
         }

--- a/src/compute/arithmetics/decimal/add.rs
+++ b/src/compute/arithmetics/decimal/add.rs
@@ -225,7 +225,7 @@ pub fn adaptive_add(
 
         let validity = combine_validities(lhs.validity(), rhs.validity());
 
-        Ok(PrimitiveArray::<i128>::from_data(
+        Ok(PrimitiveArray::<i128>::new(
             DataType::Decimal(res_p, res_s),
             values,
             validity,

--- a/src/compute/arithmetics/decimal/div.rs
+++ b/src/compute/arithmetics/decimal/div.rs
@@ -290,7 +290,7 @@ pub fn adaptive_div(
 
         let validity = combine_validities(lhs.validity(), rhs.validity());
 
-        Ok(PrimitiveArray::<i128>::from_data(
+        Ok(PrimitiveArray::<i128>::new(
             DataType::Decimal(res_p, res_s),
             values,
             validity,

--- a/src/compute/arithmetics/decimal/mul.rs
+++ b/src/compute/arithmetics/decimal/mul.rs
@@ -302,7 +302,7 @@ pub fn adaptive_mul(
 
         let validity = combine_validities(lhs.validity(), rhs.validity());
 
-        Ok(PrimitiveArray::<i128>::from_data(
+        Ok(PrimitiveArray::<i128>::new(
             DataType::Decimal(res_p, res_s),
             values,
             validity,

--- a/src/compute/arithmetics/decimal/sub.rs
+++ b/src/compute/arithmetics/decimal/sub.rs
@@ -225,7 +225,7 @@ pub fn adaptive_sub(
 
         let validity = combine_validities(lhs.validity(), rhs.validity());
 
-        Ok(PrimitiveArray::<i128>::from_data(
+        Ok(PrimitiveArray::<i128>::new(
             DataType::Decimal(res_p, res_s),
             values,
             validity,

--- a/src/compute/arity.rs
+++ b/src/compute/arity.rs
@@ -29,7 +29,7 @@ where
     let values = array.values().iter().map(|v| op(*v));
     let values = Buffer::from_trusted_len_iter(values);
 
-    PrimitiveArray::<O>::from_data(data_type, values, array.validity().cloned())
+    PrimitiveArray::<O>::new(data_type, values, array.validity().cloned())
 }
 
 /// Version of unary that checks for errors in the closure used to create the
@@ -47,7 +47,7 @@ where
     let values = array.values().iter().map(|v| op(*v));
     let values = Buffer::try_from_trusted_len_iter(values)?;
 
-    Ok(PrimitiveArray::<O>::from_data(
+    Ok(PrimitiveArray::<O>::new(
         data_type,
         values,
         array.validity().cloned(),
@@ -77,7 +77,7 @@ where
     let values = Buffer::from_trusted_len_iter(values);
 
     (
-        PrimitiveArray::<O>::from_data(data_type, values, array.validity().cloned()),
+        PrimitiveArray::<O>::new(data_type, values, array.validity().cloned()),
         mut_bitmap.into(),
     )
 }
@@ -117,7 +117,7 @@ where
     let bitmap: Bitmap = mut_bitmap.into();
     let validity = combine_validities(array.validity(), Some(&bitmap));
 
-    PrimitiveArray::<O>::from_data(data_type, values, validity)
+    PrimitiveArray::<O>::new(data_type, values, validity)
 }
 
 /// Applies a binary operations to two primitive arrays. This is the fastest
@@ -156,7 +156,7 @@ where
         .map(|(l, r)| op(*l, *r));
     let values = Buffer::from_trusted_len_iter(values);
 
-    PrimitiveArray::<T>::from_data(data_type, values, validity)
+    PrimitiveArray::<T>::new(data_type, values, validity)
 }
 
 /// Version of binary that checks for errors in the closure used to create the
@@ -184,7 +184,7 @@ where
 
     let values = Buffer::try_from_trusted_len_iter(values)?;
 
-    Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
+    Ok(PrimitiveArray::<T>::new(data_type, values, validity))
 }
 
 /// Version of binary that returns an array and bitmap. Used when working with
@@ -215,7 +215,7 @@ where
     let values = Buffer::from_trusted_len_iter(values);
 
     (
-        PrimitiveArray::<T>::from_data(data_type, values, validity),
+        PrimitiveArray::<T>::new(data_type, values, validity),
         mut_bitmap.into(),
     )
 }
@@ -264,5 +264,5 @@ where
     // as Null
     let validity = combine_validities(validity.as_ref(), Some(&bitmap));
 
-    PrimitiveArray::<T>::from_data(data_type, values, validity)
+    PrimitiveArray::<T>::new(data_type, values, validity)
 }

--- a/src/compute/boolean.rs
+++ b/src/compute/boolean.rs
@@ -25,7 +25,7 @@ where
 
     let values = op(left_buffer, right_buffer);
 
-    Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
+    Ok(BooleanArray::new(DataType::Boolean, values, validity))
 }
 
 /// Performs `AND` operation on two arrays. If either left or right value is null then the
@@ -85,7 +85,7 @@ pub fn or(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
 pub fn not(array: &BooleanArray) -> BooleanArray {
     let values = !array.values();
     let validity = array.validity().cloned();
-    BooleanArray::from_data(DataType::Boolean, values, validity)
+    BooleanArray::new(DataType::Boolean, values, validity)
 }
 
 /// Returns a non-null [BooleanArray] with whether each value of the array is null.
@@ -109,7 +109,7 @@ pub fn is_null(input: &dyn Array) -> BooleanArray {
         Some(buffer) => !buffer,
     };
 
-    BooleanArray::from_data(DataType::Boolean, values, None)
+    BooleanArray::new(DataType::Boolean, values, None)
 }
 
 /// Returns a non-null [BooleanArray] with whether each value of the array is not null.
@@ -132,7 +132,7 @@ pub fn is_not_null(input: &dyn Array) -> BooleanArray {
         }
         Some(buffer) => buffer.clone(),
     };
-    BooleanArray::from_data(DataType::Boolean, values, None)
+    BooleanArray::new(DataType::Boolean, values, None)
 }
 
 /// Performs `AND` operation on an array and a scalar value. If either left or right value
@@ -154,7 +154,7 @@ pub fn and_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray 
         Some(true) => array.clone(),
         Some(false) => {
             let values = Bitmap::new_zeroed(array.len());
-            BooleanArray::from_data(DataType::Boolean, values, array.validity().cloned())
+            BooleanArray::new(DataType::Boolean, values, array.validity().cloned())
         }
         None => BooleanArray::new_null(DataType::Boolean, array.len()),
     }
@@ -179,7 +179,7 @@ pub fn or_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray {
         Some(true) => {
             let mut values = MutableBitmap::new();
             values.extend_constant(array.len(), true);
-            BooleanArray::from_data(DataType::Boolean, values.into(), array.validity().cloned())
+            BooleanArray::new(DataType::Boolean, values.into(), array.validity().cloned())
         }
         Some(false) => array.clone(),
         None => BooleanArray::new_null(DataType::Boolean, array.len()),

--- a/src/compute/boolean_kleene.rs
+++ b/src/compute/boolean_kleene.rs
@@ -90,7 +90,7 @@ pub fn or(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
         }
         (None, None) => None,
     };
-    Ok(BooleanArray::from_data(
+    Ok(BooleanArray::new(
         DataType::Boolean,
         lhs_values | rhs_values,
         validity,
@@ -179,7 +179,7 @@ pub fn and(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
         }
         (None, None) => None,
     };
-    Ok(BooleanArray::from_data(
+    Ok(BooleanArray::new(
         DataType::Boolean,
         lhs_values & rhs_values,
         validity,
@@ -205,7 +205,7 @@ pub fn or_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray {
         Some(true) => {
             let mut values = MutableBitmap::new();
             values.extend_constant(array.len(), true);
-            BooleanArray::from_data(DataType::Boolean, values.into(), None)
+            BooleanArray::new(DataType::Boolean, values.into(), None)
         }
         Some(false) => array.clone(),
         None => {
@@ -214,7 +214,7 @@ pub fn or_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray {
                 Some(validity) => binary(values, validity, |value, validity| validity & value),
                 None => unary(values, |value| value),
             };
-            BooleanArray::from_data(DataType::Boolean, values.clone(), Some(validity))
+            BooleanArray::new(DataType::Boolean, values.clone(), Some(validity))
         }
     }
 }
@@ -238,7 +238,7 @@ pub fn and_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray 
         Some(true) => array.clone(),
         Some(false) => {
             let values = Bitmap::new_zeroed(array.len());
-            BooleanArray::from_data(DataType::Boolean, values, None)
+            BooleanArray::new(DataType::Boolean, values, None)
         }
         None => {
             let values = array.values();
@@ -246,7 +246,7 @@ pub fn and_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray 
                 Some(validity) => binary(values, validity, |value, validity| validity & !value),
                 None => unary(values, |value| !value),
             };
-            BooleanArray::from_data(DataType::Boolean, array.values().clone(), Some(validity))
+            BooleanArray::new(DataType::Boolean, array.values().clone(), Some(validity))
         }
     }
 }

--- a/src/compute/cast/binary_to.rs
+++ b/src/compute/cast/binary_to.rs
@@ -10,7 +10,7 @@ pub fn binary_to_large_binary(from: &BinaryArray<i32>, to_data_type: DataType) -
     let values = from.values().clone();
     let offsets = from.offsets().iter().map(|x| *x as i64);
     let offsets = Buffer::from_trusted_len_iter(offsets);
-    BinaryArray::<i64>::from_data(to_data_type, offsets, values, from.validity().cloned())
+    BinaryArray::<i64>::new(to_data_type, offsets, values, from.validity().cloned())
 }
 
 /// Conversion of binary
@@ -24,7 +24,7 @@ pub fn binary_large_to_binary(
 
     let offsets = from.offsets().iter().map(|x| *x as i32);
     let offsets = Buffer::from_trusted_len_iter(offsets);
-    Ok(BinaryArray::<i32>::from_data(
+    Ok(BinaryArray::<i32>::new(
         to_data_type,
         offsets,
         values,

--- a/src/compute/cast/boolean_to.rs
+++ b/src/compute/cast/boolean_to.rs
@@ -23,7 +23,7 @@ where
         .map(|x| if x { T::one() } else { T::default() });
     let values = Buffer::<T>::from_trusted_len_iter(iter);
 
-    PrimitiveArray::<T>::from_data(T::PRIMITIVE.into(), values, from.validity().cloned())
+    PrimitiveArray::<T>::new(T::PRIMITIVE.into(), values, from.validity().cloned())
 }
 
 /// Casts the [`BooleanArray`] to a [`Utf8Array`], casting trues to `"1"` and falses to `"0"`

--- a/src/compute/cast/decimal_to.rs
+++ b/src/compute/cast/decimal_to.rs
@@ -98,7 +98,7 @@ where
         .map(|x| (*x as f64 / div).as_())
         .collect();
 
-    PrimitiveArray::<T>::from_data(T::PRIMITIVE.into(), values, from.validity().cloned())
+    PrimitiveArray::<T>::new(T::PRIMITIVE.into(), values, from.validity().cloned())
 }
 
 pub(super) fn decimal_to_float_dyn<T>(from: &dyn Array) -> Result<Box<dyn Array>>

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -307,7 +307,7 @@ fn cast_list<O: Offset>(
     )?
     .into();
 
-    Ok(ListArray::<O>::from_data(
+    Ok(ListArray::<O>::new(
         to_type.clone(),
         array.offsets().clone(),
         new_values,
@@ -323,7 +323,7 @@ fn cast_list_to_large_list(array: &ListArray<i32>, to_type: &DataType) -> ListAr
         .collect::<Vec<_>>()
         .into();
 
-    ListArray::<i64>::from_data(
+    ListArray::<i64>::new(
         to_type.clone(),
         offets,
         array.values().clone(),
@@ -339,7 +339,7 @@ fn cast_large_to_list(array: &ListArray<i64>, to_type: &DataType) -> ListArray<i
         .collect::<Vec<_>>()
         .into();
 
-    ListArray::<i32>::from_data(
+    ListArray::<i32>::new(
         to_type.clone(),
         offsets,
         array.values().clone(),
@@ -419,8 +419,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             // create offsets, where if array.len() = 2, we have [0,1,2]
             let offsets = (0..=array.len() as i32).collect::<Vec<_>>();
 
-            let list_array =
-                ListArray::<i32>::from_data(to_type.clone(), offsets.into(), values, None);
+            let list_array = ListArray::<i32>::new(to_type.clone(), offsets.into(), values, None);
 
             Ok(Box::new(list_array))
         }

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -66,7 +66,7 @@ pub fn primitive_to_boolean<T: NativeType>(
     let iter = from.values().iter().map(|v| *v != T::default());
     let values = Bitmap::from_trusted_len_iter(iter);
 
-    BooleanArray::from_data(to_type, values, from.validity().cloned())
+    BooleanArray::new(to_type, values, from.validity().cloned())
 }
 
 pub(super) fn primitive_to_boolean_dyn<T>(
@@ -264,7 +264,7 @@ pub fn primitive_to_same_primitive<T>(
 where
     T: NativeType,
 {
-    PrimitiveArray::<T>::from_data(
+    PrimitiveArray::<T>::new(
         to_type.clone(),
         from.values().clone(),
         from.validity().cloned(),

--- a/src/compute/comparison/binary.rs
+++ b/src/compute/comparison/binary.rs
@@ -25,7 +25,7 @@ where
         .map(|(lhs, rhs)| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);
 
-    BooleanArray::from_data(DataType::Boolean, values, validity)
+    BooleanArray::new(DataType::Boolean, values, validity)
 }
 
 /// Evaluate `op(lhs, rhs)` for [`BinaryArray`] and scalar using
@@ -40,7 +40,7 @@ where
     let values = lhs.values_iter().map(|lhs| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);
 
-    BooleanArray::from_data(DataType::Boolean, values, validity)
+    BooleanArray::new(DataType::Boolean, values, validity)
 }
 
 /// Perform `lhs == rhs` operation on [`BinaryArray`].

--- a/src/compute/comparison/boolean.rs
+++ b/src/compute/comparison/boolean.rs
@@ -19,7 +19,7 @@ where
 
     let values = binary(lhs.values(), rhs.values(), op);
 
-    BooleanArray::from_data(DataType::Boolean, values, validity)
+    BooleanArray::new(DataType::Boolean, values, validity)
 }
 
 /// Evaluate `op(left, right)` for [`BooleanArray`] and scalar using
@@ -31,7 +31,7 @@ where
     let rhs = if rhs { !0 } else { 0 };
 
     let values = unary(lhs.values(), |x| op(x, rhs));
-    BooleanArray::from_data(DataType::Boolean, values, lhs.validity().cloned())
+    BooleanArray::new(DataType::Boolean, values, lhs.validity().cloned())
 }
 
 /// Perform `lhs == rhs` operation on two [`BooleanArray`]s.
@@ -113,7 +113,7 @@ pub fn lt_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
     if rhs {
         compare_op_scalar(lhs, rhs, |a, _| !a)
     } else {
-        BooleanArray::from_data(
+        BooleanArray::new(
             DataType::Boolean,
             Bitmap::new_zeroed(lhs.len()),
             lhs.validity().cloned(),
@@ -147,7 +147,7 @@ pub fn gt(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
 /// Non-null values are greater than null values.
 pub fn gt_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
     if rhs {
-        BooleanArray::from_data(
+        BooleanArray::new(
             DataType::Boolean,
             Bitmap::new_zeroed(lhs.len()),
             lhs.validity().cloned(),

--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -510,18 +510,18 @@ fn finish_eq_validities(
     match (validity_lhs, validity_rhs) {
         (None, None) => output_without_validities,
         (Some(lhs), None) => compute::boolean::and(
-            &BooleanArray::from_data(DataType::Boolean, lhs, None),
+            &BooleanArray::new(DataType::Boolean, lhs, None),
             &output_without_validities,
         )
         .unwrap(),
         (None, Some(rhs)) => compute::boolean::and(
             &output_without_validities,
-            &BooleanArray::from_data(DataType::Boolean, rhs, None),
+            &BooleanArray::new(DataType::Boolean, rhs, None),
         )
         .unwrap(),
         (Some(lhs), Some(rhs)) => {
-            let lhs = BooleanArray::from_data(DataType::Boolean, lhs, None);
-            let rhs = BooleanArray::from_data(DataType::Boolean, rhs, None);
+            let lhs = BooleanArray::new(DataType::Boolean, lhs, None);
+            let rhs = BooleanArray::new(DataType::Boolean, rhs, None);
             let eq_validities = compute::comparison::boolean::eq(&lhs, &rhs);
             compute::boolean::and(&output_without_validities, &eq_validities).unwrap()
         }
@@ -536,17 +536,17 @@ fn finish_neq_validities(
         (None, None) => output_without_validities,
         (Some(lhs), None) => {
             let lhs_negated =
-                compute::boolean::not(&BooleanArray::from_data(DataType::Boolean, lhs, None));
+                compute::boolean::not(&BooleanArray::new(DataType::Boolean, lhs, None));
             compute::boolean::or(&lhs_negated, &output_without_validities).unwrap()
         }
         (None, Some(rhs)) => {
             let rhs_negated =
-                compute::boolean::not(&BooleanArray::from_data(DataType::Boolean, rhs, None));
+                compute::boolean::not(&BooleanArray::new(DataType::Boolean, rhs, None));
             compute::boolean::or(&output_without_validities, &rhs_negated).unwrap()
         }
         (Some(lhs), Some(rhs)) => {
-            let lhs = BooleanArray::from_data(DataType::Boolean, lhs, None);
-            let rhs = BooleanArray::from_data(DataType::Boolean, rhs, None);
+            let lhs = BooleanArray::new(DataType::Boolean, lhs, None);
+            let rhs = BooleanArray::new(DataType::Boolean, rhs, None);
             let neq_validities = compute::comparison::boolean::neq(&lhs, &rhs);
             compute::boolean::or(&output_without_validities, &neq_validities).unwrap()
         }

--- a/src/compute/comparison/primitive.rs
+++ b/src/compute/comparison/primitive.rs
@@ -74,7 +74,7 @@ where
 
     let values = compare_values_op(lhs.values(), rhs.values(), op);
 
-    BooleanArray::from_data(DataType::Boolean, values.into(), validity)
+    BooleanArray::new(DataType::Boolean, values.into(), validity)
 }
 
 /// Evaluate `op(left, right)` for [`PrimitiveArray`] and scalar using
@@ -88,7 +88,7 @@ where
 
     let values = compare_values_op_scalar(lhs.values(), rhs, op);
 
-    BooleanArray::from_data(DataType::Boolean, values.into(), validity)
+    BooleanArray::new(DataType::Boolean, values.into(), validity)
 }
 
 /// Perform `lhs == rhs` operation on two arrays.

--- a/src/compute/comparison/utf8.rs
+++ b/src/compute/comparison/utf8.rs
@@ -24,7 +24,7 @@ where
         .map(|(lhs, rhs)| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);
 
-    BooleanArray::from_data(DataType::Boolean, values, validity)
+    BooleanArray::new(DataType::Boolean, values, validity)
 }
 
 /// Evaluate `op(lhs, rhs)` for [`Utf8Array`] and scalar using
@@ -39,7 +39,7 @@ where
     let values = lhs.values_iter().map(|lhs| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);
 
-    BooleanArray::from_data(DataType::Boolean, values, validity)
+    BooleanArray::new(DataType::Boolean, values, validity)
 }
 
 /// Perform `lhs == rhs` operation on [`Utf8Array`].

--- a/src/compute/contains.rs
+++ b/src/compute/contains.rs
@@ -42,7 +42,7 @@ where
     });
     let values = Bitmap::from_trusted_len_iter(values);
 
-    Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
+    Ok(BooleanArray::new(DataType::Boolean, values, validity))
 }
 
 /// Checks if a [`GenericListArray`] contains a value in the [`Utf8Array`]
@@ -76,7 +76,7 @@ where
     });
     let values = Bitmap::from_trusted_len_iter(values);
 
-    Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
+    Ok(BooleanArray::new(DataType::Boolean, values, validity))
 }
 
 /// Checks if a [`ListArray`] contains a value in the [`BinaryArray`]
@@ -110,7 +110,7 @@ where
     });
     let values = Bitmap::from_trusted_len_iter(values);
 
-    Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
+    Ok(BooleanArray::new(DataType::Boolean, values, validity))
 }
 
 macro_rules! primitive {

--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -170,10 +170,10 @@ fn filter_nonnull_primitive<T: NativeType + Simd>(
 
     if let Some(validity) = array.validity() {
         let (values, validity) = null_filter_simd(array.values(), validity, mask);
-        PrimitiveArray::<T>::from_data(array.data_type().clone(), values.into(), validity.into())
+        PrimitiveArray::<T>::new(array.data_type().clone(), values.into(), validity.into())
     } else {
         let values = nonnull_filter_simd(array.values(), mask);
-        PrimitiveArray::<T>::from_data(array.data_type().clone(), values.into(), None)
+        PrimitiveArray::<T>::new(array.data_type().clone(), values.into(), None)
     }
 }
 
@@ -260,7 +260,7 @@ pub fn filter(array: &dyn Array, filter: &BooleanArray) -> Result<Box<dyn Array>
     if let Some(validities) = filter.validity() {
         let values = filter.values();
         let new_values = values & validities;
-        let filter = BooleanArray::from_data(DataType::Boolean, new_values, None);
+        let filter = BooleanArray::new(DataType::Boolean, new_values, None);
         return crate::compute::filter::filter(array, &filter);
     }
 

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -38,7 +38,7 @@ pub fn hash_boolean(array: &BooleanArray) -> PrimitiveArray<u64> {
 
     let iter = array.values_iter().map(|x| u8::get_hash(&x, &state));
     let values = Buffer::from_trusted_len_iter(iter);
-    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().cloned())
+    PrimitiveArray::<u64>::new(DataType::UInt64, values, array.validity().cloned())
 }
 
 #[multiversion]
@@ -51,7 +51,7 @@ pub fn hash_utf8<O: Offset>(array: &Utf8Array<O>) -> PrimitiveArray<u64> {
         .values_iter()
         .map(|x| <[u8]>::get_hash(&x.as_bytes(), &state));
     let values = Buffer::from_trusted_len_iter(iter);
-    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().cloned())
+    PrimitiveArray::<u64>::new(DataType::UInt64, values, array.validity().cloned())
 }
 
 /// Element-wise hash of a [`BinaryArray`]. Validity is preserved.
@@ -59,7 +59,7 @@ pub fn hash_binary<O: Offset>(array: &BinaryArray<O>) -> PrimitiveArray<u64> {
     let state = new_state!();
     let iter = array.values_iter().map(|x| <[u8]>::get_hash(&x, &state));
     let values = Buffer::from_trusted_len_iter(iter);
-    PrimitiveArray::<u64>::from_data(DataType::UInt64, values, array.validity().cloned())
+    PrimitiveArray::<u64>::new(DataType::UInt64, values, array.validity().cloned())
 }
 
 macro_rules! with_match_primitive_type {(

--- a/src/compute/length.rs
+++ b/src/compute/length.rs
@@ -43,7 +43,7 @@ where
         DataType::Int32
     };
 
-    PrimitiveArray::<O>::from_data(data_type, values, array.validity().cloned())
+    PrimitiveArray::<O>::new(data_type, values, array.validity().cloned())
 }
 
 /// Returns an array of integers with the number of bytes on each string of the array.

--- a/src/compute/like.rs
+++ b/src/compute/like.rs
@@ -60,7 +60,7 @@ fn a_like_utf8<O: Offset, F: Fn(bool) -> bool>(
             }
         }))?;
 
-    Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
+    Ok(BooleanArray::new(DataType::Boolean, values, validity))
 }
 
 /// Returns `lhs LIKE rhs` operation on two [`Utf8Array`].
@@ -126,7 +126,7 @@ fn a_like_utf8_scalar<O: Offset, F: Fn(bool) -> bool>(
         })?;
         Bitmap::from_trusted_len_iter(lhs.values_iter().map(|x| op(re.is_match(x))))
     };
-    Ok(BooleanArray::from_data(
+    Ok(BooleanArray::new(
         DataType::Boolean,
         values,
         validity.cloned(),
@@ -208,7 +208,7 @@ fn a_like_binary<O: Offset, F: Fn(bool) -> bool>(
             }
         }))?;
 
-    Ok(BooleanArray::from_data(DataType::Boolean, values, validity))
+    Ok(BooleanArray::new(DataType::Boolean, values, validity))
 }
 
 /// Returns `lhs LIKE rhs` operation on two [`BinaryArray`].
@@ -281,7 +281,7 @@ fn a_like_binary_scalar<O: Offset, F: Fn(bool) -> bool>(
         })?;
         Bitmap::from_trusted_len_iter(lhs.values_iter().map(|x| op(re.is_match(x))))
     };
-    Ok(BooleanArray::from_data(
+    Ok(BooleanArray::new(
         DataType::Boolean,
         values,
         validity.cloned(),

--- a/src/compute/nullif.rs
+++ b/src/compute/nullif.rs
@@ -42,7 +42,7 @@ where
 
     let validity = combine_validities(lhs.validity(), equal.as_ref());
 
-    PrimitiveArray::<T>::from_data(lhs.data_type().clone(), lhs.values().clone(), validity)
+    PrimitiveArray::<T>::new(lhs.data_type().clone(), lhs.values().clone(), validity)
 }
 
 /// Returns a [`PrimitiveArray`] whose validity is null iff `lhs == rhs` or `lhs` is null.
@@ -75,7 +75,7 @@ where
 
     let validity = combine_validities(lhs.validity(), equal.as_ref());
 
-    PrimitiveArray::<T>::from_data(lhs.data_type().clone(), lhs.values().clone(), validity)
+    PrimitiveArray::<T>::new(lhs.data_type().clone(), lhs.values().clone(), validity)
 }
 
 /// Returns an [`Array`] with the same type as `lhs` and whose validity

--- a/src/compute/regex_match.rs
+++ b/src/compute/regex_match.rs
@@ -46,11 +46,7 @@ pub fn regex_match<O: Offset>(values: &Utf8Array<O>, regex: &Utf8Array<O>) -> Re
     });
     let new_values = Bitmap::try_from_trusted_len_iter(iterator)?;
 
-    Ok(BooleanArray::from_data(
-        DataType::Boolean,
-        new_values,
-        validity,
-    ))
+    Ok(BooleanArray::new(DataType::Boolean, new_values, validity))
 }
 
 /// Regex matches
@@ -83,5 +79,5 @@ fn unary_utf8_boolean<O: Offset, F: Fn(&str) -> bool>(
         op(value.unwrap())
     });
     let values = Bitmap::from_trusted_len_iter(iterator);
-    BooleanArray::from_data(DataType::Boolean, values, validity)
+    BooleanArray::new(DataType::Boolean, values, validity)
 }

--- a/src/compute/sort/boolean.rs
+++ b/src/compute/sort/boolean.rs
@@ -49,5 +49,5 @@ pub fn sort_boolean<I: Index>(
     }
 
     let data_type = I::PRIMITIVE.into();
-    PrimitiveArray::<I>::from_data(data_type, values.into(), None)
+    PrimitiveArray::<I>::new(data_type, values.into(), None)
 }

--- a/src/compute/sort/common.rs
+++ b/src/compute/sort/common.rs
@@ -162,5 +162,5 @@ where
     };
 
     let data_type = I::PRIMITIVE.into();
-    PrimitiveArray::<I>::from_data(data_type, indices.into(), None)
+    PrimitiveArray::<I>::new(data_type, indices.into(), None)
 }

--- a/src/compute/sort/lex_sort.rs
+++ b/src/compute/sort/lex_sort.rs
@@ -180,9 +180,5 @@ pub fn lexsort_to_indices<I: Index>(
     }
 
     let data_type = I::PRIMITIVE.into();
-    Ok(PrimitiveArray::<I>::from_data(
-        data_type,
-        values.into(),
-        None,
-    ))
+    Ok(PrimitiveArray::<I>::new(data_type, values.into(), None))
 }

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -358,7 +358,7 @@ where
     values.truncate(limit.unwrap_or(values.len()));
 
     let data_type = I::PRIMITIVE.into();
-    PrimitiveArray::<I>::from_data(data_type, values.into(), None)
+    PrimitiveArray::<I>::new(data_type, values.into(), None)
 }
 
 /// Compare two `Array`s based on the ordering defined in [ord](crate::array::ord).

--- a/src/compute/sort/primitive/sort.rs
+++ b/src/compute/sort/primitive/sort.rs
@@ -158,7 +158,7 @@ where
 
         (buffer.into(), None)
     };
-    PrimitiveArray::<T>::from_data(array.data_type().clone(), buffer, validity)
+    PrimitiveArray::<T>::new(array.data_type().clone(), buffer, validity)
 }
 
 #[cfg(test)]

--- a/src/compute/substring.rs
+++ b/src/compute/substring.rs
@@ -108,7 +108,7 @@ fn binary_substring<O: Offset>(
         new_values.extend_from_slice(&values[start..start + length]);
     });
 
-    BinaryArray::<O>::from_data(
+    BinaryArray::<O>::new(
         array.data_type().clone(),
         new_offsets.into(),
         new_values.into(),

--- a/src/compute/take/binary.rs
+++ b/src/compute/take/binary.rs
@@ -37,5 +37,5 @@ pub fn take<O: Offset, I: Index>(
         (false, true) => take_indices_validity(values.offsets(), values.values(), indices),
         (true, true) => take_values_indices_validity(values, indices),
     };
-    BinaryArray::<O>::from_data(data_type, offsets, values, validity)
+    BinaryArray::<O>::new(data_type, offsets, values, validity)
 }

--- a/src/compute/take/boolean.rs
+++ b/src/compute/take/boolean.rs
@@ -97,7 +97,7 @@ pub fn take<I: Index>(values: &BooleanArray, indices: &PrimitiveArray<I>) -> Boo
         (true, true) => take_values_indices_validity(values, indices),
     };
 
-    BooleanArray::from_data(data_type, values, validity)
+    BooleanArray::new(data_type, values, validity)
 }
 
 #[cfg(test)]

--- a/src/compute/take/mod.rs
+++ b/src/compute/take/mod.rs
@@ -44,7 +44,7 @@ pub fn take<O: Index>(values: &dyn Array, indices: &PrimitiveArray<O>) -> Result
 
     use crate::datatypes::PhysicalType::*;
     match values.data_type().to_physical_type() {
-        Null => Ok(Box::new(NullArray::from_data(
+        Null => Ok(Box::new(NullArray::new(
             values.data_type().clone(),
             indices.len(),
         ))),

--- a/src/compute/take/primitive.rs
+++ b/src/compute/take/primitive.rs
@@ -111,5 +111,5 @@ pub fn take<T: NativeType, I: Index>(
         (true, true) => take_values_indices_validity::<T, I>(values, indices),
     };
 
-    PrimitiveArray::<T>::from_data(values.data_type().clone(), buffer, validity)
+    PrimitiveArray::<T>::new(values.data_type().clone(), buffer, validity)
 }

--- a/src/compute/take/structure.rs
+++ b/src/compute/take/structure.rs
@@ -60,7 +60,7 @@ pub fn take<I: Index>(array: &StructArray, indices: &PrimitiveArray<I>) -> Resul
         .map(|a| super::take(a.as_ref(), indices).map(|x| x.into()))
         .collect::<Result<_>>()?;
     let validity = take_validity(array.validity(), indices)?;
-    Ok(StructArray::from_data(
+    Ok(StructArray::new(
         array.data_type().clone(),
         values,
         validity,

--- a/src/io/avro/read/nested.rs
+++ b/src/io/avro/read/nested.rs
@@ -80,7 +80,7 @@ impl<O: Offset> MutableArray for DynMutableListArray<O> {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(ListArray::from_data(
+        Box::new(ListArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.offsets).into(),
             self.values.as_arc(),
@@ -89,7 +89,7 @@ impl<O: Offset> MutableArray for DynMutableListArray<O> {
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(ListArray::from_data(
+        Arc::new(ListArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.offsets).into(),
             self.values.as_arc(),
@@ -246,7 +246,7 @@ impl MutableArray for DynMutableStructArray {
     fn as_box(&mut self) -> Box<dyn Array> {
         let values = self.values.iter_mut().map(|x| x.as_arc()).collect();
 
-        Box::new(StructArray::from_data(
+        Box::new(StructArray::new(
             self.data_type.clone(),
             values,
             std::mem::take(&mut self.validity).map(|x| x.into()),
@@ -256,7 +256,7 @@ impl MutableArray for DynMutableStructArray {
     fn as_arc(&mut self) -> Arc<dyn Array> {
         let values = self.values.iter_mut().map(|x| x.as_arc()).collect();
 
-        Arc::new(StructArray::from_data(
+        Arc::new(StructArray::new(
             self.data_type.clone(),
             values,
             std::mem::take(&mut self.validity).map(|x| x.into()),

--- a/src/io/ipc/read/array/binary.rs
+++ b/src/io/ipc/read/array/binary.rs
@@ -55,9 +55,7 @@ pub fn read_binary<O: Offset, R: Read + Seek>(
         compression,
     )?;
 
-    Ok(BinaryArray::<O>::from_data(
-        data_type, offsets, values, validity,
-    ))
+    BinaryArray::<O>::try_new(data_type, offsets, values, validity)
 }
 
 pub fn skip_binary(

--- a/src/io/ipc/read/array/boolean.rs
+++ b/src/io/ipc/read/array/boolean.rs
@@ -42,7 +42,7 @@ pub fn read_boolean<R: Read + Seek>(
         is_little_endian,
         compression,
     )?;
-    Ok(BooleanArray::from_data(data_type, values, validity))
+    BooleanArray::try_new(data_type, values, validity)
 }
 
 pub fn skip_boolean(

--- a/src/io/ipc/read/array/fixed_size_binary.rs
+++ b/src/io/ipc/read/array/fixed_size_binary.rs
@@ -43,7 +43,7 @@ pub fn read_fixed_size_binary<R: Read + Seek>(
         compression,
     )?;
 
-    Ok(FixedSizeBinaryArray::from_data(data_type, values, validity))
+    FixedSizeBinaryArray::try_new(data_type, values, validity)
 }
 
 pub fn skip_fixed_size_binary(

--- a/src/io/ipc/read/array/fixed_size_list.rs
+++ b/src/io/ipc/read/array/fixed_size_list.rs
@@ -54,7 +54,7 @@ pub fn read_fixed_size_list<R: Read + Seek>(
         compression,
         version,
     )?;
-    Ok(FixedSizeListArray::from_data(data_type, values, validity))
+    FixedSizeListArray::try_new(data_type, values, validity)
 }
 
 pub fn skip_fixed_size_list(

--- a/src/io/ipc/read/array/list.rs
+++ b/src/io/ipc/read/array/list.rs
@@ -70,7 +70,7 @@ where
         compression,
         version,
     )?;
-    Ok(ListArray::from_data(data_type, offsets, values, validity))
+    ListArray::try_new(data_type, offsets, values, validity)
 }
 
 pub fn skip_list<O: Offset>(

--- a/src/io/ipc/read/array/map.rs
+++ b/src/io/ipc/read/array/map.rs
@@ -66,7 +66,7 @@ pub fn read_map<R: Read + Seek>(
         compression,
         version,
     )?;
-    Ok(MapArray::from_data(data_type, offsets, field, validity))
+    MapArray::try_new(data_type, offsets, field, validity)
 }
 
 pub fn skip_map(

--- a/src/io/ipc/read/array/null.rs
+++ b/src/io/ipc/read/array/null.rs
@@ -16,10 +16,7 @@ pub fn read_null(field_nodes: &mut VecDeque<Node>, data_type: DataType) -> Resul
         ))
     })?;
 
-    Ok(NullArray::from_data(
-        data_type,
-        field_node.length() as usize,
-    ))
+    NullArray::try_new(data_type, field_node.length() as usize)
 }
 
 pub fn skip_null(field_nodes: &mut VecDeque<Node>) -> Result<()> {

--- a/src/io/ipc/read/array/primitive.rs
+++ b/src/io/ipc/read/array/primitive.rs
@@ -44,7 +44,7 @@ where
         is_little_endian,
         compression,
     )?;
-    Ok(PrimitiveArray::<T>::from_data(data_type, values, validity))
+    PrimitiveArray::<T>::try_new(data_type, values, validity)
 }
 
 pub fn skip_primitive(

--- a/src/io/ipc/read/array/struct_.rs
+++ b/src/io/ipc/read/array/struct_.rs
@@ -61,7 +61,7 @@ pub fn read_struct<R: Read + Seek>(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    Ok(StructArray::from_data(data_type, values, validity))
+    StructArray::try_new(data_type, values, validity)
 }
 
 pub fn skip_struct(

--- a/src/io/ipc/read/array/union.rs
+++ b/src/io/ipc/read/array/union.rs
@@ -85,7 +85,7 @@ pub fn read_union<R: Read + Seek>(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    Ok(UnionArray::from_data(data_type, types, fields, offsets))
+    UnionArray::try_new(data_type, types, fields, offsets)
 }
 
 pub fn skip_union(

--- a/src/io/ipc/read/array/utf8.rs
+++ b/src/io/ipc/read/array/utf8.rs
@@ -55,9 +55,7 @@ pub fn read_utf8<O: Offset, R: Read + Seek>(
         compression,
     )?;
 
-    Ok(Utf8Array::<O>::from_data(
-        data_type, offsets, values, validity,
-    ))
+    Utf8Array::<O>::try_new(data_type, offsets, values, validity)
 }
 
 pub fn skip_utf8(

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -135,7 +135,7 @@ fn deserialize_list<O: Offset, A: Borrow<Value>>(rows: &[A], data_type: DataType
 
     let values = _deserialize(&inner, child.clone());
 
-    ListArray::<O>::from_data(data_type, offsets.into(), values, validity.into())
+    ListArray::<O>::new(data_type, offsets.into(), values, validity.into())
 }
 
 fn deserialize_struct<A: Borrow<Value>>(rows: &[A], data_type: DataType) -> StructArray {
@@ -166,7 +166,7 @@ fn deserialize_struct<A: Borrow<Value>>(rows: &[A], data_type: DataType) -> Stru
         .map(|(_, (data_type, values))| _deserialize(&values, data_type.clone()))
         .collect::<Vec<_>>();
 
-    StructArray::from_data(data_type, values, None)
+    StructArray::new(data_type, values, None)
 }
 
 fn deserialize_dictionary<K: DictionaryKey, A: Borrow<Value>>(
@@ -204,7 +204,7 @@ fn deserialize_dictionary<K: DictionaryKey, A: Borrow<Value>>(
 
 pub(crate) fn _deserialize<A: Borrow<Value>>(rows: &[A], data_type: DataType) -> Arc<dyn Array> {
     match &data_type {
-        DataType::Null => Arc::new(NullArray::from_data(data_type, rows.len())),
+        DataType::Null => Arc::new(NullArray::new(data_type, rows.len())),
         DataType::Boolean => Arc::new(deserialize_boolean(rows)),
         DataType::Int8 => Arc::new(deserialize_int::<i8, _>(rows, data_type)),
         DataType::Int16 => Arc::new(deserialize_int::<i16, _>(rows, data_type)),

--- a/src/io/parquet/read/deserialize/boolean/basic.rs
+++ b/src/io/parquet/read/deserialize/boolean/basic.rs
@@ -126,7 +126,7 @@ impl<'a> Decoder<'a, bool, MutableBitmap> for BooleanDecoder {
 }
 
 fn finish(data_type: &DataType, values: MutableBitmap, validity: MutableBitmap) -> BooleanArray {
-    BooleanArray::from_data(data_type.clone(), values.into(), validity.into())
+    BooleanArray::new(data_type.clone(), values.into(), validity.into())
 }
 
 /// An iterator adapter over [`DataPages`] assumed to be encoded as boolean arrays

--- a/src/io/parquet/read/deserialize/boolean/nested.rs
+++ b/src/io/parquet/read/deserialize/boolean/nested.rs
@@ -139,7 +139,7 @@ impl<I: DataPages> ArrayIterator<I> {
 }
 
 fn finish(data_type: &DataType, values: MutableBitmap, validity: MutableBitmap) -> BooleanArray {
-    BooleanArray::from_data(data_type.clone(), values.into(), validity.into())
+    BooleanArray::new(data_type.clone(), values.into(), validity.into())
 }
 
 impl<I: DataPages> Iterator for ArrayIterator<I> {

--- a/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
@@ -204,7 +204,7 @@ fn finish(
     values: FixedSizeBinary,
     validity: MutableBitmap,
 ) -> FixedSizeBinaryArray {
-    FixedSizeBinaryArray::from_data(data_type.clone(), values.values.into(), validity.into())
+    FixedSizeBinaryArray::new(data_type.clone(), values.values.into(), validity.into())
 }
 
 pub struct Iter<I: DataPages> {

--- a/src/io/parquet/read/deserialize/mod.rs
+++ b/src/io/parquet/read/deserialize/mod.rs
@@ -45,7 +45,7 @@ fn create_list(
             let (offsets, validity) = nested.nested.pop().unwrap().inner();
 
             let offsets = offsets.iter().map(|x| *x as i32).collect::<Vec<_>>();
-            Arc::new(ListArray::<i32>::from_data(
+            Arc::new(ListArray::<i32>::new(
                 data_type,
                 offsets.into(),
                 values,
@@ -55,9 +55,7 @@ fn create_list(
         DataType::LargeList(_) => {
             let (offsets, validity) = nested.nested.pop().unwrap().inner();
 
-            Arc::new(ListArray::<i64>::from_data(
-                data_type, offsets, values, validity,
-            ))
+            Arc::new(ListArray::<i64>::new(data_type, offsets, values, validity))
         }
         _ => {
             return Err(ArrowError::NotYetImplemented(format!(

--- a/src/io/parquet/read/deserialize/null.rs
+++ b/src/io/parquet/read/deserialize/null.rs
@@ -22,12 +22,12 @@ where
     let remainder = chunk_size % len;
     let i_data_type = data_type.clone();
     let complete = (0..complete_chunks).map(move |_| {
-        Ok(Arc::new(NullArray::from_data(i_data_type.clone(), chunk_size)) as Arc<dyn Array>)
+        Ok(Arc::new(NullArray::new(i_data_type.clone(), chunk_size)) as Arc<dyn Array>)
     });
     if len % chunk_size == 0 {
         Box::new(complete)
     } else {
-        let array = NullArray::from_data(data_type, remainder);
+        let array = NullArray::new(data_type, remainder);
         Box::new(complete.chain(std::iter::once(Ok(Arc::new(array) as Arc<dyn Array>))))
     }
 }

--- a/src/io/parquet/read/deserialize/primitive/dictionary.rs
+++ b/src/io/parquet/read/deserialize/primitive/dictionary.rs
@@ -30,7 +30,7 @@ where
         .unwrap();
     let values = dict.values().iter().map(|x| (op)(*x)).collect::<Vec<_>>();
 
-    Arc::new(PrimitiveArray::from_data(data_type, values.into(), None))
+    Arc::new(PrimitiveArray::new(data_type, values.into(), None))
 }
 
 /// An iterator adapter over [`DataPages`] assumed to be encoded as boolean arrays

--- a/src/io/parquet/read/deserialize/simple.rs
+++ b/src/io/parquet/read/deserialize/simple.rs
@@ -172,11 +172,7 @@ pub fn page_iter_to_arrays<'a, I: 'a + DataPages>(
                         .collect::<Vec<_>>();
                     let validity = array.validity().cloned();
 
-                    Ok(PrimitiveArray::<i128>::from_data(
-                        data_type.clone(),
-                        values.into(),
-                        validity,
-                    ))
+                    PrimitiveArray::<i128>::try_new(data_type.clone(), values.into(), validity)
                 });
 
                 let arrays = pages.map(|x| x.map(|x| Arc::new(x) as Arc<dyn Array>));

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -216,7 +216,7 @@ pub fn array_to_page(
                 values.extend_from_slice(bytes);
                 values.resize(values.len() + 8, 0);
             });
-            let array = FixedSizeBinaryArray::from_data(
+            let array = FixedSizeBinaryArray::new(
                 DataType::FixedSizeBinary(12),
                 values.into(),
                 array.validity().cloned(),
@@ -255,20 +255,14 @@ pub fn array_to_page(
             if precision <= 9 {
                 let values = array.values().iter().map(|x| *x as i32);
                 let values = Buffer::from_trusted_len_iter(values);
-                let array = PrimitiveArray::<i32>::from_data(
-                    DataType::Int32,
-                    values,
-                    array.validity().cloned(),
-                );
+                let array =
+                    PrimitiveArray::<i32>::new(DataType::Int32, values, array.validity().cloned());
                 primitive::array_to_page::<i32, i32>(&array, options, descriptor)
             } else if precision <= 18 {
                 let values = array.values().iter().map(|x| *x as i64);
                 let values = Buffer::from_trusted_len_iter(values);
-                let array = PrimitiveArray::<i64>::from_data(
-                    DataType::Int64,
-                    values,
-                    array.validity().cloned(),
-                );
+                let array =
+                    PrimitiveArray::<i64>::new(DataType::Int64, values, array.validity().cloned());
                 primitive::array_to_page::<i64, i64>(&array, options, descriptor)
             } else {
                 let size = decimal_length_from_precision(precision);


### PR DESCRIPTION
This makes deviations to the arrow spec coming from IPC to error instead of to panic, making us a bit more resilient on that.