### PR TITLE
remove accidental quadratic null_count

### DIFF
--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -234,12 +234,6 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
         let len = self.len();
         if let Some(validity) = self.validity.as_mut() {
             validity.extend_constant(len - validity.len(), true);
-        } else {
-            let mut validity = MutableBitmap::new();
-            validity.extend_constant(len, true);
-            if validity.null_count() > 0 {
-                self.validity = Some(validity);
-            }
         }
     }
 


### PR DESCRIPTION
I noticed that the list builders in polars were extremely slow compared to the `concat` kernels, so I took a look why.

The flamegraph showed that this snippet was dominated by `null_counts`.

```rust
pub fn create_list(value: &Series, length: usize) -> ListChunked {
    let name = "foo";
    let mut builder =
        get_list_builder(value.dtype(), value.len() * length, length, name).unwrap();
    for _ in 0..length {
        builder.append_series(value)
    }
    builder.finish()
}


fn main() -> Result<()> {
    let value = Int32Chunked::full("", 10, 1000).into_series();

    for _ in 0..100 {
        create_list(&value, 1000);
    };
    Ok(())
}
```

The underlying code did a full bit count at every `extend_slice` call, leading to to `O(n^2)` behavior.

So the result improved drastically when I removed the redundant count.

```
bench_1                 time:   [129.73 us 129.86 us 130.01 us]
                        change: [-97.749% -97.737% -97.725%] (p = 0.00 < 0.05)
                        Performance has improved.

```