### PR TITLE
Fixed wrong clippy warning

### DIFF
--- a/src/io/ipc/write/serialize.rs
+++ b/src/io/ipc/write/serialize.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::ptr_arg)] // false positive in clippy, see https://github.com/rust-lang/rust-clippy/issues/8463
 use arrow_format::ipc;
 
 use crate::{


### PR DESCRIPTION
The fixed in clippy missed the 1.60 cut and will be in 1.61, see https://github.com/rust-lang/rust-clippy/issues/8463 . Meanwhile, we ignore it.