### PR TITLE
Added implementation of `nth` for some iterators

### DIFF
--- a/src/array/utf8/iterator.rs
+++ b/src/array/utf8/iterator.rs
@@ -39,6 +39,18 @@ impl<'a, O: Offset> Iterator for Utf8ValuesIter<'a, O> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.end - self.index, Some(self.end - self.index))
     }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let new_index = self.index + n;
+        if new_index > self.end {
+            self.index = self.end;
+            None
+        } else {
+            self.index = new_index;
+            self.next()
+        }
+    }
 }
 
 impl<'a, O: Offset> DoubleEndedIterator for Utf8ValuesIter<'a, O> {

--- a/src/bitmap/utils/iterator.rs
+++ b/src/bitmap/utils/iterator.rs
@@ -52,6 +52,18 @@ impl<'a> Iterator for BitmapIter<'a> {
         let exact = self.end - self.index;
         (exact, Some(exact))
     }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let new_index = self.index + n;
+        if new_index > self.end {
+            self.index = self.end;
+            None
+        } else {
+            self.index = new_index;
+            self.next()
+        }
+    }
 }
 
 impl<'a> DoubleEndedIterator for BitmapIter<'a> {

--- a/src/bitmap/utils/zip_validity.rs
+++ b/src/bitmap/utils/zip_validity.rs
@@ -52,6 +52,17 @@ impl<'a, T, I: Iterator<Item = T>> Iterator for ZipValidity<'a, T, I> {
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.values.size_hint()
     }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if !self.has_validity {
+            self.values.nth(n).map(Some)
+        } else {
+            let is_valid = self.validity_iter.nth(n);
+            let value = self.values.nth(n);
+            is_valid.map(|x| if x { value } else { None })
+        }
+    }
 }
 
 impl<'a, T, I: DoubleEndedIterator<Item = T>> DoubleEndedIterator for ZipValidity<'a, T, I> {


### PR DESCRIPTION
Calling the `skip` iterator adapter consumes the `iterator` until that `index` location by iteratively calling `next` unless you have implemented `nth`.

This PR adds an `nth` method to the most `Iterator` implementations. 