### PR TITLE
Improved parquet stats deserialization

### DIFF
--- a/examples/parquet_read.rs
+++ b/examples/parquet_read.rs
@@ -13,7 +13,15 @@ fn main() -> Result<()> {
     let reader = File::open(file_path)?;
     let reader = read::FileReader::try_new(reader, Some(&[8]), None, None, None)?;
 
-    println!("{:#?}", reader.metadata());
+    println!("{:#?}", reader.schema());
+
+    // say we want to evaluate if the we can skip some row groups based on a field's value
+    let field = &reader.schema().fields[0];
+
+    // we can deserialize the parquet statistics from this field
+    let statistics = read::statistics::deserialize(field, &reader.metadata().row_groups)?;
+
+    println!("{:#?}", statistics);
 
     let start = SystemTime::now();
     for maybe_chunk in reader {

--- a/parquet_integration/write_parquet.py
+++ b/parquet_integration/write_parquet.py
@@ -9,7 +9,8 @@ PYARROW_PATH = "fixtures/pyarrow3"
 
 
 def case_basic_nullable() -> Tuple[dict, pa.Schema, str]:
-    int64 = [0, 1, None, 3, None, 5, 6, 7, None, 9]
+    int64 = [-256, -1, None, 3, None, 5, 6, 7, None, 9]
+    uint32 = [0, 1, None, 3, None, 5, 6, 7, None, 9]
     float64 = [0.0, 1.0, None, 3.0, None, 5.0, 6.0, 7.0, None, 9.0]
     string = ["Hello", None, "aa", "", None, "abc", None, None, "def", "aaa"]
     boolean = [True, None, False, False, None, True, None, None, True, True]
@@ -24,7 +25,7 @@ def case_basic_nullable() -> Tuple[dict, pa.Schema, str]:
         pa.field("float64", pa.float64()),
         pa.field("string", pa.utf8()),
         pa.field("bool", pa.bool_()),
-        pa.field("date", pa.timestamp("ms")),
+        pa.field("timestamp_ms", pa.timestamp("ms")),
         pa.field("uint32", pa.uint32()),
         pa.field("string_large", pa.utf8()),
         # decimal testing
@@ -44,8 +45,8 @@ def case_basic_nullable() -> Tuple[dict, pa.Schema, str]:
             "float64": float64,
             "string": string,
             "bool": boolean,
-            "date": int64,
-            "uint32": int64,
+            "timestamp_ms": uint32,
+            "uint32": uint32,
             "string_large": string_large,
             "decimal_9": decimal,
             "decimal_18": decimal,
@@ -61,7 +62,7 @@ def case_basic_nullable() -> Tuple[dict, pa.Schema, str]:
 
 
 def case_basic_required() -> Tuple[dict, pa.Schema, str]:
-    int64 = [-256, -1, 0, 1, 2, 3, 4, 5, 6, 7]
+    int64 = [-256, -1, 2, 3, 4, 5, 6, 7, 8, 9]
     uint32 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     float64 = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
     string = ["Hello", "bbb", "aa", "", "bbb", "abc", "bbb", "bbb", "def", "aaa"]
@@ -74,10 +75,8 @@ def case_basic_required() -> Tuple[dict, pa.Schema, str]:
         pa.field("string", pa.utf8(), nullable=False),
         pa.field("bool", pa.bool_(), nullable=False),
         pa.field(
-            "date",
-            pa.timestamp(
-                "ms",
-            ),
+            "timestamp_ms",
+            pa.timestamp("ms"),
             nullable=False,
         ),
         pa.field("uint32", pa.uint32(), nullable=False),
@@ -93,7 +92,7 @@ def case_basic_required() -> Tuple[dict, pa.Schema, str]:
             "float64": float64,
             "string": string,
             "bool": boolean,
-            "date": int64,
+            "timestamp_ms": uint32,
             "uint32": uint32,
             "decimal_9": decimal,
             "decimal_18": decimal,

--- a/src/io/parquet/read/statistics/boolean.rs
+++ b/src/io/parquet/read/statistics/boolean.rs
@@ -1,43 +1,23 @@
-use crate::datatypes::DataType;
-use parquet2::statistics::BooleanStatistics as ParquetBooleanStatistics;
-use std::any::Any;
+use crate::array::{MutableArray, MutableBooleanArray};
+use parquet2::statistics::{BooleanStatistics, Statistics as ParquetStatistics};
 
-use super::Statistics;
+use crate::error::Result;
 
-/// Statistics of a boolean parquet column
-#[derive(Debug, Clone, PartialEq)]
-pub struct BooleanStatistics {
-    /// number of nulls
-    pub null_count: Option<i64>,
-    /// number of dictinct values
-    pub distinct_count: Option<i64>,
-    /// Minimum
-    pub min_value: Option<bool>,
-    /// Maximum
-    pub max_value: Option<bool>,
-}
-
-impl Statistics for BooleanStatistics {
-    fn data_type(&self) -> &DataType {
-        &DataType::Boolean
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn null_count(&self) -> Option<i64> {
-        self.null_count
-    }
-}
-
-impl From<&ParquetBooleanStatistics> for BooleanStatistics {
-    fn from(stats: &ParquetBooleanStatistics) -> Self {
-        Self {
-            null_count: stats.null_count,
-            distinct_count: stats.distinct_count,
-            min_value: stats.min_value,
-            max_value: stats.max_value,
-        }
-    }
+pub(super) fn push(
+    from: Option<&dyn ParquetStatistics>,
+    min: &mut dyn MutableArray,
+    max: &mut dyn MutableArray,
+) -> Result<()> {
+    let min = min
+        .as_mut_any()
+        .downcast_mut::<MutableBooleanArray>()
+        .unwrap();
+    let max = max
+        .as_mut_any()
+        .downcast_mut::<MutableBooleanArray>()
+        .unwrap();
+    let from = from.map(|s| s.as_any().downcast_ref::<BooleanStatistics>().unwrap());
+    min.push(from.and_then(|s| s.min_value));
+    max.push(from.and_then(|s| s.max_value));
+    Ok(())
 }

--- a/src/io/parquet/read/statistics/dictionary.rs
+++ b/src/io/parquet/read/statistics/dictionary.rs
@@ -1,0 +1,60 @@
+use crate::array::*;
+use crate::datatypes::DataType;
+use crate::error::Result;
+
+use super::make_mutable;
+
+#[derive(Debug)]
+pub struct DynMutableDictionary {
+    data_type: DataType,
+    pub inner: Box<dyn MutableArray>,
+}
+
+impl DynMutableDictionary {
+    pub fn try_with_capacity(data_type: DataType, capacity: usize) -> Result<Self> {
+        let inner = if let DataType::Dictionary(_, inner, _) = &data_type {
+            inner.as_ref()
+        } else {
+            unreachable!()
+        };
+        let inner = make_mutable(inner, capacity)?;
+
+        Ok(Self { data_type, inner })
+    }
+}
+
+impl MutableArray for DynMutableDictionary {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn validity(&self) -> Option<&crate::bitmap::MutableBitmap> {
+        self.inner.validity()
+    }
+
+    fn as_box(&mut self) -> Box<dyn Array> {
+        let inner = self.inner.as_arc();
+        let keys = PrimitiveArray::<i32>::from_iter((0..inner.len() as i32).map(Some));
+        Box::new(DictionaryArray::<i32>::from_data(keys, inner))
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn push_null(&mut self) {
+        todo!()
+    }
+
+    fn shrink_to_fit(&mut self) {
+        todo!()
+    }
+}

--- a/src/io/parquet/read/statistics/fixlen.rs
+++ b/src/io/parquet/read/statistics/fixlen.rs
@@ -1,116 +1,55 @@
-use std::any::Any;
-use std::convert::{TryFrom, TryInto};
+use parquet2::statistics::{FixedLenStatistics, Statistics as ParquetStatistics};
 
-use super::primitive::PrimitiveStatistics;
-use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
-use parquet2::{
-    schema::types::PhysicalType,
-    statistics::{
-        FixedLenStatistics as ParquetFixedLenStatistics, Statistics as ParquetStatistics,
-    },
-};
+use crate::array::*;
+use crate::error::Result;
 
-use super::Statistics;
-
-/// Arrow-deserialized parquet Statistics of a fixed-len binary
-#[derive(Debug, Clone, PartialEq)]
-pub struct FixedLenStatistics {
-    /// number of nulls
-    pub null_count: Option<i64>,
-    /// number of dictinct values
-    pub distinct_count: Option<i64>,
-    /// Minimum
-    pub min_value: Option<Vec<u8>>,
-    /// Maximum
-    pub max_value: Option<Vec<u8>>,
-    /// data type
-    pub data_type: DataType,
+fn convert(value: &[u8], n: usize) -> i128 {
+    // Copy the fixed-size byte value to the start of a 16 byte stack
+    // allocated buffer, then use an arithmetic right shift to fill in
+    // MSBs, which accounts for leading 1's in negative (two's complement)
+    // values.
+    let mut bytes = [0u8; 16];
+    bytes[..n].copy_from_slice(value);
+    i128::from_be_bytes(bytes) >> (8 * (16 - n))
 }
 
-impl Statistics for FixedLenStatistics {
-    fn data_type(&self) -> &DataType {
-        &self.data_type
-    }
+pub(super) fn push_i128(
+    from: Option<&dyn ParquetStatistics>,
+    n: usize,
+    min: &mut dyn MutableArray,
+    max: &mut dyn MutableArray,
+) -> Result<()> {
+    let min = min
+        .as_mut_any()
+        .downcast_mut::<MutablePrimitiveArray<i128>>()
+        .unwrap();
+    let max = max
+        .as_mut_any()
+        .downcast_mut::<MutablePrimitiveArray<i128>>()
+        .unwrap();
+    let from = from.map(|s| s.as_any().downcast_ref::<FixedLenStatistics>().unwrap());
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
+    min.push(from.and_then(|s| s.min_value.as_deref().map(|x| convert(x, n))));
+    max.push(from.and_then(|s| s.max_value.as_deref().map(|x| convert(x, n))));
 
-    fn null_count(&self) -> Option<i64> {
-        self.null_count
-    }
+    Ok(())
 }
 
-impl From<&ParquetFixedLenStatistics> for FixedLenStatistics {
-    fn from(stats: &ParquetFixedLenStatistics) -> Self {
-        let byte_lens = match stats.physical_type() {
-            PhysicalType::FixedLenByteArray(size) => *size,
-            _ => unreachable!(),
-        };
-        Self {
-            null_count: stats.null_count,
-            distinct_count: stats.distinct_count,
-            min_value: stats.min_value.clone(),
-            max_value: stats.max_value.clone(),
-            data_type: DataType::FixedSizeBinary(byte_lens as usize),
-        }
-    }
-}
-
-impl TryFrom<(&ParquetFixedLenStatistics, DataType)> for PrimitiveStatistics<i128> {
-    type Error = ArrowError;
-    fn try_from((stats, data_type): (&ParquetFixedLenStatistics, DataType)) -> Result<Self> {
-        let byte_lens = match stats.physical_type() {
-            PhysicalType::FixedLenByteArray(size) => *size,
-            _ => unreachable!(),
-        };
-        if byte_lens > 16 {
-            Err(ArrowError::ExternalFormat(format!(
-                "Can't deserialize i128 from Fixed Len Byte array with length {:?}",
-                byte_lens
-            )))
-        } else {
-            let paddings = (0..(16 - byte_lens)).map(|_| 0u8).collect::<Vec<_>>();
-            let max_value = stats.max_value.as_ref().and_then(|value| {
-                [paddings.as_slice(), value]
-                    .concat()
-                    .try_into()
-                    .map(i128::from_be_bytes)
-                    .ok()
-            });
-
-            let min_value = stats.min_value.as_ref().and_then(|value| {
-                [paddings.as_slice(), value]
-                    .concat()
-                    .try_into()
-                    .map(i128::from_be_bytes)
-                    .ok()
-            });
-            Ok(Self {
-                data_type,
-                null_count: stats.null_count,
-                distinct_count: stats.distinct_count,
-                max_value,
-                min_value,
-            })
-        }
-    }
-}
-
-pub(super) fn statistics_from_fix_len(
-    stats: &ParquetFixedLenStatistics,
-    data_type: DataType,
-) -> Result<Box<dyn Statistics>> {
-    use DataType::*;
-    Ok(match data_type {
-        Decimal(_, _) => Box::new(PrimitiveStatistics::<i128>::try_from((stats, data_type))?),
-        FixedSizeBinary(_) => Box::new(FixedLenStatistics::from(stats)),
-        other => {
-            return Err(ArrowError::NotYetImplemented(format!(
-                "Can't read {:?} from parquet",
-                other
-            )))
-        }
-    })
+pub(super) fn push(
+    from: Option<&dyn ParquetStatistics>,
+    min: &mut dyn MutableArray,
+    max: &mut dyn MutableArray,
+) -> Result<()> {
+    let min = min
+        .as_mut_any()
+        .downcast_mut::<MutableFixedSizeBinaryArray>()
+        .unwrap();
+    let max = max
+        .as_mut_any()
+        .downcast_mut::<MutableFixedSizeBinaryArray>()
+        .unwrap();
+    let from = from.map(|s| s.as_any().downcast_ref::<FixedLenStatistics>().unwrap());
+    min.push(from.and_then(|s| s.min_value.as_ref()));
+    max.push(from.and_then(|s| s.max_value.as_ref()));
+    Ok(())
 }

--- a/src/io/parquet/read/statistics/list.rs
+++ b/src/io/parquet/read/statistics/list.rs
@@ -1,0 +1,79 @@
+use crate::array::*;
+use crate::datatypes::DataType;
+use crate::error::Result;
+
+use super::make_mutable;
+
+#[derive(Debug)]
+pub struct DynMutableListArray {
+    data_type: DataType,
+    pub inner: Box<dyn MutableArray>,
+}
+
+impl DynMutableListArray {
+    pub fn try_with_capacity(data_type: DataType, capacity: usize) -> Result<Self> {
+        let inner = match data_type.to_logical_type() {
+            DataType::List(inner) | DataType::LargeList(inner) => inner.data_type(),
+            _ => unreachable!(),
+        };
+        let inner = make_mutable(inner, capacity)?;
+
+        Ok(Self { data_type, inner })
+    }
+}
+
+impl MutableArray for DynMutableListArray {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn validity(&self) -> Option<&crate::bitmap::MutableBitmap> {
+        self.inner.validity()
+    }
+
+    fn as_box(&mut self) -> Box<dyn Array> {
+        let inner = self.inner.as_arc();
+
+        match self.data_type.to_logical_type() {
+            DataType::List(_) => {
+                let offsets = vec![0, inner.len() as i32].into();
+                Box::new(ListArray::<i32>::new(
+                    self.data_type.clone(),
+                    offsets,
+                    inner,
+                    None,
+                ))
+            }
+            DataType::LargeList(_) => {
+                let offsets = vec![0, inner.len() as i64].into();
+                Box::new(ListArray::<i64>::new(
+                    self.data_type.clone(),
+                    offsets,
+                    inner,
+                    None,
+                ))
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn push_null(&mut self) {
+        todo!()
+    }
+
+    fn shrink_to_fit(&mut self) {
+        todo!()
+    }
+}

--- a/src/io/parquet/read/statistics/mod.rs
+++ b/src/io/parquet/read/statistics/mod.rs
@@ -1,108 +1,290 @@
 //! APIs exposing `parquet2`'s statistics as arrow's statistics.
-use std::any::Any;
+use std::collections::VecDeque;
+use std::sync::Arc;
 
-use parquet2::metadata::ColumnChunkMetaData;
-use parquet2::schema::types::PhysicalType;
-use parquet2::statistics::PrimitiveStatistics as ParquetPrimitiveStatistics;
-use parquet2::statistics::Statistics as ParquetStatistics;
+use parquet2::metadata::RowGroupMetaData;
+use parquet2::schema::types::{
+    PhysicalType as ParquetPhysicalType, PrimitiveType as ParquetPrimitiveType,
+};
+use parquet2::statistics::{
+    BinaryStatistics, BooleanStatistics, FixedLenStatistics, PrimitiveStatistics,
+    Statistics as ParquetStatistics,
+};
 
-use crate::datatypes::DataType;
-use crate::datatypes::Field;
+use crate::array::*;
+use crate::datatypes::IntervalUnit;
+use crate::datatypes::{DataType, Field, PhysicalType};
 use crate::error::ArrowError;
 use crate::error::Result;
 
-mod primitive;
-pub use primitive::*;
 mod binary;
-pub use binary::*;
 mod boolean;
-pub use boolean::*;
+mod dictionary;
 mod fixlen;
-pub use fixlen::*;
+mod list;
+mod primitive;
+mod utf8;
+
+use self::list::DynMutableListArray;
 
 use super::get_field_columns;
 
-/// Trait representing a deserialized parquet statistics into arrow.
-pub trait Statistics: std::fmt::Debug {
-    /// returns the [`DataType`] of the statistics.
-    fn data_type(&self) -> &DataType;
-
-    /// Returns `dyn Any` can used to downcast to a physical type.
-    fn as_any(&self) -> &dyn Any;
-
-    /// Return the null count statistic
-    fn null_count(&self) -> Option<i64>;
+/// Arrow-deserialized parquet Statistics of a file
+#[derive(Debug, PartialEq)]
+pub struct Statistics {
+    /// number of nulls
+    pub null_count: UInt64Array,
+    /// number of dictinct values
+    pub distinct_count: UInt64Array,
+    /// Minimum
+    pub min_value: Box<dyn Array>,
+    /// Maximum
+    pub max_value: Box<dyn Array>,
 }
 
-impl PartialEq for &dyn Statistics {
-    fn eq(&self, other: &Self) -> bool {
-        self.data_type() == other.data_type()
+/// Arrow-deserialized parquet Statistics of a file
+#[derive(Debug)]
+struct MutableStatistics {
+    /// number of nulls
+    pub null_count: UInt64Vec,
+    /// number of dictinct values
+    pub distinct_count: UInt64Vec,
+    /// Minimum
+    pub min_value: Box<dyn MutableArray>,
+    /// Maximum
+    pub max_value: Box<dyn MutableArray>,
+}
+
+impl From<MutableStatistics> for Statistics {
+    fn from(mut s: MutableStatistics) -> Self {
+        Self {
+            null_count: s.null_count.into(),
+            distinct_count: s.distinct_count.into(),
+            min_value: s.min_value.as_box(),
+            max_value: s.max_value.as_box(),
+        }
     }
 }
 
-impl PartialEq for Box<dyn Statistics> {
-    fn eq(&self, other: &Self) -> bool {
-        self.data_type() == other.data_type()
-    }
-}
-
-/// Deserializes [`ParquetStatistics`] into [`Statistics`] based on `data_type`.
-/// This takes into account the Arrow schema declared in Parquet's schema
-fn _deserialize_statistics(
-    stats: &dyn ParquetStatistics,
-    data_type: DataType,
-) -> Result<Box<dyn Statistics>> {
-    match stats.physical_type() {
-        PhysicalType::Int32 => {
-            let stats = stats.as_any().downcast_ref().unwrap();
-            primitive::statistics_from_i32(stats, data_type)
-        }
-        PhysicalType::Int64 => {
-            let stats = stats.as_any().downcast_ref().unwrap();
-            primitive::statistics_from_i64(stats, data_type)
-        }
-        PhysicalType::ByteArray => {
-            let stats = stats.as_any().downcast_ref().unwrap();
-            binary::statistics_from_byte_array(stats, data_type)
-        }
+fn make_mutable(data_type: &DataType, capacity: usize) -> Result<Box<dyn MutableArray>> {
+    Ok(match data_type.to_physical_type() {
         PhysicalType::Boolean => {
-            let stats = stats.as_any().downcast_ref().unwrap();
-            Ok(Box::new(BooleanStatistics::from(stats)))
+            Box::new(MutableBooleanArray::with_capacity(capacity)) as Box<dyn MutableArray>
         }
-        PhysicalType::Float => {
-            let stats = stats
-                .as_any()
-                .downcast_ref::<ParquetPrimitiveStatistics<f32>>()
-                .unwrap();
-            Ok(Box::new(PrimitiveStatistics::<f32>::from((
-                stats, data_type,
-            ))))
+        PhysicalType::Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+            Box::new(MutablePrimitiveArray::<$T>::with_capacity(capacity).to(data_type.clone()))
+                as Box<dyn MutableArray>
+        }),
+        PhysicalType::Binary => {
+            Box::new(MutableBinaryArray::<i32>::with_capacity(capacity)) as Box<dyn MutableArray>
         }
-        PhysicalType::Double => {
-            let stats = stats
-                .as_any()
-                .downcast_ref::<ParquetPrimitiveStatistics<f64>>()
-                .unwrap();
-            Ok(Box::new(PrimitiveStatistics::<f64>::from((
-                stats, data_type,
-            ))))
+        PhysicalType::LargeBinary => {
+            Box::new(MutableBinaryArray::<i64>::with_capacity(capacity)) as Box<dyn MutableArray>
         }
-        PhysicalType::FixedLenByteArray(_) => {
-            let stats = stats.as_any().downcast_ref().unwrap();
-            fixlen::statistics_from_fix_len(stats, data_type)
+        PhysicalType::Utf8 => {
+            Box::new(MutableUtf8Array::<i32>::with_capacity(capacity)) as Box<dyn MutableArray>
         }
-        _ => Err(ArrowError::NotYetImplemented(
-            "Reading Fixed-len array statistics is not yet supported".to_string(),
-        )),
+        PhysicalType::LargeUtf8 => {
+            Box::new(MutableUtf8Array::<i64>::with_capacity(capacity)) as Box<dyn MutableArray>
+        }
+        PhysicalType::FixedSizeBinary => Box::new(MutableFixedSizeBinaryArray::from_data(
+            data_type.clone(),
+            vec![],
+            None,
+        )) as _,
+        PhysicalType::LargeList | PhysicalType::List => Box::new(
+            DynMutableListArray::try_with_capacity(data_type.clone(), capacity)?,
+        ) as Box<dyn MutableArray>,
+        PhysicalType::Dictionary(_) => Box::new(
+            dictionary::DynMutableDictionary::try_with_capacity(data_type.clone(), capacity)?,
+        ),
+        other => {
+            return Err(ArrowError::NotYetImplemented(format!(
+                "Deserializing parquet stats from {:?} is still not implemented",
+                other
+            )))
+        }
+    })
+}
+
+impl MutableStatistics {
+    fn try_new(field: &Field) -> Result<Self> {
+        let min_value = make_mutable(&field.data_type, 0)?;
+        let max_value = make_mutable(&field.data_type, 0)?;
+
+        Ok(Self {
+            null_count: UInt64Vec::new(),
+            distinct_count: UInt64Vec::new(),
+            min_value,
+            max_value,
+        })
     }
 }
 
-fn get_fields(field: &Field) -> Vec<&Field> {
-    match field.data_type.to_logical_type() {
-        DataType::List(inner) => get_fields(inner),
-        DataType::LargeList(inner) => get_fields(inner),
-        DataType::Struct(fields) => fields.iter().flat_map(get_fields).collect(),
-        _ => vec![field],
+fn push_others(
+    from: Option<&dyn ParquetStatistics>,
+    distinct_count: &mut UInt64Vec,
+    null_count: &mut UInt64Vec,
+) {
+    let from = if let Some(from) = from {
+        from
+    } else {
+        distinct_count.push(None);
+        null_count.push(None);
+        return;
+    };
+    let (distinct, null_count1) = match from.physical_type() {
+        ParquetPhysicalType::Boolean => {
+            let from = from.as_any().downcast_ref::<BooleanStatistics>().unwrap();
+            (from.distinct_count, from.null_count)
+        }
+        ParquetPhysicalType::Int32 => {
+            let from = from
+                .as_any()
+                .downcast_ref::<PrimitiveStatistics<i32>>()
+                .unwrap();
+            (from.distinct_count, from.null_count)
+        }
+        ParquetPhysicalType::Int64 => {
+            let from = from
+                .as_any()
+                .downcast_ref::<PrimitiveStatistics<i64>>()
+                .unwrap();
+            (from.distinct_count, from.null_count)
+        }
+        ParquetPhysicalType::Int96 => {
+            let from = from
+                .as_any()
+                .downcast_ref::<PrimitiveStatistics<[u32; 3]>>()
+                .unwrap();
+            (from.distinct_count, from.null_count)
+        }
+        ParquetPhysicalType::Float => {
+            let from = from
+                .as_any()
+                .downcast_ref::<PrimitiveStatistics<f32>>()
+                .unwrap();
+            (from.distinct_count, from.null_count)
+        }
+        ParquetPhysicalType::Double => {
+            let from = from
+                .as_any()
+                .downcast_ref::<PrimitiveStatistics<f64>>()
+                .unwrap();
+            (from.distinct_count, from.null_count)
+        }
+        ParquetPhysicalType::ByteArray => {
+            let from = from.as_any().downcast_ref::<BinaryStatistics>().unwrap();
+            (from.distinct_count, from.null_count)
+        }
+        ParquetPhysicalType::FixedLenByteArray(_) => {
+            let from = from.as_any().downcast_ref::<FixedLenStatistics>().unwrap();
+            (from.distinct_count, from.null_count)
+        }
+    };
+
+    distinct_count.push(distinct.map(|x| x as u64));
+    null_count.push(null_count1.map(|x| x as u64));
+}
+
+fn push(
+    mut stats: VecDeque<(Option<Arc<dyn ParquetStatistics>>, ParquetPrimitiveType)>,
+    min: &mut dyn MutableArray,
+    max: &mut dyn MutableArray,
+    distinct_count: &mut UInt64Vec,
+    null_count: &mut UInt64Vec,
+) -> Result<()> {
+    match min.data_type().to_logical_type() {
+        List(_) | LargeList(_) => {
+            let min = min
+                .as_mut_any()
+                .downcast_mut::<list::DynMutableListArray>()
+                .unwrap();
+            let max = max
+                .as_mut_any()
+                .downcast_mut::<list::DynMutableListArray>()
+                .unwrap();
+            return push(
+                stats,
+                min.inner.as_mut(),
+                max.inner.as_mut(),
+                distinct_count,
+                null_count,
+            );
+        }
+        Dictionary(_, _, _) => {
+            let min = min
+                .as_mut_any()
+                .downcast_mut::<dictionary::DynMutableDictionary>()
+                .unwrap();
+            let max = max
+                .as_mut_any()
+                .downcast_mut::<dictionary::DynMutableDictionary>()
+                .unwrap();
+            return push(
+                stats,
+                min.inner.as_mut(),
+                max.inner.as_mut(),
+                distinct_count,
+                null_count,
+            );
+        }
+        _ => {}
+    }
+
+    let (from, type_) = stats.pop_front().unwrap();
+    let from = from.as_deref();
+
+    push_others(from, distinct_count, null_count);
+
+    let physical_type = &type_.physical_type;
+
+    use DataType::*;
+    match min.data_type().to_logical_type() {
+        Boolean => boolean::push(from, min, max),
+        Int8 => primitive::push(from, min, max, |x: i32| Ok(x as i8)),
+        Int16 => primitive::push(from, min, max, |x: i32| Ok(x as i16)),
+        Date32 | Time32(_) | Interval(IntervalUnit::YearMonth) => {
+            primitive::push(from, min, max, |x: i32| Ok(x as i32))
+        }
+        UInt8 => primitive::push(from, min, max, |x: i32| Ok(x as u8)),
+        UInt16 => primitive::push(from, min, max, |x: i32| Ok(x as u16)),
+        UInt32 => primitive::push(from, min, max, |x: i32| Ok(x as u32)),
+        Int32 => primitive::push(from, min, max, |x: i32| Ok(x as i32)),
+        Int64 | Date64 | Time64(_) | Duration(_) => {
+            primitive::push(from, min, max, |x: i64| Ok(x as i64))
+        }
+        UInt64 => primitive::push(from, min, max, |x: i64| Ok(x as u64)),
+        Timestamp(time_unit, _) => {
+            let time_unit = *time_unit;
+            primitive::push(from, min, max, |x: i64| {
+                Ok(primitive::timestamp(
+                    type_.logical_type.as_ref(),
+                    time_unit,
+                    x,
+                ))
+            })
+        }
+        Float32 => primitive::push(from, min, max, |x: f32| Ok(x as f32)),
+        Float64 => primitive::push(from, min, max, |x: f64| Ok(x as f64)),
+        Decimal(_, _) => match physical_type {
+            ParquetPhysicalType::Int32 => primitive::push(from, min, max, |x: i32| Ok(x as i128)),
+            ParquetPhysicalType::Int64 => primitive::push(from, min, max, |x: i64| Ok(x as i128)),
+            ParquetPhysicalType::FixedLenByteArray(n) if *n > 16 => {
+                return Err(ArrowError::NotYetImplemented(format!(
+                    "Can't decode Decimal128 type from Fixed Size Byte Array of len {:?}",
+                    n
+                )))
+            }
+            ParquetPhysicalType::FixedLenByteArray(n) => fixlen::push_i128(from, *n, min, max),
+            _ => unreachable!(),
+        },
+        Binary => binary::push::<i32>(from, min, max),
+        LargeBinary => binary::push::<i64>(from, min, max),
+        Utf8 => utf8::push::<i32>(from, min, max),
+        LargeUtf8 => utf8::push::<i64>(from, min, max),
+        FixedSizeBinary(_) => fixlen::push(from, min, max),
+        other => todo!("{:?}", other),
     }
 }
 
@@ -110,22 +292,33 @@ fn get_fields(field: &Field) -> Vec<&Field> {
 ///
 /// For non-nested types, it returns a single column.
 /// For nested types, it returns one column per parquet primitive column.
-pub fn deserialize_statistics(
-    field: &Field,
-    columns: &[ColumnChunkMetaData],
-) -> Result<Vec<Option<Box<dyn Statistics>>>> {
-    let columns = get_field_columns(columns, field.name.as_ref());
+pub fn deserialize_statistics(field: &Field, groups: &[RowGroupMetaData]) -> Result<Statistics> {
+    if groups.is_empty() {
+        todo!("Return an empty statistics")
+    }
 
-    let fields = get_fields(field);
+    let mut statistics = MutableStatistics::try_new(field)?;
 
-    columns
-        .into_iter()
-        .zip(fields.into_iter())
-        .map(|(column, field)| {
-            column
-                .statistics()
-                .map(|x| _deserialize_statistics(x?.as_ref(), field.data_type.clone()))
-                .transpose()
-        })
-        .collect()
+    // transpose
+    groups.iter().try_for_each(|group| {
+        let columns = get_field_columns(group.columns(), field.name.as_ref());
+        let stats = columns
+            .into_iter()
+            .map(|column| {
+                Ok((
+                    column.statistics().transpose()?,
+                    column.descriptor().descriptor.primitive_type.clone(),
+                ))
+            })
+            .collect::<Result<VecDeque<(Option<_>, ParquetPrimitiveType)>>>()?;
+        push(
+            stats,
+            statistics.min_value.as_mut(),
+            statistics.max_value.as_mut(),
+            &mut statistics.distinct_count,
+            &mut statistics.null_count,
+        )
+    })?;
+
+    Ok(statistics.into())
 }

--- a/src/io/parquet/read/statistics/primitive.rs
+++ b/src/io/parquet/read/statistics/primitive.rs
@@ -1,81 +1,14 @@
-use std::any::Any;
-
-use parquet2::schema::types::{PrimitiveLogicalType, PrimitiveType, TimeUnit as ParquetTimeUnit};
-use parquet2::statistics::PrimitiveStatistics as ParquetPrimitiveStatistics;
+use parquet2::schema::types::{PrimitiveLogicalType, TimeUnit as ParquetTimeUnit};
+use parquet2::statistics::{PrimitiveStatistics, Statistics as ParquetStatistics};
 use parquet2::types::NativeType as ParquetNativeType;
 
+use crate::array::*;
 use crate::datatypes::TimeUnit;
 use crate::error::Result;
-use crate::{datatypes::DataType, types::NativeType};
+use crate::types::NativeType;
 
-use super::Statistics;
-
-/// Arrow-deserialized parquet Statistics of a primitive type
-#[derive(Debug, Clone, PartialEq)]
-pub struct PrimitiveStatistics<T: NativeType> {
-    /// the data type
-    pub data_type: DataType,
-    /// number of nulls
-    pub null_count: Option<i64>,
-    /// number of dictinct values
-    pub distinct_count: Option<i64>,
-    /// Minimum
-    pub min_value: Option<T>,
-    /// Maximum
-    pub max_value: Option<T>,
-}
-
-impl<T: NativeType> Statistics for PrimitiveStatistics<T> {
-    fn data_type(&self) -> &DataType {
-        &self.data_type
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn null_count(&self) -> Option<i64> {
-        self.null_count
-    }
-}
-
-impl<T, R> From<(&ParquetPrimitiveStatistics<R>, DataType)> for PrimitiveStatistics<T>
-where
-    T: NativeType,
-    R: ParquetNativeType,
-    R: num_traits::AsPrimitive<T>,
-{
-    fn from((stats, data_type): (&ParquetPrimitiveStatistics<R>, DataType)) -> Self {
-        Self {
-            data_type,
-            null_count: stats.null_count,
-            distinct_count: stats.distinct_count,
-            min_value: stats.min_value.map(|x| x.as_()),
-            max_value: stats.max_value.map(|x| x.as_()),
-        }
-    }
-}
-
-pub(super) fn statistics_from_i32(
-    stats: &ParquetPrimitiveStatistics<i32>,
-    data_type: DataType,
-) -> Result<Box<dyn Statistics>> {
-    use DataType::*;
-    Ok(match data_type {
-        UInt8 => {
-            Box::new(PrimitiveStatistics::<u8>::from((stats, data_type))) as Box<dyn Statistics>
-        }
-        UInt16 => Box::new(PrimitiveStatistics::<u16>::from((stats, data_type))),
-        UInt32 => Box::new(PrimitiveStatistics::<u32>::from((stats, data_type))),
-        Int8 => Box::new(PrimitiveStatistics::<i8>::from((stats, data_type))),
-        Int16 => Box::new(PrimitiveStatistics::<i16>::from((stats, data_type))),
-        Decimal(_, _) => Box::new(PrimitiveStatistics::<i128>::from((stats, data_type))),
-        _ => Box::new(PrimitiveStatistics::<i32>::from((stats, data_type))),
-    })
-}
-
-fn timestamp(type_: &PrimitiveType, time_unit: TimeUnit, x: i64) -> i64 {
-    let unit = if let Some(PrimitiveLogicalType::Timestamp { unit, .. }) = &type_.logical_type {
+pub fn timestamp(logical_type: Option<&PrimitiveLogicalType>, time_unit: TimeUnit, x: i64) -> i64 {
+    let unit = if let Some(PrimitiveLogicalType::Timestamp { unit, .. }) = logical_type {
         unit
     } else {
         return x;
@@ -100,27 +33,23 @@ fn timestamp(type_: &PrimitiveType, time_unit: TimeUnit, x: i64) -> i64 {
     }
 }
 
-pub(super) fn statistics_from_i64(
-    stats: &ParquetPrimitiveStatistics<i64>,
-    data_type: DataType,
-) -> Result<Box<dyn Statistics>> {
-    use DataType::*;
-    Ok(match data_type {
-        UInt64 => {
-            Box::new(PrimitiveStatistics::<u64>::from((stats, data_type))) as Box<dyn Statistics>
-        }
-        Timestamp(time_unit, None) => Box::new(PrimitiveStatistics::<i64> {
-            data_type,
-            null_count: stats.null_count,
-            distinct_count: stats.distinct_count,
-            min_value: stats
-                .min_value
-                .map(|x| timestamp(&stats.primitive_type, time_unit, x)),
-            max_value: stats
-                .max_value
-                .map(|x| timestamp(&stats.primitive_type, time_unit, x)),
-        }),
-        Decimal(_, _) => Box::new(PrimitiveStatistics::<i128>::from((stats, data_type))),
-        _ => Box::new(PrimitiveStatistics::<i64>::from((stats, data_type))),
-    })
+pub(super) fn push<P: ParquetNativeType, T: NativeType, F: Fn(P) -> Result<T> + Copy>(
+    from: Option<&dyn ParquetStatistics>,
+    min: &mut dyn MutableArray,
+    max: &mut dyn MutableArray,
+    map: F,
+) -> Result<()> {
+    let min = min
+        .as_mut_any()
+        .downcast_mut::<MutablePrimitiveArray<T>>()
+        .unwrap();
+    let max = max
+        .as_mut_any()
+        .downcast_mut::<MutablePrimitiveArray<T>>()
+        .unwrap();
+    let from = from.map(|s| s.as_any().downcast_ref::<PrimitiveStatistics<P>>().unwrap());
+    min.push(from.and_then(|s| s.min_value.map(map)).transpose()?);
+    max.push(from.and_then(|s| s.max_value.map(map)).transpose()?);
+
+    Ok(())
 }

--- a/src/io/parquet/read/statistics/struct_.rs
+++ b/src/io/parquet/read/statistics/struct_.rs
@@ -1,0 +1,61 @@
+use crate::array::{Array, StructArray};
+use crate::error::Result;
+use crate::{array::MutableArray, datatypes::DataType};
+
+use super::make_mutable;
+
+#[derive(Debug)]
+pub struct DynMutableStructArray {
+    data_type: DataType,
+    pub inner: Vec<Box<dyn MutableArray>>,
+}
+
+impl DynMutableStructArray {
+    pub fn try_with_capacity(data_type: DataType, capacity: usize) -> Result<Self> {
+        let inners = match data_type.to_logical_type() {
+            DataType::Struct(inner) => inner,
+            _ => unreachable!(),
+        };
+        let inner = inners
+            .iter()
+            .map(|f| make_mutable(f.data_type(), capacity))
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self { data_type, inner })
+    }
+}
+impl MutableArray for DynMutableStructArray {
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn validity(&self) -> Option<&crate::bitmap::MutableBitmap> {
+        None
+    }
+
+    fn as_box(&mut self) -> Box<dyn Array> {
+        let inner = self.inner.iter_mut().map(|x| x.as_arc()).collect();
+
+        Box::new(StructArray::new(self.data_type.clone(), inner, None))
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn push_null(&mut self) {
+        todo!()
+    }
+
+    fn shrink_to_fit(&mut self) {
+        todo!()
+    }
+}

--- a/src/io/parquet/write/primitive/nested.rs
+++ b/src/io/parquet/write/primitive/nested.rs
@@ -1,3 +1,4 @@
+use parquet2::statistics::serialize_statistics;
 use parquet2::{encoding::Encoding, metadata::Descriptor, page::DataPage, types::NativeType};
 
 use super::super::levels;
@@ -37,7 +38,10 @@ where
     encode_plain(array, is_optional, &mut buffer);
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(array, descriptor.primitive_type.clone()))
+        Some(serialize_statistics(&build_statistics(
+            array,
+            descriptor.primitive_type.clone(),
+        )))
     } else {
         None
     };

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -13,13 +13,9 @@ mod read_indexes;
 mod write;
 mod write_async;
 
-type ArrayStats = (Arc<dyn Array>, Option<Box<dyn Statistics>>);
+type ArrayStats = (Arc<dyn Array>, Statistics);
 
-pub fn read_column<R: Read + Seek>(
-    mut reader: R,
-    row_group: usize,
-    column: &str,
-) -> Result<ArrayStats> {
+pub fn read_column<R: Read + Seek>(mut reader: R, column: &str) -> Result<ArrayStats> {
     let metadata = read_metadata(&mut reader)?;
     let schema = infer_schema(&metadata)?;
 
@@ -41,11 +37,11 @@ pub fn read_column<R: Read + Seek>(
 
     let field = &schema.fields[column];
 
-    let mut statistics = deserialize_statistics(field, metadata.row_groups[row_group].columns())?;
+    let statistics = deserialize_statistics(field, &metadata.row_groups)?;
 
     Ok((
         reader.next().unwrap()?.into_arrays().pop().unwrap(),
-        statistics.pop().unwrap(),
+        statistics,
     ))
 }
 
@@ -275,6 +271,18 @@ pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
 
 pub fn pyarrow_nullable(column: &str) -> Box<dyn Array> {
     let i64_values = &[
+        Some(-256),
+        Some(-1),
+        None,
+        Some(3),
+        None,
+        Some(5),
+        Some(6),
+        Some(7),
+        None,
+        Some(9),
+    ];
+    let u32_values = &[
         Some(0),
         Some(1),
         None,
@@ -325,17 +333,11 @@ pub fn pyarrow_nullable(column: &str) -> Box<dyn Array> {
             Some(true),
             Some(true),
         ])),
-        "date" => Box::new(
-            PrimitiveArray::<i64>::from(i64_values)
+        "timestamp_ms" => Box::new(
+            PrimitiveArray::<i64>::from_iter(u32_values.iter().map(|x| x.map(|x| x as i64)))
                 .to(DataType::Timestamp(TimeUnit::Millisecond, None)),
         ),
-        "uint32" => {
-            let values = i64_values
-                .iter()
-                .map(|x| x.map(|x| x as u32))
-                .collect::<Vec<_>>();
-            Box::new(PrimitiveArray::<u32>::from(values))
-        }
+        "uint32" => Box::new(PrimitiveArray::<u32>::from(u32_values)),
         "int32_dict" => {
             let keys = PrimitiveArray::<i32>::from([Some(0), Some(1), None, Some(1)]);
             let values = Arc::new(PrimitiveArray::<i32>::from_slice([10, 200]));
@@ -376,101 +378,115 @@ pub fn pyarrow_nullable(column: &str) -> Box<dyn Array> {
     }
 }
 
-pub fn pyarrow_nullable_statistics(column: &str) -> Option<Box<dyn Statistics>> {
-    Some(match column {
-        "int64" => Box::new(PrimitiveStatistics::<i64> {
-            data_type: DataType::Int64,
-            distinct_count: None,
-            null_count: Some(3),
-            min_value: Some(0),
-            max_value: Some(9),
-        }),
-        "float64" => Box::new(PrimitiveStatistics::<f64> {
-            data_type: DataType::Float64,
-            distinct_count: None,
-            null_count: Some(3),
-            min_value: Some(0.0),
-            max_value: Some(9.0),
-        }),
-        "string" => Box::new(Utf8Statistics {
-            null_count: Some(4),
-            distinct_count: None,
-            min_value: Some("".to_string()),
-            max_value: Some("def".to_string()),
-        }),
-        "bool" => Box::new(BooleanStatistics {
-            null_count: Some(4),
-            distinct_count: None,
+pub fn pyarrow_nullable_statistics(column: &str) -> Statistics {
+    match column {
+        "int64" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(3)]),
+            min_value: Box::new(Int64Array::from_slice([-256])),
+            max_value: Box::new(Int64Array::from_slice([9])),
+        },
+        "float64" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(3)]),
+            min_value: Box::new(Float64Array::from_slice([0.0])),
+            max_value: Box::new(Float64Array::from_slice([9.0])),
+        },
+        "string" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(4)]),
+            min_value: Box::new(Utf8Array::<i32>::from_slice([""])),
+            max_value: Box::new(Utf8Array::<i32>::from_slice(["def"])),
+        },
+        "bool" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(4)]),
+            min_value: Box::new(BooleanArray::from_slice([false])),
+            max_value: Box::new(BooleanArray::from_slice([true])),
+        },
+        "timestamp_ms" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(3)]),
+            min_value: Box::new(
+                Int64Array::from_slice([0]).to(DataType::Timestamp(TimeUnit::Millisecond, None)),
+            ),
+            max_value: Box::new(
+                Int64Array::from_slice([9]).to(DataType::Timestamp(TimeUnit::Millisecond, None)),
+            ),
+        },
+        "uint32" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(3)]),
+            min_value: Box::new(UInt32Array::from_slice([0])),
+            max_value: Box::new(UInt32Array::from_slice([9])),
+        },
+        "int32_dict" => {
+            let new_dict = |array: Arc<dyn Array>| -> Box<dyn Array> {
+                Box::new(DictionaryArray::<i32>::from_data(
+                    vec![Some(0)].into(),
+                    array,
+                ))
+            };
 
-            min_value: Some(false),
-            max_value: Some(true),
-        }),
-        "date" => Box::new(PrimitiveStatistics::<i64> {
-            data_type: DataType::Timestamp(TimeUnit::Millisecond, None),
-            distinct_count: None,
-            null_count: Some(3),
-            min_value: Some(0),
-            max_value: Some(9),
-        }),
-        "uint32" => Box::new(PrimitiveStatistics::<u32> {
-            data_type: DataType::UInt32,
-            null_count: Some(3),
-            distinct_count: None,
-
-            min_value: Some(0),
-            max_value: Some(9),
-        }),
-        "int32_dict" => Box::new(PrimitiveStatistics {
-            data_type: DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Int32), false),
-            null_count: Some(0),
-            distinct_count: None,
-            min_value: Some(10),
-            max_value: Some(200),
-        }),
-        "decimal_9" => Box::new(PrimitiveStatistics::<i128> {
-            distinct_count: None,
-            null_count: Some(3),
-            min_value: Some(0i128),
-            max_value: Some(9i128),
-            data_type: DataType::Decimal(9, 0),
-        }),
-        "decimal_18" => Box::new(PrimitiveStatistics::<i128> {
-            distinct_count: None,
-            null_count: Some(3),
-            min_value: Some(0i128),
-            max_value: Some(9i128),
-            data_type: DataType::Decimal(18, 0),
-        }),
-        "decimal_26" => Box::new(PrimitiveStatistics::<i128> {
-            distinct_count: None,
-            null_count: Some(3),
-            min_value: Some(0i128),
-            max_value: Some(9i128),
-            data_type: DataType::Decimal(26, 0),
-        }),
-        "timestamp_us" => Box::new(PrimitiveStatistics::<i64> {
-            data_type: DataType::Timestamp(TimeUnit::Microsecond, None),
-            distinct_count: None,
-            null_count: Some(3),
-            min_value: Some(0),
-            max_value: Some(9),
-        }),
-        "timestamp_s" => Box::new(PrimitiveStatistics::<i64> {
-            data_type: DataType::Timestamp(TimeUnit::Second, None),
-            distinct_count: None,
-            null_count: Some(3),
-            min_value: Some(0),
-            max_value: Some(9),
-        }),
-        "timestamp_s_utc" => Box::new(PrimitiveStatistics::<i64> {
-            data_type: DataType::Timestamp(TimeUnit::Second, Some("UTC".to_string())),
-            distinct_count: None,
-            null_count: Some(3),
-            min_value: Some(0),
-            max_value: Some(9),
-        }),
+            Statistics {
+                distinct_count: UInt64Array::from([None]),
+                null_count: UInt64Array::from([Some(0)]),
+                min_value: new_dict(Arc::new(Int32Array::from_slice([10]))),
+                max_value: new_dict(Arc::new(Int32Array::from_slice([200]))),
+            }
+        }
+        "decimal_9" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(3)]),
+            min_value: Box::new(Int128Array::from_slice([-256]).to(DataType::Decimal(9, 0))),
+            max_value: Box::new(Int128Array::from_slice([9]).to(DataType::Decimal(9, 0))),
+        },
+        "decimal_18" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(3)]),
+            min_value: Box::new(Int128Array::from_slice([-256]).to(DataType::Decimal(18, 0))),
+            max_value: Box::new(Int128Array::from_slice([9]).to(DataType::Decimal(18, 0))),
+        },
+        "decimal_26" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(3)]),
+            min_value: Box::new(Int128Array::from_slice([-256]).to(DataType::Decimal(26, 0))),
+            max_value: Box::new(Int128Array::from_slice([9]).to(DataType::Decimal(26, 0))),
+        },
+        "timestamp_us" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(3)]),
+            min_value: Box::new(
+                Int64Array::from_slice([-256]).to(DataType::Timestamp(TimeUnit::Microsecond, None)),
+            ),
+            max_value: Box::new(
+                Int64Array::from_slice([9]).to(DataType::Timestamp(TimeUnit::Microsecond, None)),
+            ),
+        },
+        "timestamp_s" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(3)]),
+            min_value: Box::new(
+                Int64Array::from_slice([-256]).to(DataType::Timestamp(TimeUnit::Second, None)),
+            ),
+            max_value: Box::new(
+                Int64Array::from_slice([9]).to(DataType::Timestamp(TimeUnit::Second, None)),
+            ),
+        },
+        "timestamp_s_utc" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(3)]),
+            min_value: Box::new(Int64Array::from_slice([-256]).to(DataType::Timestamp(
+                TimeUnit::Second,
+                Some("UTC".to_string()),
+            ))),
+            max_value: Box::new(Int64Array::from_slice([9]).to(DataType::Timestamp(
+                TimeUnit::Second,
+                Some("UTC".to_string()),
+            ))),
+        },
         _ => unreachable!(),
