### PR TITLE
Fixed bug in writing csv with buffer resizing

### DIFF
--- a/tests/it/io/csv/write.rs
+++ b/tests/it/io/csv/write.rs
@@ -346,3 +346,22 @@ fn write_escaping() {
 
     assert_eq!(csv, "\"Acme co., Ltd.\"\n");
 }
+
+#[test]
+fn write_escaping_resize_local_buf() {
+    // tests if local buffer reallocates properly
+    let a = Utf8Array::<i32>::from_slice(&[
+        "bar,123456789012345678901234567890123456789012345678901234567890",
+    ]);
+    let columns = Chunk::new(vec![Arc::new(a) as Arc<dyn Array>]);
+
+    let mut writer = vec![];
+    let options = SerializeOptions::default();
+    write_chunk(&mut writer, &columns, &options).unwrap();
+    let csv = std::str::from_utf8(&writer).unwrap();
+
+    assert_eq!(
+        csv,
+        "\"bar,123456789012345678901234567890123456789012345678901234567890\"\n"
+    );
+}


### PR DESCRIPTION
This fix a bug where we didn't correctly resize the buffer when encoding csv fields. We also remove the loop as it is not needed, we can simply ensure to alloc enough without looping.

Fixes https://github.com/pola-rs/polars/issues/3232