### PR TITLE
Bumped parquet2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ futures = { version = "0.3", optional = true }
 ahash = { version = "0.7", optional = true }
 
 # parquet support
-parquet2 = { version = "0.11", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { version = "0.12", optional = true, default_features = false, features = ["stream"] }
 
 # avro support
 avro-schema = { version = "0.2", optional = true }

--- a/arrow-parquet-integration-testing/src/main.rs
+++ b/arrow-parquet-integration-testing/src/main.rs
@@ -8,7 +8,7 @@ use arrow2::{
         json_integration::read,
         json_integration::ArrowJson,
         parquet::write::{
-            Compression as ParquetCompression, Encoding, FileWriter, RowGroupIterator,
+            CompressionOptions as ParquetCompression, Encoding, FileWriter, RowGroupIterator,
             Version as ParquetVersion, WriteOptions,
         },
     },
@@ -84,7 +84,7 @@ enum Compression {
 impl Into<ParquetCompression> for Compression {
     fn into(self) -> ParquetCompression {
         match self {
-            Compression::Zstd => ParquetCompression::Zstd,
+            Compression::Zstd => ParquetCompression::Zstd(None),
             Compression::Snappy => ParquetCompression::Snappy,
             Compression::Uncompressed => ParquetCompression::Uncompressed,
         }

--- a/benches/write_parquet.rs
+++ b/benches/write_parquet.rs
@@ -17,7 +17,7 @@ fn write(array: &dyn Array, encoding: Encoding) -> Result<()> {
 
     let options = WriteOptions {
         write_statistics: false,
-        compression: Compression::Uncompressed,
+        compression: CompressionOptions::Uncompressed,
         version: Version::V1,
     };
 

--- a/examples/csv_write_parallel.rs
+++ b/examples/csv_write_parallel.rs
@@ -39,7 +39,7 @@ fn parallel_write(path: &str, batches: [Chunk<Arc<dyn Array>>; 2]) -> Result<()>
     for _ in 0..2 {
         // block: assumes that the order of batches matter.
         let records = rx.recv().unwrap();
-        records.iter().try_for_each(|row| writer.write_all(&row))?
+        records.iter().try_for_each(|row| writer.write_all(row))?
     }
 
     for child in children {

--- a/examples/parquet_write.rs
+++ b/examples/parquet_write.rs
@@ -7,14 +7,14 @@ use arrow2::{
     datatypes::{Field, Schema},
     error::Result,
     io::parquet::write::{
-        Compression, Encoding, FileWriter, RowGroupIterator, Version, WriteOptions,
+        CompressionOptions, Encoding, FileWriter, RowGroupIterator, Version, WriteOptions,
     },
 };
 
 fn write_batch(path: &str, schema: Schema, columns: Chunk<Arc<dyn Array>>) -> Result<()> {
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Uncompressed,
+        compression: CompressionOptions::Uncompressed,
         version: Version::V2,
     };
 

--- a/examples/parquet_write_parallel/src/main.rs
+++ b/examples/parquet_write_parallel/src/main.rs
@@ -46,7 +46,7 @@ fn parallel_write(path: &str, schema: &Schema, batches: &[Chunk]) -> Result<()> 
     // declare the options
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Snappy,
+        compression: CompressionOptions::Snappy,
         version: Version::V2,
     };
 

--- a/src/doc/lib.md
+++ b/src/doc/lib.md
@@ -43,7 +43,7 @@ fn main() -> Result<()> {
 
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Snappy,
+        compression: CompressionOptions::Snappy,
         version: Version::V1,
     };
 

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -23,7 +23,7 @@ use crate::types::NativeType;
 
 use parquet2::page::DataPage;
 pub use parquet2::{
-    compression::Compression,
+    compression::CompressionOptions,
     encoding::Encoding,
     fallible_streaming_iterator,
     metadata::{Descriptor, KeyValue, SchemaDescriptor},
@@ -41,7 +41,7 @@ pub struct WriteOptions {
     /// The page and file version to use
     pub version: Version,
     /// The compression to apply to every page
-    pub compression: Compression,
+    pub compression: CompressionOptions,
 }
 
 use crate::compute::aggregate::estimated_bytes_size;

--- a/src/io/parquet/write/sink.rs
+++ b/src/io/parquet/write/sink.rs
@@ -23,7 +23,7 @@ use super::{Encoding, SchemaDescriptor, WriteOptions};
 /// use arrow2::array::{Array, Int32Array};
 /// use arrow2::datatypes::{DataType, Field, Schema};
 /// use arrow2::chunk::Chunk;
-/// use arrow2::io::parquet::write::{Encoding, WriteOptions, Compression, Version};
+/// use arrow2::io::parquet::write::{Encoding, WriteOptions, CompressionOptions, Version};
 /// # use arrow2::io::parquet::write::FileSink;
 /// # futures::executor::block_on(async move {
 ///
@@ -33,7 +33,7 @@ use super::{Encoding, SchemaDescriptor, WriteOptions};
 /// let encoding = vec![Encoding::Plain];
 /// let options = WriteOptions {
 ///     write_statistics: true,
-///     compression: Compression::Uncompressed,
+///     compression: CompressionOptions::Uncompressed,
 ///     version: Version::V2,
 /// };
 ///

--- a/src/io/parquet/write/utils.rs
+++ b/src/io/parquet/write/utils.rs
@@ -1,7 +1,7 @@
 use crate::bitmap::Bitmap;
 
 use parquet2::{
-    compression::Compression,
+    compression::CompressionOptions,
     encoding::{hybrid_rle::encode_bool, Encoding},
     metadata::Descriptor,
     page::{DataPage, DataPageHeader, DataPageHeaderV1, DataPageHeaderV2},
@@ -85,7 +85,7 @@ pub fn build_plain_page(
             num_rows: num_rows as i32,
             definition_levels_byte_length: definition_levels_byte_length as i32,
             repetition_levels_byte_length: repetition_levels_byte_length as i32,
-            is_compressed: Some(options.compression != Compression::Uncompressed),
+            is_compressed: Some(options.compression != CompressionOptions::Uncompressed),
             statistics,
         }),
     };

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -704,7 +704,7 @@ pub fn pyarrow_struct_statistics(column: &str) -> Option<Box<dyn Statistics>> {
 fn integration_write(schema: &Schema, batches: &[Chunk<Arc<dyn Array>>]) -> Result<Vec<u8>> {
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Uncompressed,
+        compression: CompressionOptions::Uncompressed,
         version: Version::V1,
     };
 

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -29,7 +29,7 @@ fn pages(
 
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Uncompressed,
+        compression: CompressionOptions::Uncompressed,
         version: Version::V1,
     };
 
@@ -78,7 +78,7 @@ fn read_with_indexes(
 ) -> Result<()> {
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Uncompressed,
+        compression: CompressionOptions::Uncompressed,
         version: Version::V1,
     };
 

--- a/tests/it/io/parquet/write.rs
+++ b/tests/it/io/parquet/write.rs
@@ -10,7 +10,7 @@ fn round_trip(
     nullable: bool,
     nested: bool,
     version: Version,
-    compression: Compression,
+    compression: CompressionOptions,
     encoding: Encoding,
 ) -> Result<()> {
     let (array, statistics) = if nested {
@@ -68,7 +68,7 @@ fn int64_optional_v1() -> Result<()> {
         true,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -80,7 +80,7 @@ fn int64_required_v1() -> Result<()> {
         false,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -92,7 +92,7 @@ fn int64_optional_v2() -> Result<()> {
         true,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -104,7 +104,7 @@ fn int64_optional_v2_compressed() -> Result<()> {
         true,
         false,
         Version::V2,
-        Compression::Snappy,
+        CompressionOptions::Snappy,
         Encoding::Plain,
     )
 }
@@ -116,7 +116,7 @@ fn utf8_optional_v1() -> Result<()> {
         true,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -128,7 +128,7 @@ fn utf8_required_v1() -> Result<()> {
         false,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -140,7 +140,7 @@ fn utf8_optional_v2() -> Result<()> {
         true,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -152,7 +152,7 @@ fn utf8_required_v2() -> Result<()> {
         false,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -164,7 +164,7 @@ fn utf8_optional_v2_compressed() -> Result<()> {
         true,
         false,
         Version::V2,
-        Compression::Snappy,
+        CompressionOptions::Snappy,
         Encoding::Plain,
     )
 }
@@ -176,7 +176,7 @@ fn utf8_required_v2_compressed() -> Result<()> {
         false,
         false,
         Version::V2,
-        Compression::Snappy,
+        CompressionOptions::Snappy,
         Encoding::Plain,
     )
 }
@@ -188,7 +188,7 @@ fn bool_optional_v1() -> Result<()> {
         true,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -200,7 +200,7 @@ fn bool_required_v1() -> Result<()> {
         false,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -212,7 +212,7 @@ fn bool_optional_v2_uncompressed() -> Result<()> {
         true,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -224,7 +224,7 @@ fn bool_required_v2_uncompressed() -> Result<()> {
         false,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -236,7 +236,7 @@ fn bool_required_v2_compressed() -> Result<()> {
         false,
         false,
         Version::V2,
-        Compression::Snappy,
+        CompressionOptions::Snappy,
         Encoding::Plain,
     )
 }
@@ -248,7 +248,7 @@ fn list_int64_optional_v2() -> Result<()> {
         true,
         true,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -260,7 +260,7 @@ fn list_int64_optional_v1() -> Result<()> {
         true,
         true,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -272,7 +272,7 @@ fn list_bool_optional_v2() -> Result<()> {
         true,
         true,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -284,7 +284,7 @@ fn list_bool_optional_v1() -> Result<()> {
         true,
         true,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -296,7 +296,7 @@ fn list_utf8_optional_v2() -> Result<()> {
         true,
         true,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -308,7 +308,7 @@ fn list_utf8_optional_v1() -> Result<()> {
         true,
         true,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -320,7 +320,7 @@ fn list_large_binary_optional_v2() -> Result<()> {
         true,
         true,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -332,7 +332,7 @@ fn list_large_binary_optional_v1() -> Result<()> {
         true,
         true,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -345,7 +345,7 @@ fn utf8_optional_v2_delta() -> Result<()> {
         true,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::DeltaLengthByteArray,
     )
 }
@@ -357,7 +357,7 @@ fn i32_optional_v2_dict() -> Result<()> {
         true,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::RleDictionary,
     )
 }
@@ -369,7 +369,7 @@ fn i32_optional_v2_dict_compressed() -> Result<()> {
         true,
         false,
         Version::V2,
-        Compression::Snappy,
+        CompressionOptions::Snappy,
         Encoding::RleDictionary,
     )
 }
@@ -382,7 +382,7 @@ fn decimal_9_optional_v1() -> Result<()> {
         true,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -394,7 +394,7 @@ fn decimal_9_required_v1() -> Result<()> {
         false,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -406,7 +406,7 @@ fn decimal_18_optional_v1() -> Result<()> {
         true,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -418,7 +418,7 @@ fn decimal_18_required_v1() -> Result<()> {
         false,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -430,7 +430,7 @@ fn decimal_26_optional_v1() -> Result<()> {
         true,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -442,7 +442,7 @@ fn decimal_26_required_v1() -> Result<()> {
         false,
         false,
         Version::V1,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -454,7 +454,7 @@ fn decimal_9_optional_v2() -> Result<()> {
         true,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -466,7 +466,7 @@ fn decimal_9_required_v2() -> Result<()> {
         false,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -478,7 +478,7 @@ fn decimal_18_optional_v2() -> Result<()> {
         true,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -490,7 +490,7 @@ fn decimal_18_required_v2() -> Result<()> {
         false,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -502,7 +502,7 @@ fn decimal_26_optional_v2() -> Result<()> {
         true,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }
@@ -514,7 +514,7 @@ fn decimal_26_required_v2() -> Result<()> {
         false,
         false,
         Version::V2,
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         Encoding::Plain,
     )
 }

--- a/tests/it/io/parquet/write_async.rs
+++ b/tests/it/io/parquet/write_async.rs
@@ -7,7 +7,7 @@ use arrow2::{
     error::Result,
     io::parquet::{
         read::{infer_schema, read_columns_many_async, read_metadata_async, RowGroupDeserializer},
-        write::{Compression, Encoding, Version, WriteOptions},
+        write::{CompressionOptions, Encoding, Version, WriteOptions},
     },
 };
 use futures::{future::BoxFuture, io::Cursor, SinkExt};
@@ -33,7 +33,7 @@ async fn test_parquet_async_roundtrip() {
     let encoding = vec![Encoding::Plain, Encoding::Plain];
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Uncompressed,
+        compression: CompressionOptions::Uncompressed,
         version: Version::V2,
     };
 


### PR DESCRIPTION
It adds the ability to specify the zstd compression level (thanks @TurnOfACard!) and some optimizations in reading RLE-encoded parquet (particularly important when reading dictionary-encoded pages)