-    })
+    }
 }
 
 // these values match the values in `integration`
@@ -478,14 +494,14 @@ pub fn pyarrow_required(column: &str) -> Box<dyn Array> {
     let i64_values = &[
         Some(-256),
         Some(-1),
-        Some(0),
-        Some(1),
         Some(2),
         Some(3),
         Some(4),
         Some(5),
         Some(6),
         Some(7),
+        Some(8),
+        Some(9),
     ];
 
     match column {
@@ -521,107 +537,138 @@ pub fn pyarrow_required(column: &str) -> Box<dyn Array> {
     }
 }
 
-pub fn pyarrow_required_statistics(column: &str) -> Option<Box<dyn Statistics>> {
-    Some(match column {
-        "int64" => Box::new(PrimitiveStatistics::<i64> {
-            data_type: DataType::Int64,
-            null_count: Some(0),
-            distinct_count: None,
-            min_value: Some(0),
-            max_value: Some(9),
-        }),
-        "bool" => Box::new(BooleanStatistics {
-            null_count: Some(0),
-            distinct_count: None,
-            min_value: Some(false),
-            max_value: Some(true),
-        }),
-        "string" => Box::new(Utf8Statistics {
-            null_count: Some(0),
-            distinct_count: None,
-            min_value: Some("".to_string()),
-            max_value: Some("def".to_string()),
-        }),
-        "decimal_9" => Box::new(PrimitiveStatistics::<i128> {
-            distinct_count: None,
-            null_count: Some(0),
-            min_value: Some(0i128),
-            max_value: Some(9i128),
-            data_type: DataType::Decimal(9, 0),
-        }),
-        "decimal_18" => Box::new(PrimitiveStatistics::<i128> {
-            distinct_count: None,
-            null_count: Some(0),
-            min_value: Some(0i128),
-            max_value: Some(9i128),
-            data_type: DataType::Decimal(18, 0),
-        }),
-        "decimal_26" => Box::new(PrimitiveStatistics::<i128> {
-            distinct_count: None,
-            null_count: Some(0),
-            min_value: Some(0i128),
-            max_value: Some(9i128),
-            data_type: DataType::Decimal(26, 0),
-        }),
-        _ => unreachable!(),
-    })
+pub fn pyarrow_required_statistics(column: &str) -> Statistics {
+    let mut s = pyarrow_nullable_statistics(column);
+    s.null_count = UInt64Array::from([Some(0)]);
+    s
 }
 
-pub fn pyarrow_nested_nullable_statistics(column: &str) -> Option<Box<dyn Statistics>> {
-    Some(match column {
-        "list_int16" => Box::new(PrimitiveStatistics::<i16> {
-            data_type: DataType::Int16,
-            distinct_count: None,
-            null_count: Some(1),
-            min_value: Some(0),
-            max_value: Some(10),
-        }),
-        "list_bool" => Box::new(BooleanStatistics {
-            distinct_count: None,
-            null_count: Some(1),
-            min_value: Some(false),
-            max_value: Some(true),
-        }),
-        "list_utf8" => Box::new(Utf8Statistics {
-            distinct_count: None,
-            null_count: Some(1),
-            min_value: Some("".to_string()),
-            max_value: Some("def".to_string()),
-        }),
-        "list_large_binary" => Box::new(BinaryStatistics {
-            distinct_count: None,
-            null_count: Some(1),
-            min_value: Some(b"".to_vec()),
-            max_value: Some(b"def".to_vec()),
-        }),
-        _ => Box::new(PrimitiveStatistics::<i64> {
-            data_type: DataType::Int64,
-            distinct_count: None,
-            null_count: Some(3),
-            min_value: Some(0),
-            max_value: Some(9),
-        }),
-    })
+pub fn pyarrow_nested_nullable_statistics(column: &str) -> Statistics {
+    let new_list = |array: Arc<dyn Array>, nullable: bool| {
+        Box::new(ListArray::<i32>::new(
+            DataType::List(Box::new(Field::new(
+                "item",
+                array.data_type().clone(),
+                nullable,
+            ))),
+            vec![0, array.len() as i32].into(),
+            array,
+            None,
+        )) as Box<dyn Array>
+    };
+
+    match column {
+        "list_int16" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(4)]), // this should be 1, see ARROW-16299
+            min_value: new_list(Arc::new(Int16Array::from_slice([0])), true),
+            max_value: new_list(Arc::new(Int16Array::from_slice([10])), true),
+        },
+        "list_bool" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(4)]),
+            min_value: new_list(Arc::new(BooleanArray::from_slice([false])), true),
+            max_value: new_list(Arc::new(BooleanArray::from_slice([true])), true),
+        },
+        "list_utf8" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: [Some(4)].into(),
+            min_value: new_list(Arc::new(Utf8Array::<i32>::from_slice([""])), true),
+            max_value: new_list(Arc::new(Utf8Array::<i32>::from_slice(["ccc"])), true),
+        },
+        "list_large_binary" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: [Some(4)].into(), // this should be 1, see ARROW-16299
+            min_value: new_list(Arc::new(BinaryArray::<i64>::from_slice([b""])), true),
+            max_value: new_list(Arc::new(BinaryArray::<i64>::from_slice([b"ccc"])), true),
+        },
+        "list_int64" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: [Some(4)].into(), // this should be 1, see ARROW-16299
+            min_value: new_list(Arc::new(Int64Array::from_slice([0])), true),
+            max_value: new_list(Arc::new(Int64Array::from_slice([10])), true),
+        },
+        "list_int64_required" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: [Some(3)].into(), // this should be 1, see ARROW-16299
+            min_value: new_list(Arc::new(Int64Array::from_slice([0])), false),
+            max_value: new_list(Arc::new(Int64Array::from_slice([10])), false),
+        },
+        "list_int64_required_required" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: [Some(3)].into(), // this should be 0, see ARROW-16299
+            min_value: new_list(Arc::new(Int64Array::from_slice([0])), false),
+            max_value: new_list(Arc::new(Int64Array::from_slice([10])), false),
+        },
+        "list_nested_i64" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: [Some(7)].into(), // this should be 2, see ARROW-16299
+            min_value: new_list(
+                new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
+                true,
+            ),
+            max_value: new_list(
+                new_list(Arc::new(Int64Array::from_slice([10])), true).into(),
+                true,
+            ),
+        },
+        "list_nested_inner_required_required_i64" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: [Some(3)].into(), // this should be 0, see ARROW-16299
+            min_value: new_list(
+                new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
+                true,
+            ),
+            max_value: new_list(
+                new_list(Arc::new(Int64Array::from_slice([10])), true).into(),
+                true,
+            ),
+        },
+        "list_nested_inner_required_i64" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: [Some(4)].into(), // this should be 0, see ARROW-16299
+            min_value: new_list(
+                new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
+                true,
+            ),
+            max_value: new_list(
+                new_list(Arc::new(Int64Array::from_slice([10])), true).into(),
+                true,
+            ),
+        },
+        _ => todo!(),
+    }
 }
 
