### PR TITLE
Added support to append to existing IPC Arrow file

### DIFF
--- a/src/io/flight/mod.rs
+++ b/src/io/flight/mod.rs
@@ -25,7 +25,10 @@ pub fn serialize_batch(
     fields: &[IpcField],
     options: &WriteOptions,
 ) -> (Vec<FlightData>, FlightData) {
-    let mut dictionary_tracker = DictionaryTracker::new(false);
+    let mut dictionary_tracker = DictionaryTracker {
+        dictionaries: Default::default(),
+        cannot_replace: false,
+    };
 
     let (encoded_dictionaries, encoded_batch) =
         encode_chunk(columns, fields, &mut dictionary_tracker, options)

--- a/src/io/ipc/append/mod.rs
+++ b/src/io/ipc/append/mod.rs
@@ -1,0 +1,80 @@
+//! A struct adapter of Read+Seek+Write to append to IPC files
+// read header and convert to writer information
+// seek to first byte of header - 1
+// write new batch
+// write new footer
+use std::io::{Read, Seek, SeekFrom, Write};
+
+use crate::error::{ArrowError, Result};
+
+use super::endianess::is_native_little_endian;
+use super::read::{self, FileMetadata};
+use super::write::common::DictionaryTracker;
+use super::write::writer::*;
+use super::write::*;
+
+impl<R: Read + Seek + Write> FileWriter<R> {
+    /// Creates a new [`FileWriter`] from an existing file, seeking to the last message
+    /// and appending new messages afterwards. Users call `finish` to write the footer (with both)
+    /// the existing and appended messages on it.
+    /// # Error
+    /// This function errors iff:
+    /// * the file's endianess is not the native endianess (not yet supported)
+    /// * the file is not a valid Arrow IPC file
+    pub fn try_from_file(
+        mut writer: R,
+        metadata: FileMetadata,
+        options: WriteOptions,
+    ) -> Result<FileWriter<R>> {
+        if metadata.ipc_schema.is_little_endian != is_native_little_endian() {
+            return Err(ArrowError::nyi(
+                "Appending to a file of a non-native endianess is still not supported",
+            ));
+        }
+
+        let dictionaries = if let Some(blocks) = &metadata.dictionaries {
+            read::reader::read_dictionaries(
+                &mut writer,
+                &metadata.schema.fields,
+                &metadata.ipc_schema,
+                blocks,
+            )?
+        } else {
+            Default::default()
+        };
+
+        let last_block = metadata.blocks.last().ok_or_else(|| {
+            ArrowError::oos("An Arrow IPC file must have at least 1 message (the schema message)")
+        })?;
+        let offset: u64 = last_block
+            .offset
+            .try_into()
+            .map_err(|_| ArrowError::oos("The block's offset must be a positive number"))?;
+        let meta_data_length: u64 = last_block
+            .meta_data_length
+            .try_into()
+            .map_err(|_| ArrowError::oos("The block's meta length must be a positive number"))?;
+        let body_length: u64 = last_block
+            .body_length
+            .try_into()
+            .map_err(|_| ArrowError::oos("The block's body length must be a positive number"))?;
+        let offset: u64 = offset + meta_data_length + body_length;
+
+        writer.seek(SeekFrom::Start(offset))?;
+
+        Ok(FileWriter {
+            writer,
+            options,
+            schema: metadata.schema,
+            ipc_fields: metadata.ipc_schema.fields,
+            block_offsets: offset as usize,
+            dictionary_blocks: metadata.dictionaries.unwrap_or_default(),
+            record_blocks: metadata.blocks,
+            state: State::Started, // file already exists, so we are ready
+            dictionary_tracker: DictionaryTracker {
+                dictionaries,
+                cannot_replace: true,
+            },
+        })
+    }
+}

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -81,6 +81,7 @@ use crate::error::ArrowError;
 mod compression;
 mod endianess;
 
+pub mod append;
 pub mod read;
 pub mod write;
 

--- a/src/io/ipc/read/mod.rs
+++ b/src/io/ipc/read/mod.rs
@@ -13,7 +13,7 @@ mod array;
 mod common;
 mod deserialize;
 mod read_basic;
-mod reader;
+pub(crate) mod reader;
 mod schema;
 mod stream;
 #[cfg(feature = "io_ipc_read_async")]

--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -27,10 +27,10 @@ pub struct FileMetadata {
     /// The blocks in the file
     ///
     /// A block indicates the regions in the file to read to get data
-    pub(super) blocks: Vec<arrow_format::ipc::Block>,
+    pub(crate) blocks: Vec<arrow_format::ipc::Block>,
 
     /// Dictionaries associated to each dict_id
-    pub(super) dictionaries: Option<Vec<arrow_format::ipc::Block>>,
+    pub(crate) dictionaries: Option<Vec<arrow_format::ipc::Block>>,
 }
 
 /// Arrow File reader
@@ -65,7 +65,7 @@ fn read_dictionary_message<R: Read + Seek>(
     Ok(())
 }
 
-fn read_dictionaries<R: Read + Seek>(
+pub(crate) fn read_dictionaries<R: Read + Seek>(
     reader: &mut R,
     fields: &[Field],
     ipc_schema: &IpcSchema,

--- a/src/io/ipc/write/file_async.rs
+++ b/src/io/ipc/write/file_async.rs
@@ -96,7 +96,10 @@ where
             fields,
             offset: 0,
             schema: schema.clone(),
-            dictionary_tracker: DictionaryTracker::new(true),
+            dictionary_tracker: DictionaryTracker {
+                dictionaries: Default::default(),
+                cannot_replace: true,
+            },
             record_blocks: vec![],
             dictionary_blocks: vec![],
         }

--- a/src/io/ipc/write/mod.rs
+++ b/src/io/ipc/write/mod.rs
@@ -3,7 +3,7 @@ pub(crate) mod common;
 mod schema;
 mod serialize;
 mod stream;
-mod writer;
+pub(crate) mod writer;
 
 pub use common::{Compression, Record, WriteOptions};
 pub use schema::schema_to_bytes;

--- a/src/io/ipc/write/stream.rs
+++ b/src/io/ipc/write/stream.rs
@@ -42,7 +42,10 @@ impl<W: Write> StreamWriter<W> {
             writer,
             write_options,
             finished: false,
-            dictionary_tracker: DictionaryTracker::new(false),
+            dictionary_tracker: DictionaryTracker {
+                dictionaries: Default::default(),
+                cannot_replace: false,
+            },
             ipc_fields: None,
         }
     }

--- a/src/io/ipc/write/stream_async.rs
+++ b/src/io/ipc/write/stream_async.rs
@@ -73,7 +73,10 @@ where
             writer: None,
             task,
             fields,
-            dictionary_tracker: DictionaryTracker::new(false),
+            dictionary_tracker: DictionaryTracker {
+                dictionaries: Default::default(),
+                cannot_replace: false,
+            },
             options: write_options,
         }
     }

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -16,7 +16,7 @@ use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum State {
+pub(crate) enum State {
     None,
     Started,
     Finished,
@@ -25,22 +25,22 @@ enum State {
 /// Arrow file writer
 pub struct FileWriter<W: Write> {
     /// The object to write to
-    writer: W,
+    pub(crate) writer: W,
     /// IPC write options
-    options: WriteOptions,
+    pub(crate) options: WriteOptions,
     /// A reference to the schema, used in validating record batches
-    schema: Schema,
-    ipc_fields: Vec<IpcField>,
+    pub(crate) schema: Schema,
+    pub(crate) ipc_fields: Vec<IpcField>,
     /// The number of bytes between each block of bytes, as an offset for random access
-    block_offsets: usize,
+    pub(crate) block_offsets: usize,
     /// Dictionary blocks that will be written as part of the IPC footer
-    dictionary_blocks: Vec<arrow_format::ipc::Block>,
+    pub(crate) dictionary_blocks: Vec<arrow_format::ipc::Block>,
     /// Record blocks that will be written as part of the IPC footer
-    record_blocks: Vec<arrow_format::ipc::Block>,
+    pub(crate) record_blocks: Vec<arrow_format::ipc::Block>,
     /// Whether the writer footer has been written, and the writer is finished
-    state: State,
+    pub(crate) state: State,
     /// Keeps track of dictionaries that have been written
-    dictionary_tracker: DictionaryTracker,
+    pub(crate) dictionary_tracker: DictionaryTracker,
 }
 
 impl<W: Write> FileWriter<W> {
@@ -79,7 +79,10 @@ impl<W: Write> FileWriter<W> {
             dictionary_blocks: vec![],
             record_blocks: vec![],
             state: State::None,
-            dictionary_tracker: DictionaryTracker::new(true),
+            dictionary_tracker: DictionaryTracker {
+                dictionaries: Default::default(),
+                cannot_replace: true,
+            },
         }
     }
 

--- a/tests/it/io/ipc/write/file.rs
+++ b/tests/it/io/ipc/write/file.rs
@@ -10,7 +10,7 @@ use arrow2::io::ipc::{write::*, IpcField};
 
 use crate::io::ipc::common::read_gzip_json;
 
-fn write_(
+pub(crate) fn write(
     batches: &[Chunk<Arc<dyn Array>>],
     schema: &Schema,
     ipc_fields: Option<Vec<IpcField>>,
@@ -34,7 +34,7 @@ fn round_trip(
 ) -> Result<()> {
     let (expected_schema, expected_batches) = (schema.clone(), vec![columns]);
 
-    let result = write_(&expected_batches, &schema, ipc_fields, compression)?;
+    let result = write(&expected_batches, &schema, ipc_fields, compression)?;
     let mut reader = Cursor::new(result);
     let metadata = read_file_metadata(&mut reader)?;
     let schema = metadata.schema.clone();
@@ -58,7 +58,7 @@ fn test_file(version: &str, file_name: &str, compressed: bool) -> Result<()> {
         None
     };
 
-    let result = write_(&batches, &schema, Some(ipc_fields), compression)?;
+    let result = write(&batches, &schema, Some(ipc_fields), compression)?;
     let mut reader = Cursor::new(result);
     let metadata = read_file_metadata(&mut reader)?;
     let schema = metadata.schema.clone();

--- a/tests/it/io/ipc/write/file_append.rs
+++ b/tests/it/io/ipc/write/file_append.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+
+use arrow2::array::*;
+use arrow2::chunk::Chunk;
+use arrow2::datatypes::*;
+use arrow2::error::Result;
+use arrow2::io::ipc::read;
+use arrow2::io::ipc::write::{FileWriter, WriteOptions};
+
+use super::file::write;
+
+#[test]
+fn basic() -> Result<()> {
+    // prepare some data
+    let array = Arc::new(BooleanArray::from([
+        Some(true),
+        Some(false),
+        None,
+        Some(true),
+    ])) as Arc<dyn Array>;
+    let schema = Schema::from(vec![Field::new("a", array.data_type().clone(), true)]);
+    let columns = Chunk::try_new(vec![array])?;
+
+    let (expected_schema, expected_batches) = (schema.clone(), vec![columns.clone()]);
+
+    // write to a file
+    let result = write(&expected_batches, &schema, None, None)?;
+
+    // read the file to append
+    let mut file = std::io::Cursor::new(result);
+    let metadata = read::read_file_metadata(&mut file)?;
+    let mut writer = FileWriter::try_from_file(file, metadata, WriteOptions { compression: None })?;
+
+    // write a new column
+    writer.write(&columns, None)?;
+    writer.finish()?;
+
+    let data = writer.into_inner();
+    let mut reader = std::io::Cursor::new(data.into_inner());
+
+    // read the file again and confirm that it contains both messages
+    let metadata = read::read_file_metadata(&mut reader)?;
+    assert_eq!(schema, expected_schema);
+    let reader = read::FileReader::new(reader, metadata, None);
+
+    let chunks = reader.collect::<Result<Vec<_>>>()?;
+
+    assert_eq!(chunks, vec![columns.clone(), columns]);
+
+    Ok(())
+}

--- a/tests/it/io/ipc/write/mod.rs
+++ b/tests/it/io/ipc/write/mod.rs
@@ -1,2 +1,3 @@
 mod file;
+mod file_append;
 mod stream;


### PR DESCRIPTION
This PR adds support to append new record batches to an existing Arrow IPC file.

The implementation is simple:

1. read the file's metadata
2. seek to the end of the last block
3. `write` to it

Closes #963 - thanks to @illumination-k for fielding the idea!