### PR TITLE
`dyn Array::to_boxed`

### DIFF
--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -341,6 +341,9 @@ impl<O: Offset> Array for BinaryArray<O> {
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))
     }
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
 }
 
 unsafe impl<O: Offset> GenericBinaryArray<O> for BinaryArray<O> {

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -235,4 +235,7 @@ impl Array for BooleanArray {
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))
     }
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
 }

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -202,4 +202,7 @@ impl<K: DictionaryKey> Array for DictionaryArray<K> {
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))
     }
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
 }

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -259,6 +259,9 @@ impl Array for FixedSizeBinaryArray {
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))
     }
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
 }
 
 impl FixedSizeBinaryArray {

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -255,4 +255,7 @@ impl Array for FixedSizeListArray {
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))
     }
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
 }

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -363,4 +363,7 @@ impl<O: Offset> Array for ListArray<O> {
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))
     }
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
 }

--- a/src/array/map/mod.rs
+++ b/src/array/map/mod.rs
@@ -239,6 +239,9 @@ impl Array for MapArray {
     }
 
     fn with_validity(&self, _validity: Option<Bitmap>) -> Box<dyn Array> {
+        self.to_boxed()
+    }
+    fn to_boxed(&self) -> Box<dyn Array> {
         Box::new(self.clone())
     }
 }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -103,6 +103,9 @@ pub trait Array: Send + Sync {
     /// # Panic
     /// This function panics iff `validity.len() < self.len()`.
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array>;
+
+    /// Clone a `&dyn Array` to an owned `Box<dyn Array>`.
+    fn to_boxed(&self) -> Box<dyn Array>;
 }
 
 /// A trait describing a mutable array; i.e. an array whose values can be changed.

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -99,6 +99,9 @@ impl Array for NullArray {
     fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {
         panic!("cannot set validity of a null array")
     }
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
 }
 
 impl std::fmt::Debug for NullArray {

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -278,6 +278,9 @@ impl<T: NativeType> Array for PrimitiveArray<T> {
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))
     }
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
 }
 
 /// A type definition [`PrimitiveArray`] for `i8`

--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -298,4 +298,7 @@ impl Array for StructArray {
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))
     }
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
 }

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -305,6 +305,9 @@ impl Array for UnionArray {
     fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {
         panic!("cannot set validity of a union array")
     }
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
 }
 
 impl UnionArray {

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -461,6 +461,10 @@ impl<O: Offset> Array for Utf8Array<O> {
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.with_validity(validity))
     }
+
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
 }
 
 unsafe impl<O: Offset> GenericBinaryArray<O> for Utf8Array<O> {

--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -271,8 +271,7 @@ pub fn filter(array: &dyn Array, filter: &BooleanArray) -> Result<Box<dyn Array>
     }
     if false_count == 0 {
         assert_eq!(array.len(), filter.len());
-        // a hack to clone
-        return Ok(array.with_validity(array.validity().cloned()));
+        return Ok(array.to_boxed());
     }
 
     use crate::datatypes::PhysicalType::*;


### PR DESCRIPTION
As discussed earlier, this PR adds a possibility to clone/box a `ref dyn Array`. 