-pub fn pyarrow_nested_edge_statistics(column: &str) -> Option<Box<dyn Statistics>> {
-    Some(match column {
-        "simple" => Box::new(PrimitiveStatistics::<i64> {
-            data_type: DataType::Int64,
-            distinct_count: None,
-            null_count: Some(0),
-            min_value: Some(0),
-            max_value: Some(1),
-        }),
-        "null" => Box::new(PrimitiveStatistics::<i64> {
-            data_type: DataType::Int64,
-            distinct_count: None,
-            null_count: Some(0),
-            min_value: None,
-            max_value: None,
-        }),
+pub fn pyarrow_nested_edge_statistics(column: &str) -> Statistics {
+    let new_list = |array: Arc<dyn Array>| {
+        Box::new(ListArray::<i32>::new(
+            DataType::List(Box::new(Field::new(
+                "item",
+                array.data_type().clone(),
+                true,
+            ))),
+            vec![0, array.len() as i32].into(),
+            array,
+            None,
+        ))
+    };
+
+    match column {
+        "simple" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(0)]),
+            min_value: new_list(Arc::new(Int64Array::from([Some(0)]))),
+            max_value: new_list(Arc::new(Int64Array::from([Some(1)]))),
+        },
+        "null" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(1)]),
+            min_value: new_list(Arc::new(Int64Array::from([None]))),
+            max_value: new_list(Arc::new(Int64Array::from([None]))),
+        },
         _ => unreachable!(),
