### PR TITLE
Aligns MutableDictionaryArray's with MutablePrimitiveArrays with TryPush

### DIFF
--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -22,7 +22,7 @@ use super::{DictionaryArray, DictionaryKey};
 /// let mut array: MutableDictionaryArray<i32, MutableUtf8Array<i32>> = MutableDictionaryArray::new();
 /// array.try_push(Some("A"))?;
 /// array.try_push(Some("B"))?;
-/// array.try_push(None)?;
+/// array.push_null();
 /// array.try_push(Some("C"))?;
 /// # Ok(())
 /// # }

--- a/tests/it/array/dictionary/mutable.rs
+++ b/tests/it/array/dictionary/mutable.rs
@@ -1,5 +1,8 @@
 use arrow2::array::*;
 use arrow2::error::Result;
+use hash_hasher::HashedMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 #[test]
 fn primitive() -> Result<()> {
@@ -37,4 +40,37 @@ fn binary_natural() -> Result<()> {
     assert_eq!(a.len(), 3);
     assert_eq!(a.values().len(), 2);
     Ok(())
+}
+
+#[test]
+fn push_utf8() {
+    let mut new: MutableDictionaryArray<i32, MutableUtf8Array<i32>> = MutableDictionaryArray::new();
+
+    for value in [Some("A"), Some("B"), None, Some("C"), Some("A"), Some("B")] {
+        new.try_push(value).unwrap();
+    }
+
+    assert_eq!(
+        new.values().values(),
+        MutableUtf8Array::<i32>::from_iter_values(["A", "B", "C"].into_iter()).values()
+    );
+
+    let mut expected_keys = MutablePrimitiveArray::<i32>::from_slice(&[0, 1]);
+    expected_keys.push(None);
+    expected_keys.push(Some(2));
+    expected_keys.push(Some(0));
+    expected_keys.push(Some(1));
+    assert_eq!(*new.keys(), expected_keys);
+
+    let expected_map = ["A", "B", "C"]
+        .iter()
+        .enumerate()
+        .map(|(index, value)| {
+            let mut hasher = DefaultHasher::new();
+            value.hash(&mut hasher);
+            let hash = hasher.finish();
+            (hash, index as i32)
+        })
+        .collect::<HashedMap<_, _>>();
+    assert_eq!(*new.map(), expected_map);
 }


### PR DESCRIPTION
Also removes the ability to build an invalid map when pushing individual values. try_push_valid relied on the user pushing a value to the values stack.

Could have contributed to an invalid file was generated and bug found in #976.