### PR TITLE
Fixed empty reader panic for NDJSON type infer

### DIFF
--- a/src/io/json/read/infer_schema.rs
+++ b/src/io/json/read/infer_schema.rs
@@ -78,12 +78,17 @@ fn infer_number(n: &serde_json::Number) -> DataType {
 }
 
 /// Coerce an heterogeneous set of [`DataType`] into a single one. Rules:
+/// * The empty set is coerced to `Null`
 /// * `Int64` and `Float64` are `Float64`
 /// * Lists and scalars are coerced to a list of a compatible scalar
 /// * Structs contain the union of all fields
 /// * All other types are coerced to `Utf8`
 pub(crate) fn coerce_data_type<A: Borrow<DataType>>(datatypes: &[A]) -> DataType {
     use DataType::*;
+
+    if datatypes.is_empty() {
+        return DataType::Null;
+    }
 
     let are_all_equal = datatypes.windows(2).all(|w| w[0].borrow() == w[1].borrow());
 

--- a/src/io/json/read/infer_schema.rs
+++ b/src/io/json/read/infer_schema.rs
@@ -186,4 +186,15 @@ mod test {
             List(Box::new(Field::new(ITEM_NAME, Utf8, true))),
         );
     }
+
+    #[test]
+    fn test_coersion_of_nulls() {
+        assert_eq!(coerce_data_type(&[DataType::Null]), DataType::Null);
+        assert_eq!(
+            coerce_data_type(&[DataType::Null, DataType::Boolean]),
+            DataType::Utf8
+        );
+        let vec: Vec<DataType> = vec![];
+        assert_eq!(coerce_data_type(vec.as_slice()), DataType::Null);
+    }
 }

--- a/src/io/ndjson/read/deserialize.rs
+++ b/src/io/ndjson/read/deserialize.rs
@@ -15,6 +15,13 @@ use super::super::super::json::read::_deserialize;
 /// # Errors
 /// This function errors iff any of the rows is not a valid JSON (i.e. the format is not valid NDJSON).
 pub fn deserialize(rows: &[String], data_type: DataType) -> Result<Arc<dyn Array>, ArrowError> {
+    if rows.is_empty() {
+        return Err(ArrowError::ExternalFormat(
+            "Cannot deserialize 0 NDJSON rows because empty string is not a valid JSON value"
+                .to_string(),
+        ));
+    }
+
     // deserialize strings to `Value`s
     let rows = rows
         .iter()

--- a/src/io/ndjson/read/file.rs
+++ b/src/io/ndjson/read/file.rs
@@ -104,6 +104,12 @@ pub fn infer<R: std::io::BufRead>(
     reader: &mut R,
     number_of_rows: Option<usize>,
 ) -> Result<DataType> {
+    if !reader.fill_buf().map(|b| !b.is_empty())? {
+        return Err(ArrowError::ExternalFormat(
+            "Cannot infer NDJSON types on empty reader because empty string is not a valid JSON value".to_string(),
+        ));
+    }
+
     let rows = vec!["".to_string(); 1]; // 1 <=> read row by row
     let mut reader = FileReader::new(reader, rows, number_of_rows);
 

--- a/src/io/ndjson/read/file.rs
+++ b/src/io/ndjson/read/file.rs
@@ -104,7 +104,7 @@ pub fn infer<R: std::io::BufRead>(
     reader: &mut R,
     number_of_rows: Option<usize>,
 ) -> Result<DataType> {
-    if !reader.fill_buf().map(|b| !b.is_empty())? {
+    if reader.fill_buf().map(|b| b.is_empty())? {
         return Err(ArrowError::ExternalFormat(
             "Cannot infer NDJSON types on empty reader because empty string is not a valid JSON value".to_string(),
         ));

--- a/src/io/ndjson/read/file.rs
+++ b/src/io/ndjson/read/file.rs
@@ -97,7 +97,7 @@ impl<R: BufRead> FallibleStreamingIterator for FileReader<R> {
 
 /// Infers the [`DataType`] from an NDJSON file, optionally only using `number_of_rows` rows.
 ///
-/// # Implementantion
+/// # Implementation
 /// This implementation reads the file line by line and infers the type of each line.
 /// It performs both `O(N)` IO and CPU-bounded operations where `N` is the number of rows.
 pub fn infer<R: std::io::BufRead>(

--- a/tests/it/io/ndjson/read.rs
+++ b/tests/it/io/ndjson/read.rs
@@ -57,6 +57,34 @@ fn infer_nullable() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn read_null() -> Result<()> {
+    let ndjson = "null";
+    let expected_data_type = DataType::Null;
+
+    let data_type = infer(ndjson)?;
+    assert_eq!(expected_data_type, data_type);
+
+    let arrays = read_and_deserialize(ndjson, &data_type, 1000)?;
+    let expected = NullArray::new(data_type, 1);
+    assert_eq!(expected, arrays[0].as_ref());
+    Ok(())
+}
+
+#[test]
+fn read_empty_reader() -> Result<()> {
+    let ndjson = "";
+    let expected_data_type = DataType::Null;
+
+    let data_type = infer(ndjson)?;
+    assert_eq!(expected_data_type, data_type);
+
+    let arrays = read_and_deserialize(ndjson, &data_type, 1000)?;
+    let expected: Vec<Arc<dyn Array>> = vec![];
+    assert_eq!(expected, arrays);
+    Ok(())
+}
+
 fn case_nested_struct() -> (String, Arc<dyn Array>) {
     let ndjson = r#"{"a": {"a": 2.0, "b": 2}}
     {"a": {"b": 2}}


### PR DESCRIPTION
Hi there,
I am currently in the process of learning some Rust & what better way then to contribute ;)

- Now returns an error on empty readers instead of panic in `infer`. In `deserialize` as well, to have consistent behavior.
- #911 also suggested handling that as `DataType::Null`. I decided against that, since an empty string is not valid JSON. But `null` is, which also panicked—fixed that. Or do you prefer a separate PR?
- added some explicit tests for null to `coerce_data_type`

Fixes #911 
