### PR TITLE
Fixed error in computing `min_max` in `std::simd`

### DIFF
--- a/src/compute/aggregate/simd/packed.rs
+++ b/src/compute/aggregate/simd/packed.rs
@@ -43,12 +43,12 @@ macro_rules! simd_ord_int {
 
             #[inline]
             fn max_lane(self, x: Self) -> Self {
-                self.max(x)
+                self.lanes_lt(x).select(x, self)
             }
 
             #[inline]
             fn min_lane(self, x: Self) -> Self {
-                self.min(x)
+                self.lanes_gt(x).select(x, self)
             }
 
             #[inline]

--- a/tests/it/compute/aggregate/min_max.rs
+++ b/tests/it/compute/aggregate/min_max.rs
@@ -202,3 +202,13 @@ fn test_binary_min_max_1() {
     assert_eq!(Some("a".as_bytes()), min_binary(&a));
     assert_eq!(Some("b".as_bytes()), max_binary(&a));
 }
+
+#[test]
+fn test_max_not_lexi() {
+    let values = [0, 10, 0, 0, 0, 0, 0, 0, 1, 0];
+    let arr = Int64Array::from_slice(&values);
+
+    let maximum = 10;
+    let out = max_primitive(&arr).unwrap();
+    assert_eq!(out, maximum);
+}


### PR DESCRIPTION
See https://github.com/pola-rs/polars/issues/2850 and https://github.com/rust-lang/rust/issues/94682 for details.