### PR TITLE
Rewrite `min_max_string` and `min_max_binary`

### DIFF
--- a/benches/aggregate.rs
+++ b/benches/aggregate.rs
@@ -43,13 +43,13 @@ fn add_benchmark(c: &mut Criterion) {
             b.iter(|| bench_min(&arr_a))
         });
 
-        let arr_a = create_string_array::<i32>(100, size, 0.0, 0);
+        let arr_a = create_string_array::<i32>(1, size, 0.0, 0);
 
         c.bench_function(&format!("min 2^{} utf8", log2_size), |b| {
             b.iter(|| bench_min(&arr_a))
         });
 
-        let arr_a = create_string_array::<i32>(100, size, 0.1, 0);
+        let arr_a = create_string_array::<i32>(1, size, 0.1, 0);
 
         c.bench_function(&format!("min null 2^{} utf8", log2_size), |b| {
             b.iter(|| bench_min(&arr_a))

--- a/benches/aggregate.rs
+++ b/benches/aggregate.rs
@@ -42,6 +42,18 @@ fn add_benchmark(c: &mut Criterion) {
         c.bench_function(&format!("min null 2^{} f32", log2_size), |b| {
             b.iter(|| bench_min(&arr_a))
         });
+
+        let arr_a = create_string_array::<i32>(100, size, 0.0, 0);
+
+        c.bench_function(&format!("min 2^{} utf8", log2_size), |b| {
+            b.iter(|| bench_min(&arr_a))
+        });
+
+        let arr_a = create_string_array::<i32>(100, size, 0.1, 0);
+
+        c.bench_function(&format!("min null 2^{} utf8", log2_size), |b| {
+            b.iter(|| bench_min(&arr_a))
+        });
     });
 }
 

--- a/tests/it/compute/aggregate/min_max.rs
+++ b/tests/it/compute/aggregate/min_max.rs
@@ -198,8 +198,20 @@ fn test_boolean_min_max_smaller() {
 #[test]
 fn test_binary_min_max_with_nulls() {
     let a = BinaryArray::<i32>::from(&[Some(b"b"), None, None, Some(b"a"), Some(b"c")]);
-    assert_eq!("a".as_bytes(), min_binary(&a).unwrap());
-    assert_eq!("c".as_bytes(), max_binary(&a).unwrap());
+    assert_eq!(Some("a".as_bytes()), min_binary(&a));
+    assert_eq!(Some("c".as_bytes()), max_binary(&a));
+}
+
+#[test]
+fn test_binary_min_max_no_null() {
+    let a = BinaryArray::<i32>::from(&[
+        Some("abc".as_bytes()),
+        Some(b"acd"),
+        Some(b"aabd"),
+        Some(b""),
+    ]);
+    assert_eq!(Some("".as_bytes()), min_binary(&a));
+    assert_eq!(Some("acd".as_bytes()), max_binary(&a));
 }
 
 #[test]

--- a/tests/it/compute/aggregate/min_max.rs
+++ b/tests/it/compute/aggregate/min_max.rs
@@ -112,12 +112,11 @@ fn min_max_f64_edge_cases() {
     assert_eq!(Some(f64::INFINITY), max_primitive(&a));
 }
 
-// todo: convert me
 #[test]
 fn test_string_min_max_with_nulls() {
     let a = Utf8Array::<i32>::from(&[Some("b"), None, None, Some("a"), Some("c")]);
-    assert_eq!("a", min_string(&a).unwrap());
-    assert_eq!("c", max_string(&a).unwrap());
+    assert_eq!(Some("a"), min_string(&a));
+    assert_eq!(Some("c"), max_string(&a));
 }
 
 #[test]
@@ -125,6 +124,13 @@ fn test_string_min_max_all_nulls() {
     let a = Utf8Array::<i32>::from(&[None::<&str>, None]);
     assert_eq!(None, min_string(&a));
     assert_eq!(None, max_string(&a));
+}
+
+#[test]
+fn test_string_min_max_no_null() {
+    let a = Utf8Array::<i32>::from(&[Some("abc"), Some("abd"), Some("bac"), Some("bbb")]);
+    assert_eq!(Some("abc"), min_string(&a));
+    assert_eq!(Some("bbb"), max_string(&a));
 }
 
 #[test]


### PR DESCRIPTION
Signed-off-by: remzi <13716567376yh@gmail.com>

# Changes in the PR
1. Replace `fold` with `reduce`
2. use macro to abstract the common expression
3. Add test to cover the `no null` cases.
4. Add benchmark for `min utf8`
5. Less code is better
6. Functional style

# No obvious performance impact
```
min 2^10 utf8           time:   [33.766 ns 33.786 ns 33.810 ns]                           
                        change: [+0.0167% +0.2385% +0.4298%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

min null 2^10 utf8      time:   [33.352 ns 33.370 ns 33.391 ns]                                
                        change: [-4.7561% -4.6289% -4.5317%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
```