### PR TITLE
Migrate to latest parquet2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ hex = { version = "^0.4", optional = true }
 
 # for IPC compression
 lz4 = { version = "1.23.1", optional = true }
-zstd = { version = "0.10", optional = true }
+zstd = { version = "0.11", optional = true }
 
 rand = { version = "0.8", optional = true }
 
@@ -68,7 +68,8 @@ futures = { version = "0.3", optional = true }
 ahash = { version = "0.7", optional = true }
 
 # parquet support
-parquet2 = { version = "0.10", optional = true, default_features = false, features = ["stream"] }
+#parquet2 = { version = "0.10", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "filtered", optional = true, default_features = false, features = ["stream"] }
 
 # avro support
 avro-schema = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,12 +108,26 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = []
 full = [
+    "io_odbc",
+    "io_csv",
+    "io_csv_async",
+    "io_json",
+    "io_ipc",
+    "io_flight",
+    "io_ipc_write_async",
+    "io_ipc_read_async",
+    "io_ipc_compression",
+    "io_json_integration",
+    "io_print",
     "io_parquet",
     "io_parquet_compression",
-    #"regex",
-    #"compute",
+    "io_avro",
+    "io_avro_compression",
+    "io_avro_async",
+    "regex",
+    "compute",
     # parses timezones used in timestamp conversions
-    #"chrono-tz",
+    "chrono-tz",
 ]
 io_odbc = ["odbc-api"]
 io_csv = ["io_csv_read", "io_csv_write"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ ahash = { version = "0.7", optional = true }
 
 # parquet support
 #parquet2 = { version = "0.10", optional = true, default_features = false, features = ["stream"] }
-parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "filter", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "main", optional = true, default_features = false, features = ["stream"] }
 
 # avro support
 avro-schema = { version = "0.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ ahash = { version = "0.7", optional = true }
 
 # parquet support
 #parquet2 = { version = "0.10", optional = true, default_features = false, features = ["stream"] }
-parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "filtered", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "filter", optional = true, default_features = false, features = ["stream"] }
 
 # avro support
 avro-schema = { version = "0.2", optional = true }
