### PR TITLE
Allowed creating IPC `FileWriter` without writing to the file

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,7 +172,7 @@ jobs:
           submodules: true
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-03-16
           target: ${{ matrix.target }}
           override: true
       - uses: Swatinem/rust-cache@v1

--- a/examples/extension.rs
+++ b/examples/extension.rs
@@ -38,11 +38,13 @@ fn write_ipc<W: Write + Seek>(writer: W, array: impl Array + 'static) -> Result<
     let schema = vec![Field::new("a", array.data_type().clone(), false)].into();
 
     let options = write::WriteOptions { compression: None };
-    let mut writer = write::FileWriter::try_new(writer, &schema, None, options)?;
+    let mut writer = write::FileWriter::new(writer, schema, None, options);
 
     let batch = Chunk::try_new(vec![Arc::new(array) as Arc<dyn Array>])?;
 
+    writer.start()?;
     writer.write(&batch, None)?;
+    writer.finish()?;
 
     Ok(writer.into_inner())
 }

--- a/examples/ipc_file_write.rs
+++ b/examples/ipc_file_write.rs
@@ -7,12 +7,13 @@ use arrow2::datatypes::{DataType, Field, Schema};
 use arrow2::error::Result;
 use arrow2::io::ipc::write;
 
-fn write_batches(path: &str, schema: &Schema, columns: &[Chunk<Arc<dyn Array>>]) -> Result<()> {
+fn write_batches(path: &str, schema: Schema, columns: &[Chunk<Arc<dyn Array>>]) -> Result<()> {
     let file = File::create(path)?;
 
     let options = write::WriteOptions { compression: None };
-    let mut writer = write::FileWriter::try_new(file, schema, None, options)?;
+    let mut writer = write::FileWriter::new(file, schema, None, options);
 
+    writer.start()?;
     for columns in columns {
         writer.write(columns, None)?
     }
@@ -37,6 +38,6 @@ fn main() -> Result<()> {
     let batch = Chunk::try_new(vec![Arc::new(a) as Arc<dyn Array>, Arc::new(b)])?;
 
     // write it
-    write_batches(file_path, &schema, &[batch])?;
+    write_batches(file_path, schema, &[batch])?;
     Ok(())
 }


### PR DESCRIPTION
Sometimes the operation of writing to the file may need to happen after the `FileWriter` is created.

This PR adds `new` and `start` to the `FileWriter` so that it can be created without actually writing anything to the file.
