### PR TITLE
use cached null count in filters

### DIFF
--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -264,6 +264,17 @@ pub fn filter(array: &dyn Array, filter: &BooleanArray) -> Result<Box<dyn Array>
         return crate::compute::filter::filter(array, &filter);
     }
 
+    let false_count = filter.values().null_count();
+    if false_count == filter.len() {
+        assert_eq!(array.len(), filter.len());
+        return Ok(array.slice(0, 0));
+    }
+    if false_count == 0 {
+        assert_eq!(array.len(), filter.len());
+        // a hack to clone
+        return Ok(array.with_validity(array.validity().cloned()));
+    }
+
     use crate::datatypes::PhysicalType::*;
     match array.data_type().to_physical_type() {
         Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {


### PR DESCRIPTION
We can use the cached null counts to determine fast paths in `filter` operations.

Additional note:

I used the following hack to clone `&dyn Array`. I don't like it TBH. If you are ok with it I will add a `boxed(&self) -> Box<dyn Array>` to the `Array` trait.

```rust
    if false_count == 0 {
        assert_eq!(array.len(), filter.len());
        // a hack to clone
        return Ok(array.with_validity(array.validity().cloned()));
    }
```