### PR TITLE
delay null_counts

### DIFF
--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -201,6 +201,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
             let mut validity = MutableBitmap::new();
             validity.extend_constant(self.len(), true);
             extend_trusted_len_unzip(iterator, &mut validity, &mut self.values);
+            self.validity = Some(validity);
         }
     }
     /// Extends the [`MutablePrimitiveArray`] from an iterator of values of trusted len.

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -14,7 +14,7 @@ use super::PrimitiveArray;
 
 /// The Arrow's equivalent to `Vec<Option<T>>` where `T` is byte-size (e.g. `i32`).
 /// Converting a [`MutablePrimitiveArray`] into a [`PrimitiveArray`] is `O(1)`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MutablePrimitiveArray<T: NativeType> {
     data_type: DataType,
     values: Vec<T>,

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -23,17 +23,14 @@ pub struct MutablePrimitiveArray<T: NativeType> {
 
 impl<T: NativeType> From<MutablePrimitiveArray<T>> for PrimitiveArray<T> {
     fn from(other: MutablePrimitiveArray<T>) -> Self {
-        let validity = other
-            .validity
-            .map(|x| {
-                let bitmap: Bitmap = x.into();
-                if bitmap.null_count() == 0 {
-                    None
-                } else {
-                    Some(bitmap)
-                }
-            })
-            .flatten();
+        let validity = other.validity.and_then(|x| {
+            let bitmap: Bitmap = x.into();
+            if bitmap.null_count() == 0 {
+                None
+            } else {
+                Some(bitmap)
+            }
+        });
 
         PrimitiveArray::<T>::new(other.data_type, other.values.into(), validity)
     }

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -37,17 +37,14 @@ impl<O: Offset> From<MutableUtf8Array<O>> for Utf8Array<O> {
         // Safety:
         // `MutableUtf8Array` has the same invariants as `Utf8Array` and thus
         // `Utf8Array` can be safely created from `MutableUtf8Array` without checks.
-        let validity = other
-            .validity
-            .map(|x| {
-                let bitmap: Bitmap = x.into();
-                if bitmap.null_count() == 0 {
-                    None
-                } else {
-                    Some(bitmap)
-                }
-            })
-            .flatten();
+        let validity = other.validity.and_then(|x| {
+            let bitmap: Bitmap = x.into();
+            if bitmap.null_count() == 0 {
+                None
+            } else {
+                Some(bitmap)
+            }
+        });
 
         unsafe {
             Utf8Array::<O>::from_data_unchecked(

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -14,6 +14,7 @@ use super::Bitmap;
 /// The main difference against [`Vec<bool>`] is that a bitmap cannot be represented as `&[bool]`.
 /// # Implementation
 /// This container is backed by [`Vec<u8>`].
+#[derive(Clone)]
 pub struct MutableBitmap {
     buffer: Vec<u8>,
     // invariant: length.saturating_add(7) / 8 == buffer.len();

--- a/tests/it/array/primitive/mutable.rs
+++ b/tests/it/array/primitive/mutable.rs
@@ -270,6 +270,12 @@ fn set_validity() {
     a.extend_trusted_len(vec![Some(1), Some(2)].into_iter());
     let validity = a.validity().unwrap();
     assert_eq!(validity.null_count(), 0);
+
+    // test that upon conversion to array the bitmap is set to None
+    let arr: PrimitiveArray<_> = a.clone().into();
+    assert_eq!(arr.validity(), None);
+
+    // test set_validity
     a.set_validity(Some(MutableBitmap::from([false, true])));
     assert_eq!(a.validity(), Some(&MutableBitmap::from([false, true])));
 }

--- a/tests/it/array/primitive/mutable.rs
+++ b/tests/it/array/primitive/mutable.rs
@@ -126,7 +126,8 @@ fn set() {
 fn from_iter() {
     let a = MutablePrimitiveArray::<i32>::from_iter((0..2).map(Some));
     assert_eq!(a.len(), 2);
-    assert_eq!(a.validity(), None);
+    let validity = a.validity().unwrap();
+    assert_eq!(validity.null_count(), 0);
 }
 
 #[test]
@@ -176,7 +177,8 @@ fn from_trusted_len() {
 fn extend_trusted_len() {
     let mut a = MutablePrimitiveArray::<i32>::new();
     a.extend_trusted_len(vec![Some(1), Some(2)].into_iter());
-    assert_eq!(a.validity(), None);
+    let validity = a.validity().unwrap();
+    assert_eq!(validity.null_count(), 0);
     a.extend_trusted_len(vec![None, Some(4)].into_iter());
     assert_eq!(
         a.validity(),
@@ -266,7 +268,8 @@ fn extend_from_slice() {
 fn set_validity() {
     let mut a = MutablePrimitiveArray::<i32>::new();
     a.extend_trusted_len(vec![Some(1), Some(2)].into_iter());
-    assert_eq!(a.validity(), None);
+    let validity = a.validity().unwrap();
+    assert_eq!(validity.null_count(), 0);
     a.set_validity(Some(MutableBitmap::from([false, true])));
     assert_eq!(a.validity(), Some(&MutableBitmap::from([false, true])));
 }


### PR DESCRIPTION
On several `extend` (which may be called in hot loops) there were still `null_count` check on mutable arrays.

Upon freezing a `MutableArray` to `Array` there was also this pattern

```
// first null_count
if mutable_bitmap::null_count > 0 {
  // second null_count on conversion to bitmap
  mutable_bitmap::into_bitmap
}
```

I rewrote it by first doing the `bitmap` coversions (which computes the nulls). And then if the `null_count == 0` then we set `validity = None`.

So basically this PR delays all `null_counts` until we freeze the array as we will compute it upon conversion and can then decide if we can drop the validity or not.