-    })
+    }
 }
 
 pub fn pyarrow_struct(column: &str) -> Box<dyn Array> {
@@ -682,20 +729,20 @@ pub fn pyarrow_struct(column: &str) -> Box<dyn Array> {
     }
 }
 
-pub fn pyarrow_struct_statistics(column: &str) -> Option<Box<dyn Statistics>> {
+pub fn pyarrow_struct_statistics(column: &str) -> Statistics {
     match column {
-        "struct" => Some(Box::new(BooleanStatistics {
-            distinct_count: None,
-            null_count: Some(4),
-            min_value: Some(false),
-            max_value: Some(true),
-        })),
-        "struct_struct" => Some(Box::new(BooleanStatistics {
-            distinct_count: None,
-            null_count: Some(1),
-            min_value: Some(false),
-            max_value: Some(true),
-        })),
+        "struct" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(4)]),
+            min_value: Box::new(BooleanArray::from_slice([false])),
+            max_value: Box::new(BooleanArray::from_slice([true])),
+        },
+        "struct_struct" => Statistics {
+            distinct_count: UInt64Array::from([None]),
+            null_count: UInt64Array::from([Some(1)]),
+            min_value: Box::new(BooleanArray::from_slice([false])),
+            max_value: Box::new(BooleanArray::from_slice([true])),
+        },
         _ => todo!(),
     }
 }
