### PR TITLE
don't allocate string when writing to csv

### DIFF
--- a/src/io/csv/write/serialize.rs
+++ b/src/io/csv/write/serialize.rs
@@ -14,7 +14,7 @@ use super::super::super::iterator::{BufStreamingIterator, StreamingIterator};
 use crate::array::{DictionaryArray, DictionaryKey, Offset};
 use csv_core::WriteResult;
 use std::any::Any;
-use std::fmt::{Debug, Formatter, Write};
+use std::fmt::{Debug, Write};
 
 /// Options to serialize logical types to CSV
 /// The default is to format times and dates as `chrono` crate formats them.
@@ -50,7 +50,7 @@ impl Default for SerializeOptions {
     }
 }
 
-/// Utility to write to `&muy Vec<u8>` buffer
+/// Utility to write to `&mut Vec<u8>` buffer
 struct StringWrap<'a>(pub &'a mut Vec<u8>);
 
 impl<'a> Write for StringWrap<'a> {
@@ -93,7 +93,7 @@ macro_rules! dyn_date {
                 move |x, buf| {
                     if let Some(x) = x {
                         let dt = ($fn)(*x).format(format);
-                        write!(StringWrap(buf), "{}", dt);
+                        let _ = write!(StringWrap(buf), "{}", dt);
                     }
                 },
                 vec![],
@@ -104,7 +104,7 @@ macro_rules! dyn_date {
                 move |x, buf| {
                     if let Some(x) = x {
                         let dt = ($fn)(*x);
-                        write!(StringWrap(buf), "{}", dt);
+                        let _ = write!(StringWrap(buf), "{}", dt);
                     }
                 },
                 vec![],
@@ -125,7 +125,7 @@ fn timestamp_with_tz_default<'a>(
             move |x, buf| {
                 if let Some(x) = x {
                     let dt = temporal_conversions::timestamp_to_datetime(*x, time_unit, &timezone);
-                    write!(StringWrap(buf), "{}", dt);
+                    let _ = write!(StringWrap(buf), "{}", dt);
                 }
             },
             vec![],
@@ -139,7 +139,7 @@ fn timestamp_with_tz_default<'a>(
                     if let Some(x) = x {
                         let dt =
                             temporal_conversions::timestamp_to_datetime(*x, time_unit, &timezone);
-                        write!(StringWrap(buf), "{}", dt);
+                        let _ = write!(StringWrap(buf), "{}", dt);
                     }
                 },
                 vec![],
@@ -169,7 +169,7 @@ fn timestamp_with_tz_with_format<'a>(
                 if let Some(x) = x {
                     let dt = temporal_conversions::timestamp_to_datetime(*x, time_unit, &timezone)
                         .format(format);
-                    write!(StringWrap(buf), "{}", dt);
+                    let _ = write!(StringWrap(buf), "{}", dt);
                 }
             },
             vec![],
@@ -184,7 +184,7 @@ fn timestamp_with_tz_with_format<'a>(
                         let dt =
                             temporal_conversions::timestamp_to_datetime(*x, time_unit, &timezone)
                                 .format(format);
-                        write!(StringWrap(buf), "{}", dt);
+                        let _ = write!(StringWrap(buf), "{}", dt);
                     }
                 },
                 vec![],

--- a/src/io/csv/write/serialize.rs
+++ b/src/io/csv/write/serialize.rs
@@ -14,6 +14,7 @@ use super::super::super::iterator::{BufStreamingIterator, StreamingIterator};
 use crate::array::{DictionaryArray, DictionaryKey, Offset};
 use csv_core::WriteResult;
 use std::any::Any;
+use std::fmt::{Debug, Formatter, Write};
 
 /// Options to serialize logical types to CSV
 /// The default is to format times and dates as `chrono` crate formats them.
@@ -49,6 +50,16 @@ impl Default for SerializeOptions {
     }
 }
 
+/// Utility to write to `&muy Vec<u8>` buffer
+struct StringWrap<'a>(pub &'a mut Vec<u8>);
+
+impl<'a> Write for StringWrap<'a> {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        self.0.extend_from_slice(s.as_bytes());
+        Ok(())
+    }
+}
+
 fn primitive_write<'a, T: NativeType + ToLexical>(
     array: &'a PrimitiveArray<T>,
 ) -> Box<dyn StreamingIterator<Item = [u8]> + 'a> {
@@ -81,7 +92,8 @@ macro_rules! dyn_date {
                 array.iter(),
                 move |x, buf| {
                     if let Some(x) = x {
-                        buf.extend_from_slice(($fn)(*x).format(format).to_string().as_bytes())
+                        let dt = ($fn)(*x).format(format);
+                        write!(StringWrap(buf), "{}", dt);
                     }
                 },
                 vec![],
@@ -91,7 +103,8 @@ macro_rules! dyn_date {
                 array.iter(),
                 move |x, buf| {
                     if let Some(x) = x {
-                        buf.extend_from_slice(($fn)(*x).to_string().as_bytes())
+                        let dt = ($fn)(*x);
+                        write!(StringWrap(buf), "{}", dt);
                     }
                 },
                 vec![],
@@ -111,10 +124,8 @@ fn timestamp_with_tz_default<'a>(
             array.iter(),
             move |x, buf| {
                 if let Some(x) = x {
-                    let data =
-                        temporal_conversions::timestamp_to_datetime(*x, time_unit, &timezone)
-                            .to_string();
-                    buf.extend_from_slice(data.as_bytes())
+                    let dt = temporal_conversions::timestamp_to_datetime(*x, time_unit, &timezone);
+                    write!(StringWrap(buf), "{}", dt);
                 }
             },
             vec![],
@@ -126,10 +137,9 @@ fn timestamp_with_tz_default<'a>(
                 array.iter(),
                 move |x, buf| {
                     if let Some(x) = x {
-                        let data =
-                            temporal_conversions::timestamp_to_datetime(*x, time_unit, &timezone)
-                                .to_string();
-                        buf.extend_from_slice(data.as_bytes())
+                        let dt =
+                            temporal_conversions::timestamp_to_datetime(*x, time_unit, &timezone);
+                        write!(StringWrap(buf), "{}", dt);
                     }
                 },
                 vec![],
@@ -157,11 +167,9 @@ fn timestamp_with_tz_with_format<'a>(
             array.iter(),
             move |x, buf| {
                 if let Some(x) = x {
-                    let data =
-                        temporal_conversions::timestamp_to_datetime(*x, time_unit, &timezone)
-                            .format(format)
-                            .to_string();
-                    buf.extend_from_slice(data.as_bytes())
+                    let dt = temporal_conversions::timestamp_to_datetime(*x, time_unit, &timezone)
+                        .format(format);
+                    write!(StringWrap(buf), "{}", dt);
                 }
             },
             vec![],
@@ -173,11 +181,10 @@ fn timestamp_with_tz_with_format<'a>(
                 array.iter(),
                 move |x, buf| {
                     if let Some(x) = x {
-                        let data =
+                        let dt =
                             temporal_conversions::timestamp_to_datetime(*x, time_unit, &timezone)
-                                .format(format)
-                                .to_string();
-                        buf.extend_from_slice(data.as_bytes())
+                                .format(format);
+                        write!(StringWrap(buf), "{}", dt);
                     }
                 },
                 vec![],


### PR DESCRIPTION
Writing to csv is pretty slow. Polars can read two datetime columns in 500 ms, whereas writing the same data to csv takes 33.6 seconds.

Upon looking at the code I saw we allocate a `String` for every value we `format`. 

This PR makes sure we write immediately to the `Vec<u8>` buffer.