### PR TITLE
update to odbc-api 0.36.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ strength_reduce = { version = "0.2", optional = true }
 multiversion = { version = "0.6.1", optional = true }
 
 # For support for odbc
-odbc-api = { version = "0.35", optional = true }
+odbc-api = { version = "0.36", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
Hello Jorge,

this PR handles a breaking change in the newest odbc-api version. `AnyColumnView` now holds a `TextColumnView` and `BinColumnView`. You can get to the old iterator class by calling `.iter()` on them. This has been introduced to make reading text columns more similar to how other columns work. Also the view intermediare is a good place to have some other helper methods. I added `content_length_at` in order to figure out the length of the value (in the buffer) at any position and also `raw_value_buffer`, which allows direct access to the underlying text buffers.

<https://docs.rs/odbc-api/latest/odbc_api/buffers/struct.TextColumnView.html>

Cheers, Markus