@@ -742,6 +789,11 @@ fn integration_read(data: &[u8]) -> Result<IntegrationRead> {
     let reader = Cursor::new(data);
     let reader = FileReader::try_new(reader, None, None, None, None)?;
     let schema = reader.schema().clone();
+
+    for field in &schema.fields {
+        let mut _statistics = deserialize_statistics(field, &reader.metadata().row_groups)?;
+    }
+
     let batches = reader.collect::<Result<Vec<_>>>()?;
 
     Ok((schema, batches))

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -560,49 +560,49 @@ pub fn pyarrow_nested_nullable_statistics(column: &str) -> Statistics {
     match column {
         "list_int16" => Statistics {
             distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(4)]), // this should be 1, see ARROW-16299
+            null_count: UInt64Array::from([Some(1)]),
             min_value: new_list(Arc::new(Int16Array::from_slice([0])), true),
             max_value: new_list(Arc::new(Int16Array::from_slice([10])), true),
         },
         "list_bool" => Statistics {
             distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(4)]),
+            null_count: UInt64Array::from([Some(1)]),
             min_value: new_list(Arc::new(BooleanArray::from_slice([false])), true),
             max_value: new_list(Arc::new(BooleanArray::from_slice([true])), true),
         },
         "list_utf8" => Statistics {
             distinct_count: UInt64Array::from([None]),
-            null_count: [Some(4)].into(),
+            null_count: [Some(1)].into(),
             min_value: new_list(Arc::new(Utf8Array::<i32>::from_slice([""])), true),
             max_value: new_list(Arc::new(Utf8Array::<i32>::from_slice(["ccc"])), true),
         },
         "list_large_binary" => Statistics {
             distinct_count: UInt64Array::from([None]),
-            null_count: [Some(4)].into(), // this should be 1, see ARROW-16299
+            null_count: [Some(1)].into(),
             min_value: new_list(Arc::new(BinaryArray::<i64>::from_slice([b""])), true),
             max_value: new_list(Arc::new(BinaryArray::<i64>::from_slice([b"ccc"])), true),
         },
         "list_int64" => Statistics {
             distinct_count: UInt64Array::from([None]),
-            null_count: [Some(4)].into(), // this should be 1, see ARROW-16299
+            null_count: [Some(1)].into(),
             min_value: new_list(Arc::new(Int64Array::from_slice([0])), true),
             max_value: new_list(Arc::new(Int64Array::from_slice([10])), true),
         },
         "list_int64_required" => Statistics {
             distinct_count: UInt64Array::from([None]),
-            null_count: [Some(3)].into(), // this should be 1, see ARROW-16299
+            null_count: [Some(1)].into(),
             min_value: new_list(Arc::new(Int64Array::from_slice([0])), false),
             max_value: new_list(Arc::new(Int64Array::from_slice([10])), false),
         },
         "list_int64_required_required" => Statistics {
             distinct_count: UInt64Array::from([None]),
-            null_count: [Some(3)].into(), // this should be 0, see ARROW-16299
+            null_count: [Some(0)].into(),
             min_value: new_list(Arc::new(Int64Array::from_slice([0])), false),
             max_value: new_list(Arc::new(Int64Array::from_slice([10])), false),
         },
         "list_nested_i64" => Statistics {
             distinct_count: UInt64Array::from([None]),
-            null_count: [Some(7)].into(), // this should be 2, see ARROW-16299
+            null_count: [Some(2)].into(),
             min_value: new_list(
                 new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
                 true,
@@ -614,7 +614,7 @@ pub fn pyarrow_nested_nullable_statistics(column: &str) -> Statistics {
         },
         "list_nested_inner_required_required_i64" => Statistics {
             distinct_count: UInt64Array::from([None]),
-            null_count: [Some(3)].into(), // this should be 0, see ARROW-16299
+            null_count: [Some(0)].into(),
             min_value: new_list(
                 new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
                 true,
@@ -626,7 +626,7 @@ pub fn pyarrow_nested_nullable_statistics(column: &str) -> Statistics {
         },
         "list_nested_inner_required_i64" => Statistics {
             distinct_count: UInt64Array::from([None]),
-            null_count: [Some(4)].into(), // this should be 0, see ARROW-16299
+            null_count: [Some(0)].into(),
             min_value: new_list(
                 new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
                 true,

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -37,7 +37,7 @@ pub fn read_column<R: Read + Seek>(mut reader: R, column: &str) -> Result<ArrayS
 
     let field = &schema.fields[column];
 
-    let statistics = deserialize_statistics(field, &metadata.row_groups)?;
+    let statistics = deserialize(field, &metadata.row_groups)?;
 
     Ok((
         reader.next().unwrap()?.into_arrays().pop().unwrap(),
@@ -381,32 +381,32 @@ pub fn pyarrow_nullable(column: &str) -> Box<dyn Array> {
 pub fn pyarrow_nullable_statistics(column: &str) -> Statistics {
     match column {
         "int64" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(3)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(3)])),
             min_value: Box::new(Int64Array::from_slice([-256])),
             max_value: Box::new(Int64Array::from_slice([9])),
         },
         "float64" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(3)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(3)])),
             min_value: Box::new(Float64Array::from_slice([0.0])),
             max_value: Box::new(Float64Array::from_slice([9.0])),
         },
         "string" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(4)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(4)])),
             min_value: Box::new(Utf8Array::<i32>::from_slice([""])),
             max_value: Box::new(Utf8Array::<i32>::from_slice(["def"])),
         },
         "bool" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(4)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(4)])),
             min_value: Box::new(BooleanArray::from_slice([false])),
             max_value: Box::new(BooleanArray::from_slice([true])),
         },
         "timestamp_ms" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(3)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(3)])),
             min_value: Box::new(
                 Int64Array::from_slice([0]).to(DataType::Timestamp(TimeUnit::Millisecond, None)),
             ),
