### PR TITLE
parquet: split pages by array size

### DIFF
--- a/src/compute/aggregate/mod.rs
+++ b/src/compute/aggregate/mod.rs
@@ -1,10 +1,15 @@
 //! Contains different aggregation functions
+#[cfg(feature = "compute_aggregate")]
 mod sum;
+#[cfg(feature = "compute_aggregate")]
 pub use sum::*;
 
+#[cfg(feature = "compute_aggregate")]
 mod min_max;
+#[cfg(feature = "compute_aggregate")]
 pub use min_max::*;
 
 mod memory;
 pub use memory::*;
+#[cfg(feature = "compute_aggregate")]
 mod simd;

--- a/src/compute/mod.rs
+++ b/src/compute/mod.rs
@@ -11,7 +11,7 @@
 //! Some dynamically-typed operators have an auxiliary function, `can_*`, that returns
 //! true if the operator can be applied to the particular `DataType`.
 
-#[cfg(feature = "compute_aggregate")]
+#[cfg(any(feature = "compute_aggregate", feature = "io_parquet"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "compute_aggregate")))]
 pub mod aggregate;
 #[cfg(feature = "compute_arithmetics")]


### PR DESCRIPTION
This is an attempt to resolve #932 and https://github.com/pola-rs/polars/issues/3120.

As I understand from this post, a row groups column may consist of multiple pages. http://cloudsqale.com/2020/05/29/how-parquet-files-are-written-row-groups-pages-required-memory-and-flush-operations/

So I tried to split an incoming `dyn Array` into `DynIter<Page>` of smaller pages instead of a single large one. The threshold is estimated by the estimated byte size of the array and the limit of `i32::MAX` bytes + some leeway.

Let me know if I am completely wrong here. :see_no_evil: 