### PR TITLE
Added support for custom sort `build_compare_fn`

### DIFF
--- a/src/compute/merge_sort/mod.rs
+++ b/src/compute/merge_sort/mod.rs
@@ -470,6 +470,15 @@ type IsValid<'a> = Box<dyn Fn(usize) -> bool + 'a>;
 pub fn build_comparator<'a>(
     pairs: &'a [(&'a [&'a dyn Array], &SortOptions)],
 ) -> Result<Comparator<'a>> {
+    build_comparator_impl(pairs, &build_compare)
+}
+
+/// returns a comparison function between any two arrays of each pair of arrays, according to `SortOptions`.
+/// Implementing custom `build_compare_fn` for unsupportd data types.
+pub fn build_comparator_impl<'a>(
+    pairs: &'a [(&'a [&'a dyn Array], &SortOptions)],
+    build_compare_fn: &dyn Fn(&dyn Array, &dyn Array) -> Result<DynComparator>,
+) -> Result<Comparator<'a>> {
     // prepare the comparison function of _values_ between all pairs of arrays
     let indices_pairs = (0..pairs[0].0.len())
         .combinations(2)
@@ -483,7 +492,7 @@ pub fn build_comparator<'a>(
                     Ok((
                         Box::new(move |row| arrays[lhs_index].is_valid(row)) as IsValid<'a>,
                         Box::new(move |row| arrays[rhs_index].is_valid(row)) as IsValid<'a>,
-                        build_compare(arrays[lhs_index], arrays[rhs_index])?,
+                        build_compare_fn(arrays[lhs_index], arrays[rhs_index])?,
                     ))
                 })
                 .collect::<Result<Vec<_>>>()?;

--- a/src/compute/sort/lex_sort.rs
+++ b/src/compute/sort/lex_sort.rs
@@ -79,8 +79,16 @@ fn build_is_valid(array: &dyn Array) -> IsValid {
 }
 
 pub(crate) fn build_compare(array: &dyn Array, sort_option: SortOptions) -> Result<DynComparator> {
+    build_compare_impl(array, sort_option, &ord::build_compare)
+}
+
+pub(crate) fn build_compare_impl(
+    array: &dyn Array,
+    sort_option: SortOptions,
+    build_compare_fn: &dyn Fn(&dyn Array, &dyn Array) -> Result<DynComparator>,
+) -> Result<DynComparator> {
     let is_valid = build_is_valid(array);
-    let comparator = ord::build_compare(array, array)?;
+    let comparator = build_compare_fn(array, array)?;
 
     Ok(match (sort_option.descending, sort_option.nulls_first) {
         (true, true) => Box::new(move |i: usize, j: usize| match (is_valid(i), is_valid(j)) {
@@ -128,6 +136,17 @@ pub fn lexsort_to_indices<I: Index>(
     columns: &[SortColumn],
     limit: Option<usize>,
 ) -> Result<PrimitiveArray<I>> {
+    lexsort_to_indices_impl(columns, limit, &ord::build_compare)
+}
+
+/// Sorts a list of [`SortColumn`] into a non-nullable [`PrimitiveArray`]
+/// representing the indices that would sort the columns.
+/// Implementing custom `build_compare_fn` for unsupportd data types.
+pub fn lexsort_to_indices_impl<I: Index>(
+    columns: &[SortColumn],
+    limit: Option<usize>,
+    build_compare_fn: &dyn Fn(&dyn Array, &dyn Array) -> Result<DynComparator>,
+) -> Result<PrimitiveArray<I>> {
     if columns.is_empty() {
         return Err(ArrowError::InvalidArgumentError(
             "Sort requires at least one column".to_string(),
@@ -136,7 +155,11 @@ pub fn lexsort_to_indices<I: Index>(
     if columns.len() == 1 {
         // fallback to non-lexical sort
         let column = &columns[0];
-        return sort_to_indices(column.values, &column.options.unwrap_or_default(), limit);
+        if let Ok(indices) =
+            sort_to_indices(column.values, &column.options.unwrap_or_default(), limit)
+        {
+            return Ok(indices);
+        }
     }
 
     let row_count = columns[0].values.len();
@@ -150,7 +173,11 @@ pub fn lexsort_to_indices<I: Index>(
     let comparators = columns
         .iter()
         .map(|column| -> Result<DynComparator> {
-            build_compare(column.values, column.options.unwrap_or_default())
+            build_compare_impl(
+                column.values,
+                column.options.unwrap_or_default(),
+                build_compare_fn,
+            )
         })
         .collect::<Result<Vec<DynComparator>>>()?;
 

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -18,7 +18,7 @@ mod primitive;
 mod utf8;
 
 pub(crate) use lex_sort::build_compare;
-pub use lex_sort::{lexsort, lexsort_to_indices, SortColumn};
+pub use lex_sort::{lexsort, lexsort_to_indices, lexsort_to_indices_impl, SortColumn};
 
 macro_rules! dyn_sort {
     ($ty:ty, $array:expr, $cmp:expr, $options:expr, $limit:expr) => {{


### PR DESCRIPTION
The `build_compare` function only supports build compare functions for common data types and will generate errors for other data types like `DataType::Extension`. We have some custom data types stored as `DataType::Extension` need to be sorted, but there is no proper way to implement them.

This PR adds the following functions to support the user implement custom `build_compare` function for their own data types.
```rust
pub fn lexsort_to_indices_impl<I: Index>(
    columns: &[SortColumn],
    limit: Option<usize>,
    build_compare_fn: &dyn Fn(&dyn Array, &dyn Array) -> Result<DynComparator>,
) -> Result<PrimitiveArray<I>> {
}

pub(crate) fn build_compare_impl(
    array: &dyn Array,
    sort_option: SortOptions,
    build_compare_fn: &dyn Fn(&dyn Array, &dyn Array) -> Result<DynComparator>,
) -> Result<DynComparator> {
}

pub fn build_comparator_impl<'a>(
    pairs: &'a [(&'a [&'a dyn Array], &SortOptions)],
    build_compare_fn: &dyn Fn(&dyn Array, &dyn Array) -> Result<DynComparator>,
) -> Result<Comparator<'a>> {
}
```