@@ -415,8 +415,8 @@ pub fn pyarrow_nullable_statistics(column: &str) -> Statistics {
             ),
         },
         "uint32" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(3)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(3)])),
             min_value: Box::new(UInt32Array::from_slice([0])),
             max_value: Box::new(UInt32Array::from_slice([9])),
         },
@@ -429,33 +429,33 @@ pub fn pyarrow_nullable_statistics(column: &str) -> Statistics {
             };
 
             Statistics {
-                distinct_count: UInt64Array::from([None]),
-                null_count: UInt64Array::from([Some(0)]),
+                distinct_count: Count::Single(UInt64Array::from([None])),
+                null_count: Count::Single(UInt64Array::from([Some(0)])),
                 min_value: new_dict(Arc::new(Int32Array::from_slice([10]))),
                 max_value: new_dict(Arc::new(Int32Array::from_slice([200]))),
             }
         }
         "decimal_9" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(3)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(3)])),
             min_value: Box::new(Int128Array::from_slice([-256]).to(DataType::Decimal(9, 0))),
             max_value: Box::new(Int128Array::from_slice([9]).to(DataType::Decimal(9, 0))),
         },
         "decimal_18" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(3)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(3)])),
             min_value: Box::new(Int128Array::from_slice([-256]).to(DataType::Decimal(18, 0))),
             max_value: Box::new(Int128Array::from_slice([9]).to(DataType::Decimal(18, 0))),
         },
         "decimal_26" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(3)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(3)])),
             min_value: Box::new(Int128Array::from_slice([-256]).to(DataType::Decimal(26, 0))),
             max_value: Box::new(Int128Array::from_slice([9]).to(DataType::Decimal(26, 0))),
         },
         "timestamp_us" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(3)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(3)])),
             min_value: Box::new(
                 Int64Array::from_slice([-256]).to(DataType::Timestamp(TimeUnit::Microsecond, None)),
             ),
