### PR TITLE
Rename `ArrowError` to `Error`

### DIFF
--- a/arrow-pyarrow-integration-testing/src/c_stream.rs
+++ b/arrow-pyarrow-integration-testing/src/c_stream.rs
@@ -19,7 +19,7 @@ pub fn to_rust_iterator(ob: PyObject, py: Python) -> PyResult<Vec<PyObject>> {
     ob.call_method1(py, "_export_to_c", (stream_ptr as Py_uintptr_t,))?;
 
     let mut iter =
-        unsafe { ffi::ArrowArrayStreamReader::try_new(stream).map_err(PyO3ArrowError::from) }?;
+        unsafe { ffi::ArrowArrayStreamReader::try_new(stream).map_err(PyO3Error::from) }?;
 
     let mut arrays = vec![];
     while let Some(array) = unsafe { iter.next() } {

--- a/benches/write_json.rs
+++ b/benches/write_json.rs
@@ -1,11 +1,11 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use arrow2::array::*;
-use arrow2::error::ArrowError;
+use arrow2::error::Error;
 use arrow2::io::json::write;
 use arrow2::util::bench_util::*;
 
-fn write_array(array: Box<dyn Array>) -> Result<(), ArrowError> {
+fn write_array(array: Box<dyn Array>) -> Result<(), Error> {
     let mut writer = vec![];
 
     let arrays = vec![Ok(array)].into_iter();

--- a/examples/json_write.rs
+++ b/examples/json_write.rs
@@ -2,11 +2,11 @@ use std::fs::File;
 
 use arrow2::{
     array::{Array, Int32Array},
-    error::ArrowError,
+    error::Error,
     io::json::write,
 };
 
-fn write_array(path: &str, array: Box<dyn Array>) -> Result<(), ArrowError> {
+fn write_array(path: &str, array: Box<dyn Array>) -> Result<(), Error> {
     let mut writer = File::create(path)?;
 
     let arrays = vec![Ok(array)].into_iter();
@@ -20,7 +20,7 @@ fn write_array(path: &str, array: Box<dyn Array>) -> Result<(), ArrowError> {
     Ok(())
 }
 
-fn main() -> Result<(), ArrowError> {
+fn main() -> Result<(), Error> {
     use std::env;
     let args: Vec<String> = env::args().collect();
 

--- a/examples/parquet_write_parallel/src/main.rs
+++ b/examples/parquet_write_parallel/src/main.rs
@@ -8,7 +8,7 @@ use arrow2::{
     array::*,
     chunk::Chunk as AChunk,
     datatypes::*,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     io::parquet::write::*,
 };
 
@@ -30,7 +30,7 @@ impl Bla {
 
 impl FallibleStreamingIterator for Bla {
     type Item = CompressedPage;
-    type Error = ArrowError;
+    type Error = Error;
 
     fn advance(&mut self) -> Result<()> {
         self.current = self.columns.pop_front();

--- a/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use arrow2::io::ipc::read;
 use arrow2::io::ipc::write;
 use arrow2::{
-    error::{ArrowError, Result},
+    error::{Error, Result},
     io::json_integration::write as json_write,
 };
 use arrow_integration_testing::read_json_file;
@@ -123,7 +123,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
 
     // compare schemas
     if &json_file.schema != arrow_schema {
-        return Err(ArrowError::InvalidArgumentError(format!(
+        return Err(Error::InvalidArgumentError(format!(
             "Schemas do not match. JSON: {:?}. Arrow: {:?}",
             json_file.schema, arrow_schema
         )));

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     bitmap::Bitmap,
     buffer::Buffer,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::{
@@ -55,13 +55,13 @@ impl<O: Offset> BinaryArray<O> {
             .as_ref()
             .map_or(false, |validity| validity.len() != offsets.len() - 1)
         {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "validity mask length must match the number of values",
             ));
         }
 
         if data_type.to_physical_type() != Self::default_data_type().to_physical_type() {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "BinaryArray can only be initialized with DataType::Binary or DataType::LargeBinary",
             ));
         }
@@ -158,13 +158,13 @@ impl<O: Offset> BinaryArray<O> {
             .as_ref()
             .map_or(false, |validity| validity.len() != offsets.len() - 1)
         {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "validity mask length must match the number of values",
             ));
         }
 
         if data_type.to_physical_type() != Self::default_data_type().to_physical_type() {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "BinaryArray can only be initialized with DataType::Binary or DataType::LargeBinary",
             ));
         }

--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -4,7 +4,7 @@ use crate::{
     array::{specification::check_offsets, Array, MutableArray, Offset, TryExtend, TryPush},
     bitmap::MutableBitmap,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     trusted_len::TrustedLen,
 };
 
@@ -427,7 +427,7 @@ impl<O: Offset, T: AsRef<[u8]>> TryPush<Option<T>> for MutableBinaryArray<O> {
                 let bytes = value.as_ref();
 
                 let size =
-                    O::from_usize(self.values.len() + bytes.len()).ok_or(ArrowError::Overflow)?;
+                    O::from_usize(self.values.len() + bytes.len()).ok_or(Error::Overflow)?;
 
                 self.values.extend_from_slice(bytes);
 

--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -426,8 +426,7 @@ impl<O: Offset, T: AsRef<[u8]>> TryPush<Option<T>> for MutableBinaryArray<O> {
             Some(value) => {
                 let bytes = value.as_ref();
 
-                let size =
-                    O::from_usize(self.values.len() + bytes.len()).ok_or(Error::Overflow)?;
+                let size = O::from_usize(self.values.len() + bytes.len()).ok_or(Error::Overflow)?;
 
                 self.values.extend_from_slice(bytes);
 

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, PhysicalType},
-    error::ArrowError,
+    error::Error,
 };
 use either::Either;
 
@@ -35,18 +35,18 @@ impl BooleanArray {
         data_type: DataType,
         values: Bitmap,
         validity: Option<Bitmap>,
-    ) -> Result<Self, ArrowError> {
+    ) -> Result<Self, Error> {
         if validity
             .as_ref()
             .map_or(false, |validity| validity.len() != values.len())
         {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "validity mask length must match the number of values",
             ));
         }
 
         if data_type.to_physical_type() != PhysicalType::Boolean {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "BooleanArray can only be initialized with a DataType whose physical type is Boolean",
             ));
         }

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -7,7 +7,7 @@ use crate::{
     array::{primitive::MutablePrimitiveArray, Array, MutableArray, TryExtend, TryPush},
     bitmap::MutableBitmap,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::{DictionaryArray, DictionaryKey};
@@ -91,7 +91,7 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
                 Ok(false)
             }
             None => {
-                let key = K::from_usize(self.map.len()).ok_or(ArrowError::Overflow)?;
+                let key = K::from_usize(self.map.len()).ok_or(Error::Overflow)?;
                 self.map.insert(hash, key);
                 self.keys.push(Some(key));
                 Ok(true)

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     bitmap::{Bitmap, MutableBitmap},
     buffer::Buffer,
     datatypes::DataType,
-    error::ArrowError,
+    error::Error,
 };
 
 use super::Array;
@@ -35,11 +35,11 @@ impl FixedSizeBinaryArray {
         data_type: DataType,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
-    ) -> Result<Self, ArrowError> {
+    ) -> Result<Self, Error> {
         let size = Self::maybe_get_size(&data_type)?;
 
         if values.len() % size != 0 {
-            return Err(ArrowError::oos(format!(
+            return Err(Error::oos(format!(
                 "values (of len {}) must be a multiple of size ({}) in FixedSizeBinaryArray.",
                 values.len(),
                 size
@@ -51,7 +51,7 @@ impl FixedSizeBinaryArray {
             .as_ref()
             .map_or(false, |validity| validity.len() != len)
         {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "validity mask length must be equal to the number of values divided by size",
             ));
         }
@@ -216,10 +216,10 @@ impl FixedSizeBinaryArray {
 }
 
 impl FixedSizeBinaryArray {
-    pub(crate) fn maybe_get_size(data_type: &DataType) -> Result<usize, ArrowError> {
+    pub(crate) fn maybe_get_size(data_type: &DataType) -> Result<usize, Error> {
         match data_type.to_logical_type() {
             DataType::FixedSizeBinary(size) => Ok(*size),
-            _ => Err(ArrowError::oos(
+            _ => Err(Error::oos(
                 "FixedSizeBinaryArray expects DataType::FixedSizeBinary",
             )),
         }
@@ -269,7 +269,7 @@ impl FixedSizeBinaryArray {
     pub fn try_from_iter<P: AsRef<[u8]>, I: IntoIterator<Item = Option<P>>>(
         iter: I,
         size: usize,
-    ) -> Result<Self, ArrowError> {
+    ) -> Result<Self, Error> {
         MutableFixedSizeBinaryArray::try_from_iter(iter, size).map(|x| x.into())
     }
 

--- a/src/array/fixed_size_binary/mutable.rs
+++ b/src/array/fixed_size_binary/mutable.rs
@@ -4,7 +4,7 @@ use crate::{
     array::{Array, MutableArray},
     bitmap::MutableBitmap,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::{FixedSizeBinaryArray, FixedSizeBinaryValues};
@@ -82,7 +82,7 @@ impl MutableFixedSizeBinaryArray {
             Some(bytes) => {
                 let bytes = bytes.as_ref();
                 if self.size != bytes.len() {
-                    return Err(ArrowError::InvalidArgumentError(
+                    return Err(Error::InvalidArgumentError(
                         "FixedSizeBinaryArray requires every item to be of its length".to_string(),
                     ));
                 }

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -4,7 +4,7 @@ use crate::{
     array::{Array, MutableArray, TryExtend, TryPush},
     bitmap::MutableBitmap,
     datatypes::{DataType, Field},
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::FixedSizeListArray;
@@ -80,7 +80,7 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
     /// This is a relatively low level function, prefer `try_push` when you can.
     pub fn try_push_valid(&mut self) -> Result<()> {
         if self.values.len() % self.size != 0 {
-            return Err(ArrowError::Overflow);
+            return Err(Error::Overflow);
         };
         if let Some(validity) = &mut self.validity {
             validity.push(true)

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -4,7 +4,7 @@ use crate::{
     array::{Array, MutableArray, Offset, TryExtend, TryPush},
     bitmap::MutableBitmap,
     datatypes::{DataType, Field},
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::ListArray;
@@ -129,7 +129,7 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
     /// This is a relatively low level function, prefer `try_push` when you can.
     pub fn try_push_valid(&mut self) -> Result<()> {
         let size = self.values.len();
-        let size = O::from_usize(size).ok_or(ArrowError::Overflow)?;
+        let size = O::from_usize(size).ok_or(Error::Overflow)?;
         assert!(size >= *self.offsets.last().unwrap());
 
         self.offsets.push(size);

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -3,7 +3,7 @@ use crate::{bitmap::Bitmap, datatypes::DataType};
 use crate::{
     array::{Array, FromFfi, ToFfi},
     datatypes::PhysicalType,
-    error::ArrowError,
+    error::Error,
     ffi,
 };
 
@@ -19,9 +19,9 @@ impl NullArray {
     /// # Errors
     /// This function errors iff:
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to [`crate::datatypes::PhysicalType::Null`].
-    pub fn try_new(data_type: DataType, length: usize) -> Result<Self, ArrowError> {
+    pub fn try_new(data_type: DataType, length: usize) -> Result<Self, Error> {
         if data_type.to_physical_type() != PhysicalType::Null {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "NullArray can only be initialized with a DataType whose physical type is Boolean",
             ));
         }
@@ -127,7 +127,7 @@ unsafe impl ToFfi for NullArray {
 }
 
 impl<A: ffi::ArrowArrayRef> FromFfi<A> for NullArray {
-    unsafe fn try_from_ffi(array: A) -> Result<Self, ArrowError> {
+    unsafe fn try_from_ffi(array: A) -> Result<Self, Error> {
         let data_type = array.data_type().clone();
         Self::try_new(data_type, array.array().len())
     }

--- a/src/array/ord.rs
+++ b/src/array/ord.rs
@@ -3,7 +3,7 @@
 use std::cmp::Ordering;
 
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::{array::*, types::NativeType};
 
 /// Compare the values at two arbitrary indices in two arrays.
@@ -181,7 +181,7 @@ pub fn build_compare(left: &dyn Array, right: &dyn Array) -> Result<DynComparato
     use TimeUnit::*;
     Ok(match (left.data_type(), right.data_type()) {
         (a, b) if a != b => {
-            return Err(ArrowError::InvalidArgumentError(
+            return Err(Error::InvalidArgumentError(
                 "Can't compare arrays of different types".to_string(),
             ));
         }
@@ -227,7 +227,7 @@ pub fn build_compare(left: &dyn Array, right: &dyn Array) -> Result<DynComparato
                 (IntegerType::Int32, IntegerType::Int32) => dyn_dict!(i32, left, right),
                 (IntegerType::Int64, IntegerType::Int64) => dyn_dict!(i64, left, right),
                 (lhs, _) => {
-                    return Err(ArrowError::InvalidArgumentError(format!(
+                    return Err(Error::InvalidArgumentError(format!(
                         "Dictionaries do not support keys of type {:?}",
                         lhs
                     )))
@@ -235,7 +235,7 @@ pub fn build_compare(left: &dyn Array, right: &dyn Array) -> Result<DynComparato
             }
         }
         (lhs, _) => {
-            return Err(ArrowError::InvalidArgumentError(format!(
+            return Err(Error::InvalidArgumentError(format!(
                 "The data type type {:?} has no natural order",
                 lhs
             )))

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     bitmap::Bitmap,
     buffer::Buffer,
     datatypes::*,
-    error::ArrowError,
+    error::Error,
     types::{days_ms, months_days_ns, NativeType},
 };
 
@@ -48,18 +48,18 @@ impl<T: NativeType> PrimitiveArray<T> {
         data_type: DataType,
         values: Buffer<T>,
         validity: Option<Bitmap>,
-    ) -> Result<Self, ArrowError> {
+    ) -> Result<Self, Error> {
         if validity
             .as_ref()
             .map_or(false, |validity| validity.len() != values.len())
         {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "validity mask length must match the number of values",
             ));
         }
 
         if data_type.to_physical_type() != PhysicalType::Primitive(T::PRIMITIVE) {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "BooleanArray can only be initialized with a DataType whose physical type is Primitive",
             ));
         }
@@ -199,7 +199,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     #[inline]
     pub fn to(self, data_type: DataType) -> Self {
         if !data_type.to_physical_type().eq_primitive(T::PRIMITIVE) {
-            Err(ArrowError::InvalidArgumentError(format!(
+            Err(Error::InvalidArgumentError(format!(
                 "Type {} does not support logical type {:?}",
                 std::any::type_name::<T>(),
                 data_type

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -5,7 +5,7 @@ use crate::{
     array::{Array, MutableArray, TryExtend, TryPush},
     bitmap::MutableBitmap,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     trusted_len::TrustedLen,
     types::NativeType,
 };
@@ -60,7 +60,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     /// * The validity is not `None` and its length is different from the `values`'s length
     pub fn from_data(data_type: DataType, values: Vec<T>, validity: Option<MutableBitmap>) -> Self {
         if !data_type.to_physical_type().eq_primitive(T::PRIMITIVE) {
-            Err(ArrowError::InvalidArgumentError(format!(
+            Err(Error::InvalidArgumentError(format!(
                 "Type {} does not support logical type {:?}",
                 std::any::type_name::<T>(),
                 data_type

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -1,15 +1,15 @@
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::types::Offset;
 
 pub fn try_check_offsets_bounds<O: Offset>(offsets: &[O], values_len: usize) -> Result<usize> {
     if let Some(last_offset) = offsets.last() {
         if last_offset.to_usize() > values_len {
-            Err(ArrowError::oos("offsets must not exceed the values length"))
+            Err(Error::oos("offsets must not exceed the values length"))
         } else {
             Ok(last_offset.to_usize())
         }
     } else {
-        Err(ArrowError::oos("offsets must have at least one element"))
+        Err(Error::oos("offsets must have at least one element"))
     }
 }
 
@@ -54,7 +54,7 @@ pub fn try_check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) -> Re
 
             // check monotonicity
             if start > end {
-                return Err(ArrowError::oos("offsets must be monotonically increasing"));
+                return Err(Error::oos("offsets must be monotonically increasing"));
             }
 
             let first = values.get(start);
@@ -63,7 +63,7 @@ pub fn try_check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) -> Re
                 // A valid code-point iff it does not start with 0b10xxxxxx
                 // Bit-magic taken from `std::str::is_char_boundary`
                 if (b as i8) < -0x40 {
-                    return Err(ArrowError::oos("Non-valid char boundary detected"));
+                    return Err(Error::oos("Non-valid char boundary detected"));
                 }
             }
         }
@@ -72,7 +72,7 @@ pub fn try_check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) -> Re
             .last()
             .map_or(true, |last| last.to_usize() > values.len())
         {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "offsets must have at least one element and must not exceed values length",
             ));
         };
@@ -92,12 +92,12 @@ pub fn check_offsets<O: Offset>(offsets: &[O], values_len: usize) {
 /// `values_len`.
 pub fn try_check_offsets<O: Offset>(offsets: &[O], values_len: usize) -> Result<()> {
     if offsets.windows(2).any(|window| window[0] > window[1]) {
-        Err(ArrowError::oos("offsets must be monotonically increasing"))
+        Err(Error::oos("offsets must be monotonically increasing"))
     } else if offsets
         .last()
         .map_or(true, |last| last.to_usize() > values_len)
     {
-        Err(ArrowError::oos(
+        Err(Error::oos(
             "offsets must have at least one element and must not exceed values length",
         ))
     } else {

--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, Field},
-    error::ArrowError,
+    error::Error,
 };
 
 use super::{new_empty_array, new_null_array, Array};
@@ -50,15 +50,15 @@ impl StructArray {
         data_type: DataType,
         values: Vec<Arc<dyn Array>>,
         validity: Option<Bitmap>,
-    ) -> Result<Self, ArrowError> {
+    ) -> Result<Self, Error> {
         let fields = Self::try_get_fields(&data_type)?;
         if fields.is_empty() {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "A StructArray must contain at least one field",
             ));
         }
         if fields.len() != values.len() {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "A StructArray must a number of fields in its DataType equal to the number of child values",
             ));
         }
@@ -69,7 +69,7 @@ impl StructArray {
             .enumerate()
             .try_for_each(|(index, (data_type, child))| {
                 if data_type != child {
-                    Err(ArrowError::oos(format!(
+                    Err(Error::oos(format!(
                         "The children DataTypes of a StructArray must equal the children data types. 
                          However, the field {index} has data type {data_type:?} but the value has data type {child:?}"
                     )))
@@ -85,7 +85,7 @@ impl StructArray {
             .enumerate()
             .try_for_each(|(index, a_len)| {
                 if a_len != len {
-                    Err(ArrowError::oos(format!(
+                    Err(Error::oos(format!(
                         "The children DataTypes of a StructArray must equal the children data types.
                          However, the values {index} has a length of {a_len}, which is different from values 0, {len}."
                     )))
@@ -98,7 +98,7 @@ impl StructArray {
             .as_ref()
             .map_or(false, |validity| validity.len() != len)
         {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "The validity length of a StructArray must match its number of elements",
             ));
         }
@@ -253,10 +253,10 @@ impl StructArray {
 
 impl StructArray {
     /// Returns the fields the `DataType::Struct`.
-    pub(crate) fn try_get_fields(data_type: &DataType) -> Result<&[Field], ArrowError> {
+    pub(crate) fn try_get_fields(data_type: &DataType) -> Result<&[Field], Error> {
         match data_type.to_logical_type() {
             DataType::Struct(fields) => Ok(fields),
-            _ => Err(ArrowError::oos(
+            _ => Err(Error::oos(
                 "Struct array must be created with a DataType whose physical type is Struct",
             )),
         }

--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -53,9 +53,7 @@ impl StructArray {
     ) -> Result<Self, Error> {
         let fields = Self::try_get_fields(&data_type)?;
         if fields.is_empty() {
-            return Err(Error::oos(
-                "A StructArray must contain at least one field",
-            ));
+            return Err(Error::oos("A StructArray must contain at least one field"));
         }
         if fields.len() != values.len() {
             return Err(Error::oos(

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     bitmap::Bitmap,
     buffer::Buffer,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 use either::Either;
 
@@ -68,13 +68,13 @@ impl<O: Offset> Utf8Array<O> {
             .as_ref()
             .map_or(false, |validity| validity.len() != offsets.len() - 1)
         {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "validity mask length must match the number of values",
             ));
         }
 
         if data_type.to_physical_type() != Self::default_data_type().to_physical_type() {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "Utf8Array can only be initialized with DataType::Utf8 or DataType::LargeUtf8",
             ));
         }
@@ -177,13 +177,13 @@ impl<O: Offset> Utf8Array<O> {
             .as_ref()
             .map_or(false, |validity| validity.len() != offsets.len() - 1)
         {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "validity mask length must match the number of values",
             ));
         }
 
         if data_type.to_physical_type() != Self::default_data_type().to_physical_type() {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "BinaryArray can only be initialized with DataType::Utf8 or DataType::LargeUtf8",
             ));
         }

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     bitmap::MutableBitmap,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     trusted_len::TrustedLen,
 };
 
@@ -513,7 +513,7 @@ impl<O: Offset, T: AsRef<str>> TryPush<Option<T>> for MutableUtf8Array<O> {
                 let bytes = value.as_ref().as_bytes();
                 self.values.extend_from_slice(bytes);
 
-                let size = O::from_usize(self.values.len()).ok_or(ArrowError::Overflow)?;
+                let size = O::from_usize(self.values.len()).ok_or(Error::Overflow)?;
 
                 self.offsets.push(size);
 

--- a/src/chunk.rs
+++ b/src/chunk.rs
@@ -2,7 +2,7 @@
 //! same length.
 
 use crate::array::Array;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 /// A vector of trait objects of [`Array`] where every item has
 /// the same length, [`Chunk::len`].
@@ -30,7 +30,7 @@ impl<A: AsRef<dyn Array>> Chunk<A> {
                 .map(|array| array.as_ref())
                 .any(|array| array.len() != len)
             {
-                return Err(ArrowError::InvalidArgumentError(
+                return Err(Error::InvalidArgumentError(
                     "Chunk require all its arrays to have an equal number of rows".to_string(),
                 ));
             }

--- a/src/compute/aggregate/min_max.rs
+++ b/src/compute/aggregate/min_max.rs
@@ -1,6 +1,6 @@
 use crate::bitmap::utils::{BitChunkIterExact, BitChunksExact};
 use crate::datatypes::{DataType, PhysicalType, PrimitiveType};
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::scalar::*;
 use crate::types::simd::*;
 use crate::types::NativeType;
@@ -326,7 +326,7 @@ macro_rules! with_match_primitive_type {(
         UInt64 => __with_ty__! { u64 },
         Float32 => __with_ty__! { f32 },
         Float64 => __with_ty__! { f64 },
-        _ => return Err(ArrowError::InvalidArgumentError(format!(
+        _ => return Err(Error::InvalidArgumentError(format!(
             "`min` and `max` operator do not support primitive `{:?}`",
             $key_type,
         ))),
@@ -353,7 +353,7 @@ pub fn max(array: &dyn Array) -> Result<Box<dyn Scalar>> {
             dyn_generic!(BinaryArray<i64>, BinaryScalar<i64>, array, min_binary)
         }
         _ => {
-            return Err(ArrowError::InvalidArgumentError(format!(
+            return Err(Error::InvalidArgumentError(format!(
                 "The `max` operator does not support type `{:?}`",
                 array.data_type(),
             )))
@@ -381,7 +381,7 @@ pub fn min(array: &dyn Array) -> Result<Box<dyn Scalar>> {
             dyn_generic!(BinaryArray<i64>, BinaryScalar<i64>, array, min_binary)
         }
         _ => {
-            return Err(ArrowError::InvalidArgumentError(format!(
+            return Err(Error::InvalidArgumentError(format!(
                 "The `max` operator does not support type `{:?}`",
                 array.data_type(),
             )))

--- a/src/compute/aggregate/sum.rs
+++ b/src/compute/aggregate/sum.rs
@@ -4,7 +4,7 @@ use multiversion::multiversion;
 
 use crate::bitmap::utils::{BitChunkIterExact, BitChunksExact};
 use crate::datatypes::{DataType, PhysicalType, PrimitiveType};
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::scalar::*;
 use crate::types::simd::*;
 use crate::types::NativeType;
@@ -134,7 +134,7 @@ macro_rules! with_match_primitive_type {(
         UInt64 => __with_ty__! { u64 },
         Float32 => __with_ty__! { f32 },
         Float64 => __with_ty__! { f64 },
-        _ => return Err(ArrowError::InvalidArgumentError(format!(
+        _ => return Err(Error::InvalidArgumentError(format!(
             "`sum` operator do not support primitive `{:?}`",
             $key_type,
         ))),
@@ -153,7 +153,7 @@ pub fn sum(array: &dyn Array) -> Result<Box<dyn Scalar>> {
             Box::new(PrimitiveScalar::new(data_type, sum_primitive::<$T>(array)))
         }),
         _ => {
-            return Err(ArrowError::InvalidArgumentError(format!(
+            return Err(Error::InvalidArgumentError(format!(
                 "The `sum` operator does not support type `{:?}`",
                 array.data_type(),
             )))

--- a/src/compute/arithmetics/decimal/add.rs
+++ b/src/compute/arithmetics/decimal/add.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use crate::{
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::{adjusted_precision_scale, get_parameters, max_value, number_digits};
@@ -193,7 +193,7 @@ pub fn adaptive_add(
         {
             (*lhs_p, *lhs_s, *rhs_p, *rhs_s)
         } else {
-            return Err(ArrowError::InvalidArgumentError(
+            return Err(Error::InvalidArgumentError(
                 "Incorrect data type for the array".to_string(),
             ));
         };

--- a/src/compute/arithmetics/decimal/div.rs
+++ b/src/compute/arithmetics/decimal/div.rs
@@ -9,7 +9,7 @@ use crate::{
         utils::{check_same_len, combine_validities},
     },
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     scalar::{PrimitiveScalar, Scalar},
 };
 
@@ -253,7 +253,7 @@ pub fn adaptive_div(
         {
             (*lhs_p, *lhs_s, *rhs_p, *rhs_s)
         } else {
-            return Err(ArrowError::InvalidArgumentError(
+            return Err(Error::InvalidArgumentError(
                 "Incorrect data type for the array".to_string(),
             ));
         };

--- a/src/compute/arithmetics/decimal/mod.rs
+++ b/src/compute/arithmetics/decimal/mod.rs
@@ -13,7 +13,7 @@ mod sub;
 pub use sub::*;
 
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 /// Maximum value that can exist with a selected precision
 #[inline]
@@ -42,7 +42,7 @@ fn get_parameters(lhs: &DataType, rhs: &DataType) -> Result<(usize, usize)> {
         if lhs_p == rhs_p && lhs_s == rhs_s {
             Ok((*lhs_p, *lhs_s))
         } else {
-            Err(ArrowError::InvalidArgumentError(
+            Err(Error::InvalidArgumentError(
                 "Arrays must have the same precision and scale".to_string(),
             ))
         }

--- a/src/compute/arithmetics/decimal/mul.rs
+++ b/src/compute/arithmetics/decimal/mul.rs
@@ -9,7 +9,7 @@ use crate::{
         utils::{check_same_len, combine_validities},
     },
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     scalar::{PrimitiveScalar, Scalar},
 };
 
@@ -265,7 +265,7 @@ pub fn adaptive_mul(
         {
             (*lhs_p, *lhs_s, *rhs_p, *rhs_s)
         } else {
-            return Err(ArrowError::InvalidArgumentError(
+            return Err(Error::InvalidArgumentError(
                 "Incorrect data type for the array".to_string(),
             ));
         };

--- a/src/compute/arithmetics/decimal/sub.rs
+++ b/src/compute/arithmetics/decimal/sub.rs
@@ -8,7 +8,7 @@ use crate::{
         utils::{check_same_len, combine_validities},
     },
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::{adjusted_precision_scale, get_parameters, max_value, number_digits};
@@ -192,7 +192,7 @@ pub fn adaptive_sub(
         {
             (*lhs_p, *lhs_s, *rhs_p, *rhs_s)
         } else {
-            return Err(ArrowError::InvalidArgumentError(
+            return Err(Error::InvalidArgumentError(
                 "Incorrect data type for the array".to_string(),
             ));
         };

--- a/src/compute/arithmetics/time.rs
+++ b/src/compute/arithmetics/time.rs
@@ -17,7 +17,7 @@ use crate::{
     array::PrimitiveArray,
     compute::arity::{binary, unary},
     datatypes::{DataType, TimeUnit},
-    error::{ArrowError, Result},
+    error::{Error, Result},
     scalar::{PrimitiveScalar, Scalar},
     temporal_conversions,
     types::{months_days_ns, NativeType},
@@ -54,7 +54,7 @@ fn create_scale(lhs: &DataType, rhs: &DataType) -> Result<f64> {
             temporal_conversions::timeunit_scale(TimeUnit::Millisecond, *timeunit)
         }
         _ => {
-            return Err(ArrowError::InvalidArgumentError(
+            return Err(Error::InvalidArgumentError(
                 "Incorrect data type for the arguments".to_string(),
             ));
         }
@@ -271,7 +271,7 @@ pub fn subtract_timestamps(
 
             Ok(binary(lhs, rhs, DataType::Duration(*timeunit_a), op))
         }
-        _ => Err(ArrowError::InvalidArgumentError(
+        _ => Err(Error::InvalidArgumentError(
             "Incorrect data type for the arguments".to_string(),
         )),
     }
@@ -291,7 +291,7 @@ pub fn sub_timestamps_scalar(
                 timeunit_a,
             )
         } else {
-            return Err(ArrowError::InvalidArgumentError(
+            return Err(Error::InvalidArgumentError(
                 "sub_timestamps_scalar requires both arguments to be timestamps without timezone"
                     .to_string(),
             ));
@@ -346,7 +346,7 @@ pub fn add_interval(
                     ))
                 }
                 #[cfg(not(feature = "chrono-tz"))]
-                _ => Err(ArrowError::InvalidArgumentError(format!(
+                _ => Err(Error::InvalidArgumentError(format!(
                     "timezone \"{}\" cannot be parsed (feature chrono-tz is not active)",
                     timezone_str
                 ))),
@@ -363,7 +363,7 @@ pub fn add_interval(
                 },
             ))
         }
-        _ => Err(ArrowError::InvalidArgumentError(
+        _ => Err(Error::InvalidArgumentError(
             "Adding an interval is only supported for `DataType::Timestamp`".to_string(),
         )),
     }
@@ -411,7 +411,7 @@ pub fn add_interval_scalar(
                     ))
                 }
                 #[cfg(not(feature = "chrono-tz"))]
-                _ => Err(ArrowError::InvalidArgumentError(format!(
+                _ => Err(Error::InvalidArgumentError(format!(
                     "timezone \"{}\" cannot be parsed (feature chrono-tz is not active)",
                     timezone_str
                 ))),
@@ -427,7 +427,7 @@ pub fn add_interval_scalar(
                 timestamp.data_type().clone(),
             ))
         }
-        _ => Err(ArrowError::InvalidArgumentError(
+        _ => Err(Error::InvalidArgumentError(
             "Adding an interval is only supported for `DataType::Timestamp`".to_string(),
         )),
     }

--- a/src/compute/boolean.rs
+++ b/src/compute/boolean.rs
@@ -2,7 +2,7 @@
 use crate::array::{Array, BooleanArray};
 use crate::bitmap::{Bitmap, MutableBitmap};
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::scalar::BooleanScalar;
 
 use super::utils::combine_validities;
@@ -13,7 +13,7 @@ where
     F: Fn(&Bitmap, &Bitmap) -> Bitmap,
 {
     if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Cannot perform bitwise operation on arrays of different length".to_string(),
         ));
     }

--- a/src/compute/boolean_kleene.rs
+++ b/src/compute/boolean_kleene.rs
@@ -1,6 +1,6 @@
 //! Boolean operators of [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics).
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::scalar::BooleanScalar;
 use crate::{
     array::BooleanArray,
@@ -26,7 +26,7 @@ use crate::{
 /// ```
 pub fn or(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
     if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Cannot perform bitwise operation on arrays of different length".to_string(),
         ));
     }
@@ -116,7 +116,7 @@ pub fn or(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
 /// ```
 pub fn and(lhs: &BooleanArray, rhs: &BooleanArray) -> Result<BooleanArray> {
     if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Cannot perform bitwise operation on arrays of different length".to_string(),
         ));
     }

--- a/src/compute/cast/binary_to.rs
+++ b/src/compute/cast/binary_to.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::{array::*, datatypes::DataType, types::NativeType};
 
 use super::CastOptions;
@@ -25,7 +25,7 @@ pub fn binary_large_to_binary(
 ) -> Result<BinaryArray<i32>> {
     let values = from.values().clone();
     let _ =
-        i32::try_from(*from.offsets().last().unwrap()).map_err(ArrowError::from_external_error)?;
+        i32::try_from(*from.offsets().last().unwrap()).map_err(Error::from_external_error)?;
 
     let offsets = from.offsets().iter().map(|x| *x as i32).collect::<Vec<_>>();
     // todo: use `new_unchecked` since all invariants are preserved

--- a/src/compute/cast/binary_to.rs
+++ b/src/compute/cast/binary_to.rs
@@ -24,8 +24,7 @@ pub fn binary_large_to_binary(
     to_data_type: DataType,
 ) -> Result<BinaryArray<i32>> {
     let values = from.values().clone();
-    let _ =
-        i32::try_from(*from.offsets().last().unwrap()).map_err(Error::from_external_error)?;
+    let _ = i32::try_from(*from.offsets().last().unwrap()).map_err(Error::from_external_error)?;
 
     let offsets = from.offsets().iter().map(|x| *x as i32).collect::<Vec<_>>();
     // todo: use `new_unchecked` since all invariants are preserved

--- a/src/compute/cast/dictionary_to.rs
+++ b/src/compute/cast/dictionary_to.rs
@@ -3,7 +3,7 @@ use crate::{
     array::{Array, DictionaryArray, DictionaryKey, PrimitiveArray},
     compute::{cast::cast, take::take},
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 macro_rules! key_cast {
@@ -13,7 +13,7 @@ macro_rules! key_cast {
         // Failure to cast keys (because they don't fit in the
         // target type) results in NULL values;
         if cast_keys.null_count() > $keys.null_count() {
-            return Err(ArrowError::Overflow);
+            return Err(Error::Overflow);
         }
         Ok(Box::new(DictionaryArray::<$to_type>::from_data(
             cast_keys, $values,
@@ -74,7 +74,7 @@ where
     let casted_keys = primitive_to_primitive::<K1, K2>(keys, &K2::PRIMITIVE.into());
 
     if casted_keys.null_count() > keys.null_count() {
-        Err(ArrowError::Overflow)
+        Err(Error::Overflow)
     } else {
         Ok(DictionaryArray::from_data(casted_keys, values.clone()))
     }
@@ -94,7 +94,7 @@ where
     let casted_keys = primitive_as_primitive::<K1, K2>(keys, &K2::PRIMITIVE.into());
 
     if casted_keys.null_count() > keys.null_count() {
-        Err(ArrowError::Overflow)
+        Err(Error::Overflow)
     } else {
         Ok(DictionaryArray::from_data(casted_keys, values.clone()))
     }

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -17,7 +17,7 @@ pub use utf8_to::*;
 use crate::{
     array::*,
     datatypes::*,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 /// options defining how Cast kernels behave
@@ -389,10 +389,10 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             | Int64 | UInt64 | Float64 | Date64 | List(_) | Dictionary(..),
             Null,
         ) => Ok(new_null_array(to_type.clone(), array.len())),
-        (Struct(_), _) => Err(ArrowError::NotYetImplemented(
+        (Struct(_), _) => Err(Error::NotYetImplemented(
             "Cannot cast from struct to other types".to_string(),
         )),
-        (_, Struct(_)) => Err(ArrowError::NotYetImplemented(
+        (_, Struct(_)) => Err(Error::NotYetImplemented(
             "Cannot cast to struct from other types".to_string(),
         )),
         (List(_), List(_)) => {
@@ -442,7 +442,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             Int64 => primitive_to_boolean_dyn::<i64>(array, to_type.clone()),
             Float32 => primitive_to_boolean_dyn::<f32>(array, to_type.clone()),
             Float64 => primitive_to_boolean_dyn::<f64>(array, to_type.clone()),
-            _ => Err(ArrowError::NotYetImplemented(format!(
+            _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -462,7 +462,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             LargeUtf8 => boolean_to_utf8_dyn::<i64>(array),
             Binary => boolean_to_binary_dyn::<i32>(array),
             LargeBinary => boolean_to_binary_dyn::<i64>(array),
-            _ => Err(ArrowError::NotYetImplemented(format!(
+            _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -488,7 +488,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             Timestamp(TimeUnit::Nanosecond, Some(tz)) => {
                 utf8_to_timestamp_ns_dyn::<i32>(array, tz.clone())
             }
-            _ => Err(ArrowError::NotYetImplemented(format!(
+            _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -512,7 +512,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             Timestamp(TimeUnit::Nanosecond, Some(tz)) => {
                 utf8_to_timestamp_ns_dyn::<i64>(array, tz.clone())
             }
-            _ => Err(ArrowError::NotYetImplemented(format!(
+            _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -548,7 +548,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
                 let from = array.as_any().downcast_ref().unwrap();
                 Ok(Box::new(naive_timestamp_to_utf8::<i32>(from, *from_unit)))
             }
-            _ => Err(ArrowError::NotYetImplemented(format!(
+            _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -584,7 +584,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
                 let from = array.as_any().downcast_ref().unwrap();
                 Ok(Box::new(naive_timestamp_to_utf8::<i64>(from, *from_unit)))
             }
-            _ => Err(ArrowError::NotYetImplemented(format!(
+            _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -605,7 +605,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
                 array.as_any().downcast_ref().unwrap(),
                 to_type.clone(),
             ))),
-            _ => Err(ArrowError::NotYetImplemented(format!(
+            _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -626,7 +626,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
                 binary_large_to_binary(array.as_any().downcast_ref().unwrap(), to_type.clone())
                     .map(|x| Box::new(x) as Box<dyn Array>)
             }
-            _ => Err(ArrowError::NotYetImplemented(format!(
+            _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -643,7 +643,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             Int64 => primitive_to_binary_dyn::<i64, i32>(array),
             Float32 => primitive_to_binary_dyn::<f32, i32>(array),
             Float64 => primitive_to_binary_dyn::<f64, i32>(array),
-            _ => Err(ArrowError::NotYetImplemented(format!(
+            _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -660,7 +660,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             Int64 => primitive_to_binary_dyn::<i64, i64>(array),
             Float32 => primitive_to_binary_dyn::<f32, i64>(array),
             Float64 => primitive_to_binary_dyn::<f64, i64>(array),
-            _ => Err(ArrowError::NotYetImplemented(format!(
+            _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {:?} to {:?} not supported",
                 from_type, to_type,
             ))),
@@ -850,7 +850,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             primitive_dyn!(array, months_to_months_days_ns)
         }
 
-        (_, _) => Err(ArrowError::NotYetImplemented(format!(
+        (_, _) => Err(Error::NotYetImplemented(format!(
             "Casting from {:?} to {:?} not supported",
             from_type, to_type,
         ))),
@@ -881,7 +881,7 @@ fn cast_to_dictionary<K: DictionaryKey>(
         DataType::LargeUtf8 => utf8_to_dictionary_dyn::<i64, K>(array),
         DataType::Binary => binary_to_dictionary_dyn::<i32, K>(array),
         DataType::LargeBinary => binary_to_dictionary_dyn::<i64, K>(array),
-        _ => Err(ArrowError::NotYetImplemented(format!(
+        _ => Err(Error::NotYetImplemented(format!(
             "Unsupported output type for dictionary packing: {:?}",
             dict_value_type
         ))),

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -489,8 +489,8 @@ fn chrono_tz_timestamp_to_utf8<O: Offset>(
     _: TimeUnit,
     timezone_str: &str,
 ) -> Result<Utf8Array<O>> {
-    use crate::error::ArrowError;
-    Err(ArrowError::InvalidArgumentError(format!(
+    use crate::error::Error;
+    Err(Error::InvalidArgumentError(format!(
         "timezone \"{}\" cannot be parsed (feature chrono-tz is not active)",
         timezone_str
     )))

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -5,7 +5,7 @@ use chrono::Datelike;
 use crate::{
     array::*,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     temporal_conversions::{
         utf8_to_naive_timestamp_ns as utf8_to_naive_timestamp_ns_,
         utf8_to_timestamp_ns as utf8_to_timestamp_ns_, EPOCH_DAYS_FROM_CE,
@@ -165,7 +165,7 @@ pub fn utf8_large_to_utf8(from: &Utf8Array<i64>) -> Result<Utf8Array<i32>> {
     let validity = from.validity().cloned();
     let values = from.values().clone();
     let _ =
-        i32::try_from(*from.offsets().last().unwrap()).map_err(ArrowError::from_external_error)?;
+        i32::try_from(*from.offsets().last().unwrap()).map_err(Error::from_external_error)?;
 
     let offsets = from
         .offsets()

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -164,8 +164,7 @@ pub fn utf8_large_to_utf8(from: &Utf8Array<i64>) -> Result<Utf8Array<i32>> {
     let data_type = Utf8Array::<i32>::default_data_type();
     let validity = from.validity().cloned();
     let values = from.values().clone();
-    let _ =
-        i32::try_from(*from.offsets().last().unwrap()).map_err(Error::from_external_error)?;
+    let _ = i32::try_from(*from.offsets().last().unwrap()).map_err(Error::from_external_error)?;
 
     let offsets = from
         .offsets()

--- a/src/compute/concatenate.rs
+++ b/src/compute/concatenate.rs
@@ -14,12 +14,12 @@
 //! ```
 
 use crate::array::{growable::make_growable, Array};
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 /// Concatenate multiple [Array] of the same type into a single [`Array`].
 pub fn concatenate(arrays: &[&dyn Array]) -> Result<Box<dyn Array>> {
     if arrays.is_empty() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "concat requires input of at least one array".to_string(),
         ));
     }
@@ -28,7 +28,7 @@ pub fn concatenate(arrays: &[&dyn Array]) -> Result<Box<dyn Array>> {
         .iter()
         .any(|array| array.data_type() != arrays[0].data_type())
     {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "It is not possible to concatenate arrays of different data types.".to_string(),
         ));
     }

--- a/src/compute/contains.rs
+++ b/src/compute/contains.rs
@@ -4,7 +4,7 @@ use crate::{
     array::{Array, BinaryArray, BooleanArray, ListArray, Offset, PrimitiveArray, Utf8Array},
     bitmap::Bitmap,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     types::NativeType,
 };
 
@@ -18,12 +18,12 @@ where
     O: Offset,
 {
     if list.len() != values.len() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Contains requires arrays of the same length".to_string(),
         ));
     }
     if list.values().data_type() != values.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Contains requires the inner array to be of the same logical type".to_string(),
         ));
     }
@@ -52,12 +52,12 @@ where
     OO: Offset,
 {
     if list.len() != values.len() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Contains requires arrays of the same length".to_string(),
         ));
     }
     if list.values().data_type() != values.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Contains requires the inner array to be of the same logical type".to_string(),
         ));
     }
@@ -86,12 +86,12 @@ where
     OO: Offset,
 {
     if list.len() != values.len() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Contains requires arrays of the same length".to_string(),
         ));
     }
     if list.values().data_type() != values.data_type() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Contains requires the inner array to be of the same logical type".to_string(),
         ));
     }
@@ -190,7 +190,7 @@ pub fn contains(list: &dyn Array, values: &dyn Array) -> Result<BooleanArray> {
         (DataType::LargeList(_), DataType::UInt64) => primitive!(list, values, i64, u64),
         (DataType::LargeList(_), DataType::Float32) => primitive!(list, values, i64, f32),
         (DataType::LargeList(_), DataType::Float64) => primitive!(list, values, i64, f64),
-        _ => Err(ArrowError::NotYetImplemented(format!(
+        _ => Err(Error::NotYetImplemented(format!(
             "Contains is not supported between logical types \"{:?}\" and \"{:?}\"",
             list_data_type, values_data_type
         ))),

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -14,7 +14,7 @@ macro_rules! new_state {
 use crate::{
     array::{Array, BinaryArray, BooleanArray, Offset, PrimitiveArray, Utf8Array},
     datatypes::{DataType, PhysicalType, PrimitiveType},
-    error::{ArrowError, Result},
+    error::{Error, Result},
     types::NativeType,
 };
 
@@ -89,7 +89,7 @@ macro_rules! with_match_primitive_type {(
         UInt16 => __with_ty__! { u16 },
         UInt32 => __with_ty__! { u32 },
         UInt64 => __with_ty__! { u64 },
-        _ => return Err(ArrowError::NotYetImplemented(format!(
+        _ => return Err(Error::NotYetImplemented(format!(
             "Hash not implemented for type {:?}",
             $key_type
         )))
@@ -116,7 +116,7 @@ pub fn hash(array: &dyn Array) -> Result<PrimitiveArray<u64>> {
         Utf8 => hash_utf8::<i32>(array.as_any().downcast_ref().unwrap()),
         LargeUtf8 => hash_utf8::<i64>(array.as_any().downcast_ref().unwrap()),
         t => {
-            return Err(ArrowError::NotYetImplemented(format!(
+            return Err(Error::NotYetImplemented(format!(
                 "Hash not implemented for type {:?}",
                 t
             )))

--- a/src/compute/if_then_else.rs
+++ b/src/compute/if_then_else.rs
@@ -1,7 +1,7 @@
 //! Contains the operator [`if_then_else`].
 use crate::array::{growable, Array, BooleanArray};
 use crate::bitmap::utils::SlicesIterator;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 /// Returns the values from `lhs` if the predicate is `true` or from the `rhs` if the predicate is false
 /// Returns `None` if the predicate is `None`.
@@ -29,14 +29,14 @@ pub fn if_then_else(
     rhs: &dyn Array,
 ) -> Result<Box<dyn Array>> {
     if lhs.data_type() != rhs.data_type() {
-        return Err(ArrowError::InvalidArgumentError(format!(
+        return Err(Error::InvalidArgumentError(format!(
             "If then else requires the arguments to have the same datatypes ({:?} != {:?})",
             lhs.data_type(),
             rhs.data_type()
         )));
     }
     if (lhs.len() != rhs.len()) | (lhs.len() != predicate.len()) {
-        return Err(ArrowError::InvalidArgumentError(format!(
+        return Err(Error::InvalidArgumentError(format!(
             "If then else requires all arguments to have the same length (predicate = {}, lhs = {}, rhs = {})",
             predicate.len(),
             lhs.len(),

--- a/src/compute/length.rs
+++ b/src/compute/length.rs
@@ -20,7 +20,7 @@
 use crate::{
     array::*,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     types::NativeType,
 };
 
@@ -55,7 +55,7 @@ pub fn length(array: &dyn Array) -> Result<Box<dyn Array>> {
             let array = array.as_any().downcast_ref::<Utf8Array<i64>>().unwrap();
             Ok(Box::new(unary_offsets_string::<i64, _>(array, |x| x)))
         }
-        _ => Err(ArrowError::InvalidArgumentError(format!(
+        _ => Err(Error::InvalidArgumentError(format!(
             "length not supported for {:?}",
             array.data_type()
         ))),

--- a/src/compute/like.rs
+++ b/src/compute/like.rs
@@ -9,7 +9,7 @@ use crate::{
     bitmap::Bitmap,
     compute::utils::combine_validities,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 #[inline]
@@ -28,7 +28,7 @@ fn a_like_utf8<O: Offset, F: Fn(bool) -> bool>(
     op: F,
 ) -> Result<BooleanArray> {
     if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Cannot perform comparison operation on arrays of different length".to_string(),
         ));
     }
@@ -46,7 +46,7 @@ fn a_like_utf8<O: Offset, F: Fn(bool) -> bool>(
                     } else {
                         let re_pattern = replace_pattern(pattern);
                         let re = Regex::new(&format!("^{}$", re_pattern)).map_err(|e| {
-                            ArrowError::InvalidArgumentError(format!(
+                            Error::InvalidArgumentError(format!(
                                 "Unable to build regex from LIKE pattern: {}",
                                 e
                             ))
@@ -119,10 +119,7 @@ fn a_like_utf8_scalar<O: Offset, F: Fn(bool) -> bool>(
     } else {
         let re_pattern = replace_pattern(rhs);
         let re = Regex::new(&format!("^{}$", re_pattern)).map_err(|e| {
-            ArrowError::InvalidArgumentError(format!(
-                "Unable to build regex from LIKE pattern: {}",
-                e
-            ))
+            Error::InvalidArgumentError(format!("Unable to build regex from LIKE pattern: {}", e))
         })?;
         Bitmap::from_trusted_len_iter(lhs.values_iter().map(|x| op(re.is_match(x))))
     };
@@ -175,7 +172,7 @@ fn a_like_binary<O: Offset, F: Fn(bool) -> bool>(
     op: F,
 ) -> Result<BooleanArray> {
     if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Cannot perform comparison operation on arrays of different length".to_string(),
         ));
     }
@@ -194,7 +191,7 @@ fn a_like_binary<O: Offset, F: Fn(bool) -> bool>(
                         let re_pattern = simdutf8::basic::from_utf8(pattern).unwrap();
                         let re_pattern = replace_pattern(re_pattern);
                         let re = BytesRegex::new(&format!("^{}$", re_pattern)).map_err(|e| {
-                            ArrowError::InvalidArgumentError(format!(
+                            Error::InvalidArgumentError(format!(
                                 "Unable to build regex from LIKE pattern: {}",
                                 e
                             ))
@@ -255,7 +252,7 @@ fn a_like_binary_scalar<O: Offset, F: Fn(bool) -> bool>(
 ) -> Result<BooleanArray> {
     let validity = lhs.validity();
     let pattern = simdutf8::basic::from_utf8(rhs).map_err(|e| {
-        ArrowError::InvalidArgumentError(format!(
+        Error::InvalidArgumentError(format!(
             "Unable to convert the LIKE pattern to string: {}",
             e
         ))
@@ -274,10 +271,7 @@ fn a_like_binary_scalar<O: Offset, F: Fn(bool) -> bool>(
     } else {
         let re_pattern = replace_pattern(pattern);
         let re = BytesRegex::new(&format!("^{}$", re_pattern)).map_err(|e| {
-            ArrowError::InvalidArgumentError(format!(
-                "Unable to build regex from LIKE pattern: {}",
-                e
-            ))
+            Error::InvalidArgumentError(format!("Unable to build regex from LIKE pattern: {}", e))
         })?;
         Bitmap::from_trusted_len_iter(lhs.values_iter().map(|x| op(re.is_match(x))))
     };

--- a/src/compute/partition.rs
+++ b/src/compute/partition.rs
@@ -19,7 +19,7 @@
 
 use crate::array::ord::DynComparator;
 use crate::compute::sort::{build_compare, SortColumn};
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use std::cmp::Ordering;
 use std::iter::Iterator;
 use std::ops::Range;
@@ -50,13 +50,13 @@ struct LexicographicalPartitionIterator {
 impl LexicographicalPartitionIterator {
     fn try_new(columns: &[SortColumn]) -> Result<Self> {
         if columns.is_empty() {
-            return Err(ArrowError::InvalidArgumentError(
+            return Err(Error::InvalidArgumentError(
                 "Sort requires at least one column".to_string(),
             ));
         }
         let num_rows = columns[0].values.len();
         if columns.iter().any(|item| item.values.len() != num_rows) {
-            return Err(ArrowError::InvalidArgumentError(
+            return Err(Error::InvalidArgumentError(
                 "Lexical sort columns have different row counts".to_string(),
             ));
         };

--- a/src/compute/regex_match.rs
+++ b/src/compute/regex_match.rs
@@ -8,12 +8,12 @@ use super::utils::combine_validities;
 use crate::array::{BooleanArray, Offset, Utf8Array};
 use crate::bitmap::Bitmap;
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 /// Regex matches
 pub fn regex_match<O: Offset>(values: &Utf8Array<O>, regex: &Utf8Array<O>) -> Result<BooleanArray> {
     if values.len() != regex.len() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Cannot perform comparison operation on arrays of different length".to_string(),
         ));
     }
@@ -33,7 +33,7 @@ pub fn regex_match<O: Offset>(values: &Utf8Array<O>, regex: &Utf8Array<O>) -> Re
             regex
         } else {
             let re = Regex::new(regex).map_err(|e| {
-                ArrowError::InvalidArgumentError(format!(
+                Error::InvalidArgumentError(format!(
                     "Unable to build regex from LIKE pattern: {}",
                     e
                 ))
@@ -62,7 +62,7 @@ pub fn regex_match<O: Offset>(values: &Utf8Array<O>, regex: &Utf8Array<O>) -> Re
 /// ```
 pub fn regex_match_scalar<O: Offset>(values: &Utf8Array<O>, regex: &str) -> Result<BooleanArray> {
     let regex = Regex::new(regex)
-        .map_err(|e| ArrowError::InvalidArgumentError(format!("Unable to compile regex: {}", e)))?;
+        .map_err(|e| Error::InvalidArgumentError(format!("Unable to compile regex: {}", e)))?;
     Ok(unary_utf8_boolean(values, |x| regex.is_match(x)))
 }
 

--- a/src/compute/sort/lex_sort.rs
+++ b/src/compute/sort/lex_sort.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
 use crate::compute::take;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::{
     array::{ord, Array, PrimitiveArray},
     types::Index,
@@ -25,7 +25,7 @@ pub struct SortColumn<'a> {
 /// # Implementaqtion
 /// The sort is stable and lexicographical on values.
 ///
-/// Returns an [`ArrowError`] if any of the array type is either unsupported by
+/// Returns an [`Error`] if any of the array type is either unsupported by
 /// `lexsort_to_indices` or `take`.
 ///
 /// Example:
@@ -129,7 +129,7 @@ pub fn lexsort_to_indices<I: Index>(
     limit: Option<usize>,
 ) -> Result<PrimitiveArray<I>> {
     if columns.is_empty() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Sort requires at least one column".to_string(),
         ));
     }
@@ -141,7 +141,7 @@ pub fn lexsort_to_indices<I: Index>(
 
     let row_count = columns[0].values.len();
     if columns.iter().any(|item| item.values.len() != row_count) {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "lexical sort columns have different row counts".to_string(),
         ));
     };

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use crate::array::ord;
 use crate::compute::take;
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::{
     array::*,
     types::{Index, NativeType},
@@ -162,7 +162,7 @@ pub fn sort_to_indices<I: Index>(
                 DataType::UInt16 => Ok(sort_list::<I, i32, u16>(values, v, n, options, limit)),
                 DataType::UInt32 => Ok(sort_list::<I, i32, u32>(values, v, n, options, limit)),
                 DataType::UInt64 => Ok(sort_list::<I, i32, u64>(values, v, n, options, limit)),
-                t => Err(ArrowError::NotYetImplemented(format!(
+                t => Err(Error::NotYetImplemented(format!(
                     "Sort not supported for list type {:?}",
                     t
                 ))),
@@ -179,7 +179,7 @@ pub fn sort_to_indices<I: Index>(
                 DataType::UInt16 => Ok(sort_list::<I, i64, u16>(values, v, n, options, limit)),
                 DataType::UInt32 => Ok(sort_list::<I, i64, u32>(values, v, n, options, limit)),
                 DataType::UInt64 => Ok(sort_list::<I, i64, u64>(values, v, n, options, limit)),
-                t => Err(ArrowError::NotYetImplemented(format!(
+                t => Err(Error::NotYetImplemented(format!(
                     "Sort not supported for list type {:?}",
                     t
                 ))),
@@ -196,7 +196,7 @@ pub fn sort_to_indices<I: Index>(
                 DataType::UInt16 => Ok(sort_list::<I, i32, u16>(values, v, n, options, limit)),
                 DataType::UInt32 => Ok(sort_list::<I, i32, u32>(values, v, n, options, limit)),
                 DataType::UInt64 => Ok(sort_list::<I, i32, u64>(values, v, n, options, limit)),
-                t => Err(ArrowError::NotYetImplemented(format!(
+                t => Err(Error::NotYetImplemented(format!(
                     "Sort not supported for list type {:?}",
                     t
                 ))),
@@ -205,12 +205,12 @@ pub fn sort_to_indices<I: Index>(
         DataType::Dictionary(key_type, value_type, _) => match value_type.as_ref() {
             DataType::Utf8 => Ok(sort_dict::<I, i32>(values, key_type, options, limit)),
             DataType::LargeUtf8 => Ok(sort_dict::<I, i64>(values, key_type, options, limit)),
-            t => Err(ArrowError::NotYetImplemented(format!(
+            t => Err(Error::NotYetImplemented(format!(
                 "Sort not supported for dictionary type with keys {:?}",
                 t
             ))),
         },
-        t => Err(ArrowError::NotYetImplemented(format!(
+        t => Err(Error::NotYetImplemented(format!(
             "Sort not supported for data type {:?}",
             t
         ))),

--- a/src/compute/substring.rs
+++ b/src/compute/substring.rs
@@ -20,7 +20,7 @@
 use crate::{
     array::*,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 fn utf8_substring<O: Offset>(array: &Utf8Array<O>, start: O, length: &Option<O>) -> Utf8Array<O> {
@@ -153,7 +153,7 @@ pub fn substring(array: &dyn Array, start: i64, length: &Option<u64>) -> Result<
             start as i32,
             &length.map(|e| e as i32),
         ))),
-        _ => Err(ArrowError::InvalidArgumentError(format!(
+        _ => Err(Error::InvalidArgumentError(format!(
             "substring does not support type {:?}",
             array.data_type()
         ))),

--- a/src/compute/temporal.rs
+++ b/src/compute/temporal.rs
@@ -21,7 +21,7 @@ use chrono::{Datelike, Timelike};
 
 use crate::array::*;
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::temporal_conversions::*;
 use crate::types::NativeType;
 
@@ -66,7 +66,7 @@ macro_rules! date_like {
                     chrono_tz(array, *time_unit, timezone_str, |x| x.$extract())
                 }
             }
-            dt => Err(ArrowError::NotYetImplemented(format!(
+            dt => Err(Error::NotYetImplemented(format!(
                 "\"{}\" does not support type {:?}",
                 stringify!($extract),
                 dt
@@ -129,7 +129,7 @@ macro_rules! time_like {
                     chrono_tz(array, *time_unit, timezone_str, |x| x.$extract())
                 }
             }
-            dt => Err(ArrowError::NotYetImplemented(format!(
+            dt => Err(Error::NotYetImplemented(format!(
                 "\"{}\" does not support type {:?}",
                 stringify!($extract),
                 dt
@@ -266,7 +266,7 @@ where
     O: NativeType,
     F: Fn(chrono::DateTime<chrono::FixedOffset>) -> O,
 {
-    Err(ArrowError::InvalidArgumentError(format!(
+    Err(Error::InvalidArgumentError(format!(
         "timezone \"{}\" cannot be parsed (feature chrono-tz is not active)",
         timezone_str
     )))

--- a/src/compute/utf8.rs
+++ b/src/compute/utf8.rs
@@ -3,7 +3,7 @@
 use crate::{
     array::{Array, Offset, Utf8Array},
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 /// utf8_apply will apply `Fn(&str) -> String` to every value in Utf8Array.
@@ -32,7 +32,7 @@ pub fn upper(array: &dyn Array) -> Result<Box<dyn Array>> {
                 .downcast_ref::<Utf8Array<i32>>()
                 .expect("A string is expected"),
         ))),
-        _ => Err(ArrowError::InvalidArgumentError(format!(
+        _ => Err(Error::InvalidArgumentError(format!(
             "upper does not support type {:?}",
             array.data_type()
         ))),
@@ -74,7 +74,7 @@ pub fn lower(array: &dyn Array) -> Result<Box<dyn Array>> {
                 .downcast_ref::<Utf8Array<i32>>()
                 .expect("A string is expected"),
         ))),
-        _ => Err(ArrowError::InvalidArgumentError(format!(
+        _ => Err(Error::InvalidArgumentError(format!(
             "lower does not support type {:?}",
             array.data_type()
         ))),

--- a/src/compute/utils.rs
+++ b/src/compute/utils.rs
@@ -1,7 +1,7 @@
 use crate::{
     array::Array,
     bitmap::Bitmap,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 pub fn combine_validities(lhs: Option<&Bitmap>, rhs: Option<&Bitmap>) -> Option<Bitmap> {
@@ -17,7 +17,7 @@ pub fn combine_validities(lhs: Option<&Bitmap>, rhs: Option<&Bitmap>) -> Option<
 #[inline]
 pub fn check_same_len(lhs: &dyn Array, rhs: &dyn Array) -> Result<()> {
     if lhs.len() != rhs.len() {
-        return Err(ArrowError::InvalidArgumentError(
+        return Err(Error::InvalidArgumentError(
             "Arrays must have the same length".to_string(),
         ));
     }

--- a/src/compute/window.rs
+++ b/src/compute/window.rs
@@ -22,7 +22,7 @@ use num_traits::{abs, clamp};
 
 use crate::{
     array::{new_null_array, Array},
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 /// Shifts array by defined number of items (to left or right)
@@ -40,7 +40,7 @@ use crate::{
 /// ```
 pub fn shift(array: &dyn Array, offset: i64) -> Result<Box<dyn Array>> {
     if abs(offset) as usize > array.len() {
-        return Err(ArrowError::InvalidArgumentError(format!(
+        return Err(Error::InvalidArgumentError(format!(
             "Shift's absolute offset must be smaller or equal to the arrays length. Offset is {}, length is {}",
             abs(offset), array.len()
         )));

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,16 +1,14 @@
-//! Defines [`ArrowError`], representing all errors returned by this crate.
+//! Defines [`Error`], representing all errors returned by this crate.
 use std::fmt::{Debug, Display, Formatter};
-
-use std::error::Error;
 
 /// Enum with all errors in this crate.
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum ArrowError {
+pub enum Error {
     /// Returned when functionality is not yet available.
     NotYetImplemented(String),
     /// Wrapper for an error triggered by a dependency
-    External(String, Box<dyn Error + Send + Sync>),
+    External(String, Box<dyn std::error::Error + Send + Sync>),
     /// Wrapper for IO errors
     Io(std::io::Error),
     /// When an invalid argument is passed to a function.
@@ -24,8 +22,8 @@ pub enum ArrowError {
     OutOfSpec(String),
 }
 
-impl ArrowError {
-    /// Wraps an external error in an `ArrowError`.
+impl Error {
+    /// Wraps an external error in an `Error`.
     pub fn from_external_error(error: impl std::error::Error + Send + Sync + 'static) -> Self {
         Self::External("".to_string(), Box::new(error))
     }
@@ -40,57 +38,57 @@ impl ArrowError {
     }
 }
 
-impl From<::std::io::Error> for ArrowError {
+impl From<::std::io::Error> for Error {
     fn from(error: std::io::Error) -> Self {
-        ArrowError::Io(error)
+        Error::Io(error)
     }
 }
 
-impl From<std::str::Utf8Error> for ArrowError {
+impl From<std::str::Utf8Error> for Error {
     fn from(error: std::str::Utf8Error) -> Self {
-        ArrowError::External("".to_string(), Box::new(error))
+        Error::External("".to_string(), Box::new(error))
     }
 }
 
-impl From<std::string::FromUtf8Error> for ArrowError {
+impl From<std::string::FromUtf8Error> for Error {
     fn from(error: std::string::FromUtf8Error) -> Self {
-        ArrowError::External("".to_string(), Box::new(error))
+        Error::External("".to_string(), Box::new(error))
     }
 }
 
-impl From<simdutf8::basic::Utf8Error> for ArrowError {
+impl From<simdutf8::basic::Utf8Error> for Error {
     fn from(error: simdutf8::basic::Utf8Error) -> Self {
-        ArrowError::External("".to_string(), Box::new(error))
+        Error::External("".to_string(), Box::new(error))
     }
 }
 
-impl Display for ArrowError {
+impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ArrowError::NotYetImplemented(source) => {
+            Error::NotYetImplemented(source) => {
                 write!(f, "Not yet implemented: {}", &source)
             }
-            ArrowError::External(message, source) => {
+            Error::External(message, source) => {
                 write!(f, "External error{}: {}", message, &source)
             }
-            ArrowError::Io(desc) => write!(f, "Io error: {}", desc),
-            ArrowError::InvalidArgumentError(desc) => {
+            Error::Io(desc) => write!(f, "Io error: {}", desc),
+            Error::InvalidArgumentError(desc) => {
                 write!(f, "Invalid argument error: {}", desc)
             }
-            ArrowError::ExternalFormat(desc) => {
+            Error::ExternalFormat(desc) => {
                 write!(f, "External format error: {}", desc)
             }
-            ArrowError::Overflow => {
+            Error::Overflow => {
                 write!(f, "Operation overflew the backing container.")
             }
-            ArrowError::OutOfSpec(message) => {
+            Error::OutOfSpec(message) => {
                 write!(f, "{}", message)
             }
         }
     }
 }
 
-impl Error for ArrowError {}
+impl std::error::Error for Error {}
 
-/// Typedef for a [`std::result::Result`] of an [`ArrowError`].
-pub type Result<T> = std::result::Result<T, ArrowError>;
+/// Typedef for a [`std::result::Result`] of an [`Error`].
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -9,7 +9,7 @@ use crate::{
         Buffer,
     },
     datatypes::{DataType, PhysicalType},
-    error::{ArrowError, Result},
+    error::{Error, Result},
     ffi::schema::get_child,
     types::NativeType,
 };
@@ -185,9 +185,7 @@ unsafe fn create_buffer<T: NativeType>(
     index: usize,
 ) -> Result<Buffer<T>> {
     if array.buffers.is_null() {
-        return Err(ArrowError::OutOfSpec(
-            "The array buffers are null".to_string(),
-        ));
+        return Err(Error::OutOfSpec("The array buffers are null".to_string()));
     }
 
     let buffers = array.buffers as *mut *const u8;
@@ -200,9 +198,7 @@ unsafe fn create_buffer<T: NativeType>(
     let offset = buffer_offset(array, data_type, index);
     let bytes = ptr
         .map(|ptr| Bytes::from_ffi(ptr, len, deallocation))
-        .ok_or_else(|| {
-            ArrowError::OutOfSpec(format!("The buffer at position {} is null", index))
-        })?;
+        .ok_or_else(|| Error::OutOfSpec(format!("The buffer at position {} is null", index)))?;
 
     Ok(Buffer::from_bytes(bytes).slice(offset, len - offset))
 }
@@ -220,9 +216,7 @@ unsafe fn create_bitmap(
     index: usize,
 ) -> Result<Bitmap> {
     if array.buffers.is_null() {
-        return Err(ArrowError::OutOfSpec(
-            "The array buffers are null".to_string(),
-        ));
+        return Err(Error::OutOfSpec("The array buffers are null".to_string()));
     }
     let len = array.length as usize;
     let offset = array.offset as usize;
@@ -236,7 +230,7 @@ unsafe fn create_bitmap(
     let bytes = ptr
         .map(|ptr| Bytes::from_ffi(ptr, bytes_len, deallocation))
         .ok_or_else(|| {
-            ArrowError::OutOfSpec(format!(
+            Error::OutOfSpec(format!(
                 "The buffer {} is a null pointer and cannot be interpreted as a bitmap",
                 index
             ))

--- a/src/io/avro/mod.rs
+++ b/src/io/avro/mod.rs
@@ -28,7 +28,7 @@ macro_rules! avro_decode {
             loop {
                 if j > 9 {
                     // if j * 7 > 64
-                    return Err(ArrowError::ExternalFormat(
+                    return Err(Error::ExternalFormat(
                         "zigzag decoding failed - corrupt avro file".to_string(),
                     ));
                 }
@@ -60,7 +60,7 @@ macro_rules! read_header {
             for _ in 0..len {
                 let key = _read_binary($reader)$($_await)*?;
                 let key = String::from_utf8(key)
-                    .map_err(|_| ArrowError::ExternalFormat("Invalid Avro header".to_string()))?;
+                    .map_err(|_| Error::ExternalFormat("Invalid Avro header".to_string()))?;
                 let value = _read_binary($reader)$($_await)*?;
                 items.insert(key, value);
             }
@@ -75,7 +75,7 @@ macro_rules! read_metadata {
 
         // see https://avro.apache.org/docs/current/spec.html#Object+Container+Files
         if magic_number != [b'O', b'b', b'j', 1u8] {
-            return Err(ArrowError::ExternalFormat(
+            return Err(Error::ExternalFormat(
                 "Avro header does not contain a valid magic number".to_string(),
             ));
         }

--- a/src/io/avro/read/deserialize.rs
+++ b/src/io/avro/read/deserialize.rs
@@ -7,7 +7,7 @@ use avro_schema::{Enum, Schema as AvroSchema};
 use crate::array::*;
 use crate::chunk::Chunk;
 use crate::datatypes::*;
-use crate::error::ArrowError;
+use crate::error::Error;
 use crate::error::Result;
 use crate::types::months_days_ns;
 
@@ -65,7 +65,7 @@ fn make_mutable(
                     as Box<dyn MutableArray>
             }
             other => {
-                return Err(ArrowError::NotYetImplemented(format!(
+                return Err(Error::NotYetImplemented(format!(
                     "Deserializing type {:#?} is still not implemented",
                     other
                 )))
@@ -240,7 +240,7 @@ fn deserialize_value<'a>(
                     let len = match avro_inner {
                         AvroSchema::Bytes(_) => {
                             util::zigzag_i64(&mut block)?.try_into().map_err(|_| {
-                                ArrowError::ExternalFormat(
+                                Error::ExternalFormat(
                                     "Avro format contains a non-usize number of bytes".to_string(),
                                 )
                             })?
@@ -249,7 +249,7 @@ fn deserialize_value<'a>(
                         _ => unreachable!(),
                     };
                     if len > 16 {
-                        return Err(ArrowError::ExternalFormat(
+                        return Err(Error::ExternalFormat(
                             "Avro decimal bytes return more than 16 bytes".to_string(),
                         ));
                     }
@@ -267,7 +267,7 @@ fn deserialize_value<'a>(
             },
             PhysicalType::Utf8 => {
                 let len: usize = util::zigzag_i64(&mut block)?.try_into().map_err(|_| {
-                    ArrowError::ExternalFormat(
+                    Error::ExternalFormat(
                         "Avro format contains a non-usize number of bytes".to_string(),
                     )
                 })?;
@@ -282,7 +282,7 @@ fn deserialize_value<'a>(
             }
             PhysicalType::Binary => {
                 let len: usize = util::zigzag_i64(&mut block)?.try_into().map_err(|_| {
-                    ArrowError::ExternalFormat(
+                    Error::ExternalFormat(
                         "Avro format contains a non-usize number of bytes".to_string(),
                     )
                 })?;
@@ -400,7 +400,7 @@ fn skip_item<'a>(field: &Field, avro_field: &AvroSchema, mut block: &'a [u8]) ->
                     let len = match avro_inner {
                         AvroSchema::Bytes(_) => {
                             util::zigzag_i64(&mut block)?.try_into().map_err(|_| {
-                                ArrowError::ExternalFormat(
+                                Error::ExternalFormat(
                                     "Avro format contains a non-usize number of bytes".to_string(),
                                 )
                             })?
@@ -414,7 +414,7 @@ fn skip_item<'a>(field: &Field, avro_field: &AvroSchema, mut block: &'a [u8]) ->
             },
             PhysicalType::Utf8 | PhysicalType::Binary => {
                 let len: usize = util::zigzag_i64(&mut block)?.try_into().map_err(|_| {
-                    ArrowError::ExternalFormat(
+                    Error::ExternalFormat(
                         "Avro format contains a non-usize number of bytes".to_string(),
                     )
                 })?;

--- a/src/io/avro/read/header.rs
+++ b/src/io/avro/read/header.rs
@@ -15,8 +15,7 @@ pub(crate) fn deserialize_header(
         .get("avro.schema")
         .ok_or_else(|| Error::ExternalFormat("Avro schema must be present".to_string()))
         .and_then(|bytes| {
-            serde_json::from_slice(bytes.as_ref())
-                .map_err(|e| Error::ExternalFormat(e.to_string()))
+            serde_json::from_slice(bytes.as_ref()).map_err(|e| Error::ExternalFormat(e.to_string()))
         })?;
 
     let compression = header.get("avro.codec").and_then(|bytes| {

--- a/src/io/avro/read/header.rs
+++ b/src/io/avro/read/header.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use avro_schema::Schema;
 use serde_json;
 
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::Compression;
 
@@ -13,10 +13,10 @@ pub(crate) fn deserialize_header(
 ) -> Result<(Schema, Option<Compression>)> {
     let schema = header
         .get("avro.schema")
-        .ok_or_else(|| ArrowError::ExternalFormat("Avro schema must be present".to_string()))
+        .ok_or_else(|| Error::ExternalFormat("Avro schema must be present".to_string()))
         .and_then(|bytes| {
             serde_json::from_slice(bytes.as_ref())
-                .map_err(|e| ArrowError::ExternalFormat(e.to_string()))
+                .map_err(|e| Error::ExternalFormat(e.to_string()))
         })?;
 
     let compression = header.get("avro.codec").and_then(|bytes| {

--- a/src/io/avro/read/nested.rs
+++ b/src/io/avro/read/nested.rs
@@ -36,7 +36,7 @@ impl<O: Offset> DynMutableListArray<O> {
     #[inline]
     pub fn try_push_valid(&mut self) -> Result<()> {
         let size = self.values.len();
-        let size = O::from_usize(size).ok_or(ArrowError::Overflow)?;
+        let size = O::from_usize(size).ok_or(Error::Overflow)?;
         assert!(size >= *self.offsets.last().unwrap());
 
         self.offsets.push(size);

--- a/src/io/avro/read/schema.rs
+++ b/src/io/avro/read/schema.rs
@@ -1,7 +1,7 @@
 use avro_schema::{Enum, Fixed, Record, Schema as AvroSchema};
 
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 fn external_props(schema: &AvroSchema) -> Metadata {
     let mut props = Metadata::new();
@@ -35,7 +35,7 @@ pub fn infer_schema(schema: &AvroSchema) -> Result<Schema> {
             .collect::<Result<Vec<_>>>()?
             .into())
     } else {
-        Err(ArrowError::OutOfSpec(
+        Err(Error::OutOfSpec(
             "The root AvroSchema must be of type Record".to_string(),
         ))
     }
@@ -99,7 +99,7 @@ fn schema_to_field(schema: &AvroSchema, name: Option<&str>, props: Metadata) -> 
                 {
                     schema_to_field(schema, None, Metadata::default())?.data_type
                 } else {
-                    return Err(ArrowError::NotYetImplemented(format!(
+                    return Err(Error::NotYetImplemented(format!(
                         "Can't read avro union {:?}",
                         schema
                     )));

--- a/src/io/avro/read/util.rs
+++ b/src/io/avro/read/util.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 
 use avro_schema::Schema;
 
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::{avro_decode, read_header, read_metadata};
 use super::{deserialize_header, Compression};

--- a/src/io/avro/read_async/metadata.rs
+++ b/src/io/avro/read_async/metadata.rs
@@ -6,7 +6,7 @@ use futures::AsyncRead;
 use futures::AsyncReadExt;
 
 use crate::datatypes::Schema;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::read::deserialize_header;
 use super::super::read::infer_schema;

--- a/src/io/avro/read_async/utils.rs
+++ b/src/io/avro/read_async/utils.rs
@@ -1,7 +1,7 @@
 use futures::AsyncRead;
 use futures::AsyncReadExt;
 
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::avro_decode;
 

--- a/src/io/avro/write/compress.rs
+++ b/src/io/avro/write/compress.rs
@@ -41,19 +41,19 @@ pub fn compress(
             compressed.resize(required_len, 0);
             let compressed_bytes = Encoder::new()
                 .compress(block, compressed)
-                .map_err(|e| crate::error::ArrowError::ExternalFormat(e.to_string()))?;
+                .map_err(|e| crate::error::Error::ExternalFormat(e.to_string()))?;
             compressed.truncate(compressed_bytes);
 
             compressed.extend(CRC_TABLE.checksum(block).to_be_bytes());
             Ok(false)
         }
         #[cfg(not(feature = "io_avro_compression"))]
-        Some(Compression::Deflate) => Err(crate::error::ArrowError::InvalidArgumentError(
+        Some(Compression::Deflate) => Err(crate::error::Error::InvalidArgumentError(
             "Trying to compress Avro with deflate but feature 'io_avro_compression' is not active."
                 .to_string(),
         )),
         #[cfg(not(feature = "io_avro_compression"))]
-        Some(Compression::Snappy) => Err(crate::error::ArrowError::InvalidArgumentError(
+        Some(Compression::Snappy) => Err(crate::error::Error::InvalidArgumentError(
             "Trying to compress Avro with snappy but feature 'io_avro_compression' is not active."
                 .to_string(),
         )),

--- a/src/io/avro/write/header.rs
+++ b/src/io/avro/write/header.rs
@@ -12,8 +12,7 @@ pub(crate) fn serialize_header(
     schema: &Schema,
     compression: Option<Compression>,
 ) -> Result<HashMap<String, Vec<u8>>> {
-    let schema =
-        serde_json::to_string(schema).map_err(|e| Error::ExternalFormat(e.to_string()))?;
+    let schema = serde_json::to_string(schema).map_err(|e| Error::ExternalFormat(e.to_string()))?;
 
     let mut header = HashMap::<String, Vec<u8>>::default();
 

--- a/src/io/avro/write/header.rs
+++ b/src/io/avro/write/header.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use avro_schema::Schema;
 use serde_json;
 
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::Compression;
 
@@ -13,7 +13,7 @@ pub(crate) fn serialize_header(
     compression: Option<Compression>,
 ) -> Result<HashMap<String, Vec<u8>>> {
     let schema =
-        serde_json::to_string(schema).map_err(|e| ArrowError::ExternalFormat(e.to_string()))?;
+        serde_json::to_string(schema).map_err(|e| Error::ExternalFormat(e.to_string()))?;
 
     let mut header = HashMap::<String, Vec<u8>>::default();
 

--- a/src/io/avro/write/schema.rs
+++ b/src/io/avro/write/schema.rs
@@ -4,7 +4,7 @@ use avro_schema::{
 };
 
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 /// Converts a [`Schema`] to a vector of [`AvroField`] with it.
 pub fn to_avro_schema(schema: &Schema) -> Result<Vec<AvroField>> {
@@ -63,7 +63,7 @@ fn _type_to_schema(data_type: &DataType) -> Result<AvroSchema> {
         DataType::FixedSizeBinary(size) => AvroSchema::Fixed(Fixed::new("", *size)),
         DataType::Decimal(p, s) => AvroSchema::Bytes(Some(BytesLogical::Decimal(*p, *s))),
         other => {
-            return Err(ArrowError::NotYetImplemented(format!(
+            return Err(Error::NotYetImplemented(format!(
                 "write {:?} to avro",
                 other
             )))

--- a/src/io/csv/mod.rs
+++ b/src/io/csv/mod.rs
@@ -1,6 +1,6 @@
 //! Convert data between the Arrow and CSV (comma-separated values).
 
-use crate::error::ArrowError;
+use crate::error::Error;
 
 #[cfg(any(feature = "io_csv_read_async", feature = "io_csv_read"))]
 mod read_utils;
@@ -8,15 +8,15 @@ mod read_utils;
 mod utils;
 
 #[cfg(feature = "io_csv_read")]
-impl From<csv::Error> for ArrowError {
+impl From<csv::Error> for Error {
     fn from(error: csv::Error) -> Self {
-        ArrowError::External("".to_string(), Box::new(error))
+        Error::External("".to_string(), Box::new(error))
     }
 }
 
-impl From<chrono::ParseError> for ArrowError {
+impl From<chrono::ParseError> for Error {
     fn from(error: chrono::ParseError) -> Self {
-        ArrowError::External("".to_string(), Box::new(error))
+        Error::External("".to_string(), Box::new(error))
     }
 }
 

--- a/src/io/csv/read/reader.rs
+++ b/src/io/csv/read/reader.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 
 use super::{ByteRecord, Reader};
 
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 /// Reads `len` rows from `reader` into `row`, skiping the first `skip`.
 /// This operation has minimal CPU work and is thus the fastest way to read through a CSV
@@ -24,7 +24,7 @@ pub fn read_rows<R: Read>(
     let mut row_number = 0;
     for row in rows.iter_mut() {
         let has_more = reader.read_byte_record(row).map_err(|e| {
-            ArrowError::External(format!(" at line {}", skip + row_number), Box::new(e))
+            Error::External(format!(" at line {}", skip + row_number), Box::new(e))
         })?;
         if !has_more {
             break;

--- a/src/io/csv/read/reader.rs
+++ b/src/io/csv/read/reader.rs
@@ -23,9 +23,9 @@ pub fn read_rows<R: Read>(
 
     let mut row_number = 0;
     for row in rows.iter_mut() {
-        let has_more = reader.read_byte_record(row).map_err(|e| {
-            Error::External(format!(" at line {}", skip + row_number), Box::new(e))
-        })?;
+        let has_more = reader
+            .read_byte_record(row)
+            .map_err(|e| Error::External(format!(" at line {}", skip + row_number), Box::new(e)))?;
         if !has_more {
             break;
         }

--- a/src/io/csv/read_async/mod.rs
+++ b/src/io/csv/read_async/mod.rs
@@ -14,8 +14,8 @@ pub use reader::*;
 
 pub use csv_async::Error as CSVError;
 
-impl From<CSVError> for crate::error::ArrowError {
+impl From<CSVError> for crate::error::Error {
     fn from(error: CSVError) -> Self {
-        crate::error::ArrowError::External("".to_string(), Box::new(error))
+        crate::error::Error::External("".to_string(), Box::new(error))
     }
 }

--- a/src/io/csv/read_async/reader.rs
+++ b/src/io/csv/read_async/reader.rs
@@ -2,7 +2,7 @@ use futures::AsyncRead;
 
 use super::{AsyncReader, ByteRecord};
 
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 /// Asynchronosly read `len` rows from `reader` into `row`, skiping the first `skip`.
 /// This operation has minimal CPU work and is thus the fastest way to read through a CSV
@@ -27,7 +27,7 @@ where
     let mut row_number = 0;
     for row in rows.iter_mut() {
         let has_more = reader.read_byte_record(row).await.map_err(|e| {
-            ArrowError::External(format!(" at line {}", skip + row_number), Box::new(e))
+            Error::External(format!(" at line {}", skip + row_number), Box::new(e))
         })?;
         if !has_more {
             break;

--- a/src/io/csv/read_async/reader.rs
+++ b/src/io/csv/read_async/reader.rs
@@ -26,9 +26,10 @@ where
 
     let mut row_number = 0;
     for row in rows.iter_mut() {
-        let has_more = reader.read_byte_record(row).await.map_err(|e| {
-            Error::External(format!(" at line {}", skip + row_number), Box::new(e))
-        })?;
+        let has_more = reader
+            .read_byte_record(row)
+            .await
+            .map_err(|e| Error::External(format!(" at line {}", skip + row_number), Box::new(e)))?;
         if !has_more {
             break;
         }

--- a/src/io/csv/read_utils.rs
+++ b/src/io/csv/read_utils.rs
@@ -13,7 +13,7 @@ use crate::{
     array::*,
     chunk::Chunk,
     datatypes::*,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     temporal_conversions,
     types::NativeType,
 };
@@ -249,7 +249,7 @@ pub(crate) fn deserialize_column<B: ByteRecordGeneric>(
         Binary => deserialize_binary::<i32, _>(rows, column),
         LargeBinary => deserialize_binary::<i64, _>(rows, column),
         other => {
-            return Err(ArrowError::NotYetImplemented(format!(
+            return Err(Error::NotYetImplemented(format!(
                 "Deserializing type \"{:?}\" is not implemented",
                 other
             )))

--- a/src/io/csv/write/serialize.rs
+++ b/src/io/csv/write/serialize.rs
@@ -147,7 +147,7 @@ fn timestamp_with_tz_default<'a>(
         }
         #[cfg(not(feature = "chrono-tz"))]
         _ => {
-            return Err(crate::error::ArrowError::InvalidArgumentError(
+            return Err(crate::error::Error::InvalidArgumentError(
                 "Invalid Offset format (must be [-]00:00) or chrono-tz feature not active"
                     .to_string(),
             ))
@@ -192,7 +192,7 @@ fn timestamp_with_tz_with_format<'a>(
         }
         #[cfg(not(feature = "chrono-tz"))]
         _ => {
-            return Err(crate::error::ArrowError::InvalidArgumentError(
+            return Err(crate::error::Error::InvalidArgumentError(
                 "Invalid Offset format (must be [-]00:00) or chrono-tz feature not active"
                     .to_string(),
             ))

--- a/src/io/flight/mod.rs
+++ b/src/io/flight/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     array::Array,
     chunk::Chunk,
     datatypes::*,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     io::ipc::read,
     io::ipc::write,
     io::ipc::write::common::{encode_chunk, DictionaryTracker, EncodedData, WriteOptions},
@@ -118,13 +118,13 @@ pub fn deserialize_batch(
     // check that the data_header is a record batch message
     let message =
         arrow_format::ipc::MessageRef::read_as_root(&data.data_header).map_err(|err| {
-            ArrowError::OutOfSpec(format!("Unable to get root as message: {:?}", err))
+            Error::OutOfSpec(format!("Unable to get root as message: {:?}", err))
         })?;
 
     let mut reader = std::io::Cursor::new(&data.data_body);
 
     match message.header()?.ok_or_else(|| {
-        ArrowError::oos("Unable to convert flight data header to a record batch".to_string())
+        Error::oos("Unable to convert flight data header to a record batch".to_string())
     })? {
         ipc::MessageHeaderRef::RecordBatch(batch) => read::read_record_batch(
             batch,
@@ -136,7 +136,7 @@ pub fn deserialize_batch(
             &mut reader,
             0,
         ),
-        _ => Err(ArrowError::nyi(
+        _ => Err(Error::nyi(
             "flight currently only supports reading RecordBatch messages",
         )),
     }

--- a/src/io/flight/mod.rs
+++ b/src/io/flight/mod.rs
@@ -116,10 +116,8 @@ pub fn deserialize_batch(
     dictionaries: &read::Dictionaries,
 ) -> Result<Chunk<Arc<dyn Array>>> {
     // check that the data_header is a record batch message
-    let message =
-        arrow_format::ipc::MessageRef::read_as_root(&data.data_header).map_err(|err| {
-            Error::OutOfSpec(format!("Unable to get root as message: {:?}", err))
-        })?;
+    let message = arrow_format::ipc::MessageRef::read_as_root(&data.data_header)
+        .map_err(|err| Error::OutOfSpec(format!("Unable to get root as message: {:?}", err)))?;
 
     let mut reader = std::io::Cursor::new(&data.data_body);
 

--- a/src/io/ipc/append/mod.rs
+++ b/src/io/ipc/append/mod.rs
@@ -5,7 +5,7 @@
 // write new footer
 use std::io::{Read, Seek, SeekFrom, Write};
 
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::endianess::is_native_little_endian;
 use super::read::{self, FileMetadata};
@@ -27,7 +27,7 @@ impl<R: Read + Seek + Write> FileWriter<R> {
         options: WriteOptions,
     ) -> Result<FileWriter<R>> {
         if metadata.ipc_schema.is_little_endian != is_native_little_endian() {
-            return Err(ArrowError::nyi(
+            return Err(Error::nyi(
                 "Appending to a file of a non-native endianess is still not supported",
             ));
         }
@@ -44,20 +44,20 @@ impl<R: Read + Seek + Write> FileWriter<R> {
         };
 
         let last_block = metadata.blocks.last().ok_or_else(|| {
-            ArrowError::oos("An Arrow IPC file must have at least 1 message (the schema message)")
+            Error::oos("An Arrow IPC file must have at least 1 message (the schema message)")
         })?;
         let offset: u64 = last_block
             .offset
             .try_into()
-            .map_err(|_| ArrowError::oos("The block's offset must be a positive number"))?;
+            .map_err(|_| Error::oos("The block's offset must be a positive number"))?;
         let meta_data_length: u64 = last_block
             .meta_data_length
             .try_into()
-            .map_err(|_| ArrowError::oos("The block's meta length must be a positive number"))?;
+            .map_err(|_| Error::oos("The block's meta length must be a positive number"))?;
         let body_length: u64 = last_block
             .body_length
             .try_into()
-            .map_err(|_| ArrowError::oos("The block's body length must be a positive number"))?;
+            .map_err(|_| Error::oos("The block's body length must be a positive number"))?;
         let offset: u64 = offset + meta_data_length + body_length;
 
         writer.seek(SeekFrom::Start(offset))?;

--- a/src/io/ipc/compression.rs
+++ b/src/io/ipc/compression.rs
@@ -18,14 +18,14 @@ pub fn decompress_zstd(input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
 
 #[cfg(not(feature = "io_ipc_compression"))]
 pub fn decompress_lz4(_input_buf: &[u8], _output_buf: &mut [u8]) -> Result<()> {
-    use crate::error::ArrowError;
-    Err(ArrowError::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
+    use crate::error::Error;
+    Err(Error::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
 }
 
 #[cfg(not(feature = "io_ipc_compression"))]
 pub fn decompress_zstd(_input_buf: &[u8], _output_buf: &mut [u8]) -> Result<()> {
-    use crate::error::ArrowError;
-    Err(ArrowError::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
+    use crate::error::Error;
+    Err(Error::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to read compressed IPC.".to_string()))
 }
 
 #[cfg(feature = "io_ipc_compression")]
@@ -33,10 +33,10 @@ pub fn decompress_zstd(_input_buf: &[u8], _output_buf: &mut [u8]) -> Result<()> 
 pub fn compress_lz4(input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
     use std::io::Write;
 
-    use crate::error::ArrowError;
+    use crate::error::Error;
     let mut encoder = lz4::EncoderBuilder::new()
         .build(output_buf)
-        .map_err(ArrowError::from)?;
+        .map_err(Error::from)?;
     encoder.write_all(input_buf)?;
     encoder.finish().1.map_err(|e| e.into())
 }
@@ -49,14 +49,14 @@ pub fn compress_zstd(input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
 
 #[cfg(not(feature = "io_ipc_compression"))]
 pub fn compress_lz4(_input_buf: &[u8], _output_buf: &mut Vec<u8>) -> Result<()> {
-    use crate::error::ArrowError;
-    Err(ArrowError::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to write compressed IPC.".to_string()))
+    use crate::error::Error;
+    Err(Error::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to write compressed IPC.".to_string()))
 }
 
 #[cfg(not(feature = "io_ipc_compression"))]
 pub fn compress_zstd(_input_buf: &[u8], _output_buf: &mut Vec<u8>) -> Result<()> {
-    use crate::error::ArrowError;
-    Err(ArrowError::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to write compressed IPC.".to_string()))
+    use crate::error::Error;
+    Err(Error::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to write compressed IPC.".to_string()))
 }
 
 #[cfg(test)]

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -35,7 +35,7 @@
 //! # use arrow2::datatypes::{Field, Schema, DataType};
 //! # use arrow2::array::{Int32Array, Array};
 //! # use arrow2::chunk::Chunk;
-//! # use arrow2::error::ArrowError;
+//! # use arrow2::error::Error;
 //! // Setup the writer
 //! let path = "example.arrow".to_string();
 //! let mut file = File::create(&path)?;
@@ -66,7 +66,7 @@
 //! let row2 = filereader.next().unwrap();  // [[-1, 1], [1, -1]]
 //! let mut reader = filereader.into_inner();
 //! // Do more stuff with the reader, like seeking ahead.
-//! # Ok::<(), ArrowError>(())
+//! # Ok::<(), Error>(())
 //! ```
 //!
 //! For further information and examples please consult the
@@ -76,7 +76,7 @@
 //! [2](https://github.com/jorgecarleitao/arrow2/blob/main/examples/ipc_file_write.rs),
 //! [3](https://github.com/jorgecarleitao/arrow2/tree/main/examples/ipc_pyarrow)).
 
-use crate::error::ArrowError;
+use crate::error::Error;
 
 mod compression;
 mod endianess;
@@ -107,8 +107,8 @@ pub struct IpcSchema {
     pub is_little_endian: bool,
 }
 
-impl From<arrow_format::ipc::planus::Error> for ArrowError {
+impl From<arrow_format::ipc::planus::Error> for Error {
     fn from(error: arrow_format::ipc::planus::Error) -> Self {
-        ArrowError::OutOfSpec(error.to_string())
+        Error::OutOfSpec(error.to_string())
     }
 }

--- a/src/io/ipc/read/array/binary.rs
+++ b/src/io/ipc/read/array/binary.rs
@@ -63,9 +63,7 @@ pub fn skip_binary(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(
-            "IPC: unable to fetch the field for binary. The file or stream is corrupted.",
-        )
+        Error::oos("IPC: unable to fetch the field for binary. The file or stream is corrupted.")
     })?;
 
     let _ = buffers

--- a/src/io/ipc/read/array/binary.rs
+++ b/src/io/ipc/read/array/binary.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Seek};
 use crate::array::{BinaryArray, Offset};
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node};
@@ -19,7 +19,7 @@ pub fn read_binary<O: Offset, R: Read + Seek>(
     compression: Option<Compression>,
 ) -> Result<BinaryArray<O>> {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(format!(
+        Error::oos(format!(
             "IPC: unable to fetch the field for {:?}. The file or stream is corrupted.",
             data_type
         ))
@@ -63,19 +63,19 @@ pub fn skip_binary(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(
+        Error::oos(
             "IPC: unable to fetch the field for binary. The file or stream is corrupted.",
         )
     })?;
 
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing validity buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing offsets buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing offsets buffer."))?;
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing values buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing values buffer."))?;
     Ok(())
 }

--- a/src/io/ipc/read/array/boolean.rs
+++ b/src/io/ipc/read/array/boolean.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Seek};
 
 use crate::array::BooleanArray;
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node};
@@ -18,7 +18,7 @@ pub fn read_boolean<R: Read + Seek>(
     compression: Option<Compression>,
 ) -> Result<BooleanArray> {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(format!(
+        Error::oos(format!(
             "IPC: unable to fetch the field for {:?}. The file or stream is corrupted.",
             data_type
         ))
@@ -50,16 +50,16 @@ pub fn skip_boolean(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(
+        Error::oos(
             "IPC: unable to fetch the field for boolean. The file or stream is corrupted.",
         )
     })?;
 
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing validity buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing values buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing values buffer."))?;
     Ok(())
 }

--- a/src/io/ipc/read/array/boolean.rs
+++ b/src/io/ipc/read/array/boolean.rs
@@ -50,9 +50,7 @@ pub fn skip_boolean(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(
-            "IPC: unable to fetch the field for boolean. The file or stream is corrupted.",
-        )
+        Error::oos("IPC: unable to fetch the field for boolean. The file or stream is corrupted.")
     })?;
 
     let _ = buffers

--- a/src/io/ipc/read/array/dictionary.rs
+++ b/src/io/ipc/read/array/dictionary.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use std::io::{Read, Seek};
 
 use crate::array::{DictionaryArray, DictionaryKey};
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::Dictionaries;
 use super::super::{Compression, IpcBuffer, Node};
@@ -26,13 +26,13 @@ where
     let id = if let Some(id) = id {
         id
     } else {
-        return Err(ArrowError::OutOfSpec("Dictionary has no id.".to_string()));
+        return Err(Error::OutOfSpec("Dictionary has no id.".to_string()));
     };
     let values = dictionaries
         .get(&id)
         .ok_or_else(|| {
             let valid_ids = dictionaries.keys().collect::<HashSet<_>>();
-            ArrowError::OutOfSpec(format!(
+            Error::OutOfSpec(format!(
                 "Dictionary id {} not found. Valid ids: {:?}",
                 id, valid_ids
             ))

--- a/src/io/ipc/read/array/fixed_size_binary.rs
+++ b/src/io/ipc/read/array/fixed_size_binary.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Seek};
 
 use crate::array::FixedSizeBinaryArray;
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node};
@@ -18,7 +18,7 @@ pub fn read_fixed_size_binary<R: Read + Seek>(
     compression: Option<Compression>,
 ) -> Result<FixedSizeBinaryArray> {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(format!(
+        Error::oos(format!(
             "IPC: unable to fetch the field for {:?}. The file or stream is corrupted.",
             data_type
         ))
@@ -51,16 +51,16 @@ pub fn skip_fixed_size_binary(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(
+        Error::oos(
             "IPC: unable to fetch the field for fixed-size binary. The file or stream is corrupted.",
         )
     })?;
 
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing validity buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing values buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing values buffer."))?;
     Ok(())
 }

--- a/src/io/ipc/read/array/fixed_size_list.rs
+++ b/src/io/ipc/read/array/fixed_size_list.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Seek};
 
 use crate::array::FixedSizeListArray;
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
@@ -25,7 +25,7 @@ pub fn read_fixed_size_list<R: Read + Seek>(
     version: Version,
 ) -> Result<FixedSizeListArray> {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(format!(
+        Error::oos(format!(
             "IPC: unable to fetch the field for {:?}. The file or stream is corrupted.",
             data_type
         ))
@@ -63,14 +63,14 @@ pub fn skip_fixed_size_list(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(
+        Error::oos(
             "IPC: unable to fetch the field for fixed-size list. The file or stream is corrupted.",
         )
     })?;
 
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing validity buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
 
     let (field, _) = FixedSizeListArray::get_child_and_size(data_type);
 

--- a/src/io/ipc/read/array/list.rs
+++ b/src/io/ipc/read/array/list.rs
@@ -5,7 +5,7 @@ use std::io::{Read, Seek};
 use crate::array::{ListArray, Offset};
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
@@ -30,7 +30,7 @@ where
     Vec<u8>: TryInto<O::Bytes>,
 {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(format!(
+        Error::oos(format!(
             "IPC: unable to fetch the field for {:?}. The file or stream is corrupted.",
             data_type
         ))
@@ -79,15 +79,15 @@ pub fn skip_list<O: Offset>(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos("IPC: unable to fetch the field for list. The file or stream is corrupted.")
+        Error::oos("IPC: unable to fetch the field for list. The file or stream is corrupted.")
     })?;
 
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing validity buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing offsets buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing offsets buffer."))?;
 
     let data_type = ListArray::<O>::get_child_type(data_type);
 

--- a/src/io/ipc/read/array/map.rs
+++ b/src/io/ipc/read/array/map.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Seek};
 use crate::array::MapArray;
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
@@ -26,7 +26,7 @@ pub fn read_map<R: Read + Seek>(
     version: Version,
 ) -> Result<MapArray> {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(format!(
+        Error::oos(format!(
             "IPC: unable to fetch the field for {:?}. The file or stream is corrupted.",
             data_type
         ))
@@ -75,15 +75,15 @@ pub fn skip_map(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos("IPC: unable to fetch the field for map. The file or stream is corrupted.")
+        Error::oos("IPC: unable to fetch the field for map. The file or stream is corrupted.")
     })?;
 
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing validity buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing offsets buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing offsets buffer."))?;
 
     let data_type = MapArray::get_field(data_type).data_type();
 

--- a/src/io/ipc/read/array/null.rs
+++ b/src/io/ipc/read/array/null.rs
@@ -3,14 +3,14 @@ use std::collections::VecDeque;
 use crate::{
     array::NullArray,
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::super::Node;
 
 pub fn read_null(field_nodes: &mut VecDeque<Node>, data_type: DataType) -> Result<NullArray> {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(format!(
+        Error::oos(format!(
             "IPC: unable to fetch the field for {:?}. The file or stream is corrupted.",
             data_type
         ))
@@ -21,7 +21,7 @@ pub fn read_null(field_nodes: &mut VecDeque<Node>, data_type: DataType) -> Resul
 
 pub fn skip_null(field_nodes: &mut VecDeque<Node>) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos("IPC: unable to fetch the field for null. The file or stream is corrupted.")
+        Error::oos("IPC: unable to fetch the field for null. The file or stream is corrupted.")
     })?;
     Ok(())
 }

--- a/src/io/ipc/read/array/primitive.rs
+++ b/src/io/ipc/read/array/primitive.rs
@@ -52,9 +52,7 @@ pub fn skip_primitive(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(
-            "IPC: unable to fetch the field for primitive. The file or stream is corrupted.",
-        )
+        Error::oos("IPC: unable to fetch the field for primitive. The file or stream is corrupted.")
     })?;
 
     let _ = buffers

--- a/src/io/ipc/read/array/primitive.rs
+++ b/src/io/ipc/read/array/primitive.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Seek};
 use std::{collections::VecDeque, convert::TryInto};
 
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::{array::PrimitiveArray, types::NativeType};
 
 use super::super::read_basic::*;
@@ -21,7 +21,7 @@ where
     Vec<u8>: TryInto<T::Bytes>,
 {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(format!(
+        Error::oos(format!(
             "IPC: unable to fetch the field for {:?}. The file or stream is corrupted.",
             data_type
         ))
@@ -52,16 +52,16 @@ pub fn skip_primitive(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(
+        Error::oos(
             "IPC: unable to fetch the field for primitive. The file or stream is corrupted.",
         )
     })?;
 
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing validity buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing values buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing values buffer."))?;
     Ok(())
 }

--- a/src/io/ipc/read/array/struct_.rs
+++ b/src/io/ipc/read/array/struct_.rs
@@ -70,9 +70,7 @@ pub fn skip_struct(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(
-            "IPC: unable to fetch the field for struct. The file or stream is corrupted.",
-        )
+        Error::oos("IPC: unable to fetch the field for struct. The file or stream is corrupted.")
     })?;
 
     let _ = buffers

--- a/src/io/ipc/read/array/struct_.rs
+++ b/src/io/ipc/read/array/struct_.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Seek};
 
 use crate::array::StructArray;
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
@@ -25,7 +25,7 @@ pub fn read_struct<R: Read + Seek>(
     version: Version,
 ) -> Result<StructArray> {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(format!(
+        Error::oos(format!(
             "IPC: unable to fetch the field for {:?}. The file or stream is corrupted.",
             data_type
         ))
@@ -70,14 +70,14 @@ pub fn skip_struct(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(
+        Error::oos(
             "IPC: unable to fetch the field for struct. The file or stream is corrupted.",
         )
     })?;
 
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing validity buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
 
     let fields = StructArray::get_fields(data_type);
 

--- a/src/io/ipc/read/array/union.rs
+++ b/src/io/ipc/read/array/union.rs
@@ -94,9 +94,7 @@ pub fn skip_union(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(
-            "IPC: unable to fetch the field for struct. The file or stream is corrupted.",
-        )
+        Error::oos("IPC: unable to fetch the field for struct. The file or stream is corrupted.")
     })?;
 
     let _ = buffers

--- a/src/io/ipc/read/array/union.rs
+++ b/src/io/ipc/read/array/union.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Seek};
 use crate::array::UnionArray;
 use crate::datatypes::DataType;
 use crate::datatypes::UnionMode::Dense;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
@@ -26,7 +26,7 @@ pub fn read_union<R: Read + Seek>(
     version: Version,
 ) -> Result<UnionArray> {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(format!(
+        Error::oos(format!(
             "IPC: unable to fetch the field for {:?}. The file or stream is corrupted.",
             data_type
         ))
@@ -35,7 +35,7 @@ pub fn read_union<R: Read + Seek>(
     if version != Version::V5 {
         let _ = buffers
             .pop_front()
-            .ok_or_else(|| ArrowError::oos("IPC: missing validity buffer."))?;
+            .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
     };
 
     let types = read_buffer(
@@ -94,18 +94,18 @@ pub fn skip_union(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(
+        Error::oos(
             "IPC: unable to fetch the field for struct. The file or stream is corrupted.",
         )
     })?;
 
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing validity buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
     if let DataType::Union(_, _, Dense) = data_type {
         let _ = buffers
             .pop_front()
-            .ok_or_else(|| ArrowError::oos("IPC: missing offsets buffer."))?;
+            .ok_or_else(|| Error::oos("IPC: missing offsets buffer."))?;
     } else {
         unreachable!()
     };

--- a/src/io/ipc/read/array/utf8.rs
+++ b/src/io/ipc/read/array/utf8.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Seek};
 use crate::array::{Offset, Utf8Array};
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node};
@@ -19,7 +19,7 @@ pub fn read_utf8<O: Offset, R: Read + Seek>(
     compression: Option<Compression>,
 ) -> Result<Utf8Array<O>> {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos(format!(
+        Error::oos(format!(
             "IPC: unable to fetch the field for {:?}. The file or stream is corrupted.",
             data_type
         ))
@@ -63,17 +63,17 @@ pub fn skip_utf8(
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
-        ArrowError::oos("IPC: unable to fetch the field for utf8. The file or stream is corrupted.")
+        Error::oos("IPC: unable to fetch the field for utf8. The file or stream is corrupted.")
     })?;
 
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing validity buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing offsets buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing offsets buffer."))?;
     let _ = buffers
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: missing values buffer."))?;
+        .ok_or_else(|| Error::oos("IPC: missing values buffer."))?;
     Ok(())
 }

--- a/src/io/ipc/read/common.rs
+++ b/src/io/ipc/read/common.rs
@@ -7,7 +7,7 @@ use arrow_format;
 use crate::array::*;
 use crate::chunk::Chunk;
 use crate::datatypes::{DataType, Field};
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::io::ipc::{IpcField, IpcSchema};
 
 use super::deserialize::{read, skip};
@@ -90,12 +90,12 @@ pub fn read_record_batch<R: Read + Seek>(
     assert_eq!(fields.len(), ipc_schema.fields.len());
     let buffers = batch
         .buffers()?
-        .ok_or_else(|| ArrowError::oos("IPC RecordBatch must contain buffers"))?;
+        .ok_or_else(|| Error::oos("IPC RecordBatch must contain buffers"))?;
     let mut buffers: VecDeque<arrow_format::ipc::BufferRef> = buffers.iter().collect();
 
     let field_nodes = batch
         .nodes()?
-        .ok_or_else(|| ArrowError::oos("IPC RecordBatch must contain field nodes"))?;
+        .ok_or_else(|| Error::oos("IPC RecordBatch must contain field nodes"))?;
     let mut field_nodes = field_nodes.iter().collect::<VecDeque<_>>();
 
     let columns = if let Some(projection) = projection {
@@ -193,7 +193,7 @@ fn first_dict_field<'a>(
             return Ok(field);
         }
     }
-    Err(ArrowError::OutOfSpec(format!(
+    Err(Error::OutOfSpec(format!(
         "dictionary id {} not found in schema",
         id
     )))
@@ -210,7 +210,7 @@ pub fn read_dictionary<R: Read + Seek>(
     block_offset: u64,
 ) -> Result<()> {
     if batch.is_delta()? {
-        return Err(ArrowError::NotYetImplemented(
+        return Err(Error::NotYetImplemented(
             "delta dictionary batches not supported".to_string(),
         ));
     }
@@ -232,7 +232,7 @@ pub fn read_dictionary<R: Read + Seek>(
             let columns = read_record_batch(
                 batch
                     .data()?
-                    .ok_or_else(|| ArrowError::oos("The dictionary batch must have data."))?,
+                    .ok_or_else(|| Error::oos("The dictionary batch must have data."))?,
                 &fields,
                 &ipc_schema,
                 None,
@@ -247,7 +247,7 @@ pub fn read_dictionary<R: Read + Seek>(
         _ => None,
     }
     .ok_or_else(|| {
-        ArrowError::InvalidArgumentError("dictionary id not found in schema".to_string())
+        Error::InvalidArgumentError("dictionary id not found in schema".to_string())
     })?;
 
     dictionaries.insert(id, dictionary_values);

--- a/src/io/ipc/read/common.rs
+++ b/src/io/ipc/read/common.rs
@@ -246,9 +246,7 @@ pub fn read_dictionary<R: Read + Seek>(
         }
         _ => None,
     }
-    .ok_or_else(|| {
-        Error::InvalidArgumentError("dictionary id not found in schema".to_string())
-    })?;
+    .ok_or_else(|| Error::InvalidArgumentError("dictionary id not found in schema".to_string()))?;
 
     dictionaries.insert(id, dictionary_values);
 

--- a/src/io/ipc/read/file_async.rs
+++ b/src/io/ipc/read/file_async.rs
@@ -210,9 +210,8 @@ where
         let length = block.body_length as usize;
         read_dictionary_message(&mut reader, offset, &mut data).await?;
 
-        let message = MessageRef::read_as_root(&data).map_err(|err| {
-            Error::OutOfSpec(format!("unable to get root as message: {:?}", err))
-        })?;
+        let message = MessageRef::read_as_root(&data)
+            .map_err(|err| Error::OutOfSpec(format!("unable to get root as message: {:?}", err)))?;
         let header = message
             .header()?
             .ok_or_else(|| Error::oos("message must have a header"))?;

--- a/src/io/ipc/read/read_basic.rs
+++ b/src/io/ipc/read/read_basic.rs
@@ -230,9 +230,9 @@ pub fn read_validity<R: Read + Seek>(
             compression,
         )?)
     } else {
-        let _ = buffers.pop_front().ok_or_else(|| {
-            Error::oos("IPC: unable to fetch a buffer. The file is corrupted.")
-        })?;
+        let _ = buffers
+            .pop_front()
+            .ok_or_else(|| Error::oos("IPC: unable to fetch a buffer. The file is corrupted."))?;
         None
     })
 }

--- a/src/io/ipc/read/read_basic.rs
+++ b/src/io/ipc/read/read_basic.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::{collections::VecDeque, convert::TryInto};
 
 use crate::buffer::Buffer;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::{bitmap::Bitmap, types::NativeType};
 
 use super::super::compression;
@@ -36,7 +36,7 @@ fn read_swapped<T: NativeType, R: Read + Seek>(
             })?;
     } else {
         // machine is big endian, file is little endian
-        return Err(ArrowError::NotYetImplemented(
+        return Err(Error::NotYetImplemented(
             "Reading little endian files from big endian machines".to_string(),
         ));
     }
@@ -51,7 +51,7 @@ fn read_uncompressed_buffer<T: NativeType, R: Read + Seek>(
 ) -> Result<Vec<T>> {
     let bytes = length * std::mem::size_of::<T>();
     if bytes > buffer_length {
-        return Err(ArrowError::OutOfSpec(
+        return Err(Error::OutOfSpec(
             format!("The slots of the array times the physical size must \
             be smaller or equal to the length of the IPC buffer. \
             However, this array reports {} slots, which, for physical type \"{}\", corresponds to {} bytes, \
@@ -86,7 +86,7 @@ fn read_compressed_buffer<T: NativeType, R: Read + Seek>(
     compression: Compression,
 ) -> Result<Vec<T>> {
     if is_little_endian != is_native_little_endian() {
-        return Err(ArrowError::NotYetImplemented(
+        return Err(Error::NotYetImplemented(
             "Reading compressed and big endian IPC".to_string(),
         ));
     }
@@ -124,7 +124,7 @@ pub fn read_buffer<T: NativeType, R: Read + Seek>(
 ) -> Result<Buffer<T>> {
     let buf = buf
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: unable to fetch a buffer. The file is corrupted."))?;
+        .ok_or_else(|| Error::oos("IPC: unable to fetch a buffer. The file is corrupted."))?;
 
     reader.seek(SeekFrom::Start(block_offset + buf.offset() as u64))?;
 
@@ -146,7 +146,7 @@ fn read_uncompressed_bitmap<R: Read + Seek>(
     reader: &mut R,
 ) -> Result<Vec<u8>> {
     if length > bytes * 8 {
-        return Err(ArrowError::OutOfSpec(format!(
+        return Err(Error::OutOfSpec(format!(
             "An array requires a bitmap with at least the same number of bits as slots. \
             However, this array reports {} slots but the the bitmap in IPC only contains \
             {} bits",
@@ -197,7 +197,7 @@ pub fn read_bitmap<R: Read + Seek>(
 ) -> Result<Bitmap> {
     let buf = buf
         .pop_front()
-        .ok_or_else(|| ArrowError::oos("IPC: unable to fetch a buffer. The file is corrupted."))?;
+        .ok_or_else(|| Error::oos("IPC: unable to fetch a buffer. The file is corrupted."))?;
 
     reader.seek(SeekFrom::Start(block_offset + buf.offset() as u64))?;
 
@@ -231,7 +231,7 @@ pub fn read_validity<R: Read + Seek>(
         )?)
     } else {
         let _ = buffers.pop_front().ok_or_else(|| {
-            ArrowError::oos("IPC: unable to fetch a buffer. The file is corrupted.")
+            Error::oos("IPC: unable to fetch a buffer. The file is corrupted.")
         })?;
         None
     })

--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -79,9 +79,8 @@ pub(crate) fn read_dictionaries<R: Read + Seek>(
         let length = block.meta_data_length as u64;
         read_dictionary_message(reader, offset, &mut data)?;
 
-        let message = arrow_format::ipc::MessageRef::read_as_root(&data).map_err(|err| {
-            Error::OutOfSpec(format!("Unable to get root as message: {:?}", err))
-        })?;
+        let message = arrow_format::ipc::MessageRef::read_as_root(&data)
+            .map_err(|err| Error::OutOfSpec(format!("Unable to get root as message: {:?}", err)))?;
 
         let header = message
             .header()?
@@ -133,9 +132,9 @@ pub(super) fn deserialize_footer(footer_data: &[u8]) -> Result<FileMetadata> {
     let footer = arrow_format::ipc::FooterRef::read_as_root(footer_data)
         .map_err(|err| Error::OutOfSpec(format!("Unable to get root as footer: {:?}", err)))?;
 
-    let blocks = footer.record_batches()?.ok_or_else(|| {
-        Error::OutOfSpec("Unable to get record batches from footer".to_string())
-    })?;
+    let blocks = footer
+        .record_batches()?
+        .ok_or_else(|| Error::OutOfSpec("Unable to get record batches from footer".to_string()))?;
 
     let blocks = blocks
         .iter()

--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use crate::array::Array;
 use crate::chunk::Chunk;
 use crate::datatypes::{Field, Schema};
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::io::ipc::IpcSchema;
 
 use super::super::{ARROW_MAGIC, CONTINUATION_MARKER};
@@ -80,12 +80,12 @@ pub(crate) fn read_dictionaries<R: Read + Seek>(
         read_dictionary_message(reader, offset, &mut data)?;
 
         let message = arrow_format::ipc::MessageRef::read_as_root(&data).map_err(|err| {
-            ArrowError::OutOfSpec(format!("Unable to get root as message: {:?}", err))
+            Error::OutOfSpec(format!("Unable to get root as message: {:?}", err))
         })?;
 
         let header = message
             .header()?
-            .ok_or_else(|| ArrowError::oos("Message must have an header"))?;
+            .ok_or_else(|| Error::oos("Message must have an header"))?;
 
         match header {
             arrow_format::ipc::MessageHeaderRef::DictionaryBatch(batch) => {
@@ -100,7 +100,7 @@ pub(crate) fn read_dictionaries<R: Read + Seek>(
                 )?;
             }
             t => {
-                return Err(ArrowError::OutOfSpec(format!(
+                return Err(Error::OutOfSpec(format!(
                     "Expecting DictionaryBatch in dictionary blocks, found {:?}.",
                     t
                 )));
@@ -120,21 +120,21 @@ fn read_footer_len<R: Read + Seek>(reader: &mut R) -> Result<usize> {
     let footer_len = i32::from_le_bytes(footer[..4].try_into().unwrap());
 
     if footer[4..] != ARROW_MAGIC {
-        return Err(ArrowError::OutOfSpec(
+        return Err(Error::OutOfSpec(
             "Arrow file does not contain correct footer".to_string(),
         ));
     }
     footer_len
         .try_into()
-        .map_err(|_| ArrowError::oos("The footer's lenght must be a positive number"))
+        .map_err(|_| Error::oos("The footer's lenght must be a positive number"))
 }
 
 pub(super) fn deserialize_footer(footer_data: &[u8]) -> Result<FileMetadata> {
     let footer = arrow_format::ipc::FooterRef::read_as_root(footer_data)
-        .map_err(|err| ArrowError::OutOfSpec(format!("Unable to get root as footer: {:?}", err)))?;
+        .map_err(|err| Error::OutOfSpec(format!("Unable to get root as footer: {:?}", err)))?;
 
     let blocks = footer.record_batches()?.ok_or_else(|| {
-        ArrowError::OutOfSpec("Unable to get record batches from footer".to_string())
+        Error::OutOfSpec("Unable to get record batches from footer".to_string())
     })?;
 
     let blocks = blocks
@@ -144,7 +144,7 @@ pub(super) fn deserialize_footer(footer_data: &[u8]) -> Result<FileMetadata> {
 
     let ipc_schema = footer
         .schema()?
-        .ok_or_else(|| ArrowError::OutOfSpec("Unable to get the schema from footer".to_string()))?;
+        .ok_or_else(|| Error::OutOfSpec("Unable to get the schema from footer".to_string()))?;
     let (schema, ipc_schema) = fb_to_schema(ipc_schema)?;
 
     let dictionaries = footer
@@ -171,7 +171,7 @@ pub fn read_file_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetadata
     let mut magic_buffer: [u8; 6] = [0; 6];
     reader.read_exact(&mut magic_buffer)?;
     if magic_buffer != ARROW_MAGIC {
-        return Err(ArrowError::OutOfSpec(
+        return Err(Error::OutOfSpec(
             "Arrow file does not contain correct header".to_string(),
         ));
     }
@@ -203,14 +203,14 @@ pub(super) fn get_serialized_batch<'a>(
     message: &'a arrow_format::ipc::MessageRef,
 ) -> Result<arrow_format::ipc::RecordBatchRef<'a>> {
     let header = message.header()?.ok_or_else(|| {
-        ArrowError::oos("IPC: unable to fetch the message header. The file or stream is corrupted.")
+        Error::oos("IPC: unable to fetch the message header. The file or stream is corrupted.")
     })?;
     match header {
-        arrow_format::ipc::MessageHeaderRef::Schema(_) => Err(ArrowError::OutOfSpec(
+        arrow_format::ipc::MessageHeaderRef::Schema(_) => Err(Error::OutOfSpec(
             "Not expecting a schema when messages are read".to_string(),
         )),
         arrow_format::ipc::MessageHeaderRef::RecordBatch(batch) => Ok(batch),
-        t => Err(ArrowError::OutOfSpec(format!(
+        t => Err(Error::OutOfSpec(format!(
             "Reading types other than record batches not yet supported, unable to read {:?}",
             t
         ))),
@@ -243,7 +243,7 @@ pub fn read_batch<R: Read + Seek>(
     reader.read_exact(block_data)?;
 
     let message = arrow_format::ipc::MessageRef::read_as_root(&block_data[..])
-        .map_err(|err| ArrowError::oos(format!("Unable parse message: {:?}", err)))?;
+        .map_err(|err| Error::oos(format!("Unable parse message: {:?}", err)))?;
 
     let batch = get_serialized_batch(&message)?;
 

--- a/src/io/ipc/read/schema.rs
+++ b/src/io/ipc/read/schema.rs
@@ -70,11 +70,7 @@ fn deserialize_integer(int: arrow_format::ipc::IntRef) -> Result<IntegerType> {
         (32, false) => IntegerType::UInt32,
         (64, true) => IntegerType::Int64,
         (64, false) => IntegerType::UInt64,
-        _ => {
-            return Err(Error::oos(
-                "IPC: indexType can only be 8, 16, 32 or 64.",
-            ))
-        }
+        _ => return Err(Error::oos("IPC: indexType can only be 8, 16, 32 or 64.")),
     })
 }
 
@@ -259,9 +255,7 @@ fn get_data_type(
                 .children()?
                 .ok_or_else(|| Error::oos("IPC: Struct must contain children"))?;
             if fields.is_empty() {
-                return Err(Error::oos(
-                    "IPC: Struct must contain at least one child",
-                ));
+                return Err(Error::oos("IPC: Struct must contain at least one child"));
             }
             let (fields, ipc_fields) = try_unzip_vec(fields.iter().map(|field| {
                 let (field, fields) = deserialize_field(field?)?;
@@ -281,9 +275,7 @@ fn get_data_type(
                 .children()?
                 .ok_or_else(|| Error::oos("IPC: Union must contain children"))?;
             if fields.is_empty() {
-                return Err(Error::oos(
-                    "IPC: Union must contain at least one child",
-                ));
+                return Err(Error::oos("IPC: Union must contain at least one child"));
             }
 
             let (fields, ipc_fields) = try_unzip_vec(fields.iter().map(|field| {
@@ -375,9 +367,8 @@ pub(super) fn fb_to_schema(schema: arrow_format::ipc::SchemaRef) -> Result<(Sche
 }
 
 pub(super) fn deserialize_stream_metadata(meta: &[u8]) -> Result<StreamMetadata> {
-    let message = arrow_format::ipc::MessageRef::read_as_root(meta).map_err(|err| {
-        Error::OutOfSpec(format!("Unable to get root as message: {:?}", err))
-    })?;
+    let message = arrow_format::ipc::MessageRef::read_as_root(meta)
+        .map_err(|err| Error::OutOfSpec(format!("Unable to get root as message: {:?}", err)))?;
     let version = message.version()?;
     // message header is a Schema, so read it
     let header = message

--- a/src/io/ipc/read/stream.rs
+++ b/src/io/ipc/read/stream.rs
@@ -123,9 +123,8 @@ fn read_next<R: Read>(
     message_buffer.resize(meta_length, 0);
     reader.read_exact(message_buffer)?;
 
-    let message = arrow_format::ipc::MessageRef::read_as_root(message_buffer).map_err(|err| {
-        Error::OutOfSpec(format!("Unable to get root as message: {:?}", err))
-    })?;
+    let message = arrow_format::ipc::MessageRef::read_as_root(message_buffer)
+        .map_err(|err| Error::OutOfSpec(format!("Unable to get root as message: {:?}", err)))?;
     let header = message.header()?.ok_or_else(|| {
         Error::oos("IPC: unable to fetch the message header. The file or stream is corrupted.")
     })?;

--- a/src/io/ipc/read/stream_async.rs
+++ b/src/io/ipc/read/stream_async.rs
@@ -9,7 +9,7 @@ use futures::Stream;
 
 use crate::array::*;
 use crate::chunk::Chunk;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::super::CONTINUATION_MARKER;
 use super::common::{read_dictionary, read_record_batch};
@@ -75,7 +75,7 @@ async fn maybe_next<R: AsyncRead + Unpin + Send>(
                 // https://arrow.apache.org/docs/format/Columnar.html#ipc-streaming-format
                 Ok(Some(StreamState::Waiting(state)))
             } else {
-                Err(ArrowError::from(e))
+                Err(Error::from(e))
             };
         }
     }
@@ -100,14 +100,14 @@ async fn maybe_next<R: AsyncRead + Unpin + Send>(
 
     let message =
         arrow_format::ipc::MessageRef::read_as_root(&state.message_buffer).map_err(|err| {
-            ArrowError::OutOfSpec(format!("Unable to get root as message: {:?}", err))
+            Error::OutOfSpec(format!("Unable to get root as message: {:?}", err))
         })?;
     let header = message.header()?.ok_or_else(|| {
-        ArrowError::oos("IPC: unable to fetch the message header. The file or stream is corrupted.")
+        Error::oos("IPC: unable to fetch the message header. The file or stream is corrupted.")
     })?;
 
     match header {
-        arrow_format::ipc::MessageHeaderRef::Schema(_) => Err(ArrowError::oos("A stream ")),
+        arrow_format::ipc::MessageHeaderRef::Schema(_) => Err(Error::oos("A stream ")),
         arrow_format::ipc::MessageHeaderRef::RecordBatch(batch) => {
             // read the block that makes up the record batch into a buffer
             state.data_buffer.clear();
@@ -145,7 +145,7 @@ async fn maybe_next<R: AsyncRead + Unpin + Send>(
             // read the next message until we encounter a Chunk<Arc<dyn Array>> message
             Ok(Some(StreamState::Waiting(state)))
         }
-        t => Err(ArrowError::OutOfSpec(format!(
+        t => Err(Error::OutOfSpec(format!(
             "Reading types other than record batches not yet supported, unable to read {:?} ",
             t
         ))),

--- a/src/io/ipc/read/stream_async.rs
+++ b/src/io/ipc/read/stream_async.rs
@@ -98,10 +98,8 @@ async fn maybe_next<R: AsyncRead + Unpin + Send>(
     state.message_buffer.resize(meta_length, 0);
     state.reader.read_exact(&mut state.message_buffer).await?;
 
-    let message =
-        arrow_format::ipc::MessageRef::read_as_root(&state.message_buffer).map_err(|err| {
-            Error::OutOfSpec(format!("Unable to get root as message: {:?}", err))
-        })?;
+    let message = arrow_format::ipc::MessageRef::read_as_root(&state.message_buffer)
+        .map_err(|err| Error::OutOfSpec(format!("Unable to get root as message: {:?}", err)))?;
     let header = message.header()?.ok_or_else(|| {
         Error::oos("IPC: unable to fetch the message header. The file or stream is corrupted.")
     })?;

--- a/src/io/ipc/write/common.rs
+++ b/src/io/ipc/write/common.rs
@@ -6,7 +6,7 @@ use arrow_format::ipc::planus::Builder;
 use crate::array::*;
 use crate::chunk::Chunk;
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::io::ipc::endianess::is_native_little_endian;
 use crate::io::ipc::read::Dictionaries;
 
@@ -43,7 +43,7 @@ fn encode_dictionary(
         | FixedSizeBinary => Ok(()),
         Dictionary(key_type) => match_integer_type!(key_type, |$T| {
             let dict_id = field.dictionary_id
-                .ok_or_else(|| ArrowError::InvalidArgumentError("Dictionaries must have an associated id".to_string()))?;
+                .ok_or_else(|| Error::InvalidArgumentError("Dictionaries must have an associated id".to_string()))?;
 
             let emit = dictionary_tracker.insert(dict_id, array)?;
 
@@ -70,7 +70,7 @@ fn encode_dictionary(
             let array = array.as_any().downcast_ref::<StructArray>().unwrap();
             let fields = field.fields.as_slice();
             if array.fields().len() != fields.len() {
-                return Err(ArrowError::InvalidArgumentError(
+                return Err(Error::InvalidArgumentError(
                     "The number of fields in a struct must equal the number of children in IpcField".to_string(),
                 ));
             }
@@ -140,7 +140,7 @@ fn encode_dictionary(
                 .fields();
             let fields = &field.fields[..]; // todo: error instead
             if values.len() != fields.len() {
-                return Err(ArrowError::InvalidArgumentError(
+                return Err(Error::InvalidArgumentError(
                     "The number of fields in a union must equal the number of children in IpcField"
                         .to_string(),
                 ));
@@ -346,7 +346,7 @@ impl DictionaryTracker {
                 // Same dictionary values => no need to emit it again
                 return Ok(false);
             } else if self.cannot_replace {
-                return Err(ArrowError::InvalidArgumentError(
+                return Err(Error::InvalidArgumentError(
                     "Dictionary replacement detected when writing IPC file format. \
                      Arrow IPC files only support a single dictionary for a given field \
                      across all batches."

--- a/src/io/ipc/write/file_async.rs
+++ b/src/io/ipc/write/file_async.rs
@@ -10,7 +10,7 @@ use super::common_async::{write_continuation, write_message};
 use super::schema::serialize_schema;
 use super::{default_ipc_fields, schema_to_bytes, Record};
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::io::ipc::{IpcField, ARROW_MAGIC};
 
 type WriteOutput<W> = (usize, Option<Block>, Vec<Block>, Option<W>);
@@ -184,7 +184,7 @@ impl<'a, W> Sink<Record<'_>> for FileSink<'a, W>
 where
     W: AsyncWrite + Unpin + Send + 'a,
 {
-    type Error = ArrowError;
+    type Error = Error;
 
     fn poll_ready(
         self: std::pin::Pin<&mut Self>,
@@ -209,7 +209,7 @@ where
             this.task = Some(Self::write(writer, this.offset, record, dictionaries).boxed());
             Ok(())
         } else {
-            Err(ArrowError::Io(std::io::Error::new(
+            Err(Error::Io(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 "writer is closed",
             )))

--- a/src/io/ipc/write/stream.rs
+++ b/src/io/ipc/write/stream.rs
@@ -14,7 +14,7 @@ use super::{default_ipc_fields, schema_to_bytes};
 use crate::array::Array;
 use crate::chunk::Chunk;
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 /// Arrow stream writer
 ///
@@ -74,7 +74,7 @@ impl<W: Write> StreamWriter<W> {
         ipc_fields: Option<&[IpcField]>,
     ) -> Result<()> {
         if self.finished {
-            return Err(ArrowError::Io(std::io::Error::new(
+            return Err(Error::Io(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 "Cannot write to a finished stream".to_string(),
             )));

--- a/src/io/ipc/write/stream_async.rs
+++ b/src/io/ipc/write/stream_async.rs
@@ -11,7 +11,7 @@ use super::common_async::{write_continuation, write_message};
 use super::{default_ipc_fields, schema_to_bytes, Record};
 
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 /// A sink that writes array [`chunks`](Chunk) as an IPC stream.
 ///
@@ -119,7 +119,7 @@ where
             );
             Ok(())
         } else {
-            Err(ArrowError::Io(std::io::Error::new(
+            Err(Error::Io(std::io::Error::new(
                 std::io::ErrorKind::UnexpectedEof,
                 "writer closed".to_string(),
             )))
@@ -149,7 +149,7 @@ impl<'a, W> Sink<Record<'_>> for StreamSink<'a, W>
 where
     W: AsyncWrite + Unpin + Send,
 {
-    type Error = ArrowError;
+    type Error = Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Result<()>> {
         self.get_mut().poll_complete(cx)

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -13,7 +13,7 @@ use super::{
 use crate::array::Array;
 use crate::chunk::Chunk;
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum State {
@@ -96,7 +96,7 @@ impl<W: Write> FileWriter<W> {
     /// Errors if the file has been started or has finished.
     pub fn start(&mut self) -> Result<()> {
         if self.state != State::None {
-            return Err(ArrowError::oos("The IPC file can only be started once"));
+            return Err(Error::oos("The IPC file can only be started once"));
         }
         // write magic to header
         self.writer.write_all(&ARROW_MAGIC[..])?;
@@ -122,7 +122,7 @@ impl<W: Write> FileWriter<W> {
         ipc_fields: Option<&[IpcField]>,
     ) -> Result<()> {
         if self.state != State::Started {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "The IPC file must be started before it can be written to. Call `start` before `write`",
             ));
         }
@@ -168,7 +168,7 @@ impl<W: Write> FileWriter<W> {
     /// Write footer and closing tag, then mark the writer as done
     pub fn finish(&mut self) -> Result<()> {
         if self.state != State::Started {
-            return Err(ArrowError::oos(
+            return Err(Error::oos(
                 "The IPC file must be started before it can be finished. Call `start` before `finish`",
             ));
         }

--- a/src/io/json/mod.rs
+++ b/src/io/json/mod.rs
@@ -3,10 +3,10 @@
 pub mod read;
 pub mod write;
 
-use crate::error::ArrowError;
+use crate::error::Error;
 
-impl From<serde_json::error::Error> for ArrowError {
+impl From<serde_json::error::Error> for Error {
     fn from(error: serde_json::error::Error) -> Self {
-        ArrowError::External("".to_string(), Box::new(error))
+        Error::External("".to_string(), Box::new(error))
     }
 }

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -11,7 +11,7 @@ use crate::{
     array::*,
     bitmap::MutableBitmap,
     datatypes::{DataType, IntervalUnit},
-    error::ArrowError,
+    error::Error,
     types::NativeType,
 };
 
@@ -260,14 +260,14 @@ pub(crate) fn _deserialize<A: Borrow<Value>>(rows: &[A], data_type: DataType) ->
 /// This function errors iff either:
 /// * `json` is not a [`Value::Array`]
 /// * `data_type` is neither [`DataType::List`] nor [`DataType::LargeList`]
-pub fn deserialize(json: &Value, data_type: DataType) -> Result<Arc<dyn Array>, ArrowError> {
+pub fn deserialize(json: &Value, data_type: DataType) -> Result<Arc<dyn Array>, Error> {
     match json {
         Value::Array(rows) => match data_type {
             DataType::List(inner) | DataType::LargeList(inner) => {
                 Ok(_deserialize(rows, inner.data_type))
             }
-            _ => Err(ArrowError::nyi("read an Array from a non-Array data type")),
+            _ => Err(Error::nyi("read an Array from a non-Array data type")),
         },
-        _ => Err(ArrowError::nyi("read an Array from a non-Array JSON")),
+        _ => Err(Error::nyi("read an Array from a non-Array JSON")),
     }
 }

--- a/src/io/json/write/mod.rs
+++ b/src/io/json/write/mod.rs
@@ -5,7 +5,7 @@ pub use fallible_streaming_iterator::*;
 pub(crate) use serialize::new_serializer;
 use serialize::serialize;
 
-use crate::{array::Array, error::ArrowError};
+use crate::{array::Array, error::Error};
 
 /// [`FallibleStreamingIterator`] that serializes an [`Array`] to bytes of valid JSON
 /// # Implementation
@@ -14,7 +14,7 @@ use crate::{array::Array, error::ArrowError};
 pub struct Serializer<A, I>
 where
     A: AsRef<dyn Array>,
-    I: Iterator<Item = Result<A, ArrowError>>,
+    I: Iterator<Item = Result<A, Error>>,
 {
     arrays: I,
     buffer: Vec<u8>,
@@ -23,7 +23,7 @@ where
 impl<A, I> Serializer<A, I>
 where
     A: AsRef<dyn Array>,
-    I: Iterator<Item = Result<A, ArrowError>>,
+    I: Iterator<Item = Result<A, Error>>,
 {
     /// Creates a new [`Serializer`].
     pub fn new(arrays: I, buffer: Vec<u8>) -> Self {
@@ -34,13 +34,13 @@ where
 impl<A, I> FallibleStreamingIterator for Serializer<A, I>
 where
     A: AsRef<dyn Array>,
-    I: Iterator<Item = Result<A, ArrowError>>,
+    I: Iterator<Item = Result<A, Error>>,
 {
     type Item = [u8];
 
-    type Error = ArrowError;
+    type Error = Error;
 
-    fn advance(&mut self) -> Result<(), ArrowError> {
+    fn advance(&mut self) -> Result<(), Error> {
         self.buffer.clear();
         self.arrays
             .next()
@@ -59,10 +59,10 @@ where
 }
 
 /// Writes valid JSON from an iterator of (assumed JSON-encoded) bytes to `writer`
-pub fn write<W, I>(writer: &mut W, mut blocks: I) -> Result<(), ArrowError>
+pub fn write<W, I>(writer: &mut W, mut blocks: I) -> Result<(), Error>
 where
     W: std::io::Write,
-    I: FallibleStreamingIterator<Item = [u8], Error = ArrowError>,
+    I: FallibleStreamingIterator<Item = [u8], Error = Error>,
 {
     writer.write_all(&[b'['])?;
     let mut is_first_row = true;

--- a/src/io/json_integration/read/array.rs
+++ b/src/io/json_integration/read/array.rs
@@ -9,7 +9,7 @@ use crate::{
     buffer::Buffer,
     chunk::Chunk,
     datatypes::{DataType, PhysicalType, PrimitiveType, Schema},
-    error::{ArrowError, Result},
+    error::{Error, Result},
     io::ipc::IpcField,
     types::{days_ms, months_days_ns, NativeType},
 };
@@ -239,7 +239,7 @@ fn to_dictionary<K: DictionaryKey>(
     // find dictionary
     let dict_id = field.dictionary_id.unwrap();
     let dictionary = dictionaries.get(&dict_id).ok_or_else(|| {
-        ArrowError::OutOfSpec(format!("Unable to find any dictionary id {}", dict_id))
+        Error::OutOfSpec(format!("Unable to find any dictionary id {}", dict_id))
     })?;
 
     let keys = to_primitive(json_col, K::PRIMITIVE.into());

--- a/src/io/json_integration/read/array.rs
+++ b/src/io/json_integration/read/array.rs
@@ -238,9 +238,9 @@ fn to_dictionary<K: DictionaryKey>(
 ) -> Result<Arc<dyn Array>> {
     // find dictionary
     let dict_id = field.dictionary_id.unwrap();
-    let dictionary = dictionaries.get(&dict_id).ok_or_else(|| {
-        Error::OutOfSpec(format!("Unable to find any dictionary id {}", dict_id))
-    })?;
+    let dictionary = dictionaries
+        .get(&dict_id)
+        .ok_or_else(|| Error::OutOfSpec(format!("Unable to find any dictionary id {}", dict_id)))?;
 
     let keys = to_primitive(json_col, K::PRIMITIVE.into());
 

--- a/src/io/json_integration/read/schema.rs
+++ b/src/io/json_integration/read/schema.rs
@@ -17,9 +17,7 @@ fn to_time_unit(item: Option<&Value>) -> Result<TimeUnit> {
         Some(p) if p == "MILLISECOND" => Ok(TimeUnit::Millisecond),
         Some(p) if p == "MICROSECOND" => Ok(TimeUnit::Microsecond),
         Some(p) if p == "NANOSECOND" => Ok(TimeUnit::Nanosecond),
-        _ => Err(Error::OutOfSpec(
-            "time unit missing or invalid".to_string(),
-        )),
+        _ => Err(Error::OutOfSpec("time unit missing or invalid".to_string())),
     }
 }
 
@@ -78,9 +76,7 @@ fn deserialize_fields(children: Option<&Value>) -> Result<Vec<Field>> {
                     .map(deserialize_field)
                     .collect::<Result<Vec<_>>>()
             } else {
-                Err(Error::OutOfSpec(
-                    "children must be an array".to_string(),
-                ))
+                Err(Error::OutOfSpec("children must be an array".to_string()))
             }
         })
         .unwrap_or_else(|| Ok(vec![]))
@@ -204,20 +200,14 @@ fn to_data_type(item: &Value, mut children: Vec<Field>) -> Result<DataType> {
             let tz = match item.get("timezone") {
                 None => Ok(None),
                 Some(Value::String(tz)) => Ok(Some(tz.clone())),
-                _ => Err(Error::OutOfSpec(
-                    "timezone must be a string".to_string(),
-                )),
+                _ => Err(Error::OutOfSpec("timezone must be a string".to_string())),
             }?;
             DataType::Timestamp(unit, tz)
         }
         "date" => match item.get("unit") {
             Some(p) if p == "DAY" => DataType::Date32,
             Some(p) if p == "MILLISECOND" => DataType::Date64,
-            _ => {
-                return Err(Error::OutOfSpec(
-                    "date unit missing or invalid".to_string(),
-                ))
-            }
+            _ => return Err(Error::OutOfSpec("date unit missing or invalid".to_string())),
         },
         "time" => {
             let unit = to_time_unit(item.get("unit"))?;
@@ -309,9 +299,7 @@ fn deserialize_ipc_field(value: &Value) -> Result<IpcField> {
                     .map(deserialize_ipc_field)
                     .collect::<Result<Vec<_>>>()
             } else {
-                Err(Error::OutOfSpec(
-                    "children must be an array".to_string(),
-                ))
+                Err(Error::OutOfSpec("children must be an array".to_string()))
             }
         })
         .unwrap_or_else(|| Ok(vec![]))?;
@@ -320,9 +308,7 @@ fn deserialize_ipc_field(value: &Value) -> Result<IpcField> {
         match dictionary.get("id") {
             Some(Value::Number(n)) => Some(n.as_i64().unwrap()),
             _ => {
-                return Err(Error::OutOfSpec(
-                    "Field missing 'id' attribute".to_string(),
-                ));
+                return Err(Error::OutOfSpec("Field missing 'id' attribute".to_string()));
             }
         }
     } else {

--- a/src/io/ndjson/read/deserialize.rs
+++ b/src/io/ndjson/read/deserialize.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 
 use crate::array::Array;
 use crate::datatypes::DataType;
-use crate::error::ArrowError;
+use crate::error::Error;
 
 use super::super::super::json::read::_deserialize;
 
@@ -14,9 +14,9 @@ use super::super::super::json::read::_deserialize;
 /// This function is guaranteed to return an array of length equal to `rows.len()`.
 /// # Errors
 /// This function errors iff any of the rows is not a valid JSON (i.e. the format is not valid NDJSON).
-pub fn deserialize(rows: &[String], data_type: DataType) -> Result<Arc<dyn Array>, ArrowError> {
+pub fn deserialize(rows: &[String], data_type: DataType) -> Result<Arc<dyn Array>, Error> {
     if rows.is_empty() {
-        return Err(ArrowError::ExternalFormat(
+        return Err(Error::ExternalFormat(
             "Cannot deserialize 0 NDJSON rows because empty string is not a valid JSON value"
                 .to_string(),
         ));
@@ -34,11 +34,11 @@ pub fn deserialize(rows: &[String], data_type: DataType) -> Result<Arc<dyn Array
 pub fn deserialize_iter<A: AsRef<str>>(
     rows: impl Iterator<Item = A>,
     data_type: DataType,
-) -> Result<Arc<dyn Array>, ArrowError> {
+) -> Result<Arc<dyn Array>, Error> {
     // deserialize strings to `Value`s
     let rows = rows
-        .map(|row| serde_json::from_str(row.as_ref()).map_err(ArrowError::from))
-        .collect::<Result<Vec<Value>, ArrowError>>()?;
+        .map(|row| serde_json::from_str(row.as_ref()).map_err(Error::from))
+        .collect::<Result<Vec<Value>, Error>>()?;
 
     // deserialize &[Value] to Array
     Ok(_deserialize(&rows, data_type))

--- a/src/io/ndjson/read/file.rs
+++ b/src/io/ndjson/read/file.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 
 use crate::{
     datatypes::DataType,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::super::super::json::read::{coerce_data_type, infer as infer_json};
@@ -22,7 +22,7 @@ fn read_rows<R: BufRead>(reader: &mut R, rows: &mut [String], limit: usize) -> R
         loop {
             row.clear();
             let _ = reader.read_line(row).map_err(|e| {
-                ArrowError::External(format!(" at line {}", row_number), Box::new(e))
+                Error::External(format!(" at line {}", row_number), Box::new(e))
             })?;
             if row.is_empty() {
                 break;
@@ -77,7 +77,7 @@ impl<R: BufRead> FileReader<R> {
 }
 
 impl<R: BufRead> FallibleStreamingIterator for FileReader<R> {
-    type Error = ArrowError;
+    type Error = Error;
     type Item = [String];
 
     fn advance(&mut self) -> Result<()> {
@@ -105,7 +105,7 @@ pub fn infer<R: std::io::BufRead>(
     number_of_rows: Option<usize>,
 ) -> Result<DataType> {
     if reader.fill_buf().map(|b| b.is_empty())? {
-        return Err(ArrowError::ExternalFormat(
+        return Err(Error::ExternalFormat(
             "Cannot infer NDJSON types on empty reader because empty string is not a valid JSON value".to_string(),
         ));
     }

--- a/src/io/ndjson/read/file.rs
+++ b/src/io/ndjson/read/file.rs
@@ -21,9 +21,9 @@ fn read_rows<R: BufRead>(reader: &mut R, rows: &mut [String], limit: usize) -> R
     for row in rows.iter_mut() {
         loop {
             row.clear();
-            let _ = reader.read_line(row).map_err(|e| {
-                Error::External(format!(" at line {}", row_number), Box::new(e))
-            })?;
+            let _ = reader
+                .read_line(row)
+                .map_err(|e| Error::External(format!(" at line {}", row_number), Box::new(e)))?;
             if row.is_empty() {
                 break;
             }

--- a/src/io/ndjson/write/mod.rs
+++ b/src/io/ndjson/write/mod.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 pub use fallible_streaming_iterator::FallibleStreamingIterator;
 
 use crate::array::Array;
-use crate::error::ArrowError;
+use crate::error::Error;
 
 use super::super::json::write::new_serializer;
 
@@ -24,7 +24,7 @@ fn serialize(array: &dyn Array, buffer: &mut Vec<u8>) {
 pub struct Serializer<A, I>
 where
     A: AsRef<dyn Array>,
-    I: Iterator<Item = Result<A, ArrowError>>,
+    I: Iterator<Item = Result<A, Error>>,
 {
     arrays: I,
     buffer: Vec<u8>,
@@ -33,7 +33,7 @@ where
 impl<A, I> Serializer<A, I>
 where
     A: AsRef<dyn Array>,
-    I: Iterator<Item = Result<A, ArrowError>>,
+    I: Iterator<Item = Result<A, Error>>,
 {
     /// Creates a new [`Serializer`].
     pub fn new(arrays: I, buffer: Vec<u8>) -> Self {
@@ -44,13 +44,13 @@ where
 impl<A, I> FallibleStreamingIterator for Serializer<A, I>
 where
     A: AsRef<dyn Array>,
-    I: Iterator<Item = Result<A, ArrowError>>,
+    I: Iterator<Item = Result<A, Error>>,
 {
     type Item = [u8];
 
-    type Error = ArrowError;
+    type Error = Error;
 
-    fn advance(&mut self) -> Result<(), ArrowError> {
+    fn advance(&mut self) -> Result<(), Error> {
         self.buffer.clear();
         self.arrays
             .next()
@@ -76,7 +76,7 @@ where
 pub struct FileWriter<W, I>
 where
     W: Write,
-    I: FallibleStreamingIterator<Item = [u8], Error = ArrowError>,
+    I: FallibleStreamingIterator<Item = [u8], Error = Error>,
 {
     writer: W,
     iterator: I,
@@ -85,7 +85,7 @@ where
 impl<W, I> FileWriter<W, I>
 where
     W: Write,
-    I: FallibleStreamingIterator<Item = [u8], Error = ArrowError>,
+    I: FallibleStreamingIterator<Item = [u8], Error = Error>,
 {
     /// Creates a new [`FileWriter`].
     pub fn new(writer: W, iterator: I) -> Self {
@@ -105,9 +105,9 @@ where
 impl<W, I> Iterator for FileWriter<W, I>
 where
     W: Write,
-    I: FallibleStreamingIterator<Item = [u8], Error = ArrowError>,
+    I: FallibleStreamingIterator<Item = [u8], Error = Error>,
 {
-    type Item = Result<(), ArrowError>;
+    type Item = Result<(), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let item = self.iterator.next().transpose()?;

--- a/src/io/odbc/mod.rs
+++ b/src/io/odbc/mod.rs
@@ -4,8 +4,8 @@ pub use odbc_api as api;
 pub mod read;
 pub mod write;
 
-impl From<api::Error> for crate::error::ArrowError {
+impl From<api::Error> for crate::error::Error {
     fn from(error: api::Error) -> Self {
-        crate::error::ArrowError::External("".to_string(), Box::new(error))
+        crate::error::Error::External("".to_string(), Box::new(error))
     }
 }

--- a/src/io/odbc/write/schema.rs
+++ b/src/io/odbc/write/schema.rs
@@ -1,7 +1,7 @@
 use super::super::api;
 
 use crate::datatypes::{DataType, Field};
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 /// Infers the [`api::ColumnDescription`] from the fields
 pub fn infer_descriptions(fields: &[Field]) -> Result<Vec<api::ColumnDescription>> {
@@ -33,6 +33,6 @@ fn data_type_to(data_type: &DataType) -> Result<api::DataType> {
         DataType::FixedSizeBinary(length) => api::DataType::Binary { length: *length },
         DataType::Binary | DataType::LargeBinary => api::DataType::Varbinary { length: 0 },
         DataType::Utf8 | DataType::LargeUtf8 => api::DataType::Varchar { length: 0 },
-        other => return Err(ArrowError::nyi(format!("{other:?} to ODBC"))),
+        other => return Err(Error::nyi(format!("{other:?} to ODBC"))),
     })
 }

--- a/src/io/odbc/write/serialize.rs
+++ b/src/io/odbc/write/serialize.rs
@@ -3,7 +3,7 @@ use api::buffers::{BinColumnWriter, TextColumnWriter};
 use crate::array::*;
 use crate::bitmap::Bitmap;
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::types::NativeType;
 
 use super::super::api;
@@ -21,7 +21,7 @@ pub fn serialize(array: &dyn Array, column: &mut api::buffers::AnyColumnViewMut)
                 bool_optional(array.as_any().downcast_ref().unwrap(), values);
                 Ok(())
             } else {
-                Err(ArrowError::nyi("serialize bool to non-bool ODBC"))
+                Err(Error::nyi("serialize bool to non-bool ODBC"))
             }
         }
         DataType::Int16 => {
@@ -32,7 +32,7 @@ pub fn serialize(array: &dyn Array, column: &mut api::buffers::AnyColumnViewMut)
                 primitive_optional(array.as_any().downcast_ref().unwrap(), values);
                 Ok(())
             } else {
-                Err(ArrowError::nyi("serialize i16 to non-i16 ODBC"))
+                Err(Error::nyi("serialize i16 to non-i16 ODBC"))
             }
         }
         DataType::Int32 => {
@@ -43,7 +43,7 @@ pub fn serialize(array: &dyn Array, column: &mut api::buffers::AnyColumnViewMut)
                 primitive_optional(array.as_any().downcast_ref().unwrap(), values);
                 Ok(())
             } else {
-                Err(ArrowError::nyi("serialize i32 to non-i32 ODBC"))
+                Err(Error::nyi("serialize i32 to non-i32 ODBC"))
             }
         }
         DataType::Float32 => {
@@ -54,7 +54,7 @@ pub fn serialize(array: &dyn Array, column: &mut api::buffers::AnyColumnViewMut)
                 primitive_optional(array.as_any().downcast_ref().unwrap(), values);
                 Ok(())
             } else {
-                Err(ArrowError::nyi("serialize f32 to non-f32 ODBC"))
+                Err(Error::nyi("serialize f32 to non-f32 ODBC"))
             }
         }
         DataType::Float64 => {
@@ -65,7 +65,7 @@ pub fn serialize(array: &dyn Array, column: &mut api::buffers::AnyColumnViewMut)
                 primitive_optional(array.as_any().downcast_ref().unwrap(), values);
                 Ok(())
             } else {
-                Err(ArrowError::nyi("serialize f64 to non-f64 ODBC"))
+                Err(Error::nyi("serialize f64 to non-f64 ODBC"))
             }
         }
         DataType::Utf8 => {
@@ -73,7 +73,7 @@ pub fn serialize(array: &dyn Array, column: &mut api::buffers::AnyColumnViewMut)
                 utf8::<i32>(array.as_any().downcast_ref().unwrap(), values);
                 Ok(())
             } else {
-                Err(ArrowError::nyi("serialize utf8 to non-text ODBC"))
+                Err(Error::nyi("serialize utf8 to non-text ODBC"))
             }
         }
         DataType::LargeUtf8 => {
@@ -81,7 +81,7 @@ pub fn serialize(array: &dyn Array, column: &mut api::buffers::AnyColumnViewMut)
                 utf8::<i64>(array.as_any().downcast_ref().unwrap(), values);
                 Ok(())
             } else {
-                Err(ArrowError::nyi("serialize utf8 to non-text ODBC"))
+                Err(Error::nyi("serialize utf8 to non-text ODBC"))
             }
         }
         DataType::Binary => {
@@ -89,7 +89,7 @@ pub fn serialize(array: &dyn Array, column: &mut api::buffers::AnyColumnViewMut)
                 binary::<i32>(array.as_any().downcast_ref().unwrap(), values);
                 Ok(())
             } else {
-                Err(ArrowError::nyi("serialize utf8 to non-binary ODBC"))
+                Err(Error::nyi("serialize utf8 to non-binary ODBC"))
             }
         }
         DataType::LargeBinary => {
@@ -97,7 +97,7 @@ pub fn serialize(array: &dyn Array, column: &mut api::buffers::AnyColumnViewMut)
                 binary::<i64>(array.as_any().downcast_ref().unwrap(), values);
                 Ok(())
             } else {
-                Err(ArrowError::nyi("serialize utf8 to non-text ODBC"))
+                Err(Error::nyi("serialize utf8 to non-text ODBC"))
             }
         }
         DataType::FixedSizeBinary(_) => {
@@ -105,10 +105,10 @@ pub fn serialize(array: &dyn Array, column: &mut api::buffers::AnyColumnViewMut)
                 fixed_binary(array.as_any().downcast_ref().unwrap(), values);
                 Ok(())
             } else {
-                Err(ArrowError::nyi("serialize fixed to non-binary ODBC"))
+                Err(Error::nyi("serialize fixed to non-binary ODBC"))
             }
         }
-        other => Err(ArrowError::nyi(format!("{other:?} to ODBC"))),
+        other => Err(Error::nyi(format!("{other:?} to ODBC"))),
     }
 }
 

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -1,27 +1,27 @@
 //! APIs to read from and write to Parquet format.
-use crate::error::ArrowError;
+use crate::error::Error;
 
 pub mod read;
 pub mod write;
 
 const ARROW_SCHEMA_META_KEY: &str = "ARROW:schema";
 
-impl From<parquet2::error::Error> for ArrowError {
+impl From<parquet2::error::Error> for Error {
     fn from(error: parquet2::error::Error) -> Self {
         match error {
             parquet2::error::Error::FeatureNotActive(_, _) => {
                 let message = "Failed to read a compressed parquet file. \
                     Use the cargo feature \"io_parquet_compression\" to read compressed parquet files."
                     .to_string();
-                ArrowError::ExternalFormat(message)
+                Error::ExternalFormat(message)
             }
-            _ => ArrowError::ExternalFormat(error.to_string()),
+            _ => Error::ExternalFormat(error.to_string()),
         }
     }
 }
 
-impl From<ArrowError> for parquet2::error::Error {
-    fn from(error: ArrowError) -> Self {
+impl From<Error> for parquet2::error::Error {
+    fn from(error: Error) -> Self {
         parquet2::error::Error::General(error.to_string())
     }
 }

--- a/src/io/parquet/read/deserialize/dictionary.rs
+++ b/src/io/parquet/read/deserialize/dictionary.rs
@@ -10,7 +10,7 @@ use parquet2::{
 use crate::{
     array::{Array, DictionaryArray, DictionaryKey, PrimitiveArray},
     bitmap::MutableBitmap,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::{
@@ -230,7 +230,7 @@ pub(super) fn next_dict<
             // consume the dictionary page
             match (&dict, page.dictionary_page()) {
                 (Dict::Empty, None) => {
-                    return MaybeNext::Some(Err(ArrowError::nyi(
+                    return MaybeNext::Some(Err(Error::nyi(
                         "dictionary arrays from non-dict-encoded pages",
                     )));
                 }

--- a/src/io/parquet/read/deserialize/mod.rs
+++ b/src/io/parquet/read/deserialize/mod.rs
@@ -13,7 +13,7 @@ mod utils;
 use crate::{
     array::{Array, BinaryArray, FixedSizeListArray, ListArray, Utf8Array},
     datatypes::{DataType, Field},
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use self::nested_utils::{InitNested, NestedArrayIter, NestedState};
@@ -76,7 +76,7 @@ fn create_list(
             ))
         }
         _ => {
-            return Err(ArrowError::NotYetImplemented(format!(
+            return Err(Error::NotYetImplemented(format!(
                 "Read nested datatype {:?}",
                 data_type
             )))

--- a/src/io/parquet/read/deserialize/simple.rs
+++ b/src/io/parquet/read/deserialize/simple.rs
@@ -244,9 +244,7 @@ fn timestamp<'a, I: 'a + DataPages>(
                 int96_to_i64_ns,
             ))));
         } else {
-            return Err(Error::nyi(
-                "Can't decode int96 to timestamp other than ns",
-            ));
+            return Err(Error::nyi("Can't decode int96 to timestamp other than ns"));
         }
     };
     if physical_type != &PhysicalType::Int64 {
@@ -305,9 +303,7 @@ fn timestamp_dict<'a, K: DictionaryKey, I: 'a + DataPages>(
                 int96_to_i64_ns,
             )));
         } else {
-            return Err(Error::nyi(
-                "Can't decode int96 to timestamp other than ns",
-            ));
+            return Err(Error::nyi("Can't decode int96 to timestamp other than ns"));
         }
     };
 

--- a/src/io/parquet/read/deserialize/simple.rs
+++ b/src/io/parquet/read/deserialize/simple.rs
@@ -10,7 +10,7 @@ use parquet2::{
 use crate::{
     array::{Array, BinaryArray, DictionaryKey, MutablePrimitiveArray, PrimitiveArray, Utf8Array},
     datatypes::{DataType, IntervalUnit, TimeUnit},
-    error::{ArrowError, Result},
+    error::{Error, Result},
     types::NativeType,
 };
 
@@ -134,7 +134,7 @@ pub fn page_iter_to_arrays<'a, I: 'a + DataPages>(
                 |x: i64| x as i128,
             ))),
             &PhysicalType::FixedLenByteArray(n) if n > 16 => {
-                return Err(ArrowError::NotYetImplemented(format!(
+                return Err(Error::NotYetImplemented(format!(
                     "Can't decode Decimal128 type from Fixed Size Byte Array of len {:?}",
                     n
                 )))
@@ -219,7 +219,7 @@ pub fn page_iter_to_arrays<'a, I: 'a + DataPages>(
         }
 
         other => {
-            return Err(ArrowError::NotYetImplemented(format!(
+            return Err(Error::NotYetImplemented(format!(
                 "Reading {:?} from parquet still not implemented",
                 other
             )))
@@ -244,13 +244,13 @@ fn timestamp<'a, I: 'a + DataPages>(
                 int96_to_i64_ns,
             ))));
         } else {
-            return Err(ArrowError::nyi(
+            return Err(Error::nyi(
                 "Can't decode int96 to timestamp other than ns",
             ));
         }
     };
     if physical_type != &PhysicalType::Int64 {
-        return Err(ArrowError::nyi(
+        return Err(Error::nyi(
             "Can't decode a timestamp from a non-int64 parquet type",
         ));
     }
@@ -305,7 +305,7 @@ fn timestamp_dict<'a, K: DictionaryKey, I: 'a + DataPages>(
                 int96_to_i64_ns,
             )));
         } else {
-            return Err(ArrowError::nyi(
+            return Err(Error::nyi(
                 "Can't decode int96 to timestamp other than ns",
             ));
         }
@@ -514,7 +514,7 @@ fn dict_read<'a, K: DictionaryKey, I: 'a + DataPages>(
             iter, data_type, chunk_size,
         )),
         other => {
-            return Err(ArrowError::nyi(format!(
+            return Err(Error::nyi(format!(
                 "Reading dictionaries of type {:?}",
                 other
             )))

--- a/src/io/parquet/read/deserialize/struct_.rs
+++ b/src/io/parquet/read/deserialize/struct_.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::array::{Array, StructArray};
 use crate::datatypes::{DataType, Field};
-use crate::error::ArrowError;
+use crate::error::Error;
 
 use super::nested_utils::{NestedArrayIter, NestedState};
 
@@ -19,7 +19,7 @@ impl<'a> StructIterator<'a> {
 }
 
 impl<'a> Iterator for StructIterator<'a> {
-    type Item = Result<(NestedState, Arc<dyn Array>), ArrowError>;
+    type Item = Result<(NestedState, Arc<dyn Array>), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let values = self
@@ -34,7 +34,7 @@ impl<'a> Iterator for StructIterator<'a> {
         let values = values
             .into_iter()
             .map(|x| x.unwrap().map(|x| x.1))
-            .collect::<Result<Vec<_>, ArrowError>>();
+            .collect::<Result<Vec<_>, Error>>();
 
         match values {
             Ok(values) => Some(Ok((

--- a/src/io/parquet/read/file.rs
+++ b/src/io/parquet/read/file.rs
@@ -7,7 +7,7 @@ use crate::datatypes::Schema;
 use crate::io::parquet::read::read_columns_many;
 use crate::{
     datatypes::Field,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::{infer_schema, read_metadata, FileMetaData, RowGroupDeserializer, RowGroupMetaData};
@@ -68,7 +68,7 @@ impl<R: Read + Seek> FileReader<R> {
 
         if let Some(projection) = &projection {
             if fields.len() != projection.len() {
-                return Err(ArrowError::InvalidArgumentError(
+                return Err(Error::InvalidArgumentError(
                     "While reading parquet, some columns in the projection do not exist in the file"
                         .to_string(),
                 ));

--- a/src/io/parquet/read/indexes/binary.rs
+++ b/src/io/parquet/read/indexes/binary.rs
@@ -3,7 +3,7 @@ use parquet2::indexes::PageIndex;
 use crate::{
     array::{Array, BinaryArray, PrimitiveArray, Utf8Array},
     datatypes::{DataType, PhysicalType},
-    error::ArrowError,
+    error::Error,
     trusted_len::TrustedLen,
 };
 
@@ -12,7 +12,7 @@ use super::ColumnIndex;
 pub fn deserialize(
     indexes: &[PageIndex<Vec<u8>>],
     data_type: &DataType,
-) -> Result<ColumnIndex, ArrowError> {
+) -> Result<ColumnIndex, Error> {
     Ok(ColumnIndex {
         min: deserialize_binary_iter(indexes.iter().map(|index| index.min.as_ref()), data_type)?,
         max: deserialize_binary_iter(indexes.iter().map(|index| index.max.as_ref()), data_type)?,
@@ -27,7 +27,7 @@ pub fn deserialize(
 fn deserialize_binary_iter<'a, I: TrustedLen<Item = Option<&'a Vec<u8>>>>(
     iter: I,
     data_type: &DataType,
-) -> Result<Box<dyn Array>, ArrowError> {
+) -> Result<Box<dyn Array>, Error> {
     match data_type.to_physical_type() {
         PhysicalType::LargeBinary => Ok(Box::new(BinaryArray::<i64>::from_iter(iter))),
         PhysicalType::Utf8 => {

--- a/src/io/parquet/read/indexes/mod.rs
+++ b/src/io/parquet/read/indexes/mod.rs
@@ -16,7 +16,7 @@ use crate::datatypes::Field;
 use crate::{
     array::{Array, UInt64Array},
     datatypes::DataType,
-    error::ArrowError,
+    error::Error,
 };
 
 /// Arrow-deserialized [`ColumnIndex`] containing the minimum and maximum value
@@ -51,7 +51,7 @@ impl ColumnIndex {
 fn deserialize(
     indexes: &[Box<dyn ParquetIndex>],
     data_types: Vec<DataType>,
-) -> Result<Vec<ColumnIndex>, ArrowError> {
+) -> Result<Vec<ColumnIndex>, Error> {
     indexes
         .iter()
         .zip(data_types.into_iter())
@@ -126,7 +126,7 @@ pub fn read_columns_indexes<R: Read + Seek>(
     reader: &mut R,
     chunks: &[ColumnChunkMetaData],
     fields: &[Field],
-) -> Result<Vec<ColumnIndex>, ArrowError> {
+) -> Result<Vec<ColumnIndex>, Error> {
     let indexes = _read_columns_indexes(reader, chunks)?;
 
     // map arrow fields to the corresponding columns in parquet taking into account

--- a/src/io/parquet/read/schema/metadata.rs
+++ b/src/io/parquet/read/schema/metadata.rs
@@ -1,7 +1,7 @@
 pub use parquet2::metadata::KeyValue;
 
 use crate::datatypes::{Metadata, Schema};
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::io::ipc::read::deserialize_schema;
 
 use super::super::super::ARROW_SCHEMA_META_KEY;
@@ -30,7 +30,7 @@ fn get_arrow_schema_from_metadata(encoded_meta: &str) -> Result<Schema> {
         }
         Err(err) => {
             // The C++ implementation returns an error if the schema can't be parsed.
-            Err(ArrowError::InvalidArgumentError(format!(
+            Err(Error::InvalidArgumentError(format!(
                 "Unable to decode the encoded schema stored in {}, {:?}",
                 ARROW_SCHEMA_META_KEY, err
             )))

--- a/src/io/parquet/read/statistics/mod.rs
+++ b/src/io/parquet/read/statistics/mod.rs
@@ -14,7 +14,7 @@ use parquet2::statistics::{
 use crate::array::*;
 use crate::datatypes::IntervalUnit;
 use crate::datatypes::{DataType, Field, PhysicalType};
-use crate::error::ArrowError;
+use crate::error::Error;
 use crate::error::Result;
 
 mod binary;
@@ -152,7 +152,7 @@ fn make_mutable(data_type: &DataType, capacity: usize) -> Result<Box<dyn Mutable
             capacity,
         )?),
         other => {
-            return Err(ArrowError::NotYetImplemented(format!(
+            return Err(Error::NotYetImplemented(format!(
                 "Deserializing parquet stats from {:?} is still not implemented",
                 other
             )))
@@ -377,7 +377,7 @@ fn push(
             ParquetPhysicalType::Int32 => primitive::push(from, min, max, |x: i32| Ok(x as i128)),
             ParquetPhysicalType::Int64 => primitive::push(from, min, max, |x: i64| Ok(x as i128)),
             ParquetPhysicalType::FixedLenByteArray(n) if *n > 16 => {
-                return Err(ArrowError::NotYetImplemented(format!(
+                return Err(Error::NotYetImplemented(format!(
                     "Can't decode Decimal128 type from Fixed Size Byte Array of len {:?}",
                     n
                 )))

--- a/src/io/parquet/write/binary/basic.rs
+++ b/src/io/parquet/write/binary/basic.rs
@@ -10,7 +10,7 @@ use super::super::WriteOptions;
 use crate::{
     array::{Array, BinaryArray, Offset},
     bitmap::Bitmap,
-    error::{ArrowError, Result},
+    error::{Error, Result},
     io::parquet::read::schema::is_nullable,
 };
 
@@ -69,7 +69,7 @@ pub fn array_to_page<O: Offset>(
             &mut buffer,
         ),
         _ => {
-            return Err(ArrowError::InvalidArgumentError(format!(
+            return Err(Error::InvalidArgumentError(format!(
                 "Datatype {:?} cannot be encoded by {:?} encoding",
                 array.data_type(),
                 encoding

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -17,7 +17,7 @@ use super::utf8::encode_plain as utf8_encode_plain;
 use super::WriteOptions;
 use crate::bitmap::Bitmap;
 use crate::datatypes::DataType;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::io::parquet::write::utils;
 use crate::{
     array::{Array, DictionaryArray, DictionaryKey, PrimitiveArray},
@@ -193,7 +193,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                     (EncodedDictPage::new(buffer, array.len()), stats)
                 }
                 other => {
-                    return Err(ArrowError::NotYetImplemented(format!(
+                    return Err(Error::NotYetImplemented(format!(
                         "Writing dictionary arrays to parquet only support data type {:?}",
                         other
                     )))
@@ -213,7 +213,7 @@ pub fn array_to_pages<K: DictionaryKey>(
             let iter = std::iter::once(Ok(dict_page)).chain(std::iter::once(Ok(data_page)));
             Ok(DynIter::new(Box::new(iter)))
         }
-        _ => Err(ArrowError::NotYetImplemented(
+        _ => Err(Error::NotYetImplemented(
             "Dictionary arrays only support dictionary encoding".to_string(),
         )),
     }

--- a/src/io/parquet/write/file.rs
+++ b/src/io/parquet/write/file.rs
@@ -6,7 +6,7 @@ use parquet2::write::RowGroupIter;
 use parquet2::write::WriteOptions as FileWriteOptions;
 
 use crate::datatypes::Schema;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 
 use super::{schema::schema_to_metadata_key, to_parquet_schema, WriteOptions};
 
@@ -78,7 +78,7 @@ impl<W: Write> FileWriter<W> {
     }
 
     /// Writes a row group to the file.
-    pub fn write(&mut self, row_group: RowGroupIter<'_, ArrowError>) -> Result<()> {
+    pub fn write(&mut self, row_group: RowGroupIter<'_, Error>) -> Result<()> {
         Ok(self.writer.write(row_group)?)
     }
 

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -16,7 +16,7 @@ mod utils;
 
 use crate::array::*;
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
+use crate::error::{Error, Result};
 use crate::types::days_ms;
 use crate::types::NativeType;
 
@@ -153,7 +153,7 @@ pub fn array_to_page_simple(
 ) -> Result<EncodedPage> {
     let data_type = array.data_type();
     if !can_encode(data_type, encoding) {
-        return Err(ArrowError::InvalidArgumentError(format!(
+        return Err(Error::InvalidArgumentError(format!(
             "The datatype {:?} cannot be encoded by {:?}",
             data_type, encoding
         )));
@@ -360,7 +360,7 @@ pub fn array_to_page_simple(
                 fixed_len_bytes::array_to_page(&array, options, type_, statistics)
             }
         }
-        other => Err(ArrowError::NotYetImplemented(format!(
+        other => Err(Error::NotYetImplemented(format!(
             "Writing parquet pages for data type {:?}",
             other
         ))),
@@ -441,7 +441,7 @@ fn array_to_page_nested(
             let array = array.as_any().downcast_ref().unwrap();
             primitive::nested_array_to_page::<f64, f64>(array, options, type_, nested)
         }
-        other => Err(ArrowError::NotYetImplemented(format!(
+        other => Err(Error::NotYetImplemented(format!(
             "Writing nested parquet pages for data type {:?}",
             other
         ))),

--- a/src/io/parquet/write/pages.rs
+++ b/src/io/parquet/write/pages.rs
@@ -7,7 +7,7 @@ use crate::datatypes::PhysicalType;
 use crate::io::parquet::read::schema::is_nullable;
 use crate::{
     array::Array,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::{array_to_pages, Encoding, WriteOptions};
@@ -77,7 +77,7 @@ fn to_nested_recursive<'a>(
             let fields = if let ParquetType::GroupType { fields, .. } = type_ {
                 fields
             } else {
-                return Err(ArrowError::InvalidArgumentError(
+                return Err(Error::InvalidArgumentError(
                     "Parquet type must be a group for a struct array".to_string(),
                 ));
             };
@@ -94,12 +94,12 @@ fn to_nested_recursive<'a>(
                 if let ParquetType::GroupType { fields, .. } = &fields[0] {
                     &fields[0]
                 } else {
-                    return Err(ArrowError::InvalidArgumentError(
+                    return Err(Error::InvalidArgumentError(
                         "Parquet type must be a group for a list array".to_string(),
                     ));
                 }
             } else {
-                return Err(ArrowError::InvalidArgumentError(
+                return Err(Error::InvalidArgumentError(
                     "Parquet type must be a group for a list array".to_string(),
                 ));
             };
@@ -117,12 +117,12 @@ fn to_nested_recursive<'a>(
                 if let ParquetType::GroupType { fields, .. } = &fields[0] {
                     &fields[0]
                 } else {
-                    return Err(ArrowError::InvalidArgumentError(
+                    return Err(Error::InvalidArgumentError(
                         "Parquet type must be a group for a list array".to_string(),
                     ));
                 }
             } else {
-                return Err(ArrowError::InvalidArgumentError(
+                return Err(Error::InvalidArgumentError(
                     "Parquet type must be a group for a list array".to_string(),
                 ));
             };

--- a/src/io/parquet/write/row_group.rs
+++ b/src/io/parquet/write/row_group.rs
@@ -7,7 +7,7 @@ use crate::{
     array::Array,
     chunk::Chunk,
     datatypes::Schema,
-    error::{ArrowError, Result},
+    error::{Error, Result},
 };
 
 use super::{
@@ -22,7 +22,7 @@ pub fn row_group_iter<A: AsRef<dyn Array> + 'static + Send + Sync>(
     encodings: Vec<Vec<Encoding>>,
     fields: Vec<ParquetType>,
     options: WriteOptions,
-) -> RowGroupIter<'static, ArrowError> {
+) -> RowGroupIter<'static, Error> {
     DynIter::new(
         chunk
             .into_arrays()
@@ -43,7 +43,7 @@ pub fn row_group_iter<A: AsRef<dyn Array> + 'static + Send + Sync>(
                         );
 
                         let compressed_pages = Compressor::new(pages, options.compression, vec![])
-                            .map_err(ArrowError::from);
+                            .map_err(Error::from);
                         Ok(DynStreamingIterator::new(compressed_pages))
                     })
                     .collect::<Vec<_>>()
@@ -88,7 +88,7 @@ impl<A: AsRef<dyn Array> + 'static, I: Iterator<Item = Result<Chunk<A>>>> RowGro
 impl<A: AsRef<dyn Array> + 'static + Send + Sync, I: Iterator<Item = Result<Chunk<A>>>> Iterator
     for RowGroupIterator<A, I>
 {
-    type Item = Result<RowGroupIter<'static, ArrowError>>;
+    type Item = Result<RowGroupIter<'static, Error>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let options = self.options;

--- a/src/io/parquet/write/schema.rs
+++ b/src/io/parquet/write/schema.rs
@@ -11,7 +11,7 @@ use parquet2::{
 
 use crate::{
     datatypes::{DataType, Field, Schema, TimeUnit},
-    error::{ArrowError, Result},
+    error::{Error, Result},
     io::ipc::write::default_ipc_fields,
     io::ipc::write::schema_to_bytes,
     io::parquet::write::decimal_length_from_precision,
@@ -247,7 +247,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
         )?),
         DataType::Struct(fields) => {
             if fields.is_empty() {
-                return Err(ArrowError::InvalidArgumentError(
+                return Err(Error::InvalidArgumentError(
                     "Parquet does not support writing empty structs".to_string(),
                 ));
             }
@@ -319,7 +319,7 @@ pub fn to_parquet_type(field: &Field) -> Result<ParquetType> {
                 None,
             ))
         }
-        other => Err(ArrowError::NotYetImplemented(format!(
+        other => Err(Error::NotYetImplemented(format!(
             "Writing the data type {:?} is not yet implemented",
             other
         ))),

--- a/src/io/parquet/write/utf8/basic.rs
+++ b/src/io/parquet/write/utf8/basic.rs
@@ -10,7 +10,7 @@ use super::super::utils;
 use super::super::WriteOptions;
 use crate::{
     array::{Array, Offset, Utf8Array},
-    error::{ArrowError, Result},
+    error::{Error, Result},
     io::parquet::read::schema::is_nullable,
 };
 
@@ -68,7 +68,7 @@ pub fn array_to_page<O: Offset>(
             &mut buffer,
         ),
         _ => {
-            return Err(ArrowError::InvalidArgumentError(format!(
+            return Err(Error::InvalidArgumentError(format!(
                 "Datatype {:?} cannot be encoded by {:?} encoding",
                 array.data_type(),
                 encoding

--- a/src/scalar/primitive.rs
+++ b/src/scalar/primitive.rs
@@ -1,4 +1,4 @@
-use crate::{datatypes::DataType, error::ArrowError, types::NativeType};
+use crate::{datatypes::DataType, error::Error, types::NativeType};
 
 use super::Scalar;
 
@@ -15,7 +15,7 @@ impl<T: NativeType> PrimitiveScalar<T> {
     #[inline]
     pub fn new(data_type: DataType, value: Option<T>) -> Self {
         if !data_type.to_physical_type().eq_primitive(T::PRIMITIVE) {
-            Err(ArrowError::InvalidArgumentError(format!(
+            Err(Error::InvalidArgumentError(format!(
                 "Type {} does not support logical type {:?}",
                 std::any::type_name::<T>(),
                 data_type

--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -8,7 +8,7 @@ use chrono::{
 use crate::error::Result;
 use crate::{
     array::{Offset, PrimitiveArray, Utf8Array},
-    error::ArrowError,
+    error::Error,
 };
 use crate::{
     datatypes::{DataType, TimeUnit},
@@ -194,17 +194,17 @@ pub fn parse_offset(offset: &str) -> Result<FixedOffset> {
     let first = a
         .next()
         .map(Ok)
-        .unwrap_or_else(|| Err(ArrowError::InvalidArgumentError(error.to_string())))?;
+        .unwrap_or_else(|| Err(Error::InvalidArgumentError(error.to_string())))?;
     let last = a
         .next()
         .map(Ok)
-        .unwrap_or_else(|| Err(ArrowError::InvalidArgumentError(error.to_string())))?;
+        .unwrap_or_else(|| Err(Error::InvalidArgumentError(error.to_string())))?;
     let hours: i32 = first
         .parse()
-        .map_err(|_| ArrowError::InvalidArgumentError(error.to_string()))?;
+        .map_err(|_| Error::InvalidArgumentError(error.to_string()))?;
     let minutes: i32 = last
         .parse()
-        .map_err(|_| ArrowError::InvalidArgumentError(error.to_string()))?;
+        .map_err(|_| Error::InvalidArgumentError(error.to_string()))?;
 
     Ok(FixedOffset::east(hours * 60 * 60 + minutes * 60))
 }
@@ -263,7 +263,7 @@ fn utf8_to_timestamp_ns_impl<O: Offset, T: chrono::TimeZone>(
 #[cfg_attr(docsrs, doc(cfg(feature = "chrono-tz")))]
 pub fn parse_offset_tz(timezone: &str) -> Result<chrono_tz::Tz> {
     timezone.parse::<chrono_tz::Tz>().map_err(|_| {
-        ArrowError::InvalidArgumentError(format!("timezone \"{}\" cannot be parsed", timezone))
+        Error::InvalidArgumentError(format!("timezone \"{}\" cannot be parsed", timezone))
     })
 }
 
@@ -284,7 +284,7 @@ fn chrono_tz_utf_to_timestamp_ns<O: Offset>(
     _: &str,
     timezone: String,
 ) -> Result<PrimitiveArray<i64>> {
-    Err(ArrowError::InvalidArgumentError(format!(
+    Err(Error::InvalidArgumentError(format!(
         "timezone \"{}\" cannot be parsed (feature chrono-tz is not active)",
         timezone
     )))

--- a/tests/it/array/binary/mutable.rs
+++ b/tests/it/array/binary/mutable.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use arrow2::array::{BinaryArray, MutableArray, MutableBinaryArray};
 use arrow2::bitmap::Bitmap;
-use arrow2::error::ArrowError;
+use arrow2::error::Error;
 
 #[test]
 fn new() {
@@ -49,7 +49,7 @@ fn from_trusted_len_iter() {
     assert_eq!(a.validity(), None);
 
     let a = unsafe {
-        MutableBinaryArray::<i32>::try_from_trusted_len_iter_unchecked::<ArrowError, _, _>(
+        MutableBinaryArray::<i32>::try_from_trusted_len_iter_unchecked::<Error, _, _>(
             iter.clone().map(Some).map(Ok),
         )
     }

--- a/tests/it/io/ndjson/read.rs
+++ b/tests/it/io/ndjson/read.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use arrow2::array::*;
 use arrow2::datatypes::{DataType, Field};
-use arrow2::error::{ArrowError, Result};
+use arrow2::error::{Error, Result};
 use arrow2::io::ndjson::read as ndjson_read;
 use arrow2::io::ndjson::read::FallibleStreamingIterator;
 
@@ -76,12 +76,12 @@ fn read_empty_reader() -> Result<()> {
     let ndjson = "";
 
     let infer_error = infer(ndjson);
-    assert!(matches!(infer_error, Err(ArrowError::ExternalFormat(_))));
+    assert!(matches!(infer_error, Err(Error::ExternalFormat(_))));
 
     let deserialize_error = ndjson_read::deserialize(&[], DataType::Null);
     assert!(matches!(
         deserialize_error,
-        Err(ArrowError::ExternalFormat(_))
+        Err(Error::ExternalFormat(_))
     ));
     Ok(())
 }

--- a/tests/it/io/ndjson/read.rs
+++ b/tests/it/io/ndjson/read.rs
@@ -79,10 +79,7 @@ fn read_empty_reader() -> Result<()> {
     assert!(matches!(infer_error, Err(Error::ExternalFormat(_))));
 
     let deserialize_error = ndjson_read::deserialize(&[], DataType::Null);
-    assert!(matches!(
-        deserialize_error,
-        Err(Error::ExternalFormat(_))
-    ));
+    assert!(matches!(deserialize_error, Err(Error::ExternalFormat(_))));
     Ok(())
 }
 

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -1,7 +1,7 @@
 use std::io::Cursor;
 use std::sync::Arc;
 
-use arrow2::error::ArrowError;
+use arrow2::error::Error;
 use arrow2::{array::*, datatypes::*, error::Result, io::parquet::read::*, io::parquet::write::*};
 use parquet2::indexes::{compute_rows, select_pages};
 use parquet2::read::IndexedPageReader;
@@ -85,7 +85,7 @@ fn read_with_indexes(
     let to_compressed = |pages: Vec<EncodedPage>| {
         let encoded_pages = DynIter::new(pages.into_iter().map(Ok));
         let compressed_pages =
-            Compressor::new(encoded_pages, options.compression, vec![]).map_err(ArrowError::from);
+            Compressor::new(encoded_pages, options.compression, vec![]).map_err(Error::from);
         Result::Ok(DynStreamingIterator::new(compressed_pages))
     };
 


### PR DESCRIPTION
The rest of the ecosystem uses `Error` to describe the crate own errors, see e.g. `std::io::Error`, `tokio::time::error::Error`, `serde::de::Error`, `odbc_api::Error`, `lexical_core::Error`.

I would like to propose that we align our error name with the rest of the ecosystem, to reduce the mental load of using this crate and make the crate a bit more standard also in this aspect.

Any thoughts?
