### PR TITLE
MutableBitmap::from_len_set

### DIFF
--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -58,6 +58,15 @@ impl MutableBitmap {
         }
     }
 
+    /// Initializes a [`MutableBitmap`] with all values set to valid/ true.
+    #[inline]
+    pub fn from_len_set(length: usize) -> Self {
+        Self {
+            buffer: vec![u8::MAX; length.saturating_add(7) / 8],
+            length,
+        }
+    }
+
     /// Initializes a pre-allocated [`MutableBitmap`] with capacity for `capacity` bits.
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {


### PR DESCRIPTION
The API counterpart from `MutableBitmap::from_len_zeroed`. I could not find a name that is a good opposite of `zeroed` so I went with `set`.

The rationale is that there often cases when you want to set a all set bitmap and only wnat to unset a few bits. This should make that a bit easier.