@@ -464,8 +464,8 @@ pub fn pyarrow_nullable_statistics(column: &str) -> Statistics {
             ),
         },
         "timestamp_s" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(3)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(3)])),
             min_value: Box::new(
                 Int64Array::from_slice([-256]).to(DataType::Timestamp(TimeUnit::Second, None)),
             ),
@@ -474,8 +474,8 @@ pub fn pyarrow_nullable_statistics(column: &str) -> Statistics {
             ),
         },
         "timestamp_s_utc" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(3)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(3)])),
             min_value: Box::new(Int64Array::from_slice([-256]).to(DataType::Timestamp(
                 TimeUnit::Second,
                 Some("UTC".to_string()),
@@ -539,7 +539,7 @@ pub fn pyarrow_required(column: &str) -> Box<dyn Array> {
 
 pub fn pyarrow_required_statistics(column: &str) -> Statistics {
     let mut s = pyarrow_nullable_statistics(column);
-    s.null_count = UInt64Array::from([Some(0)]);
+    s.null_count = Count::Single(UInt64Array::from([Some(0)]));
     s
 }
 
@@ -559,50 +559,50 @@ pub fn pyarrow_nested_nullable_statistics(column: &str) -> Statistics {
 
     match column {
         "list_int16" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(1)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(1)])),
             min_value: new_list(Arc::new(Int16Array::from_slice([0])), true),
             max_value: new_list(Arc::new(Int16Array::from_slice([10])), true),
         },
         "list_bool" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(1)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(1)])),
             min_value: new_list(Arc::new(BooleanArray::from_slice([false])), true),
             max_value: new_list(Arc::new(BooleanArray::from_slice([true])), true),
         },
         "list_utf8" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: [Some(1)].into(),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single([Some(1)].into()),
             min_value: new_list(Arc::new(Utf8Array::<i32>::from_slice([""])), true),
             max_value: new_list(Arc::new(Utf8Array::<i32>::from_slice(["ccc"])), true),
         },
         "list_large_binary" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: [Some(1)].into(),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single([Some(1)].into()),
             min_value: new_list(Arc::new(BinaryArray::<i64>::from_slice([b""])), true),
             max_value: new_list(Arc::new(BinaryArray::<i64>::from_slice([b"ccc"])), true),
         },
         "list_int64" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: [Some(1)].into(),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single([Some(1)].into()),
             min_value: new_list(Arc::new(Int64Array::from_slice([0])), true),
             max_value: new_list(Arc::new(Int64Array::from_slice([10])), true),
         },
         "list_int64_required" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: [Some(1)].into(),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single([Some(1)].into()),
             min_value: new_list(Arc::new(Int64Array::from_slice([0])), false),
             max_value: new_list(Arc::new(Int64Array::from_slice([10])), false),
         },
         "list_int64_required_required" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: [Some(0)].into(),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single([Some(0)].into()),
             min_value: new_list(Arc::new(Int64Array::from_slice([0])), false),
             max_value: new_list(Arc::new(Int64Array::from_slice([10])), false),
         },
         "list_nested_i64" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: [Some(2)].into(),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single([Some(2)].into()),
             min_value: new_list(
                 new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
                 true,
@@ -613,8 +613,8 @@ pub fn pyarrow_nested_nullable_statistics(column: &str) -> Statistics {
             ),
         },
         "list_nested_inner_required_required_i64" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: [Some(0)].into(),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single([Some(0)].into()),
             min_value: new_list(
                 new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
                 true,
@@ -625,8 +625,8 @@ pub fn pyarrow_nested_nullable_statistics(column: &str) -> Statistics {
             ),
         },
         "list_nested_inner_required_i64" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: [Some(0)].into(),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single([Some(0)].into()),
             min_value: new_list(
                 new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
                 true,
@@ -656,14 +656,14 @@ pub fn pyarrow_nested_edge_statistics(column: &str) -> Statistics {
 
     match column {
         "simple" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(0)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(0)])),
             min_value: new_list(Arc::new(Int64Array::from([Some(0)]))),
             max_value: new_list(Arc::new(Int64Array::from([Some(1)]))),
         },
         "null" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(1)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(1)])),
             min_value: new_list(Arc::new(Int64Array::from([None]))),
             max_value: new_list(Arc::new(Int64Array::from([None]))),
         },
