### PR TITLE
Made reading of IPC dictionaries lazy

### DIFF
--- a/src/io/flight/mod.rs
+++ b/src/io/flight/mod.rs
@@ -120,8 +120,6 @@ pub fn deserialize_batch(
 
     let mut reader = std::io::Cursor::new(&data.data_body);
 
-    let version = message.version()?;
-
     match message.header()?.ok_or_else(|| {
         ArrowError::oos("Unable to convert flight data header to a record batch".to_string())
     })? {
@@ -131,7 +129,7 @@ pub fn deserialize_batch(
             ipc_schema,
             None,
             dictionaries,
-            version,
+            message.version()?,
             &mut reader,
             0,
         ),


### PR DESCRIPTION
This PR moves the reading of IPC dictionaries to when they are needed.

If a file has dictionaries, currently we read them to memory when reading the files' metadata. This causes metadata reading quite expensive if dictionaries exist.

This PR makes reading of dictionaries happen when the first IPC record batch is requested (via `.next` or `poll` for `sync` and `async` respectively), which allows users that just want to read the metadata to not have to read dictionaries.

The other advantage of this approach is that it allows projection push down to be applied to dictionaries, where we skip dictionaries that are not needed (follow-up PR).