### PR TITLE
Make sure that NullArray return a single buffer pointer to null.

### DIFF
--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -109,7 +109,7 @@ impl std::fmt::Debug for NullArray {
 
 unsafe impl ToFfi for NullArray {
     fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
-        vec![]
+        vec![None]
     }
 
     fn offset(&self) -> Option<usize> {

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -109,6 +109,8 @@ impl std::fmt::Debug for NullArray {
 
 unsafe impl ToFfi for NullArray {
     fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>> {
+        // `None` is technically not required by the specification, but older C++ implementations require it, so leaving
+        // it here for backward compatibility
         vec![None]
     }
 


### PR DESCRIPTION
Null column must produce n_buffers=1  with a single nullpointer in buffers array. Otherwise `import_array_from_c` would fail with validation error.