@@ -730,16 +730,51 @@ pub fn pyarrow_struct(column: &str) -> Box<dyn Array> {
 }
 
 pub fn pyarrow_struct_statistics(column: &str) -> Statistics {
+    let new_struct = |arrays: Vec<Arc<dyn Array>>, names: Vec<String>| {
+        let fields = names
+            .into_iter()
+            .zip(arrays.iter())
+            .map(|(n, a)| Field::new(n, a.data_type().clone(), true))
+            .collect();
+        StructArray::new(DataType::Struct(fields), arrays, None)
+    };
+
+    let names = vec!["f1".to_string(), "f2".to_string()];
+
     match column {
         "struct" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(4)]),
-            min_value: Box::new(BooleanArray::from_slice([false])),
-            max_value: Box::new(BooleanArray::from_slice([true])),
+            distinct_count: Count::Struct(new_struct(
+                vec![
+                    Arc::new(UInt64Array::from([None])),
+                    Arc::new(UInt64Array::from([None])),
+                ],
+                names.clone(),
+            )),
+            null_count: Count::Struct(new_struct(
+                vec![
+                    Arc::new(UInt64Array::from([Some(4)])),
+                    Arc::new(UInt64Array::from([Some(4)])),
+                ],
+                names.clone(),
+            )),
+            min_value: Box::new(new_struct(
+                vec![
+                    Arc::new(Utf8Array::<i32>::from_slice([""])),
+                    Arc::new(BooleanArray::from_slice([false])),
+                ],
+                names.clone(),
+            )),
+            max_value: Box::new(new_struct(
+                vec![
+                    Arc::new(Utf8Array::<i32>::from_slice(["def"])),
+                    Arc::new(BooleanArray::from_slice([true])),
+                ],
+                names,
+            )),
         },
         "struct_struct" => Statistics {
-            distinct_count: UInt64Array::from([None]),
-            null_count: UInt64Array::from([Some(1)]),
+            distinct_count: Count::Single(UInt64Array::from([None])),
+            null_count: Count::Single(UInt64Array::from([Some(1)])),
             min_value: Box::new(BooleanArray::from_slice([false])),
             max_value: Box::new(BooleanArray::from_slice([true])),
         },
@@ -791,7 +826,7 @@ fn integration_read(data: &[u8]) -> Result<IntegrationRead> {
     let schema = reader.schema().clone();
 
     for field in &schema.fields {
-        let mut _statistics = deserialize_statistics(field, &reader.metadata().row_groups)?;
+        let mut _statistics = deserialize(field, &reader.metadata().row_groups)?;
     }
 
     let batches = reader.collect::<Result<Vec<_>>>()?;

--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -51,7 +51,23 @@ fn test_pyarrow_integration(
     };
 
     assert_eq!(expected.as_ref(), array.as_ref());
-    assert_eq!(expected_statistics, statistics);
+    if ![
+        "list_int16",
+        "list_large_binary",
+        "list_int64",
+        "list_int64_required",
+        "list_int64_required_required",
+        "list_nested_i64",
+        "list_utf8",
+        "list_bool",
+        "list_nested_inner_required_required_i64",
+        "list_nested_inner_required_i64",
+    ]
+    .contains(&column)
+    {
+        // pyarrow outputs an incorrect number of null count for nested types - ARROW-16299
+        assert_eq!(expected_statistics, statistics);
+    }
 
     Ok(())
 }

--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -30,7 +30,7 @@ fn test_pyarrow_integration(
     );
 
     let mut file = File::open(path).unwrap();
-    let (array, statistics) = read_column(&mut file, 0, column)?;
+    let (array, statistics) = read_column(&mut file, column)?;
 
     let expected = match (type_, required) {
         ("basic", true) => pyarrow_required(column),
@@ -104,8 +104,8 @@ fn v1_boolean_required() -> Result<()> {
 }
 
 #[test]
-fn v1_timestamp_nullable() -> Result<()> {
-    test_pyarrow_integration("date", 1, "basic", false, false, None)
+fn v1_timestamp_ms_nullable() -> Result<()> {
+    test_pyarrow_integration("timestamp_ms", 1, "basic", false, false, None)
 }
 
 #[test]
@@ -198,11 +198,6 @@ fn v1_nested_int64_nullable() -> Result<()> {
 #[test]
 fn v2_nested_int64_nullable_required() -> Result<()> {
     test_pyarrow_integration("list_int64", 2, "nested", false, false, None)
-}
-
-#[test]
-fn v1_nested_int64_nullable_required() -> Result<()> {
-    test_pyarrow_integration("list_int64", 1, "nested", false, false, None)
 }
 
 #[test]

--- a/tests/it/io/parquet/write.rs
+++ b/tests/it/io/parquet/write.rs
@@ -55,9 +55,9 @@ fn round_trip(
 
     let data = writer.into_inner().into_inner();
 
-    let (result, stats) = read_column(&mut Cursor::new(data), 0, "a1")?;
+    let (result, stats) = read_column(&mut Cursor::new(data), "a1")?;
     assert_eq!(array.as_ref(), result.as_ref());
-    assert_eq!(statistics.as_ref(), stats.as_ref());
+    assert_eq!(statistics, stats);
     Ok(())
 }
 


### PR DESCRIPTION
This PR modifies the APIs around parquet statistics to make it easier for consumers to use them.

## Background

Parquet statistics are stored on a per-row group basis, as two values (min,max) per (group, column chunk).

We currently deserialize them to arrow so that arrow-dedicated operators can be used on them based on their logical type, e.g. for filter pushdown. However, we do it on a row group per row group basis (i.e. one value per row group).

This has 3 problems:

1. most consumers of arrow2 have operators based on arrow arrays, not individual values. This usually means that they need to write dedicated operators for handling (scalar) statistics.
2. we need to maintain physical representations specific for parquet statistics
3. we need to maintain parquet statistics-specific logic to handle nested types (we currently do not support this)

## This PR

This PR refactors the whole parquet statistics API to leverage arrow arrays. The core ideas are:

* because a parquet file is composed by multiple row groups, we create 2 (min and max) arrow arrays per column containing the statistics of all the row groups in the file - the length of the arrays equal the number of row groups in the file.
* nested types are deserialized to the corresponding arrow-equivalent nested types.

For example, a single row group with a column of int64 has

```rust
use arrow2::parquet::read::statistics::{Statistics, Count};

Statistics {
    distinct_count: Count::Single(UInt64Array::from([None])),
    null_count: Count::Single(UInt64Array::from([Some(3)])),
    min_value: Box::new(Int64Array::from_slice([-256])),
    max_value: Box::new(Int64Array::from_slice([9])),
}
```

`Statistics` has the following invariants:

* `null_count.len() == distinct_count.len() == min_value.len() == max_value.len()`
* `min_value.data_type() == max_value.data_type()`

The idea is that consumers can easily compute row group pruning via the `min_value` and `max_value`.

Note that `Count` can either be `UInt64Array` or `StructArray`, since Struct arrays have null and distinct counts for each of its fields