### PR TITLE
use cached null_count for fastpaths in bitmap ops

### DIFF
--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -1,3 +1,4 @@
+use crate::bitmap::MutableBitmap;
 use std::ops::{BitAnd, BitOr, BitXor, Not};
 
 use crate::trusted_len::TrustedLen;
@@ -163,17 +164,50 @@ pub(crate) fn align(bitmap: &Bitmap, new_offset: usize) -> Bitmap {
 }
 
 #[inline]
-fn and(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
-    binary(lhs, rhs, |x, y| x & y)
+/// Compute bitwise AND operation
+pub fn and(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
+    if lhs.null_count() == lhs.len() || rhs.null_count() == rhs.len() {
+        assert_eq!(lhs.len(), rhs.len());
+        return Bitmap::new_zeroed(lhs.len());
+    } else {
+        binary(lhs, rhs, |x, y| x & y)
+    }
 }
 
 #[inline]
-fn or(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
-    binary(lhs, rhs, |x, y| x | y)
+/// Compute bitwise OR operation
+pub fn or(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
+    if lhs.null_count() == 0 || rhs.null_count() == 0 {
+        assert_eq!(lhs.len(), rhs.len());
+        let mut mutable = MutableBitmap::with_capacity(lhs.len());
+        mutable.extend_constant(lhs.len(), true);
+        return mutable.into();
+    } else {
+        binary(lhs, rhs, |x, y| x | y)
+    }
 }
 
 #[inline]
-fn xor(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
+/// Compute bitwise XOR operation
+pub fn xor(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
+    let lhs_nulls = lhs.null_count();
+    let rhs_nulls = rhs.null_count();
+
+    // all false or all true
+    if lhs_nulls == rhs_nulls && rhs_nulls == rhs.len() || lhs_nulls == 0 && rhs_nulls == 0 {
+        assert_eq!(lhs.len(), rhs.len());
+        return Bitmap::new_zeroed(rhs.len());
+    }
+    // all false and all true or vice versa
+    else if (lhs_nulls == 0 && rhs_nulls == rhs.len())
+        || (lhs_nulls == lhs.len() && rhs_nulls == 0)
+    {
+        assert_eq!(lhs.len(), rhs.len());
+        let mut mutable = MutableBitmap::with_capacity(lhs.len());
+        mutable.extend_constant(lhs.len(), true);
+        return mutable.into();
+    }
+
     binary(lhs, rhs, |x, y| x ^ y)
 }
 

--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -168,7 +168,7 @@ pub(crate) fn align(bitmap: &Bitmap, new_offset: usize) -> Bitmap {
 pub fn and(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
     if lhs.null_count() == lhs.len() || rhs.null_count() == rhs.len() {
         assert_eq!(lhs.len(), rhs.len());
-        return Bitmap::new_zeroed(lhs.len());
+        Bitmap::new_zeroed(lhs.len())
     } else {
         binary(lhs, rhs, |x, y| x & y)
     }
@@ -181,7 +181,7 @@ pub fn or(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
         assert_eq!(lhs.len(), rhs.len());
         let mut mutable = MutableBitmap::with_capacity(lhs.len());
         mutable.extend_constant(lhs.len(), true);
-        return mutable.into();
+        mutable.into()
     } else {
         binary(lhs, rhs, |x, y| x | y)
     }
@@ -196,7 +196,7 @@ pub fn xor(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
     // all false or all true
     if lhs_nulls == rhs_nulls && rhs_nulls == rhs.len() || lhs_nulls == 0 && rhs_nulls == 0 {
         assert_eq!(lhs.len(), rhs.len());
-        return Bitmap::new_zeroed(rhs.len());
+        Bitmap::new_zeroed(rhs.len())
     }
     // all false and all true or vice versa
     else if (lhs_nulls == 0 && rhs_nulls == rhs.len())
@@ -205,10 +205,10 @@ pub fn xor(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
         assert_eq!(lhs.len(), rhs.len());
         let mut mutable = MutableBitmap::with_capacity(lhs.len());
         mutable.extend_constant(lhs.len(), true);
-        return mutable.into();
+        mutable.into()
+    } else {
+        binary(lhs, rhs, |x, y| x ^ y)
     }
-
-    binary(lhs, rhs, |x, y| x ^ y)
 }
 
 fn eq(lhs: &Bitmap, rhs: &Bitmap) -> bool {

--- a/tests/it/bitmap/bitmap_ops.rs
+++ b/tests/it/bitmap/bitmap_ops.rs
@@ -1,6 +1,6 @@
 use proptest::prelude::*;
 
-use arrow2::bitmap::Bitmap;
+use arrow2::bitmap::{and, or, xor, Bitmap};
 
 use crate::bitmap::bitmap_strategy;
 
@@ -13,4 +13,29 @@ proptest! {
 
         assert_eq!(!&bitmap, not_bitmap);
     }
+}
+
+#[test]
+fn test_fast_paths() {
+    let all_true = Bitmap::from(&[true, true]);
+    let all_false = Bitmap::from(&[false, false]);
+    let toggled = Bitmap::from(&[true, false]);
+
+    assert_eq!(and(&all_true, &all_true), all_true);
+    assert_eq!(and(&all_false, &all_true), all_false);
+    assert_eq!(and(&all_true, &all_false), all_false);
+    assert_eq!(and(&toggled, &all_false), all_false);
+    assert_eq!(and(&toggled, &all_true), toggled);
+
+    assert_eq!(or(&all_true, &all_true), all_true);
+    assert_eq!(or(&all_true, &all_false), all_true);
+    assert_eq!(or(&all_false, &all_true), all_true);
+    assert_eq!(or(&all_false, &all_false), all_false);
+    assert_eq!(or(&toggled, &all_false), toggled);
+
+    assert_eq!(xor(&all_true, &all_true), all_false);
+    assert_eq!(xor(&all_true, &all_false), all_true);
+    assert_eq!(xor(&all_false, &all_true), all_true);
+    assert_eq!(xor(&all_false, &all_false), all_false);
+    assert_eq!(xor(&toggled, &toggled), all_false);
 }


### PR DESCRIPTION
`Bitmap`s always have a cached `null_count` or even better `false_count`.

We can use that information to determine fast paths in operations on bitmaps. 

This PR adds those fast paths to `and` `or` and `xor`. I also made the kernels public. They are very thin wrappers around `binary` but they give us more information on the operation that is done, so we are able to opt for fast paths.