@@ -108,26 +108,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = []
 full = [
-    "io_odbc",
-    "io_csv",
-    "io_csv_async",
-    "io_json",
-    "io_ipc",
-    "io_flight",
-    "io_ipc_write_async",
-    "io_ipc_read_async",
-    "io_ipc_compression",
-    "io_json_integration",
-    "io_print",
     "io_parquet",
     "io_parquet_compression",
-    "io_avro",
-    "io_avro_compression",
-    "io_avro_async",
-    "regex",
-    "compute",
+    #"regex",
+    #"compute",
     # parses timezones used in timestamp conversions
-    "chrono-tz",
+    #"chrono-tz",
 ]
 io_odbc = ["odbc-api"]
 io_csv = ["io_csv_read", "io_csv_write"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,7 @@ futures = { version = "0.3", optional = true }
 ahash = { version = "0.7", optional = true }
 
 # parquet support
-#parquet2 = { version = "0.10", optional = true, default_features = false, features = ["stream"] }
-parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "main", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { version = "0.11", optional = true, default_features = false, features = ["stream"] }
 
 # avro support
 avro-schema = { version = "0.2", optional = true }

--- a/arrow-parquet-integration-testing/src/main.rs
+++ b/arrow-parquet-integration-testing/src/main.rs
@@ -196,8 +196,7 @@ fn main() -> Result<()> {
 
     writer.start()?;
     for group in row_groups {
-        let (group, len) = group?;
-        writer.write(group, len)?;
+        writer.write(group?)?;
     }
     let _ = writer.end(None)?;
 

--- a/benches/write_parquet.rs
+++ b/benches/write_parquet.rs
@@ -34,8 +34,7 @@ fn write(array: &dyn Array, encoding: Encoding) -> Result<()> {
 
     writer.start()?;
     for group in row_groups {
-        let (group, len) = group?;
-        writer.write(group, len)?;
+        writer.write(group?)?;
     }
     let _ = writer.end(None)?;
     Ok(())

--- a/examples/parquet_write.rs
+++ b/examples/parquet_write.rs
@@ -30,8 +30,7 @@ fn write_batch(path: &str, schema: Schema, columns: Chunk<Arc<dyn Array>>) -> Re
 
     writer.start()?;
     for group in row_groups {
-        let (group, len) = group?;
-        writer.write(group, len)?;
+        writer.write(group?)?;
     }
     let _size = writer.end(None)?;
     Ok(())

--- a/examples/parquet_write_parallel/src/main.rs
+++ b/examples/parquet_write_parallel/src/main.rs
@@ -99,8 +99,7 @@ fn parallel_write(path: &str, schema: &Schema, batches: &[Chunk]) -> Result<()> 
     // Write the file.
     writer.start()?;
     for group in row_groups {
-        let (group, len) = group?;
-        writer.write(group, len)?;
+        writer.write(group?)?;
     }
     let _size = writer.end(None)?;
 

--- a/src/doc/lib.md
+++ b/src/doc/lib.md
@@ -62,8 +62,7 @@ fn main() -> Result<()> {
     // Write the file.
     writer.start()?;
     for group in row_groups {
-        let (group, len) = group?;
-        writer.write(group, len)?;
+        writer.write(group?)?;
     }
     let _ = writer.end(None)?;
     Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,6 +52,12 @@ impl From<std::str::Utf8Error> for ArrowError {
     }
 }
 
+impl From<std::string::FromUtf8Error> for ArrowError {
+    fn from(error: std::string::FromUtf8Error) -> Self {
+        ArrowError::External("".to_string(), Box::new(error))
+    }
+}
+
 impl From<simdutf8::basic::Utf8Error> for ArrowError {
     fn from(error: simdutf8::basic::Utf8Error) -> Self {
         ArrowError::External("".to_string(), Box::new(error))

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -6,10 +6,10 @@ pub mod write;
 
 const ARROW_SCHEMA_META_KEY: &str = "ARROW:schema";
 
-impl From<parquet2::error::ParquetError> for ArrowError {
-    fn from(error: parquet2::error::ParquetError) -> Self {
+impl From<parquet2::error::Error> for ArrowError {
+    fn from(error: parquet2::error::Error) -> Self {
         match error {
-            parquet2::error::ParquetError::FeatureNotActive(_, _) => {
+            parquet2::error::Error::FeatureNotActive(_, _) => {
                 let message = "Failed to read a compressed parquet file. \
                     Use the cargo feature \"io_parquet_compression\" to read compressed parquet files."
                     .to_string();
@@ -20,8 +20,8 @@ impl From<parquet2::error::ParquetError> for ArrowError {
     }
 }
 
-impl From<ArrowError> for parquet2::error::ParquetError {
+impl From<ArrowError> for parquet2::error::Error {
     fn from(error: ArrowError) -> Self {
-        parquet2::error::ParquetError::General(error.to_string())
+        parquet2::error::Error::General(error.to_string())
     }
 }

--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -18,11 +18,10 @@ use crate::{
 };
 
 use super::super::utils::{
-    extend_from_decoder, next, BinaryIter, DecodedState, MaybeNext, OptionalPageValidity,
-    SizedBinaryIter,
+    extend_from_decoder, next, DecodedState, MaybeNext, OptionalPageValidity,
 };
 use super::super::DataPages;
-use super::{super::utils, utils::Binary};
+use super::{super::utils, utils::*};
 
 /*
 fn read_delta_optional<O: Offset>(

--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -208,13 +208,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 Ok(State::Optional(OptionalPageValidity::new(page), values))
             }
             (Encoding::Plain, _, false) => Ok(State::Required(Required::new(page))),
-            _ => Err(utils::not_implemented(
-                &page.encoding(),
-                is_optional,
-                false,
-                "any",
-                "Binary",
-            )),
+            _ => Err(utils::not_implemented(page)),
         }
     }
 

--- a/src/io/parquet/read/deserialize/binary/nested.rs
+++ b/src/io/parquet/read/deserialize/binary/nested.rs
@@ -69,13 +69,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 Ok(State::Optional(Optional::new(page), values))
             }
             (Encoding::Plain, None, false) => Ok(State::Required(Required::new(page))),
-            _ => Err(utils::not_implemented(
-                &page.encoding(),
-                is_optional,
-                false,
-                "any",
-                "Binary",
-            )),
+            _ => Err(utils::not_implemented(page)),
         }
     }
 

--- a/src/io/parquet/read/deserialize/binary/nested.rs
+++ b/src/io/parquet/read/deserialize/binary/nested.rs
@@ -10,7 +10,7 @@ use crate::{
 use super::super::nested_utils::*;
 use super::super::utils::MaybeNext;
 use super::basic::ValuesDictionary;
-use super::utils::Binary;
+use super::utils::*;
 use super::{
     super::utils,
     basic::{finish, Required, TraitBinaryArray},
@@ -19,7 +19,7 @@ use super::{
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 enum State<'a> {
-    Optional(Optional<'a>, utils::BinaryIter<'a>),
+    Optional(Optional<'a>, BinaryIter<'a>),
     Required(Required<'a>),
     RequiredDictionary(ValuesDictionary<'a>),
     OptionalDictionary(Optional<'a>, ValuesDictionary<'a>),
@@ -64,7 +64,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
             (Encoding::Plain, None, true) => {
                 let (_, _, values) = utils::split_buffer(page);
 
-                let values = utils::BinaryIter::new(values);
+                let values = BinaryIter::new(values);
 
                 Ok(State::Optional(Optional::new(page), values))
             }

--- a/src/io/parquet/read/deserialize/binary/nested.rs
+++ b/src/io/parquet/read/deserialize/binary/nested.rs
@@ -29,7 +29,7 @@ impl<'a> utils::PageState<'a> for State<'a> {
     fn len(&self) -> usize {
         match self {
             State::Optional(validity, _) => validity.len(),
-            State::Required(state) => state.remaining,
+            State::Required(state) => state.len(),
             State::RequiredDictionary(required) => required.len(),
             State::OptionalDictionary(optional, _) => optional.len(),
         }
@@ -95,7 +95,6 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 read_optional_values(items, values, validity)
             }
             State::Required(page) => {
-                page.remaining -= additional;
                 for x in page.values.by_ref().take(additional) {
                     values.push(x)
                 }

--- a/src/io/parquet/read/deserialize/binary/nested.rs
+++ b/src/io/parquet/read/deserialize/binary/nested.rs
@@ -47,7 +47,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
 
     fn build_state(&self, page: &'a DataPage) -> Result<Self::State> {
         let is_optional =
-            page.descriptor().type_().get_basic_info().repetition() == &Repetition::Optional;
+            page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
 
         match (page.encoding(), page.dictionary_page(), is_optional) {
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false) => {
@@ -95,15 +95,10 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
         let (values, validity) = decoded;
         match state {
             State::Optional(page_validity, page_values) => {
-                let max_def = page_validity.max_def();
-                read_optional_values(
-                    page_validity.definition_levels.by_ref(),
-                    max_def,
-                    page_values.by_ref(),
-                    values,
-                    validity,
-                    additional,
-                )
+                let items = page_validity.by_ref().take(additional);
+                let items = Zip::new(items, page_values.by_ref());
+
+                read_optional_values(items, values, validity)
             }
             State::Required(page) => {
                 page.remaining -= additional;
@@ -126,7 +121,6 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 }
             }
             State::OptionalDictionary(page_validity, page_values) => {
-                let max_def = page_validity.max_def();
                 let dict_values = page_values.dict.values();
                 let dict_offsets = page_values.dict.offsets();
 
@@ -136,14 +130,11 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                     let dict_offset_ip1 = dict_offsets[index + 1] as usize;
                     &dict_values[dict_offset_i..dict_offset_ip1]
                 };
-                read_optional_values(
-                    page_validity.definition_levels.by_ref(),
-                    max_def,
-                    page_values.values.by_ref().map(op),
-                    values,
-                    validity,
-                    additional,
-                )
+
+                let items = page_validity.by_ref().take(additional);
+                let items = Zip::new(items, page_values.values.by_ref().map(op));
+
+                read_optional_values(items, values, validity)
             }
         }
     }

--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -87,3 +87,65 @@ impl<'a, O: Offset> Pushable<&'a [u8]> for Binary<O> {
         self.extend_constant(additional)
     }
 }
+
+
+#[derive(Debug)]
+pub struct BinaryIter<'a> {
+    values: &'a [u8],
+}
+
+impl<'a> BinaryIter<'a> {
+    pub fn new(values: &'a [u8]) -> Self {
+        Self { values }
+    }
+}
+
+impl<'a> Iterator for BinaryIter<'a> {
+    type Item = &'a [u8];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.values.is_empty() {
+            return None;
+        }
+        let length = u32::from_le_bytes(self.values[0..4].try_into().unwrap()) as usize;
+        self.values = &self.values[4..];
+        let result = &self.values[..length];
+        self.values = &self.values[length..];
+        Some(result)
+    }
+}
+
+#[derive(Debug)]
+pub struct SizedBinaryIter<'a> {
+    iter: BinaryIter<'a>,
+    remaining: usize,
+}
+
+impl<'a> SizedBinaryIter<'a> {
+    pub fn new(values: &'a [u8], size: usize) -> Self {
+        let iter = BinaryIter::new(values);
+        Self {
+            iter,
+            remaining: size,
+        }
+    }
+}
+
+impl<'a> Iterator for SizedBinaryIter<'a> {
+    type Item = &'a [u8];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        } else {
+            self.remaining -= 1
+        };
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}

--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -88,7 +88,6 @@ impl<'a, O: Offset> Pushable<&'a [u8]> for Binary<O> {
     }
 }
 
-
 #[derive(Debug)]
 pub struct BinaryIter<'a> {
     values: &'a [u8],

--- a/src/io/parquet/read/deserialize/boolean/basic.rs
+++ b/src/io/parquet/read/deserialize/boolean/basic.rs
@@ -89,7 +89,7 @@ impl<'a> Decoder<'a> for BooleanDecoder {
 
     fn build_state(&self, page: &'a DataPage) -> Result<Self::State> {
         let is_optional =
-            page.descriptor().type_().get_basic_info().repetition() == &Repetition::Optional;
+            page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
 
         match (page.encoding(), is_optional) {
             (Encoding::Plain, true) => Ok(State::Optional(Optional::new(page))),

--- a/src/io/parquet/read/deserialize/boolean/basic.rs
+++ b/src/io/parquet/read/deserialize/boolean/basic.rs
@@ -94,13 +94,7 @@ impl<'a> Decoder<'a> for BooleanDecoder {
         match (page.encoding(), is_optional) {
             (Encoding::Plain, true) => Ok(State::Optional(Optional::new(page))),
             (Encoding::Plain, false) => Ok(State::Required(Required::new(page))),
-            _ => Err(utils::not_implemented(
-                &page.encoding(),
-                is_optional,
-                false,
-                "any",
-                "Boolean",
-            )),
+            _ => Err(utils::not_implemented(page)),
         }
     }
 

--- a/src/io/parquet/read/deserialize/boolean/basic.rs
+++ b/src/io/parquet/read/deserialize/boolean/basic.rs
@@ -1,6 +1,8 @@
 use std::collections::VecDeque;
 
-use parquet2::{encoding::Encoding, page::DataPage, schema::Repetition};
+use parquet2::{
+    deserialize::SliceFilteredIter, encoding::Encoding, page::DataPage, schema::Repetition,
+};
 
 use crate::{
     array::BooleanArray,
@@ -11,25 +13,19 @@ use crate::{
 
 use super::super::utils;
 use super::super::utils::{
-    extend_from_decoder, next, split_buffer, DecodedState, Decoder, MaybeNext, OptionalPageValidity,
+    extend_from_decoder, get_selected_rows, next, split_buffer, DecodedState, Decoder,
+    FilteredOptionalPageValidity, MaybeNext, OptionalPageValidity,
 };
 use super::super::DataPages;
 
-// The state of an optional DataPage with a boolean physical type
 #[derive(Debug)]
-struct Optional<'a> {
-    values: BitmapIter<'a>,
-    validity: OptionalPageValidity<'a>,
-}
+struct Values<'a>(BitmapIter<'a>);
 
-impl<'a> Optional<'a> {
+impl<'a> Values<'a> {
     pub fn new(page: &'a DataPage) -> Self {
-        let (_, _, values_buffer) = split_buffer(page);
+        let (_, _, values) = split_buffer(page);
 
-        Self {
-            values: BitmapIter::new(values_buffer, 0, values_buffer.len() * 8),
-            validity: OptionalPageValidity::new(page),
-        }
+        Self(BitmapIter::new(values, 0, values.len() * 8))
     }
 }
 
@@ -52,18 +48,44 @@ impl<'a> Required<'a> {
     }
 }
 
+#[derive(Debug)]
+struct FilteredRequired<'a> {
+    values: SliceFilteredIter<BitmapIter<'a>>,
+}
+
+impl<'a> FilteredRequired<'a> {
+    pub fn new(page: &'a DataPage) -> Self {
+        // todo: replace this by an iterator over slices, for faster deserialization
+        let values = BitmapIter::new(page.buffer(), 0, page.num_values());
+
+        let rows = get_selected_rows(page);
+        let values = SliceFilteredIter::new(values, rows);
+
+        Self { values }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.values.size_hint().0
+    }
+}
+
 // The state of a `DataPage` of `Boolean` parquet boolean type
 #[derive(Debug)]
 enum State<'a> {
-    Optional(Optional<'a>),
+    Optional(OptionalPageValidity<'a>, Values<'a>),
     Required(Required<'a>),
+    FilteredRequired(FilteredRequired<'a>),
+    FilteredOptional(FilteredOptionalPageValidity<'a>, Values<'a>),
 }
 
 impl<'a> State<'a> {
     pub fn len(&self) -> usize {
         match self {
-            State::Optional(page) => page.validity.len(),
+            State::Optional(validity, _) => validity.len(),
             State::Required(page) => page.length - page.offset,
+            State::FilteredRequired(page) => page.len(),
+            State::FilteredOptional(optional, _) => optional.len(),
         }
     }
 }
@@ -90,10 +112,21 @@ impl<'a> Decoder<'a> for BooleanDecoder {
     fn build_state(&self, page: &'a DataPage) -> Result<Self::State> {
         let is_optional =
             page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
+        let is_filtered = page.selected_rows().is_some();
 
-        match (page.encoding(), is_optional) {
-            (Encoding::Plain, true) => Ok(State::Optional(Optional::new(page))),
-            (Encoding::Plain, false) => Ok(State::Required(Required::new(page))),
+        match (page.encoding(), is_optional, is_filtered) {
+            (Encoding::Plain, true, false) => Ok(State::Optional(
+                OptionalPageValidity::new(page),
+                Values::new(page),
+            )),
+            (Encoding::Plain, false, false) => Ok(State::Required(Required::new(page))),
+            (Encoding::Plain, true, true) => Ok(State::FilteredOptional(
+                FilteredOptionalPageValidity::new(page),
+                Values::new(page),
+            )),
+            (Encoding::Plain, false, true) => {
+                Ok(State::FilteredRequired(FilteredRequired::new(page)))
+            }
             _ => Err(utils::not_implemented(page)),
         }
     }
@@ -113,17 +146,32 @@ impl<'a> Decoder<'a> for BooleanDecoder {
     ) {
         let (values, validity) = decoded;
         match state {
-            State::Optional(page) => extend_from_decoder(
+            State::Optional(page_validity, page_values) => extend_from_decoder(
                 validity,
-                &mut page.validity,
+                page_validity,
                 Some(remaining),
                 values,
-                &mut page.values,
+                &mut page_values.0,
             ),
             State::Required(page) => {
                 let remaining = remaining.min(page.length - page.offset);
                 values.extend_from_slice(page.values, page.offset, remaining);
                 page.offset += remaining;
+            }
+            State::FilteredRequired(page) => {
+                values.reserve(remaining);
+                for item in page.values.by_ref().take(remaining) {
+                    values.push(item)
+                }
+            }
+            State::FilteredOptional(page_validity, page_values) => {
+                utils::extend_from_decoder(
+                    validity,
+                    page_validity,
+                    Some(remaining),
+                    values,
+                    page_values.0.by_ref(),
+                );
             }
         }
     }

--- a/src/io/parquet/read/deserialize/boolean/nested.rs
+++ b/src/io/parquet/read/deserialize/boolean/nested.rs
@@ -75,13 +75,7 @@ impl<'a> Decoder<'a> for BooleanDecoder {
                 Ok(State::Optional(Optional::new(page), values))
             }
             (Encoding::Plain, false) => Ok(State::Required(Required::new(page))),
-            _ => Err(utils::not_implemented(
-                &page.encoding(),
-                is_optional,
-                false,
-                "any",
-                "Boolean",
-            )),
+            _ => Err(utils::not_implemented(page)),
         }
     }
 

--- a/src/io/parquet/read/deserialize/dictionary.rs
+++ b/src/io/parquet/read/deserialize/dictionary.rs
@@ -103,13 +103,7 @@ where
             (Encoding::PlainDictionary | Encoding::RleDictionary, true) => {
                 Ok(State::Optional(Optional::new(page)))
             }
-            _ => Err(utils::not_implemented(
-                &page.encoding(),
-                is_optional,
-                false,
-                "any",
-                "Primitive",
-            )),
+            _ => Err(utils::not_implemented(page)),
         }
     }
 

--- a/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
@@ -140,13 +140,7 @@ impl<'a> Decoder<'a> for BinaryDecoder {
                     dict.as_any().downcast_ref().unwrap(),
                 )))
             }
-            _ => Err(not_implemented(
-                &page.encoding(),
-                is_optional,
-                false,
-                "any",
-                "FixedBinary",
-            )),
+            _ => Err(not_implemented(page)),
         }
     }
 

--- a/src/io/parquet/read/deserialize/mod.rs
+++ b/src/io/parquet/read/deserialize/mod.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 
 use self::nested_utils::{InitNested, NestedArrayIter, NestedState};
+use parquet2::schema::types::PrimitiveType;
 use simple::page_iter_to_arrays;
 
 use super::*;
@@ -27,7 +28,7 @@ pub fn get_page_iterator<R: Read + Seek>(
     reader: R,
     pages_filter: Option<PageFilter>,
     buffer: Vec<u8>,
-) -> Result<PageIterator<R>> {
+) -> Result<PageReader<R>> {
     Ok(_get_page_iterator(
         column_metadata,
         reader,
@@ -76,7 +77,7 @@ fn create_list(
 
 fn columns_to_iter_recursive<'a, I: 'a>(
     mut columns: Vec<I>,
-    mut types: Vec<&ParquetType>,
+    mut types: Vec<&PrimitiveType>,
     field: Field,
     mut init: Vec<InitNested>,
     chunk_size: usize,
@@ -238,7 +239,7 @@ fn field_to_init(field: &Field) -> Vec<InitNested> {
 /// The arrays are guaranteed to be at most of size `chunk_size` and data type `field.data_type`.
 pub fn column_iter_to_arrays<'a, I: 'a>(
     columns: Vec<I>,
-    types: Vec<&ParquetType>,
+    types: Vec<&PrimitiveType>,
     field: Field,
     chunk_size: usize,
 ) -> Result<ArrayIter<'a>>

--- a/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/src/io/parquet/read/deserialize/nested_utils.rs
@@ -7,6 +7,7 @@ use parquet2::{
 use crate::{array::Array, bitmap::MutableBitmap, error::Result};
 
 use super::super::DataPages;
+pub use super::utils::Zip;
 use super::utils::{split_buffer, DecodedState, Decoder, MaybeNext, Pushable};
 
 /// trait describing deserialized repetition and definition levels
@@ -203,31 +204,19 @@ impl Nested for NestedStruct {
     }
 }
 
-pub(super) fn read_optional_values<D, C, G, P>(
-    def_levels: D,
-    max_def: u32,
-    mut new_values: G,
-    values: &mut P,
-    validity: &mut MutableBitmap,
-    mut remaining: usize,
-) where
-    D: Iterator<Item = u32>,
-    G: Iterator<Item = C>,
+pub(super) fn read_optional_values<D, C, P>(items: D, values: &mut P, validity: &mut MutableBitmap)
+where
+    D: Iterator<Item = Option<C>>,
     C: Default,
     P: Pushable<C>,
 {
-    for def in def_levels {
-        if def == max_def {
-            values.push(new_values.next().unwrap());
+    for item in items {
+        if let Some(item) = item {
+            values.push(item);
             validity.push(true);
-            remaining -= 1;
-        } else if def == max_def - 1 {
-            values.push(C::default());
+        } else {
+            values.push_null();
             validity.push(false);
-            remaining -= 1;
-        }
-        if remaining == 0 {
-            break;
         }
     }
 }
@@ -283,8 +272,8 @@ impl<'a> NestedPage<'a> {
     pub fn new(page: &'a DataPage) -> Self {
         let (rep_levels, def_levels, _) = split_buffer(page);
 
-        let max_rep_level = page.descriptor().max_rep_level();
-        let max_def_level = page.descriptor().max_def_level();
+        let max_rep_level = page.descriptor.max_rep_level;
+        let max_def_level = page.descriptor.max_def_level;
 
         let reps =
             HybridRleDecoder::new(rep_levels, get_bit_width(max_rep_level), page.num_values());
@@ -440,37 +429,44 @@ fn extend_offsets2<'a>(page: &mut NestedPage<'a>, nested: &mut NestedState, addi
     }
 }
 
-// The state of an optional DataPage with a boolean physical type
 #[derive(Debug)]
 pub struct Optional<'a> {
-    pub definition_levels: HybridRleDecoder<'a>,
-    max_def: u32,
+    iter: HybridRleDecoder<'a>,
+    max: u32,
+}
+
+impl<'a> Iterator for Optional<'a> {
+    type Item = bool;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next().and_then(|x| {
+            if x == self.max {
+                Some(true)
+            } else if x == self.max - 1 {
+                Some(false)
+            } else {
+                self.next()
+            }
+        })
+    }
 }
 
 impl<'a> Optional<'a> {
     pub fn new(page: &'a DataPage) -> Self {
         let (_, def_levels, _) = split_buffer(page);
 
-        let max_def = page.descriptor().max_def_level();
+        let max_def = page.descriptor.max_def_level;
 
         Self {
-            definition_levels: HybridRleDecoder::new(
-                def_levels,
-                get_bit_width(max_def),
-                page.num_values(),
-            ),
-            max_def: max_def as u32,
+            iter: HybridRleDecoder::new(def_levels, get_bit_width(max_def), page.num_values()),
+            max: max_def as u32,
         }
     }
 
     #[inline]
     pub fn len(&self) -> usize {
-        self.definition_levels.size_hint().0
-    }
-
-    #[inline]
-    pub fn max_def(&self) -> u32 {
-        self.max_def
+        unreachable!();
     }
 }
 

--- a/src/io/parquet/read/deserialize/primitive/basic.rs
+++ b/src/io/parquet/read/deserialize/primitive/basic.rs
@@ -158,13 +158,7 @@ where
                 Ok(State::Optional(validity, values))
             }
             (Encoding::Plain, _, false) => Ok(State::Required(Values::new::<P>(page))),
-            _ => Err(utils::not_implemented(
-                &page.encoding(),
-                is_optional,
-                false,
-                "any",
-                "Primitive",
-            )),
+            _ => Err(utils::not_implemented(page)),
         }
     }
 

--- a/src/io/parquet/read/deserialize/primitive/basic.rs
+++ b/src/io/parquet/read/deserialize/primitive/basic.rs
@@ -18,6 +18,26 @@ use super::super::utils::OptionalPageValidity;
 use super::super::DataPages;
 
 #[derive(Debug)]
+pub(super) struct RequiredValues<'a> {
+    pub values: std::slice::ChunksExact<'a, u8>,
+}
+
+impl<'a> RequiredValues<'a> {
+    pub fn new<P: ParquetNativeType>(page: &'a DataPage) -> Self {
+        let (_, _, values) = utils::split_buffer(page);
+        assert_eq!(values.len() % std::mem::size_of::<P>(), 0);
+        let values = values.chunks_exact(std::mem::size_of::<P>());
+
+        Self { values }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.values.size_hint().0
+    }
+}
+
+#[derive(Debug)]
 pub(super) struct Values<'a> {
     pub values: std::slice::ChunksExact<'a, u8>,
 }
@@ -28,6 +48,34 @@ impl<'a> Values<'a> {
         assert_eq!(values.len() % std::mem::size_of::<P>(), 0);
         Self {
             values: values.chunks_exact(std::mem::size_of::<P>()),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.values.size_hint().0
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct RequiredDictionary<'a, P>
+where
+    P: ParquetNativeType,
+{
+    pub values: hybrid_rle::HybridRleDecoder<'a>,
+    pub dict: &'a [P],
+}
+
+impl<'a, P> RequiredDictionary<'a, P>
+where
+    P: ParquetNativeType,
+{
+    pub fn new(page: &'a DataPage, dict: &'a PrimitivePageDict<P>) -> Self {
+        let values = utils::dict_indices_decoder(page);
+
+        Self {
+            dict: dict.values(),
+            values,
         }
     }
 
@@ -51,8 +99,7 @@ where
     P: ParquetNativeType,
 {
     pub fn new(page: &'a DataPage, dict: &'a PrimitivePageDict<P>) -> Self {
-        let (_, _, indices_buffer) = utils::split_buffer(page);
-        let values = utils::dict_indices_decoder(indices_buffer, page.num_values());
+        let values = utils::dict_indices_decoder(page);
 
         Self {
             dict: dict.values(),
@@ -73,8 +120,8 @@ where
     P: ParquetNativeType,
 {
     Optional(OptionalPageValidity<'a>, Values<'a>),
-    Required(Values<'a>),
-    RequiredDictionary(ValuesDictionary<'a, P>),
+    Required(RequiredValues<'a>),
+    RequiredDictionary(RequiredDictionary<'a, P>),
     OptionalDictionary(OptionalPageValidity<'a>, ValuesDictionary<'a, P>),
 }
 
@@ -137,12 +184,14 @@ where
 
     fn build_state(&self, page: &'a DataPage) -> Result<Self::State> {
         let is_optional =
-            page.descriptor().type_().get_basic_info().repetition() == &Repetition::Optional;
+            page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
 
         match (page.encoding(), page.dictionary_page(), is_optional) {
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false) => {
                 let dict = dict.as_any().downcast_ref().unwrap();
-                Ok(State::RequiredDictionary(ValuesDictionary::new(page, dict)))
+                Ok(State::RequiredDictionary(RequiredDictionary::new(
+                    page, dict,
+                )))
             }
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true) => {
                 let dict = dict.as_any().downcast_ref().unwrap();
@@ -158,7 +207,7 @@ where
 
                 Ok(State::Optional(validity, values))
             }
-            (Encoding::Plain, _, false) => Ok(State::Required(Values::new::<P>(page))),
+            (Encoding::Plain, _, false) => Ok(State::Required(RequiredValues::new::<P>(page))),
             _ => Err(utils::not_implemented(
                 &page.encoding(),
                 is_optional,

--- a/src/io/parquet/read/deserialize/primitive/nested.rs
+++ b/src/io/parquet/read/deserialize/primitive/nested.rs
@@ -99,13 +99,7 @@ where
                 Ok(State::Optional(Optional::new(page), Values::new::<P>(page)))
             }
             (Encoding::Plain, _, false) => Ok(State::Required(Values::new::<P>(page))),
-            _ => Err(utils::not_implemented(
-                &page.encoding(),
-                is_optional,
-                false,
-                "any",
-                "Primitive",
-            )),
+            _ => Err(utils::not_implemented(page)),
         }
     }
 

--- a/src/io/parquet/read/deserialize/utils.rs
+++ b/src/io/parquet/read/deserialize/utils.rs
@@ -39,6 +39,40 @@ impl<'a> Iterator for BinaryIter<'a> {
     }
 }
 
+#[derive(Debug)]
+pub struct SizedBinaryIter<'a> {
+    iter: BinaryIter<'a>,
+    remaining: usize,
+}
+
+impl<'a> SizedBinaryIter<'a> {
+    pub fn new(values: &'a [u8], size: usize) -> Self {
+        let iter = BinaryIter::new(values);
+        Self {
+            iter,
+            remaining: size,
+        }
+    }
+}
+
+impl<'a> Iterator for SizedBinaryIter<'a> {
+    type Item = &'a [u8];
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        } else {
+            self.remaining -= 1
+        };
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
 pub fn not_implemented(page: &DataPage) -> ArrowError {
     let is_optional = page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
     let required = if is_optional { "optional" } else { "required" };

--- a/src/io/parquet/read/deserialize/utils.rs
+++ b/src/io/parquet/read/deserialize/utils.rs
@@ -1,5 +1,4 @@
 use std::collections::VecDeque;
-use std::convert::TryInto;
 
 use parquet2::encoding::hybrid_rle;
 use parquet2::page::{split_buffer as _split_buffer, DataPage};
@@ -11,67 +10,6 @@ use crate::bitmap::MutableBitmap;
 use crate::error::ArrowError;
 
 use super::super::DataPages;
-
-#[derive(Debug)]
-pub struct BinaryIter<'a> {
-    values: &'a [u8],
-}
-
-impl<'a> BinaryIter<'a> {
-    pub fn new(values: &'a [u8]) -> Self {
-        Self { values }
-    }
-}
-
-impl<'a> Iterator for BinaryIter<'a> {
-    type Item = &'a [u8];
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.values.is_empty() {
-            return None;
-        }
-        let length = u32::from_le_bytes(self.values[0..4].try_into().unwrap()) as usize;
-        self.values = &self.values[4..];
-        let result = &self.values[..length];
-        self.values = &self.values[length..];
-        Some(result)
-    }
-}
-
-#[derive(Debug)]
-pub struct SizedBinaryIter<'a> {
-    iter: BinaryIter<'a>,
-    remaining: usize,
-}
-
-impl<'a> SizedBinaryIter<'a> {
-    pub fn new(values: &'a [u8], size: usize) -> Self {
-        let iter = BinaryIter::new(values);
-        Self {
-            iter,
-            remaining: size,
-        }
-    }
-}
-
-impl<'a> Iterator for SizedBinaryIter<'a> {
-    type Item = &'a [u8];
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.remaining == 0 {
-            return None;
-        } else {
-            self.remaining -= 1
-        };
-        self.iter.next()
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.remaining, Some(self.remaining))
-    }
-}
 
 pub fn not_implemented(page: &DataPage) -> ArrowError {
     let is_optional = page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;

--- a/src/io/parquet/read/deserialize/utils.rs
+++ b/src/io/parquet/read/deserialize/utils.rs
@@ -16,18 +16,21 @@ use super::super::DataPages;
 
 pub fn not_implemented(page: &DataPage) -> ArrowError {
     let is_optional = page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
+    let is_filtered = page.selected_rows().is_some();
     let required = if is_optional { "optional" } else { "required" };
+    let is_filtered = if is_filtered { ", index-filtered" } else { "" };
     let dict = if page.dictionary_page().is_some() {
         ", dictionary-encoded"
     } else {
         ""
     };
     ArrowError::NotYetImplemented(format!(
-        "Decoding {:?} \"{:?}\"-encoded{} {} parquet pages",
+        "Decoding {:?} \"{:?}\"-encoded{} {} {} parquet pages",
         page.descriptor.primitive_type.physical_type,
         page.encoding(),
         dict,
         required,
+        is_filtered,
     ))
 }
 

--- a/src/io/parquet/read/indexes/binary.rs
+++ b/src/io/parquet/read/indexes/binary.rs
@@ -1,0 +1,43 @@
+use parquet2::indexes::PageIndex;
+
+use crate::{
+    array::{Array, BinaryArray, PrimitiveArray, Utf8Array},
+    datatypes::{DataType, PhysicalType},
+    error::ArrowError,
+    trusted_len::TrustedLen,
+};
+
+use super::ColumnIndex;
+
+pub fn deserialize(
+    indexes: &[PageIndex<Vec<u8>>],
+    data_type: &DataType,
+) -> Result<ColumnIndex, ArrowError> {
+    Ok(ColumnIndex {
+        min: deserialize_binary_iter(indexes.iter().map(|index| index.min.as_ref()), data_type)?,
+        max: deserialize_binary_iter(indexes.iter().map(|index| index.max.as_ref()), data_type)?,
+        null_count: PrimitiveArray::from_trusted_len_iter(
+            indexes
+                .iter()
+                .map(|index| index.null_count.map(|x| x as u64)),
+        ),
+    })
+}
+
+fn deserialize_binary_iter<'a, I: TrustedLen<Item = Option<&'a Vec<u8>>>>(
+    iter: I,
+    data_type: &DataType,
+) -> Result<Box<dyn Array>, ArrowError> {
+    match data_type.to_physical_type() {
+        PhysicalType::LargeBinary => Ok(Box::new(BinaryArray::<i64>::from_iter(iter))),
+        PhysicalType::Utf8 => {
+            let iter = iter.map(|x| x.map(|x| std::str::from_utf8(x)).transpose());
+            Ok(Box::new(Utf8Array::<i32>::try_from_trusted_len_iter(iter)?))
+        }
+        PhysicalType::LargeUtf8 => {
+            let iter = iter.map(|x| x.map(|x| std::str::from_utf8(x)).transpose());
+            Ok(Box::new(Utf8Array::<i64>::try_from_trusted_len_iter(iter)?))
+        }
+        _ => Ok(Box::new(BinaryArray::<i32>::from_iter(iter))),
+    }
+}

--- a/src/io/parquet/read/indexes/boolean.rs
+++ b/src/io/parquet/read/indexes/boolean.rs
@@ -1,0 +1,21 @@
+use parquet2::indexes::PageIndex;
+
+use crate::array::{BooleanArray, PrimitiveArray};
+
+use super::ColumnIndex;
+
+pub fn deserialize(indexes: &[PageIndex<bool>]) -> ColumnIndex {
+    ColumnIndex {
+        min: Box::new(BooleanArray::from_trusted_len_iter(
+            indexes.iter().map(|index| index.min),
+        )),
+        max: Box::new(BooleanArray::from_trusted_len_iter(
+            indexes.iter().map(|index| index.max),
+        )),
+        null_count: PrimitiveArray::from_trusted_len_iter(
+            indexes
+                .iter()
+                .map(|index| index.null_count.map(|x| x as u64)),
+        ),
+    }
+}

--- a/src/io/parquet/read/indexes/fixed_len_binary.rs
+++ b/src/io/parquet/read/indexes/fixed_len_binary.rs
@@ -1,0 +1,58 @@
+use parquet2::indexes::PageIndex;
+
+use crate::{
+    array::{Array, FixedSizeBinaryArray, MutableFixedSizeBinaryArray, PrimitiveArray},
+    datatypes::{DataType, PhysicalType, PrimitiveType},
+    trusted_len::TrustedLen,
+};
+
+use super::ColumnIndex;
+
+pub fn deserialize(indexes: &[PageIndex<Vec<u8>>], data_type: DataType) -> ColumnIndex {
+    ColumnIndex {
+        min: deserialize_binary_iter(
+            indexes.iter().map(|index| index.min.as_ref()),
+            data_type.clone(),
+        ),
+        max: deserialize_binary_iter(indexes.iter().map(|index| index.max.as_ref()), data_type),
+        null_count: PrimitiveArray::from_trusted_len_iter(
+            indexes
+                .iter()
+                .map(|index| index.null_count.map(|x| x as u64)),
+        ),
+    }
+}
+
+fn deserialize_binary_iter<'a, I: TrustedLen<Item = Option<&'a Vec<u8>>>>(
+    iter: I,
+    data_type: DataType,
+) -> Box<dyn Array> {
+    match data_type.to_physical_type() {
+        PhysicalType::Primitive(PrimitiveType::Int128) => {
+            Box::new(PrimitiveArray::from_trusted_len_iter(iter.map(|v| {
+                v.map(|x| {
+                    // Copy the fixed-size byte value to the start of a 16 byte stack
+                    // allocated buffer, then use an arithmetic right shift to fill in
+                    // MSBs, which accounts for leading 1's in negative (two's complement)
+                    // values.
+                    let n = x.len();
+                    let mut bytes = [0u8; 16];
+                    bytes[..n].copy_from_slice(x);
+                    i128::from_be_bytes(bytes) >> (8 * (16 - n))
+                })
+            })))
+        }
+        _ => {
+            let mut a = MutableFixedSizeBinaryArray::from_data(
+                data_type,
+                Vec::with_capacity(iter.size_hint().0),
+                None,
+            );
+            for item in iter {
+                a.push(item);
+            }
+            let a: FixedSizeBinaryArray = a.into();
+            Box::new(a)
+        }
+    }
+}

--- a/src/io/parquet/read/indexes/mod.rs
+++ b/src/io/parquet/read/indexes/mod.rs
@@ -1,0 +1,141 @@
+use parquet2::indexes::{
+    BooleanIndex, ByteIndex, FixedLenByteIndex, Index as ParquetIndex, NativeIndex,
+};
+use parquet2::metadata::ColumnChunkMetaData;
+use parquet2::read::read_columns_indexes as _read_columns_indexes;
+use parquet2::schema::types::PhysicalType as ParquetPhysicalType;
+
+mod binary;
+mod boolean;
+mod fixed_len_binary;
+mod primitive;
+
+use std::io::{Read, Seek};
+
+use crate::datatypes::Field;
+use crate::{
+    array::{Array, UInt64Array},
+    datatypes::DataType,
+    error::ArrowError,
+};
+
+/// Arrow-deserialized [`ColumnIndex`] containing the minimum and maximum value
+/// of every page from the column.
+/// # Invariants
+/// The minimum and maximum are guaranteed to have the same logical type.
+#[derive(Debug, PartialEq)]
+pub struct ColumnIndex {
+    /// The minimum values in the pages
+    pub min: Box<dyn Array>,
+    /// The maximum values in the pages
+    pub max: Box<dyn Array>,
+    /// The number of null values in the pages
+    pub null_count: UInt64Array,
+}
+
+impl ColumnIndex {
+    /// The [`DataType`] of the column index.
+    pub fn data_type(&self) -> &DataType {
+        self.min.data_type()
+    }
+}
+
+/// Given a sequence of [`ParquetIndex`] representing the page indexes of each column in the
+/// parquet file, returns the page-level statistics as arrow's arrays, as a vector of [`ColumnIndex`].
+///
+/// This function maps timestamps, decimal types, etc. accordingly.
+/// # Implementation
+/// This function is CPU-bounded but `O(P)` where `P` is the total number of pages in all columns.
+/// # Error
+/// This function errors iff the value is not deserializable to arrow (e.g. invalid utf-8)
+fn deserialize(
+    indexes: &[Box<dyn ParquetIndex>],
+    data_types: Vec<DataType>,
+) -> Result<Vec<ColumnIndex>, ArrowError> {
+    indexes
+        .iter()
+        .zip(data_types.into_iter())
+        .map(|(index, data_type)| match index.physical_type() {
+            ParquetPhysicalType::Boolean => {
+                let index = index.as_any().downcast_ref::<BooleanIndex>().unwrap();
+                Ok(boolean::deserialize(&index.indexes))
+            }
+            ParquetPhysicalType::Int32 => {
+                let index = index.as_any().downcast_ref::<NativeIndex<i32>>().unwrap();
+                Ok(primitive::deserialize_i32(&index.indexes, data_type))
+            }
+            ParquetPhysicalType::Int64 => {
+                let index = index.as_any().downcast_ref::<NativeIndex<i64>>().unwrap();
+                Ok(primitive::deserialize_i64(
+                    &index.indexes,
+                    &index.primitive_type,
+                    data_type,
+                ))
+            }
+            ParquetPhysicalType::Int96 => {
+                let index = index
+                    .as_any()
+                    .downcast_ref::<NativeIndex<[u32; 3]>>()
+                    .unwrap();
+                Ok(primitive::deserialize_i96(&index.indexes, data_type))
+            }
+            ParquetPhysicalType::Float => {
+                let index = index.as_any().downcast_ref::<NativeIndex<f32>>().unwrap();
+                Ok(primitive::deserialize_id(&index.indexes, data_type))
+            }
+            ParquetPhysicalType::Double => {
+                let index = index.as_any().downcast_ref::<NativeIndex<f64>>().unwrap();
+                Ok(primitive::deserialize_id(&index.indexes, data_type))
+            }
+            ParquetPhysicalType::ByteArray => {
+                let index = index.as_any().downcast_ref::<ByteIndex>().unwrap();
+                binary::deserialize(&index.indexes, &data_type)
+            }
+            ParquetPhysicalType::FixedLenByteArray(_) => {
+                let index = index.as_any().downcast_ref::<FixedLenByteIndex>().unwrap();
+                Ok(fixed_len_binary::deserialize(&index.indexes, data_type))
+            }
+        })
+        .collect()
+}
+
+// recursive function to get the corresponding leaf data_types corresponding to the
+// parquet columns
+fn populate_dt(data_type: &DataType, container: &mut Vec<DataType>) {
+    match data_type.to_logical_type() {
+        DataType::List(inner) => populate_dt(&inner.data_type, container),
+        DataType::LargeList(inner) => populate_dt(&inner.data_type, container),
+        DataType::Dictionary(_, inner, _) => populate_dt(inner, container),
+        DataType::Struct(fields) => fields
+            .iter()
+            .for_each(|f| populate_dt(&f.data_type, container)),
+        _ => container.push(data_type.clone()),
+    }
+}
+
+/// Reads the column indexes from the reader assuming a valid set of derived Arrow fields
+/// for all parquet the columns in the file.
+///
+/// This function is expected to be used to filter out parquet pages.
+///
+/// # Implementation
+/// This function is IO-bounded and calls `reader.read_exact` exactly once.
+/// # Error
+/// Errors iff the indexes can't be read or their deserialization to arrow is incorrect (e.g. invalid utf-8)
+pub fn read_columns_indexes<R: Read + Seek>(
+    reader: &mut R,
+    chunks: &[ColumnChunkMetaData],
+    fields: &[Field],
+) -> Result<Vec<ColumnIndex>, ArrowError> {
+    let indexes = _read_columns_indexes(reader, chunks)?;
+
+    // map arrow fields to the corresponding columns in parquet taking into account
+    // that fields may be nested but parquet column indexes are only leaf columns
+    let mut data_types = vec![];
+    fields
+        .iter()
+        .map(|f| &f.data_type)
+        .for_each(|d| populate_dt(d, &mut data_types));
+
+    deserialize(&indexes, data_types)
+}

--- a/src/io/parquet/read/indexes/primitive.rs
+++ b/src/io/parquet/read/indexes/primitive.rs
@@ -1,0 +1,204 @@
+use parquet2::indexes::PageIndex;
+use parquet2::schema::types::{PrimitiveLogicalType, PrimitiveType, TimeUnit as ParquetTimeUnit};
+use parquet2::types::int96_to_i64_ns;
+
+use crate::array::{Array, MutablePrimitiveArray, PrimitiveArray};
+use crate::datatypes::{DataType, TimeUnit};
+use crate::trusted_len::TrustedLen;
+use crate::types::NativeType;
+
+use super::ColumnIndex;
+
+#[inline]
+fn deserialize_int32<I: TrustedLen<Item = Option<i32>>>(
+    iter: I,
+    data_type: DataType,
+) -> Box<dyn Array> {
+    use DataType::*;
+    match data_type.to_logical_type() {
+        UInt8 => Box::new(
+            PrimitiveArray::<u8>::from_trusted_len_iter(iter.map(|x| x.map(|x| x as u8)))
+                .to(data_type),
+        ) as _,
+        UInt16 => Box::new(
+            PrimitiveArray::<u16>::from_trusted_len_iter(iter.map(|x| x.map(|x| x as u16)))
+                .to(data_type),
+        ),
+        UInt32 => Box::new(
+            PrimitiveArray::<u32>::from_trusted_len_iter(iter.map(|x| x.map(|x| x as u32)))
+                .to(data_type),
+        ),
+        Decimal(_, _) => Box::new(
+            PrimitiveArray::<i128>::from_trusted_len_iter(iter.map(|x| x.map(|x| x as i128)))
+                .to(data_type),
+        ),
+        _ => Box::new(PrimitiveArray::<i32>::from_trusted_len_iter(iter).to(data_type)),
+    }
+}
+
+#[inline]
+fn timestamp(
+    array: &mut MutablePrimitiveArray<i64>,
+    time_unit: TimeUnit,
+    logical_type: Option<PrimitiveLogicalType>,
+) {
+    let unit = if let Some(PrimitiveLogicalType::Timestamp { unit, .. }) = logical_type {
+        unit
+    } else {
+        return;
+    };
+
+    match (unit, time_unit) {
+        (ParquetTimeUnit::Milliseconds, TimeUnit::Second) => array
+            .values_mut_slice()
+            .iter_mut()
+            .for_each(|x| *x /= 1_000),
+        (ParquetTimeUnit::Microseconds, TimeUnit::Second) => array
+            .values_mut_slice()
+            .iter_mut()
+            .for_each(|x| *x /= 1_000_000),
+        (ParquetTimeUnit::Nanoseconds, TimeUnit::Second) => array
+            .values_mut_slice()
+            .iter_mut()
+            .for_each(|x| *x /= 1_000_000_000),
+
+        (ParquetTimeUnit::Milliseconds, TimeUnit::Millisecond) => {}
+        (ParquetTimeUnit::Microseconds, TimeUnit::Millisecond) => array
+            .values_mut_slice()
+            .iter_mut()
+            .for_each(|x| *x /= 1_000),
+        (ParquetTimeUnit::Nanoseconds, TimeUnit::Millisecond) => array
+            .values_mut_slice()
+            .iter_mut()
+            .for_each(|x| *x /= 1_000_000),
+
+        (ParquetTimeUnit::Milliseconds, TimeUnit::Microsecond) => array
+            .values_mut_slice()
+            .iter_mut()
+            .for_each(|x| *x *= 1_000),
+        (ParquetTimeUnit::Microseconds, TimeUnit::Microsecond) => {}
+        (ParquetTimeUnit::Nanoseconds, TimeUnit::Microsecond) => array
+            .values_mut_slice()
+            .iter_mut()
+            .for_each(|x| *x /= 1_000),
+
+        (ParquetTimeUnit::Milliseconds, TimeUnit::Nanosecond) => array
+            .values_mut_slice()
+            .iter_mut()
+            .for_each(|x| *x *= 1_000_000),
+        (ParquetTimeUnit::Microseconds, TimeUnit::Nanosecond) => array
+            .values_mut_slice()
+            .iter_mut()
+            .for_each(|x| *x /= 1_000),
+        (ParquetTimeUnit::Nanoseconds, TimeUnit::Nanosecond) => {}
+    }
+}
+
+#[inline]
+fn deserialize_int64<I: TrustedLen<Item = Option<i64>>>(
+    iter: I,
+    primitive_type: &PrimitiveType,
+    data_type: DataType,
+) -> Box<dyn Array> {
+    use DataType::*;
+    match data_type.to_logical_type() {
+        UInt64 => Box::new(
+            PrimitiveArray::<u64>::from_trusted_len_iter(iter.map(|x| x.map(|x| x as u64)))
+                .to(data_type),
+        ) as _,
+        Decimal(_, _) => Box::new(
+            PrimitiveArray::<i128>::from_trusted_len_iter(iter.map(|x| x.map(|x| x as i128)))
+                .to(data_type),
+        ) as _,
+        Timestamp(time_unit, _) => {
+            let mut array =
+                MutablePrimitiveArray::<i64>::from_trusted_len_iter(iter).to(data_type.clone());
+
+            timestamp(&mut array, *time_unit, primitive_type.logical_type);
+
+            let array: PrimitiveArray<i64> = array.into();
+
+            Box::new(array)
+        }
+        _ => Box::new(PrimitiveArray::<i64>::from_trusted_len_iter(iter).to(data_type)),
+    }
+}
+
+#[inline]
+fn deserialize_int96<I: TrustedLen<Item = Option<[u32; 3]>>>(
+    iter: I,
+    data_type: DataType,
+) -> Box<dyn Array> {
+    Box::new(
+        PrimitiveArray::<i64>::from_trusted_len_iter(iter.map(|x| x.map(int96_to_i64_ns)))
+            .to(data_type),
+    )
+}
+
+#[inline]
+fn deserialize_id_s<T: NativeType, I: TrustedLen<Item = Option<T>>>(
+    iter: I,
+    data_type: DataType,
+) -> Box<dyn Array> {
+    Box::new(PrimitiveArray::<T>::from_trusted_len_iter(iter).to(data_type))
+}
+
+pub fn deserialize_i32(indexes: &[PageIndex<i32>], data_type: DataType) -> ColumnIndex {
+    ColumnIndex {
+        min: deserialize_int32(indexes.iter().map(|index| index.min), data_type.clone()),
+        max: deserialize_int32(indexes.iter().map(|index| index.max), data_type),
+        null_count: PrimitiveArray::from_trusted_len_iter(
+            indexes
+                .iter()
+                .map(|index| index.null_count.map(|x| x as u64)),
+        ),
+    }
+}
+
+pub fn deserialize_i64(
+    indexes: &[PageIndex<i64>],
+    primitive_type: &PrimitiveType,
+    data_type: DataType,
+) -> ColumnIndex {
+    ColumnIndex {
+        min: deserialize_int64(
+            indexes.iter().map(|index| index.min),
+            primitive_type,
+            data_type.clone(),
+        ),
+        max: deserialize_int64(
+            indexes.iter().map(|index| index.max),
+            primitive_type,
+            data_type,
+        ),
+        null_count: PrimitiveArray::from_trusted_len_iter(
+            indexes
+                .iter()
+                .map(|index| index.null_count.map(|x| x as u64)),
+        ),
+    }
+}
+
+pub fn deserialize_i96(indexes: &[PageIndex<[u32; 3]>], data_type: DataType) -> ColumnIndex {
+    ColumnIndex {
+        min: deserialize_int96(indexes.iter().map(|index| index.min), data_type.clone()),
+        max: deserialize_int96(indexes.iter().map(|index| index.max), data_type),
+        null_count: PrimitiveArray::from_trusted_len_iter(
+            indexes
+                .iter()
+                .map(|index| index.null_count.map(|x| x as u64)),
+        ),
+    }
+}
+
+pub fn deserialize_id<T: NativeType>(indexes: &[PageIndex<T>], data_type: DataType) -> ColumnIndex {
+    ColumnIndex {
+        min: deserialize_id_s(indexes.iter().map(|index| index.min), data_type.clone()),
+        max: deserialize_id_s(indexes.iter().map(|index| index.max), data_type),
+        null_count: PrimitiveArray::from_trusted_len_iter(
+            indexes
+                .iter()
+                .map(|index| index.null_count.map(|x| x as u64)),
+        ),
+    }
+}

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -3,44 +3,46 @@
 
 mod deserialize;
 mod file;
+mod indexes;
 mod row_group;
 pub mod schema;
 pub mod statistics;
-
-use futures::{AsyncRead, AsyncSeek};
-
-// re-exports of parquet2's relevant APIs
-pub use parquet2::{
-    error::ParquetError,
-    fallible_streaming_iterator,
-    metadata::{ColumnChunkMetaData, ColumnDescriptor, RowGroupMetaData},
-    page::{CompressedDataPage, DataPage, DataPageHeader},
-    read::{
-        decompress, get_column_iterator, get_page_iterator as _get_page_iterator,
-        get_page_stream as _get_page_stream, read_metadata as _read_metadata,
-        read_metadata_async as _read_metadata_async, BasicDecompressor, ColumnChunkIter,
-        Decompressor, MutStreamingIterator, PageFilter, PageIterator, ReadColumnIterator, State,
-    },
-    schema::types::{
-        LogicalType, ParquetType, PhysicalType, PrimitiveConvertedType,
-        TimeUnit as ParquetTimeUnit, TimestampType,
-    },
-    types::int96_to_i64_ns,
-    FallibleStreamingIterator,
-};
-
-pub use deserialize::{column_iter_to_arrays, get_page_iterator};
-pub use file::{FileReader, RowGroupReader};
-pub use row_group::*;
-pub(crate) use schema::is_type_nullable;
-pub use schema::{infer_schema, FileMetaData};
 
 use std::{
     io::{Read, Seek},
     sync::Arc,
 };
 
+use futures::{AsyncRead, AsyncSeek};
+
+// re-exports of parquet2's relevant APIs
+pub use parquet2::{
+    error::Error as ParquetError,
+    fallible_streaming_iterator,
+    metadata::{ColumnChunkMetaData, ColumnDescriptor, RowGroupMetaData},
+    page::{CompressedDataPage, DataPage, DataPageHeader},
+    read::{
+        decompress, get_column_iterator, get_page_iterator as _get_page_iterator,
+        get_page_stream as _get_page_stream, read_columns_indexes as _read_columns_indexes,
+        read_metadata as _read_metadata, read_metadata_async as _read_metadata_async,
+        read_pages_locations, BasicDecompressor, ColumnChunkIter, Decompressor,
+        MutStreamingIterator, PageFilter, PageReader, ReadColumnIterator, State,
+    },
+    schema::types::{
+        GroupLogicalType, ParquetType, PhysicalType, PrimitiveConvertedType, PrimitiveLogicalType,
+        TimeUnit as ParquetTimeUnit,
+    },
+    types::int96_to_i64_ns,
+    FallibleStreamingIterator,
+};
+
 use crate::{array::Array, error::Result};
+
+pub use deserialize::{column_iter_to_arrays, get_page_iterator};
+pub use file::{FileReader, RowGroupReader};
+pub use indexes::{read_columns_indexes, ColumnIndex};
+pub use row_group::*;
+pub use schema::{infer_schema, FileMetaData};
 
 /// Trait describing a [`FallibleStreamingIterator`] of [`DataPage`]
 pub trait DataPages:

--- a/src/io/parquet/read/schema/mod.rs
+++ b/src/io/parquet/read/schema/mod.rs
@@ -28,7 +28,3 @@ pub fn infer_schema(file_metadata: &FileMetaData) -> Result<Schema> {
         Schema { fields, metadata }
     }))
 }
-
-pub(crate) fn is_type_nullable(type_: &ParquetType) -> bool {
-    is_nullable(type_.get_basic_info())
-}

--- a/src/io/parquet/write/binary/basic.rs
+++ b/src/io/parquet/write/binary/basic.rs
@@ -6,8 +6,8 @@ use parquet2::{
     statistics::{serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics},
 };
 
-use super::super::WriteOptions;
 use super::super::utils;
+use super::super::WriteOptions;
 use crate::{
     array::{Array, BinaryArray, Offset},
     bitmap::Bitmap,

--- a/src/io/parquet/write/binary/basic.rs
+++ b/src/io/parquet/write/binary/basic.rs
@@ -4,9 +4,9 @@ use parquet2::{
     page::DataPage,
     schema::types::PrimitiveType,
     statistics::{serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics},
-    write::WriteOptions,
 };
 
+use super::super::WriteOptions;
 use super::super::utils;
 use crate::{
     array::{Array, BinaryArray, Offset},

--- a/src/io/parquet/write/binary/basic.rs
+++ b/src/io/parquet/write/binary/basic.rs
@@ -1,7 +1,8 @@
 use parquet2::{
     encoding::{delta_bitpacked, Encoding},
-    metadata::ColumnDescriptor,
+    metadata::Descriptor,
     page::DataPage,
+    schema::types::PrimitiveType,
     statistics::{serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics},
     write::WriteOptions,
 };
@@ -11,7 +12,7 @@ use crate::{
     array::{Array, BinaryArray, Offset},
     bitmap::Bitmap,
     error::{ArrowError, Result},
-    io::parquet::read::is_type_nullable,
+    io::parquet::read::schema::is_nullable,
 };
 
 pub(crate) fn encode_plain<O: Offset>(
@@ -42,11 +43,11 @@ pub(crate) fn encode_plain<O: Offset>(
 pub fn array_to_page<O: Offset>(
     array: &BinaryArray<O>,
     options: WriteOptions,
-    descriptor: ColumnDescriptor,
+    descriptor: Descriptor,
     encoding: Encoding,
 ) -> Result<DataPage> {
     let validity = array.validity();
-    let is_optional = is_type_nullable(descriptor.type_());
+    let is_optional = is_nullable(&descriptor.primitive_type.field_info);
 
     let mut buffer = vec![];
     utils::write_def_levels(
@@ -78,13 +79,14 @@ pub fn array_to_page<O: Offset>(
     }
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(array, descriptor.clone()))
+        Some(build_statistics(array, descriptor.primitive_type.clone()))
     } else {
         None
     };
 
     utils::build_plain_page(
         buffer,
+        array.len(),
         array.len(),
         array.null_count(),
         0,
@@ -96,12 +98,12 @@ pub fn array_to_page<O: Offset>(
     )
 }
 
-pub(super) fn build_statistics<O: Offset>(
+pub(crate) fn build_statistics<O: Offset>(
     array: &BinaryArray<O>,
-    descriptor: ColumnDescriptor,
+    primitive_type: PrimitiveType,
 ) -> ParquetStatistics {
     let statistics = &BinaryStatistics {
-        descriptor,
+        primitive_type,
         null_count: Some(array.null_count() as i64),
         distinct_count: None,
         max_value: array

--- a/src/io/parquet/write/binary/mod.rs
+++ b/src/io/parquet/write/binary/mod.rs
@@ -2,6 +2,7 @@ mod basic;
 mod nested;
 
 pub use basic::array_to_page;
+pub(crate) use basic::build_statistics;
 pub(crate) use basic::encode_plain;
 pub(super) use basic::{encode_delta, ord_binary};
 pub use nested::array_to_page as nested_array_to_page;

--- a/src/io/parquet/write/binary/nested.rs
+++ b/src/io/parquet/write/binary/nested.rs
@@ -1,7 +1,7 @@
 use parquet2::metadata::Descriptor;
-use parquet2::{encoding::Encoding, page::DataPage, write::WriteOptions};
+use parquet2::{encoding::Encoding, page::DataPage};
 
-use super::super::{levels, utils};
+use super::super::{levels, utils, WriteOptions};
 use super::basic::{build_statistics, encode_plain};
 use crate::io::parquet::read::schema::is_nullable;
 use crate::{

--- a/src/io/parquet/write/binary/nested.rs
+++ b/src/io/parquet/write/binary/nested.rs
@@ -1,26 +1,25 @@
-use parquet2::{
-    encoding::Encoding, metadata::ColumnDescriptor, page::DataPage, write::WriteOptions,
-};
+use parquet2::metadata::Descriptor;
+use parquet2::{encoding::Encoding, page::DataPage, write::WriteOptions};
 
 use super::super::{levels, utils};
 use super::basic::{build_statistics, encode_plain};
+use crate::io::parquet::read::schema::is_nullable;
 use crate::{
     array::{Array, BinaryArray, Offset},
     error::Result,
-    io::parquet::read::is_type_nullable,
 };
 
 pub fn array_to_page<O, OO>(
     array: &BinaryArray<O>,
     options: WriteOptions,
-    descriptor: ColumnDescriptor,
+    descriptor: Descriptor,
     nested: levels::NestedInfo<OO>,
 ) -> Result<DataPage>
 where
     OO: Offset,
     O: Offset,
 {
-    let is_optional = is_type_nullable(descriptor.type_());
+    let is_optional = is_nullable(&descriptor.primitive_type.field_info);
 
     let validity = array.validity();
 
@@ -34,7 +33,7 @@ where
     encode_plain(array, is_optional, &mut buffer);
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(array, descriptor.clone()))
+        Some(build_statistics(array, descriptor.primitive_type.clone()))
     } else {
         None
     };
@@ -42,6 +41,7 @@ where
     utils::build_plain_page(
         buffer,
         levels::num_values(nested.offsets()),
+        nested.offsets().len().saturating_sub(1),
         array.null_count(),
         repetition_levels_byte_length,
         definition_levels_byte_length,

--- a/src/io/parquet/write/boolean/basic.rs
+++ b/src/io/parquet/write/boolean/basic.rs
@@ -3,10 +3,10 @@ use parquet2::{
     metadata::Descriptor,
     page::DataPage,
     statistics::{serialize_statistics, BooleanStatistics, ParquetStatistics, Statistics},
-    write::WriteOptions,
 };
 
 use super::super::utils;
+use super::super::WriteOptions;
 use crate::array::*;
 use crate::{error::Result, io::parquet::read::schema::is_nullable};
 

--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -1,25 +1,23 @@
-use parquet2::{
-    encoding::Encoding, metadata::ColumnDescriptor, page::DataPage, write::WriteOptions,
-};
+use parquet2::{encoding::Encoding, metadata::Descriptor, page::DataPage, write::WriteOptions};
 
 use super::super::{levels, utils};
 use super::basic::{build_statistics, encode_plain};
+use crate::io::parquet::read::schema::is_nullable;
 use crate::{
     array::{Array, BooleanArray, Offset},
     error::Result,
-    io::parquet::read::is_type_nullable,
 };
 
 pub fn array_to_page<O>(
     array: &BooleanArray,
     options: WriteOptions,
-    descriptor: ColumnDescriptor,
+    descriptor: Descriptor,
     nested: levels::NestedInfo<O>,
 ) -> Result<DataPage>
 where
     O: Offset,
 {
-    let is_optional = is_type_nullable(descriptor.type_());
+    let is_optional = is_nullable(&descriptor.primitive_type.field_info);
 
     let validity = array.validity();
 
@@ -41,6 +39,7 @@ where
     utils::build_plain_page(
         buffer,
         levels::num_values(nested.offsets()),
+        nested.offsets().len().saturating_sub(1),
         array.null_count(),
         repetition_levels_byte_length,
         definition_levels_byte_length,

--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -1,6 +1,6 @@
-use parquet2::{encoding::Encoding, metadata::Descriptor, page::DataPage, write::WriteOptions};
+use parquet2::{encoding::Encoding, metadata::Descriptor, page::DataPage};
 
-use super::super::{levels, utils};
+use super::super::{levels, utils, WriteOptions};
 use super::basic::{build_statistics, encode_plain};
 use crate::io::parquet::read::schema::is_nullable;
 use crate::{

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -3,9 +3,10 @@ use parquet2::{
     metadata::Descriptor,
     page::{EncodedDictPage, EncodedPage},
     statistics::ParquetStatistics,
-    write::{DynIter, WriteOptions},
+    write::DynIter,
 };
 
+use super::WriteOptions;
 use super::binary::build_statistics as binary_build_statistics;
 use super::binary::encode_plain as binary_encode_plain;
 use super::fixed_len_bytes::build_statistics as fixed_binary_build_statistics;

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -6,7 +6,6 @@ use parquet2::{
     write::DynIter,
 };
 
-use super::WriteOptions;
 use super::binary::build_statistics as binary_build_statistics;
 use super::binary::encode_plain as binary_encode_plain;
 use super::fixed_len_bytes::build_statistics as fixed_binary_build_statistics;
@@ -15,6 +14,7 @@ use super::primitive::build_statistics as primitive_build_statistics;
 use super::primitive::encode_plain as primitive_encode_plain;
 use super::utf8::build_statistics as utf8_build_statistics;
 use super::utf8::encode_plain as utf8_encode_plain;
+use super::WriteOptions;
 use crate::bitmap::Bitmap;
 use crate::datatypes::DataType;
 use crate::error::{ArrowError, Result};

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -1,29 +1,36 @@
 use parquet2::{
     encoding::{hybrid_rle::encode_u32, Encoding},
-    metadata::ColumnDescriptor,
+    metadata::Descriptor,
     page::{EncodedDictPage, EncodedPage},
+    statistics::ParquetStatistics,
     write::{DynIter, WriteOptions},
 };
 
+use super::binary::build_statistics as binary_build_statistics;
 use super::binary::encode_plain as binary_encode_plain;
+use super::fixed_len_bytes::build_statistics as fixed_binary_build_statistics;
 use super::fixed_len_bytes::encode_plain as fixed_binary_encode_plain;
+use super::primitive::build_statistics as primitive_build_statistics;
 use super::primitive::encode_plain as primitive_encode_plain;
+use super::utf8::build_statistics as utf8_build_statistics;
 use super::utf8::encode_plain as utf8_encode_plain;
-use crate::array::{Array, DictionaryArray, DictionaryKey, PrimitiveArray};
 use crate::bitmap::Bitmap;
 use crate::datatypes::DataType;
 use crate::error::{ArrowError, Result};
-use crate::io::parquet::read::is_type_nullable;
 use crate::io::parquet::write::utils;
+use crate::{
+    array::{Array, DictionaryArray, DictionaryKey, PrimitiveArray},
+    io::parquet::read::schema::is_nullable,
+};
 
 fn encode_keys<K: DictionaryKey>(
     array: &PrimitiveArray<K>,
-    // todo: merge this to not discard values' validity
     validity: Option<&Bitmap>,
-    descriptor: ColumnDescriptor,
+    descriptor: Descriptor,
+    statistics: ParquetStatistics,
     options: WriteOptions,
 ) -> Result<EncodedPage> {
-    let is_optional = is_type_nullable(descriptor.type_());
+    let is_optional = is_nullable(&descriptor.primitive_type.field_info);
 
     let mut buffer = vec![];
 
@@ -94,10 +101,11 @@ fn encode_keys<K: DictionaryKey>(
     utils::build_plain_page(
         buffer,
         array.len(),
+        array.len(),
         array.null_count(),
         0,
         definition_levels_byte_length,
-        None,
+        Some(statistics),
         descriptor,
         options,
         Encoding::RleDictionary,
@@ -106,74 +114,83 @@ fn encode_keys<K: DictionaryKey>(
 }
 
 macro_rules! dyn_prim {
-    ($from:ty, $to:ty, $array:expr, $options:expr) => {{
+    ($from:ty, $to:ty, $array:expr, $options:expr, $descriptor:expr) => {{
         let values = $array.values().as_any().downcast_ref().unwrap();
 
         let mut buffer = vec![];
         primitive_encode_plain::<$from, $to>(values, false, &mut buffer);
-        EncodedDictPage::new(buffer, values.len())
+        (
+            EncodedDictPage::new(buffer, values.len()),
+            primitive_build_statistics::<$from, $to>(values, $descriptor.primitive_type.clone()),
+        )
     }};
 }
 
 pub fn array_to_pages<K: DictionaryKey>(
     array: &DictionaryArray<K>,
-    descriptor: ColumnDescriptor,
+    descriptor: Descriptor,
     options: WriteOptions,
     encoding: Encoding,
 ) -> Result<DynIter<'static, Result<EncodedPage>>> {
     match encoding {
         Encoding::PlainDictionary | Encoding::RleDictionary => {
             // write DictPage
-            let dict_page = match array.values().data_type().to_logical_type() {
-                DataType::Int8 => dyn_prim!(i8, i32, array, options),
-                DataType::Int16 => dyn_prim!(i16, i32, array, options),
+            let (dict_page, statistics) = match array.values().data_type().to_logical_type() {
+                DataType::Int8 => dyn_prim!(i8, i32, array, options, descriptor),
+                DataType::Int16 => dyn_prim!(i16, i32, array, options, descriptor),
                 DataType::Int32 | DataType::Date32 | DataType::Time32(_) => {
-                    dyn_prim!(i32, i32, array, options)
+                    dyn_prim!(i32, i32, array, options, descriptor)
                 }
                 DataType::Int64
                 | DataType::Date64
                 | DataType::Time64(_)
                 | DataType::Timestamp(_, _)
-                | DataType::Duration(_) => dyn_prim!(i64, i64, array, options),
-                DataType::UInt8 => dyn_prim!(u8, i32, array, options),
-                DataType::UInt16 => dyn_prim!(u16, i32, array, options),
-                DataType::UInt32 => dyn_prim!(u32, i32, array, options),
-                DataType::UInt64 => dyn_prim!(i64, i64, array, options),
-                DataType::Float32 => dyn_prim!(f32, f32, array, options),
-                DataType::Float64 => dyn_prim!(f64, f64, array, options),
+                | DataType::Duration(_) => dyn_prim!(i64, i64, array, options, descriptor),
+                DataType::UInt8 => dyn_prim!(u8, i32, array, options, descriptor),
+                DataType::UInt16 => dyn_prim!(u16, i32, array, options, descriptor),
+                DataType::UInt32 => dyn_prim!(u32, i32, array, options, descriptor),
+                DataType::UInt64 => dyn_prim!(i64, i64, array, options, descriptor),
+                DataType::Float32 => dyn_prim!(f32, f32, array, options, descriptor),
+                DataType::Float64 => dyn_prim!(f64, f64, array, options, descriptor),
                 DataType::Utf8 => {
-                    let values = array.values().as_any().downcast_ref().unwrap();
+                    let array = array.values().as_any().downcast_ref().unwrap();
 
                     let mut buffer = vec![];
-                    utf8_encode_plain::<i32>(values, false, &mut buffer);
-                    EncodedDictPage::new(buffer, values.len())
+                    utf8_encode_plain::<i32>(array, false, &mut buffer);
+                    let stats = utf8_build_statistics(array, descriptor.primitive_type.clone());
+                    (EncodedDictPage::new(buffer, array.len()), stats)
                 }
                 DataType::LargeUtf8 => {
-                    let values = array.values().as_any().downcast_ref().unwrap();
+                    let array = array.values().as_any().downcast_ref().unwrap();
 
                     let mut buffer = vec![];
-                    utf8_encode_plain::<i64>(values, false, &mut buffer);
-                    EncodedDictPage::new(buffer, values.len())
+                    utf8_encode_plain::<i64>(array, false, &mut buffer);
+                    let stats = utf8_build_statistics(array, descriptor.primitive_type.clone());
+                    (EncodedDictPage::new(buffer, array.len()), stats)
                 }
                 DataType::Binary => {
-                    let values = array.values().as_any().downcast_ref().unwrap();
+                    let array = array.values().as_any().downcast_ref().unwrap();
 
                     let mut buffer = vec![];
-                    binary_encode_plain::<i32>(values, false, &mut buffer);
-                    EncodedDictPage::new(buffer, values.len())
+                    binary_encode_plain::<i32>(array, false, &mut buffer);
+                    let stats = binary_build_statistics(array, descriptor.primitive_type.clone());
+                    (EncodedDictPage::new(buffer, array.len()), stats)
                 }
                 DataType::LargeBinary => {
-                    let values = array.values().as_any().downcast_ref().unwrap();
+                    let array = array.values().as_any().downcast_ref().unwrap();
 
                     let mut buffer = vec![];
-                    binary_encode_plain::<i64>(values, false, &mut buffer);
-                    EncodedDictPage::new(buffer, values.len())
+                    binary_encode_plain::<i64>(array, false, &mut buffer);
+                    let stats = binary_build_statistics(array, descriptor.primitive_type.clone());
+                    (EncodedDictPage::new(buffer, array.len()), stats)
                 }
                 DataType::FixedSizeBinary(_) => {
                     let mut buffer = vec![];
                     let array = array.values().as_any().downcast_ref().unwrap();
                     fixed_binary_encode_plain(array, false, &mut buffer);
-                    EncodedDictPage::new(buffer, array.len())
+                    let stats =
+                        fixed_binary_build_statistics(array, descriptor.primitive_type.clone());
+                    (EncodedDictPage::new(buffer, array.len()), stats)
                 }
                 other => {
                     return Err(ArrowError::NotYetImplemented(format!(
@@ -185,8 +202,13 @@ pub fn array_to_pages<K: DictionaryKey>(
             let dict_page = EncodedPage::Dict(dict_page);
 
             // write DataPage pointing to DictPage
-            let data_page =
-                encode_keys(array.keys(), array.values().validity(), descriptor, options)?;
+            let data_page = encode_keys(
+                array.keys(),
+                array.values().validity(),
+                descriptor,
+                statistics,
+                options,
+            )?;
 
             let iter = std::iter::once(Ok(dict_page)).chain(std::iter::once(Ok(data_page)));
             Ok(DynIter::new(Box::new(iter)))

--- a/src/io/parquet/write/file.rs
+++ b/src/io/parquet/write/file.rs
@@ -67,12 +67,8 @@ impl<W: Write> FileWriter<W> {
     }
 
     /// Writes a row group to the file.
-    pub fn write(
-        &mut self,
-        row_group: RowGroupIter<'_, ArrowError>,
-        num_rows: usize,
-    ) -> Result<()> {
-        Ok(self.writer.write(row_group, num_rows)?)
+    pub fn write(&mut self, row_group: RowGroupIter<'_, ArrowError>) -> Result<()> {
+        Ok(self.writer.write(row_group)?)
     }
 
     /// Writes the footer of the parquet file. Returns the total size of the file.

--- a/src/io/parquet/write/file.rs
+++ b/src/io/parquet/write/file.rs
@@ -83,8 +83,13 @@ impl<W: Write> FileWriter<W> {
     }
 
     /// Writes the footer of the parquet file. Returns the total size of the file.
-    pub fn end(self, key_value_metadata: Option<Vec<KeyValue>>) -> Result<(u64, W)> {
+    pub fn end(&mut self, key_value_metadata: Option<Vec<KeyValue>>) -> Result<u64> {
         let key_value_metadata = add_arrow_schema(&self.schema, key_value_metadata);
         Ok(self.writer.end(key_value_metadata)?)
+    }
+
+    /// Consumes this writer and returns the inner writer
+    pub fn into_inner(self) -> W {
+        self.writer.into_inner()
     }
 }

--- a/src/io/parquet/write/fixed_len_bytes.rs
+++ b/src/io/parquet/write/fixed_len_bytes.rs
@@ -1,8 +1,9 @@
 use parquet2::{
     encoding::Encoding,
-    metadata::ColumnDescriptor,
+    metadata::Descriptor,
     page::DataPage,
-    statistics::{deserialize_statistics, serialize_statistics, ParquetStatistics},
+    schema::types::PrimitiveType,
+    statistics::{serialize_statistics, FixedLenStatistics, ParquetStatistics, Statistics},
     write::WriteOptions,
 };
 
@@ -10,7 +11,7 @@ use super::{binary::ord_binary, utils};
 use crate::{
     array::{Array, FixedSizeBinaryArray},
     error::Result,
-    io::parquet::read::is_type_nullable,
+    io::parquet::read::schema::is_nullable,
 };
 
 pub(crate) fn encode_plain(array: &FixedSizeBinaryArray, is_optional: bool, buffer: &mut Vec<u8>) {
@@ -29,9 +30,9 @@ pub(crate) fn encode_plain(array: &FixedSizeBinaryArray, is_optional: bool, buff
 pub fn array_to_page(
     array: &FixedSizeBinaryArray,
     options: WriteOptions,
-    descriptor: ColumnDescriptor,
+    descriptor: Descriptor,
 ) -> Result<DataPage> {
-    let is_optional = is_type_nullable(descriptor.type_());
+    let is_optional = is_nullable(&descriptor.primitive_type.field_info);
     let validity = array.validity();
 
     let mut buffer = vec![];
@@ -48,13 +49,14 @@ pub fn array_to_page(
     encode_plain(array, is_optional, &mut buffer);
 
     let statistics = if options.write_statistics {
-        build_statistics(array, descriptor.clone())
+        Some(build_statistics(array, descriptor.primitive_type.clone()))
     } else {
         None
     };
 
     utils::build_plain_page(
         buffer,
+        array.len(),
         array.len(),
         array.null_count(),
         0,
@@ -68,11 +70,10 @@ pub fn array_to_page(
 
 pub(super) fn build_statistics(
     array: &FixedSizeBinaryArray,
-    descriptor: ColumnDescriptor,
-) -> Option<ParquetStatistics> {
-    let pq_statistics = &ParquetStatistics {
-        max: None,
-        min: None,
+    primitive_type: PrimitiveType,
+) -> ParquetStatistics {
+    let statistics = &FixedLenStatistics {
+        primitive_type,
         null_count: Some(array.null_count() as i64),
         distinct_count: None,
         max_value: array
@@ -85,8 +86,6 @@ pub(super) fn build_statistics(
             .flatten()
             .min_by(|x, y| ord_binary(x, y))
             .map(|x| x.to_vec()),
-    };
-    deserialize_statistics(pq_statistics, descriptor)
-        .map(|e| serialize_statistics(&*e))
-        .ok()
+    } as &dyn Statistics;
+    serialize_statistics(statistics)
 }

--- a/src/io/parquet/write/fixed_len_bytes.rs
+++ b/src/io/parquet/write/fixed_len_bytes.rs
@@ -4,10 +4,9 @@ use parquet2::{
     page::DataPage,
     schema::types::PrimitiveType,
     statistics::{serialize_statistics, FixedLenStatistics, ParquetStatistics, Statistics},
-    write::WriteOptions,
 };
 
-use super::{binary::ord_binary, utils};
+use super::{binary::ord_binary, utils, WriteOptions};
 use crate::{
     array::{Array, FixedSizeBinaryArray},
     error::Result,

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -29,11 +29,20 @@ pub use parquet2::{
     metadata::{Descriptor, KeyValue, SchemaDescriptor},
     page::{CompressedDataPage, CompressedPage, EncodedPage},
     schema::types::ParquetType,
-    write::{
-        compress, Compressor, DynIter, DynStreamingIterator, RowGroupIter, Version, WriteOptions,
-    },
+    write::{compress, Compressor, DynIter, DynStreamingIterator, RowGroupIter, Version},
     FallibleStreamingIterator,
 };
+
+/// Currently supported options to write to parquet
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WriteOptions {
+    /// Whether to write statistics
+    pub write_statistics: bool,
+    /// The page and file version to use
+    pub version: Version,
+    /// The compression to apply to every page
+    pub compression: Compression,
+}
 
 pub use file::FileWriter;
 pub use row_group::{row_group_iter, RowGroupIterator};

--- a/src/io/parquet/write/primitive/basic.rs
+++ b/src/io/parquet/write/primitive/basic.rs
@@ -5,10 +5,10 @@ use parquet2::{
     schema::types::PrimitiveType,
     statistics::{serialize_statistics, ParquetStatistics, PrimitiveStatistics, Statistics},
     types::NativeType,
-    write::WriteOptions,
 };
 
 use super::super::utils;
+use super::super::WriteOptions;
 use crate::{
     array::{Array, PrimitiveArray},
     error::Result,

--- a/src/io/parquet/write/primitive/mod.rs
+++ b/src/io/parquet/write/primitive/mod.rs
@@ -2,5 +2,6 @@ mod basic;
 mod nested;
 
 pub use basic::array_to_page;
+pub(crate) use basic::build_statistics;
 pub(crate) use basic::encode_plain;
 pub use nested::array_to_page as nested_array_to_page;

--- a/src/io/parquet/write/primitive/nested.rs
+++ b/src/io/parquet/write/primitive/nested.rs
@@ -1,10 +1,8 @@
-use parquet2::{
-    encoding::Encoding, metadata::Descriptor, page::DataPage, types::NativeType,
-    write::WriteOptions,
-};
+use parquet2::{encoding::Encoding, metadata::Descriptor, page::DataPage, types::NativeType};
 
 use super::super::levels;
 use super::super::utils;
+use super::super::WriteOptions;
 use super::basic::{build_statistics, encode_plain};
 use crate::io::parquet::read::schema::is_nullable;
 use crate::{

--- a/src/io/parquet/write/primitive/nested.rs
+++ b/src/io/parquet/write/primitive/nested.rs
@@ -1,22 +1,22 @@
 use parquet2::{
-    encoding::Encoding, metadata::ColumnDescriptor, page::DataPage, types::NativeType,
+    encoding::Encoding, metadata::Descriptor, page::DataPage, types::NativeType,
     write::WriteOptions,
 };
 
 use super::super::levels;
 use super::super::utils;
 use super::basic::{build_statistics, encode_plain};
+use crate::io::parquet::read::schema::is_nullable;
 use crate::{
     array::{Array, Offset, PrimitiveArray},
     error::Result,
-    io::parquet::read::is_type_nullable,
     types::NativeType as ArrowNativeType,
 };
 
 pub fn array_to_page<T, R, O>(
     array: &PrimitiveArray<T>,
     options: WriteOptions,
-    descriptor: ColumnDescriptor,
+    descriptor: Descriptor,
     nested: levels::NestedInfo<O>,
 ) -> Result<DataPage>
 where
@@ -25,7 +25,7 @@ where
     T: num_traits::AsPrimitive<R>,
     O: Offset,
 {
-    let is_optional = is_type_nullable(descriptor.type_());
+    let is_optional = is_nullable(&descriptor.primitive_type.field_info);
 
     let validity = array.validity();
 
@@ -39,7 +39,7 @@ where
     encode_plain(array, is_optional, &mut buffer);
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(array, descriptor.clone()))
+        Some(build_statistics(array, descriptor.primitive_type.clone()))
     } else {
         None
     };
@@ -47,6 +47,7 @@ where
     utils::build_plain_page(
         buffer,
         levels::num_values(nested.offsets()),
+        nested.offsets().len().saturating_sub(1),
         array.null_count(),
         repetition_levels_byte_length,
         definition_levels_byte_length,

--- a/src/io/parquet/write/schema.rs
+++ b/src/io/parquet/write/schema.rs
@@ -2,8 +2,8 @@ use parquet2::{
     metadata::KeyValue,
     schema::{
         types::{
-            DecimalType, IntType, LogicalType, ParquetType, PhysicalType, PrimitiveConvertedType,
-            TimeType, TimeUnit as ParquetTimeUnit, TimestampType,
+            GroupLogicalType, IntegerType, ParquetType, PhysicalType, PrimitiveConvertedType,
+            PrimitiveLogicalType, TimeUnit as ParquetTimeUnit,
         },
         Repetition,
     },
@@ -53,7 +53,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             PhysicalType::Int32,
             repetition,
             None,
-            Some(LogicalType::UNKNOWN(Default::default())),
+            Some(PrimitiveLogicalType::Unknown),
             None,
         )?),
         DataType::Boolean => Ok(ParquetType::try_from_primitive(
@@ -120,7 +120,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             PhysicalType::ByteArray,
             repetition,
             Some(PrimitiveConvertedType::Utf8),
-            Some(LogicalType::STRING(Default::default())),
+            Some(PrimitiveLogicalType::String),
             None,
         )?),
         DataType::Date32 => Ok(ParquetType::try_from_primitive(
@@ -128,7 +128,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             PhysicalType::Int32,
             repetition,
             Some(PrimitiveConvertedType::Date),
-            Some(LogicalType::DATE(Default::default())),
+            Some(PrimitiveLogicalType::Date),
             None,
         )?),
         DataType::Int8 => Ok(ParquetType::try_from_primitive(
@@ -136,10 +136,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             PhysicalType::Int32,
             repetition,
             Some(PrimitiveConvertedType::Int8),
-            Some(LogicalType::INTEGER(IntType {
-                bit_width: 8,
-                is_signed: true,
-            })),
+            Some(PrimitiveLogicalType::Integer(IntegerType::Int8)),
             None,
         )?),
         DataType::Int16 => Ok(ParquetType::try_from_primitive(
@@ -147,10 +144,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             PhysicalType::Int32,
             repetition,
             Some(PrimitiveConvertedType::Int16),
-            Some(LogicalType::INTEGER(IntType {
-                bit_width: 16,
-                is_signed: true,
-            })),
+            Some(PrimitiveLogicalType::Integer(IntegerType::Int16)),
             None,
         )?),
         DataType::UInt8 => Ok(ParquetType::try_from_primitive(
@@ -158,10 +152,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             PhysicalType::Int32,
             repetition,
             Some(PrimitiveConvertedType::Uint8),
-            Some(LogicalType::INTEGER(IntType {
-                bit_width: 8,
-                is_signed: false,
-            })),
+            Some(PrimitiveLogicalType::Integer(IntegerType::UInt8)),
             None,
         )?),
         DataType::UInt16 => Ok(ParquetType::try_from_primitive(
@@ -169,10 +160,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             PhysicalType::Int32,
             repetition,
             Some(PrimitiveConvertedType::Uint16),
-            Some(LogicalType::INTEGER(IntType {
-                bit_width: 16,
-                is_signed: false,
-            })),
+            Some(PrimitiveLogicalType::Integer(IntegerType::UInt16)),
             None,
         )?),
         DataType::UInt32 => Ok(ParquetType::try_from_primitive(
@@ -180,10 +168,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             PhysicalType::Int32,
             repetition,
             Some(PrimitiveConvertedType::Uint32),
-            Some(LogicalType::INTEGER(IntType {
-                bit_width: 32,
-                is_signed: false,
-            })),
+            Some(PrimitiveLogicalType::Integer(IntegerType::UInt32)),
             None,
         )?),
         DataType::UInt64 => Ok(ParquetType::try_from_primitive(
@@ -191,10 +176,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             PhysicalType::Int64,
             repetition,
             Some(PrimitiveConvertedType::Uint64),
-            Some(LogicalType::INTEGER(IntType {
-                bit_width: 64,
-                is_signed: false,
-            })),
+            Some(PrimitiveLogicalType::Integer(IntegerType::UInt64)),
             None,
         )?),
         // no natural representation in parquet; leave it as is.
@@ -212,15 +194,15 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             PhysicalType::Int64,
             repetition,
             None,
-            Some(LogicalType::TIMESTAMP(TimestampType {
-                is_adjusted_to_u_t_c: matches!(zone, Some(z) if !z.as_str().is_empty()),
+            Some(PrimitiveLogicalType::Timestamp {
+                is_adjusted_to_utc: matches!(zone, Some(z) if !z.as_str().is_empty()),
                 unit: match time_unit {
                     TimeUnit::Second => unreachable!(),
-                    TimeUnit::Millisecond => ParquetTimeUnit::MILLIS(Default::default()),
-                    TimeUnit::Microsecond => ParquetTimeUnit::MICROS(Default::default()),
-                    TimeUnit::Nanosecond => ParquetTimeUnit::NANOS(Default::default()),
+                    TimeUnit::Millisecond => ParquetTimeUnit::Milliseconds,
+                    TimeUnit::Microsecond => ParquetTimeUnit::Microseconds,
+                    TimeUnit::Nanosecond => ParquetTimeUnit::Nanoseconds,
                 },
-            })),
+            }),
             None,
         )?),
         // no natural representation in parquet; leave it as is.
@@ -238,10 +220,10 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             PhysicalType::Int32,
             repetition,
             Some(PrimitiveConvertedType::TimeMillis),
-            Some(LogicalType::TIME(TimeType {
-                is_adjusted_to_u_t_c: false,
-                unit: ParquetTimeUnit::MILLIS(Default::default()),
-            })),
+            Some(PrimitiveLogicalType::Time {
+                is_adjusted_to_utc: false,
+                unit: ParquetTimeUnit::Milliseconds,
+            }),
             None,
         )?),
         DataType::Time64(time_unit) => Ok(ParquetType::try_from_primitive(
@@ -253,14 +235,14 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
                 TimeUnit::Nanosecond => None,
                 _ => unreachable!(),
             },
-            Some(LogicalType::TIME(TimeType {
-                is_adjusted_to_u_t_c: false,
+            Some(PrimitiveLogicalType::Time {
+                is_adjusted_to_utc: false,
                 unit: match time_unit {
-                    TimeUnit::Microsecond => ParquetTimeUnit::MICROS(Default::default()),
-                    TimeUnit::Nanosecond => ParquetTimeUnit::NANOS(Default::default()),
+                    TimeUnit::Microsecond => ParquetTimeUnit::Microseconds,
+                    TimeUnit::Nanosecond => ParquetTimeUnit::Nanoseconds,
                     _ => unreachable!(),
                 },
-            })),
+            }),
             None,
         )?),
         DataType::Struct(fields) => {
@@ -274,9 +256,9 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
                 .iter()
                 .map(to_parquet_type)
                 .collect::<Result<Vec<_>>>()?;
-            Ok(ParquetType::try_from_group(
+            Ok(ParquetType::from_group(
                 name, repetition, None, None, fields, None,
-            )?)
+            ))
         }
         DataType::Dictionary(_, value, _) => {
             let dict_field = Field::new(name.as_str(), value.as_ref().clone(), field.is_nullable);
@@ -284,7 +266,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
         }
         DataType::FixedSizeBinary(size) => Ok(ParquetType::try_from_primitive(
             name,
-            PhysicalType::FixedLenByteArray(*size as i32),
+            PhysicalType::FixedLenByteArray(*size),
             repetition,
             None,
             None,
@@ -293,27 +275,21 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
         DataType::Decimal(precision, scale) => {
             let precision = *precision;
             let scale = *scale;
-            let logical_type = Some(LogicalType::DECIMAL(DecimalType {
-                scale: scale as i32,
-                precision: precision as i32,
-            }));
+            let logical_type = Some(PrimitiveLogicalType::Decimal(precision, scale));
 
             let physical_type = if precision <= 9 {
                 PhysicalType::Int32
             } else if precision <= 18 {
                 PhysicalType::Int64
             } else {
-                let len = decimal_length_from_precision(precision) as i32;
+                let len = decimal_length_from_precision(precision);
                 PhysicalType::FixedLenByteArray(len)
             };
             Ok(ParquetType::try_from_primitive(
                 name,
                 physical_type,
                 repetition,
-                Some(PrimitiveConvertedType::Decimal(
-                    precision as i32,
-                    scale as i32,
-                )),
+                Some(PrimitiveConvertedType::Decimal(precision, scale)),
                 logical_type,
                 None,
             )?)
@@ -327,21 +303,21 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
             None,
         )?),
         DataType::List(f) | DataType::FixedSizeList(f, _) | DataType::LargeList(f) => {
-            Ok(ParquetType::try_from_group(
+            Ok(ParquetType::from_group(
                 name,
                 repetition,
                 None,
-                Some(LogicalType::LIST(Default::default())),
-                vec![ParquetType::try_from_group(
+                Some(GroupLogicalType::List),
+                vec![ParquetType::from_group(
                     "list".to_string(),
                     Repetition::Repeated,
                     None,
                     None,
                     vec![to_parquet_type(f)?],
                     None,
-                )?],
+                )],
                 None,
-            )?)
+            ))
         }
         other => Err(ArrowError::NotYetImplemented(format!(
             "Writing the data type {:?} is not yet implemented",

--- a/src/io/parquet/write/sink.rs
+++ b/src/io/parquet/write/sink.rs
@@ -5,15 +5,10 @@ use parquet2::metadata::KeyValue;
 use parquet2::write::FileStreamer;
 use parquet2::write::WriteOptions as ParquetWriteOptions;
 
-use crate::{
-    array::Array,
-    chunk::Chunk,
-    datatypes::Schema,
-    error::ArrowError,
-};
+use crate::{array::Array, chunk::Chunk, datatypes::Schema, error::ArrowError};
 
-use super::{Encoding, SchemaDescriptor, WriteOptions};
 use super::file::add_arrow_schema;
+use super::{Encoding, SchemaDescriptor, WriteOptions};
 
 /// Sink that writes array [`chunks`](Chunk) as a Parquet file.
 ///

--- a/src/io/parquet/write/sink.rs
+++ b/src/io/parquet/write/sink.rs
@@ -150,7 +150,6 @@ where
     fn start_send(self: Pin<&mut Self>, item: Chunk<Arc<dyn Array>>) -> Result<(), Self::Error> {
         let this = self.get_mut();
         if let Some(mut writer) = this.writer.take() {
-            let count = item.len();
             let rows = crate::io::parquet::write::row_group_iter(
                 item,
                 this.encoding.clone(),
@@ -158,7 +157,7 @@ where
                 this.options,
             );
             this.task = Some(Box::pin(async move {
-                writer.write(rows, count).await?;
+                writer.write(rows).await?;
                 Ok(Some(writer))
             }));
             Ok(())

--- a/src/io/parquet/write/utf8/basic.rs
+++ b/src/io/parquet/write/utf8/basic.rs
@@ -6,9 +6,9 @@ use parquet2::{
     statistics::{serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics},
 };
 
-use super::super::WriteOptions;
 use super::super::binary::{encode_delta, ord_binary};
 use super::super::utils;
+use super::super::WriteOptions;
 use crate::{
     array::{Array, Offset, Utf8Array},
     error::{ArrowError, Result},

--- a/src/io/parquet/write/utf8/basic.rs
+++ b/src/io/parquet/write/utf8/basic.rs
@@ -4,9 +4,9 @@ use parquet2::{
     page::DataPage,
     schema::types::PrimitiveType,
     statistics::{serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics},
-    write::WriteOptions,
 };
 
+use super::super::WriteOptions;
 use super::super::binary::{encode_delta, ord_binary};
 use super::super::utils;
 use crate::{

--- a/src/io/parquet/write/utf8/basic.rs
+++ b/src/io/parquet/write/utf8/basic.rs
@@ -1,7 +1,8 @@
 use parquet2::{
     encoding::Encoding,
-    metadata::ColumnDescriptor,
+    metadata::Descriptor,
     page::DataPage,
+    schema::types::PrimitiveType,
     statistics::{serialize_statistics, BinaryStatistics, ParquetStatistics, Statistics},
     write::WriteOptions,
 };
@@ -11,7 +12,7 @@ use super::super::utils;
 use crate::{
     array::{Array, Offset, Utf8Array},
     error::{ArrowError, Result},
-    io::parquet::read::is_type_nullable,
+    io::parquet::read::schema::is_nullable,
 };
 
 pub(crate) fn encode_plain<O: Offset>(
@@ -41,11 +42,11 @@ pub(crate) fn encode_plain<O: Offset>(
 pub fn array_to_page<O: Offset>(
     array: &Utf8Array<O>,
     options: WriteOptions,
-    descriptor: ColumnDescriptor,
+    descriptor: Descriptor,
     encoding: Encoding,
 ) -> Result<DataPage> {
     let validity = array.validity();
-    let is_optional = is_type_nullable(descriptor.type_());
+    let is_optional = is_nullable(&descriptor.primitive_type.field_info);
 
     let mut buffer = vec![];
     utils::write_def_levels(
@@ -77,13 +78,14 @@ pub fn array_to_page<O: Offset>(
     }
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(array, descriptor.clone()))
+        Some(build_statistics(array, descriptor.primitive_type.clone()))
     } else {
         None
     };
 
     utils::build_plain_page(
         buffer,
+        array.len(),
         array.len(),
         array.null_count(),
         0,
@@ -95,12 +97,12 @@ pub fn array_to_page<O: Offset>(
     )
 }
 
-pub(super) fn build_statistics<O: Offset>(
+pub(crate) fn build_statistics<O: Offset>(
     array: &Utf8Array<O>,
-    descriptor: ColumnDescriptor,
+    primitive_type: PrimitiveType,
 ) -> ParquetStatistics {
     let statistics = &BinaryStatistics {
-        descriptor,
+        primitive_type,
         null_count: Some(array.null_count() as i64),
         distinct_count: None,
         max_value: array

--- a/src/io/parquet/write/utf8/mod.rs
+++ b/src/io/parquet/write/utf8/mod.rs
@@ -2,5 +2,6 @@ mod basic;
 mod nested;
 
 pub use basic::array_to_page;
+pub(crate) use basic::build_statistics;
 pub(crate) use basic::encode_plain;
 pub use nested::array_to_page as nested_array_to_page;

--- a/src/io/parquet/write/utf8/nested.rs
+++ b/src/io/parquet/write/utf8/nested.rs
@@ -1,26 +1,24 @@
-use parquet2::{
-    encoding::Encoding, metadata::ColumnDescriptor, page::DataPage, write::WriteOptions,
-};
+use parquet2::{encoding::Encoding, metadata::Descriptor, page::DataPage, write::WriteOptions};
 
 use super::super::{levels, utils};
 use super::basic::{build_statistics, encode_plain};
+use crate::io::parquet::read::schema::is_nullable;
 use crate::{
     array::{Array, Offset, Utf8Array},
     error::Result,
-    io::parquet::read::is_type_nullable,
 };
 
 pub fn array_to_page<O, OO>(
     array: &Utf8Array<O>,
     options: WriteOptions,
-    descriptor: ColumnDescriptor,
+    descriptor: Descriptor,
     nested: levels::NestedInfo<OO>,
 ) -> Result<DataPage>
 where
     OO: Offset,
     O: Offset,
 {
-    let is_optional = is_type_nullable(descriptor.type_());
+    let is_optional = is_nullable(&descriptor.primitive_type.field_info);
 
     let validity = array.validity();
 
@@ -34,7 +32,7 @@ where
     encode_plain(array, is_optional, &mut buffer);
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(array, descriptor.clone()))
+        Some(build_statistics(array, descriptor.primitive_type.clone()))
     } else {
         None
     };
@@ -42,6 +40,7 @@ where
     utils::build_plain_page(
         buffer,
         levels::num_values(nested.offsets()),
+        nested.offsets().len().saturating_sub(1),
         array.null_count(),
         repetition_levels_byte_length,
         definition_levels_byte_length,

--- a/src/io/parquet/write/utf8/nested.rs
+++ b/src/io/parquet/write/utf8/nested.rs
@@ -1,6 +1,6 @@
-use parquet2::{encoding::Encoding, metadata::Descriptor, page::DataPage, write::WriteOptions};
+use parquet2::{encoding::Encoding, metadata::Descriptor, page::DataPage};
 
-use super::super::{levels, utils};
+use super::super::{levels, utils, WriteOptions};
 use super::basic::{build_statistics, encode_plain};
 use crate::io::parquet::read::schema::is_nullable;
 use crate::{

--- a/src/io/parquet/write/utils.rs
+++ b/src/io/parquet/write/utils.rs
@@ -6,9 +6,9 @@ use parquet2::{
     metadata::Descriptor,
     page::{DataPage, DataPageHeader, DataPageHeaderV1, DataPageHeaderV2},
     statistics::ParquetStatistics,
-    write::WriteOptions,
 };
 
+use super::WriteOptions;
 use crate::error::Result;
 
 use super::Version;

--- a/src/io/parquet/write/utils.rs
+++ b/src/io/parquet/write/utils.rs
@@ -3,7 +3,7 @@ use crate::bitmap::Bitmap;
 use parquet2::{
     compression::Compression,
     encoding::{hybrid_rle::encode_bool, Encoding},
-    metadata::ColumnDescriptor,
+    metadata::Descriptor,
     page::{DataPage, DataPageHeader, DataPageHeaderV1, DataPageHeaderV2},
     statistics::ParquetStatistics,
     write::WriteOptions,
@@ -60,42 +60,42 @@ pub fn write_def_levels(
 #[allow(clippy::too_many_arguments)]
 pub fn build_plain_page(
     buffer: Vec<u8>,
-    len: usize,
+    num_values: usize,
+    num_rows: usize,
     null_count: usize,
     repetition_levels_byte_length: usize,
     definition_levels_byte_length: usize,
     statistics: Option<ParquetStatistics>,
-    descriptor: ColumnDescriptor,
+    descriptor: Descriptor,
     options: WriteOptions,
     encoding: Encoding,
 ) -> Result<DataPage> {
-    match options.version {
-        Version::V1 => {
-            let header = DataPageHeader::V1(DataPageHeaderV1 {
-                num_values: len as i32,
-                encoding: encoding.into(),
-                definition_level_encoding: Encoding::Rle.into(),
-                repetition_level_encoding: Encoding::Rle.into(),
-                statistics,
-            });
-
-            Ok(DataPage::new(header, buffer, None, descriptor))
-        }
-        Version::V2 => {
-            let header = DataPageHeader::V2(DataPageHeaderV2 {
-                num_values: len as i32,
-                encoding: encoding.into(),
-                num_nulls: null_count as i32,
-                num_rows: len as i32,
-                definition_levels_byte_length: definition_levels_byte_length as i32,
-                repetition_levels_byte_length: repetition_levels_byte_length as i32,
-                is_compressed: Some(options.compression != Compression::Uncompressed),
-                statistics,
-            });
-
-            Ok(DataPage::new(header, buffer, None, descriptor))
-        }
-    }
+    let header = match options.version {
+        Version::V1 => DataPageHeader::V1(DataPageHeaderV1 {
+            num_values: num_values as i32,
+            encoding: encoding.into(),
+            definition_level_encoding: Encoding::Rle.into(),
+            repetition_level_encoding: Encoding::Rle.into(),
+            statistics,
+        }),
+        Version::V2 => DataPageHeader::V2(DataPageHeaderV2 {
+            num_values: num_values as i32,
+            encoding: encoding.into(),
+            num_nulls: null_count as i32,
+            num_rows: num_rows as i32,
+            definition_levels_byte_length: definition_levels_byte_length as i32,
+            repetition_levels_byte_length: repetition_levels_byte_length as i32,
+            is_compressed: Some(options.compression != Compression::Uncompressed),
+            statistics,
+        }),
+    };
+    Ok(DataPage::new(
+        header,
+        buffer,
+        None,
+        descriptor,
+        Some(num_rows),
+    ))
 }
 
 /// Auxiliary iterator adapter to declare the size hint of an iterator.

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -731,9 +731,9 @@ fn integration_write(schema: &Schema, batches: &[Chunk<Arc<dyn Array>>]) -> Resu
     for group in row_groups {
         writer.write(group?)?;
     }
-    let (_size, writer) = writer.end(None)?;
+    writer.end(None)?;
 
-    Ok(writer.into_inner())
+    Ok(writer.into_inner().into_inner())
 }
 
 type IntegrationRead = (Schema, Vec<Chunk<Arc<dyn Array>>>);

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -9,6 +9,7 @@ use arrow2::{
 use crate::io::ipc::read_gzip_json;
 
 mod read;
+mod read_indexes;
 mod write;
 mod write_async;
 
@@ -22,12 +23,18 @@ pub fn read_column<R: Read + Seek>(
     let metadata = read_metadata(&mut reader)?;
     let schema = infer_schema(&metadata)?;
 
+    // verify that we can read indexes
+    let _indexes = read_columns_indexes(
+        &mut reader,
+        metadata.row_groups[0].columns(),
+        &schema.fields,
+    )?;
+
     let column = schema
         .fields
         .iter()
         .enumerate()
-        .filter_map(|(i, f)| if f.name == column { Some(i) } else { None })
-        .next()
+        .find_map(|(i, f)| if f.name == column { Some(i) } else { None })
         .unwrap();
 
     let mut reader = FileReader::try_new(reader, Some(&[column]), None, None, None)?;
@@ -329,7 +336,7 @@ pub fn pyarrow_nullable(column: &str) -> Box<dyn Array> {
                 .collect::<Vec<_>>();
             Box::new(PrimitiveArray::<u32>::from(values))
         }
-        "string_large" => {
+        "int32_dict" => {
             let keys = PrimitiveArray::<i32>::from([Some(0), Some(1), None, Some(1)]);
             let values = Arc::new(PrimitiveArray::<i32>::from_slice([10, 200]));
             Box::new(DictionaryArray::<i32>::from_data(keys, values))
@@ -413,7 +420,13 @@ pub fn pyarrow_nullable_statistics(column: &str) -> Option<Box<dyn Statistics>> 
             min_value: Some(0),
             max_value: Some(9),
         }),
-        "string_large" => return None,
+        "int32_dict" => Box::new(PrimitiveStatistics {
+            data_type: DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Int32), false),
+            null_count: Some(0),
+            distinct_count: None,
+            min_value: Some(10),
+            max_value: Some(200),
+        }),
         "decimal_9" => Box::new(PrimitiveStatistics::<i128> {
             distinct_count: None,
             null_count: Some(3),
@@ -716,8 +729,7 @@ fn integration_write(schema: &Schema, batches: &[Chunk<Arc<dyn Array>>]) -> Resu
 
     writer.start()?;
     for group in row_groups {
-        let (group, len) = group?;
-        writer.write(group, len)?;
+        writer.write(group?)?;
     }
     let (_size, writer) = writer.end(None)?;
 

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -96,7 +96,8 @@ fn read_with_indexes(
 
     writer.start()?;
     writer.write(row_group)?;
-    let (_, data) = writer.end(None)?;
+    writer.end(None)?;
+    let data = writer.into_inner();
 
     let mut reader = Cursor::new(data);
 

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -1,0 +1,222 @@
+use std::io::Cursor;
+use std::sync::Arc;
+
+use arrow2::error::ArrowError;
+use arrow2::{array::*, datatypes::*, error::Result, io::parquet::read::*, io::parquet::write::*};
+use parquet2::indexes::{compute_rows, select_pages};
+use parquet2::read::IndexedPageReader;
+
+/// Returns 2 sets of pages with different the same number of rows distributed un-evenly
+fn pages(
+    arrays: &[&dyn Array],
+    encoding: Encoding,
+) -> Result<(Vec<EncodedPage>, Vec<EncodedPage>, Schema)> {
+    // create pages with different number of rows
+    let array11 = PrimitiveArray::<i64>::from_slice([1, 2, 3, 4]);
+    let array12 = PrimitiveArray::<i64>::from_slice([5]);
+    let array13 = PrimitiveArray::<i64>::from_slice([6]);
+
+    let schema = Schema::from(vec![
+        Field::new("a1", DataType::Int64, false),
+        Field::new(
+            "a2",
+            arrays[0].data_type().clone(),
+            arrays.iter().map(|x| x.null_count()).sum::<usize>() != 0usize,
+        ),
+    ]);
+
+    let parquet_schema = to_parquet_schema(&schema)?;
+
+    let options = WriteOptions {
+        write_statistics: true,
+        compression: Compression::Uncompressed,
+        version: Version::V1,
+    };
+
+    let pages1 = vec![
+        array_to_page(
+            &array11,
+            parquet_schema.columns()[0].descriptor.clone(),
+            options,
+            Encoding::Plain,
+        )?,
+        array_to_page(
+            &array12,
+            parquet_schema.columns()[0].descriptor.clone(),
+            options,
+            Encoding::Plain,
+        )?,
+        array_to_page(
+            &array13,
+            parquet_schema.columns()[0].descriptor.clone(),
+            options,
+            Encoding::Plain,
+        )?,
+    ];
+    let pages2 = arrays
+        .iter()
+        .flat_map(|array| {
+            array_to_pages(
+                *array,
+                parquet_schema.columns()[1].descriptor.clone(),
+                options,
+                encoding,
+            )
+            .unwrap()
+            .collect::<Result<Vec<_>>>()
+            .unwrap()
+        })
+        .collect::<Vec<_>>();
+
+    Ok((pages1, pages2, schema))
+}
+
+/// Tests reading pages while skipping indexes
+fn read_with_indexes(
+    (pages1, pages2, schema): (Vec<EncodedPage>, Vec<EncodedPage>, Schema),
+    expected: Arc<dyn Array>,
+) -> Result<()> {
+    let options = WriteOptions {
+        write_statistics: true,
+        compression: Compression::Uncompressed,
+        version: Version::V1,
+    };
+
+    let to_compressed = |pages: Vec<EncodedPage>| {
+        let encoded_pages = DynIter::new(pages.into_iter().map(Ok));
+        let compressed_pages =
+            Compressor::new(encoded_pages, options.compression, vec![]).map_err(ArrowError::from);
+        Result::Ok(DynStreamingIterator::new(compressed_pages))
+    };
+
+    let row_group = DynIter::new(vec![to_compressed(pages1), to_compressed(pages2)].into_iter());
+
+    let writer = vec![];
+    let mut writer = FileWriter::try_new(writer, schema, options)?;
+
+    writer.start()?;
+    writer.write(row_group)?;
+    let (_, data) = writer.end(None)?;
+
+    let mut reader = Cursor::new(data);
+
+    let metadata = read_metadata(&mut reader)?;
+
+    let schema = infer_schema(&metadata)?;
+
+    let row_group = &metadata.row_groups[0];
+
+    let pages = read_pages_locations(&mut reader, row_group.columns())?;
+
+    // say we concluded from the indexes that we only needed the "6" from the first column, so second page.
+    let _indexes = read_columns_indexes(&mut reader, row_group.columns(), &schema.fields)?;
+    let intervals = compute_rows(&[false, true, false], &pages[0], row_group.num_rows())?;
+
+    // based on the intervals from c1, we compute which pages from the second column are required:
+    let pages = select_pages(&intervals, &pages[1], row_group.num_rows())?;
+
+    // and read them:
+    let c1 = &metadata.row_groups[0].columns()[1];
+
+    let pages = IndexedPageReader::new(reader, c1, pages, vec![], vec![]);
+    let pages = BasicDecompressor::new(pages, vec![]);
+
+    let arrays = column_iter_to_arrays(
+        vec![pages],
+        vec![&c1.descriptor().descriptor.primitive_type],
+        schema.fields[1].clone(),
+        row_group.num_rows() as usize,
+    )?;
+
+    let arrays = arrays.collect::<Result<Vec<_>>>()?;
+
+    assert_eq!(arrays, vec![expected]);
+    Ok(())
+}
+
+#[test]
+fn indexed_required_utf8() -> Result<()> {
+    let array21 = Utf8Array::<i32>::from_slice(["a", "b", "c"]);
+    let array22 = Utf8Array::<i32>::from_slice(["d", "e", "f"]);
+    let expected = Arc::new(Utf8Array::<i32>::from_slice(["e"])) as Arc<dyn Array>;
+
+    read_with_indexes(pages(&[&array21, &array22], Encoding::Plain)?, expected)
+}
+
+#[test]
+fn indexed_required_i32() -> Result<()> {
+    let array21 = Int32Array::from_slice([1, 2, 3]);
+    let array22 = Int32Array::from_slice([4, 5, 6]);
+    let expected = Arc::new(Int32Array::from_slice([5])) as Arc<dyn Array>;
+
+    read_with_indexes(pages(&[&array21, &array22], Encoding::Plain)?, expected)
+}
+
+#[test]
+fn indexed_optional_i32() -> Result<()> {
+    let array21 = Int32Array::from([Some(1), Some(2), None]);
+    let array22 = Int32Array::from([None, Some(5), Some(6)]);
+    let expected = Arc::new(Int32Array::from_slice([5])) as Arc<dyn Array>;
+
+    read_with_indexes(pages(&[&array21, &array22], Encoding::Plain)?, expected)
+}
+
+#[test]
+fn indexed_optional_utf8() -> Result<()> {
+    let array21 = Utf8Array::<i32>::from([Some("a"), Some("b"), None]);
+    let array22 = Utf8Array::<i32>::from([None, Some("e"), Some("f")]);
+    let expected = Arc::new(Utf8Array::<i32>::from_slice(["e"])) as Arc<dyn Array>;
+
+    read_with_indexes(pages(&[&array21, &array22], Encoding::Plain)?, expected)
+}
+
+#[test]
+fn indexed_required_fixed_len() -> Result<()> {
+    let array21 = FixedSizeBinaryArray::from_slice([[127], [128], [129]]);
+    let array22 = FixedSizeBinaryArray::from_slice([[130], [131], [132]]);
+    let expected = Arc::new(FixedSizeBinaryArray::from_slice([[131]])) as Arc<dyn Array>;
+
+    read_with_indexes(pages(&[&array21, &array22], Encoding::Plain)?, expected)
+}
+
+#[test]
+fn indexed_optional_fixed_len() -> Result<()> {
+    let array21 = FixedSizeBinaryArray::from([Some([127]), Some([128]), None]);
+    let array22 = FixedSizeBinaryArray::from([None, Some([131]), Some([132])]);
+    let expected = Arc::new(FixedSizeBinaryArray::from_slice([[131]])) as Arc<dyn Array>;
+
+    read_with_indexes(pages(&[&array21, &array22], Encoding::Plain)?, expected)
+}
+
+#[test]
+fn indexed_required_boolean() -> Result<()> {
+    let array21 = BooleanArray::from_slice([true, false, true]);
+    let array22 = BooleanArray::from_slice([false, false, true]);
+    let expected = Arc::new(BooleanArray::from_slice([false])) as Arc<dyn Array>;
+
+    read_with_indexes(pages(&[&array21, &array22], Encoding::Plain)?, expected)
+}
+
+#[test]
+fn indexed_optional_boolean() -> Result<()> {
+    let array21 = BooleanArray::from([Some(true), Some(false), None]);
+    let array22 = BooleanArray::from([None, Some(false), Some(true)]);
+    let expected = Arc::new(BooleanArray::from_slice([false])) as Arc<dyn Array>;
+
+    read_with_indexes(pages(&[&array21, &array22], Encoding::Plain)?, expected)
+}
+
+#[test]
+fn indexed_dict() -> Result<()> {
+    let indices = PrimitiveArray::from_values((0..6u64).map(|x| x % 2));
+    let values = PrimitiveArray::from_slice([4i32, 6i32]);
+    let array = DictionaryArray::from_data(indices, std::sync::Arc::new(values));
+
+    let indices = PrimitiveArray::from_slice(&[0u64]);
+    let values = PrimitiveArray::from_slice([4i32, 6i32]);
+    let expected = DictionaryArray::from_data(indices, std::sync::Arc::new(values));
+
+    let expected = Arc::new(expected) as Arc<dyn Array>;
+
+    read_with_indexes(pages(&[&array], Encoding::RleDictionary)?, expected)
+}

--- a/tests/it/io/parquet/write.rs
+++ b/tests/it/io/parquet/write.rs
@@ -49,8 +49,7 @@ fn round_trip(
 
     writer.start()?;
     for group in row_groups {
-        let (group, len) = group?;
-        writer.write(group, len)?;
+        writer.write(group?)?;
     }
     let (_size, writer) = writer.end(None)?;
 
@@ -354,7 +353,7 @@ fn utf8_optional_v2_delta() -> Result<()> {
 #[test]
 fn i32_optional_v2_dict() -> Result<()> {
     round_trip(
-        "string_large",
+        "int32_dict",
         true,
         false,
         Version::V2,
@@ -366,7 +365,7 @@ fn i32_optional_v2_dict() -> Result<()> {
 #[test]
 fn i32_optional_v2_dict_compressed() -> Result<()> {
     round_trip(
-        "string_large",
+        "int32_dict",
         true,
         false,
         Version::V2,

--- a/tests/it/io/parquet/write.rs
+++ b/tests/it/io/parquet/write.rs
@@ -51,9 +51,9 @@ fn round_trip(
     for group in row_groups {
         writer.write(group?)?;
     }
-    let (_size, writer) = writer.end(None)?;
+    writer.end(None)?;
 
-    let data = writer.into_inner();
+    let data = writer.into_inner().into_inner();
 
     let (result, stats) = read_column(&mut Cursor::new(data), 0, "a1")?;
     assert_eq!(array.as_ref(), result.as_ref());

--- a/tests/it/io/parquet/write_async.rs
+++ b/tests/it/io/parquet/write_async.rs
@@ -7,14 +7,10 @@ use arrow2::{
     error::Result,
     io::parquet::{
         read::{infer_schema, read_columns_many_async, read_metadata_async, RowGroupDeserializer},
-        write::Encoding,
+        write::{Compression, Encoding, Version, WriteOptions},
     },
 };
 use futures::{future::BoxFuture, io::Cursor, SinkExt};
-use parquet2::{
-    compression::Compression,
-    write::{Version, WriteOptions},
-};
 
 use super::FileSink;
 


### PR DESCRIPTION
This PR adds support for bloom filters (read) and column/offset indexes (read and write).

Work needed:

- [x] map parquet types to arrow types to be able to map min and max in the column indexes to arrow, just like we do for statistics.
- [x] generalize deserialization to support offsetted parquet pages [difficult]

The writing of offsets works out of the box and is active whenever the option `write_statistics` is active, since page offsets are just page-level statistics written outside of a page header.

See https://github.com/jorgecarleitao/parquet2/issues/102 and https://github.com/jorgecarleitao/parquet2/pull/107 for more details