### PR TITLE
Make convert mod public to expose parquet_to_arrow_schema utility function

### DIFF
--- a/src/io/parquet/read/schema/mod.rs
+++ b/src/io/parquet/read/schema/mod.rs
@@ -9,7 +9,7 @@ pub use metadata::read_schema_from_metadata;
 pub use parquet2::metadata::{FileMetaData, KeyValue, SchemaDescriptor};
 pub use parquet2::schema::types::ParquetType;
 
-pub(crate) use convert::*;
+pub use convert::*;
 
 use self::metadata::parse_key_value_metadata;
 

--- a/src/io/parquet/read/schema/mod.rs
+++ b/src/io/parquet/read/schema/mod.rs
@@ -10,6 +10,8 @@ pub use metadata::read_schema_from_metadata;
 pub use parquet2::metadata::{FileMetaData, KeyValue, SchemaDescriptor};
 pub use parquet2::schema::types::ParquetType;
 
+pub(crate) use convert::*;
+
 use self::metadata::parse_key_value_metadata;
 
 /// Infers a [`Schema`] from parquet's [`FileMetaData`]. This first looks for the metadata key

--- a/src/io/parquet/read/schema/mod.rs
+++ b/src/io/parquet/read/schema/mod.rs
@@ -5,11 +5,10 @@ use crate::error::Result;
 mod convert;
 mod metadata;
 
+pub use convert::parquet_to_arrow_schema;
 pub use metadata::read_schema_from_metadata;
 pub use parquet2::metadata::{FileMetaData, KeyValue, SchemaDescriptor};
 pub use parquet2::schema::types::ParquetType;
-
-pub use convert::*;
 
 use self::metadata::parse_key_value_metadata;
 


### PR DESCRIPTION
Exposes the utility function to go from `parquet2`'s `SchemaDescriptor` to `arrow2` `Schema`

Maybe a `arrow2::schema::Schema::try_from_message` is more desirable?