### PR TITLE
Re-added support for reading nested parquet arrays

### DIFF
--- a/src/io/parquet/read/deserialize/mod.rs
+++ b/src/io/parquet/read/deserialize/mod.rs
@@ -160,6 +160,26 @@ where
                 |x: i64| x,
             )
         }
+        Float32 => {
+            types.pop();
+            primitive::iter_to_arrays_nested(
+                columns.pop().unwrap(),
+                init.pop().unwrap(),
+                field.data_type().clone(),
+                chunk_size,
+                |x: f32| x,
+            )
+        }
+        Float64 => {
+            types.pop();
+            primitive::iter_to_arrays_nested(
+                columns.pop().unwrap(),
+                init.pop().unwrap(),
+                field.data_type().clone(),
+                chunk_size,
+                |x: f64| x,
+            )
+        }
         Utf8 => {
             types.pop();
             binary::iter_to_arrays_nested::<i32, Utf8Array<i32>, _>(

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -174,6 +174,7 @@ pub fn pyarrow_nested_nullable(column: usize) -> Box<dyn Array> {
             ))
         }
         7 => {
+            // [[0, 1]], None, [[2, None], [3]], [[4, 5], [6]], [], [[7], None, [9]], [[], [None], None], [[10]]
             let data = [
                 Some(vec![Some(vec![Some(0), Some(1)])]),
                 None,

--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -259,13 +259,11 @@ fn v2_nested_nested() -> Result<()> {
 }
 
 #[test]
-#[ignore] // todo
 fn v2_nested_nested_required() -> Result<()> {
     test_pyarrow_integration(8, 2, "nested", false, false, None)
 }
 
 #[test]
-#[ignore] // todo
 fn v2_nested_nested_required_required() -> Result<()> {
     test_pyarrow_integration(9, 2, "nested", false, false, None)
 }


### PR DESCRIPTION
This was deactivated in main with the large refactor of parquet reading. This PR brings it back to the menu.
