### PR TITLE
Replace `fn Offset::is_large()` as `const Offset::IS_LARGE`

### DIFF
--- a/src/array/binary/fmt.rs
+++ b/src/array/binary/fmt.rs
@@ -15,7 +15,7 @@ impl<O: Offset> Debug for BinaryArray<O> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, f);
 
-        let head = if O::is_large() {
+        let head = if O::IS_LARGE {
             "LargeBinaryArray"
         } else {
             "BinaryArray"

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -124,7 +124,7 @@ impl<O: Offset> BinaryArray<O> {
 
     /// Returns the default [`DataType`], `DataType::Binary` or `DataType::LargeBinary`
     pub fn default_data_type() -> DataType {
-        if O::is_large() {
+        if O::IS_LARGE {
             DataType::LargeBinary
         } else {
             DataType::Binary

--- a/src/array/list/fmt.rs
+++ b/src/array/list/fmt.rs
@@ -20,7 +20,7 @@ impl<O: Offset> Debug for ListArray<O> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, "None", f);
 
-        let head = if O::is_large() {
+        let head = if O::IS_LARGE {
             "LargeListArray"
         } else {
             "ListArray"

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -292,7 +292,7 @@ impl<O: Offset> ListArray<O> {
     /// Returns a default [`DataType`]: inner field is named "item" and is nullable
     pub fn default_datatype(data_type: DataType) -> DataType {
         let field = Box::new(Field::new("item", data_type, true));
-        if O::is_large() {
+        if O::IS_LARGE {
             DataType::LargeList(field)
         } else {
             DataType::List(field)
@@ -310,7 +310,7 @@ impl<O: Offset> ListArray<O> {
     /// # Errors
     /// Panics iff the logical type is not consistent with this struct.
     fn try_get_child(data_type: &DataType) -> Result<&Field, ArrowError> {
-        if O::is_large() {
+        if O::IS_LARGE {
             match data_type.to_logical_type() {
                 DataType::LargeList(child) => Ok(child.as_ref()),
                 _ => Err(ArrowError::oos(

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -110,7 +110,7 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
     /// Creates a new [`MutableListArray`] from a [`MutableArray`].
     pub fn new_with_field(values: M, name: &str, nullable: bool) -> Self {
         let field = Box::new(Field::new(name, values.data_type().clone(), nullable));
-        let data_type = if O::is_large() {
+        let data_type = if O::IS_LARGE {
             DataType::LargeList(field)
         } else {
             DataType::List(field)

--- a/src/array/utf8/fmt.rs
+++ b/src/array/utf8/fmt.rs
@@ -12,7 +12,7 @@ impl<O: Offset> Debug for Utf8Array<O> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, f);
 
-        let head = if O::is_large() {
+        let head = if O::IS_LARGE {
             "LargeUtf8Array"
         } else {
             "Utf8Array"

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -142,7 +142,7 @@ impl<O: Offset> Utf8Array<O> {
 
     /// Returns the default [`DataType`], `DataType::Utf8` or `DataType::LargeUtf8`
     pub fn default_data_type() -> DataType {
-        if O::is_large() {
+        if O::IS_LARGE {
             DataType::LargeUtf8
         } else {
             DataType::Utf8

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -265,7 +265,7 @@ impl<O: Offset> MutableArray for MutableUtf8Array<O> {
     }
 
     fn data_type(&self) -> &DataType {
-        if O::is_large() {
+        if O::IS_LARGE {
             &DataType::LargeUtf8
         } else {
             &DataType::Utf8

--- a/src/compute/length.rs
+++ b/src/compute/length.rs
@@ -35,7 +35,7 @@ where
         .map(|offset| op(offset[1] - offset[0]))
         .collect::<Vec<_>>();
 
-    let data_type = if O::is_large() {
+    let data_type = if O::IS_LARGE {
         DataType::Int64
     } else {
         DataType::Int32

--- a/src/scalar/binary.rs
+++ b/src/scalar/binary.rs
@@ -46,7 +46,7 @@ impl<O: Offset> Scalar for BinaryScalar<O> {
 
     #[inline]
     fn data_type(&self) -> &DataType {
-        if O::is_large() {
+        if O::IS_LARGE {
             &DataType::LargeBinary
         } else {
             &DataType::Binary

--- a/src/scalar/utf8.rs
+++ b/src/scalar/utf8.rs
@@ -46,7 +46,7 @@ impl<O: Offset> Scalar for Utf8Scalar<O> {
 
     #[inline]
     fn data_type(&self) -> &DataType {
-        if O::is_large() {
+        if O::IS_LARGE {
             &DataType::LargeUtf8
         } else {
             &DataType::Utf8

--- a/src/types/offset.rs
+++ b/src/types/offset.rs
@@ -4,19 +4,13 @@ use super::Index;
 /// as offsets of variable-length Arrow arrays.
 pub trait Offset: super::private::Sealed + Index {
     /// Whether it is `i32` (false) or `i64` (true).
-    fn is_large() -> bool;
+    const IS_LARGE: bool;
 }
 
 impl Offset for i32 {
-    #[inline]
-    fn is_large() -> bool {
-        false
-    }
+    const IS_LARGE: bool = false;
 }
 
 impl Offset for i64 {
-    #[inline]
-    fn is_large() -> bool {
-        true
-    }
+    const IS_LARGE: bool = true;
 }

--- a/tests/it/compute/length.rs
+++ b/tests/it/compute/length.rs
@@ -15,7 +15,7 @@ fn length_test_string<O: Offset>() {
         let array = Utf8Array::<O>::from(&input);
         let result = length(&array).unwrap();
 
-        let data_type = if O::is_large() {
+        let data_type = if O::IS_LARGE {
             DataType::Int64
         } else {
             DataType::Int32


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Which issue does this PR close?

Closes #999.

# Rationale for this change
`Offset::IS_LARGE` can be computed at compile time.

# What changes are included in this PR?
1. Remove the inline function `Offset::is_large()`
2. Add const `Offset::IS_LARGE`

# Are there any user-facing changes?
Yes.
