### PR TITLE
Fixed panic sort list array with different length

### DIFF
--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -364,7 +364,7 @@ where
 /// Compare two `Array`s based on the ordering defined in [ord](crate::array::ord).
 fn cmp_array(a: &dyn Array, b: &dyn Array) -> Ordering {
     let cmp_op = ord::build_compare(a, b).unwrap();
-    let length = a.len().max(b.len());
+    let length = a.len().min(b.len());
 
     for i in 0..length {
         let result = cmp_op(i, i);
@@ -372,5 +372,5 @@ fn cmp_array(a: &dyn Array, b: &dyn Array) -> Ordering {
             return result;
         }
     }
-    Ordering::Equal
+    a.len().cmp(&b.len())
 }


### PR DESCRIPTION
When sorting a list array, if the length of two values is not equal, it will panic because of `index out of bounds`

```
thread 'kernels::data_block_sort::test_data_block_sort' panicked at 'index out of bounds: the len is 2 but the index is 2', /Users/baishen/.cargo/git/checkouts/arrow2-6249446b5f8db6f7/588e74f/src/array/primitive/mod.rs:186:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/cd282d7f75da9080fda0f1740a729516e7fbec68/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/cd282d7f75da9080fda0f1740a729516e7fbec68/library/core/src/panicking.rs:142:14
   2: core::panicking::panic_bounds_check
             at /rustc/cd282d7f75da9080fda0f1740a729516e7fbec68/library/core/src/panicking.rs:84:5
   3: arrow2::array::primitive::PrimitiveArray<T>::value
             at /Users/baishen/.cargo/git/checkouts/arrow2-6249446b5f8db6f7/588e74f/src/array/primitive/mod.rs:186:9
   4: arrow2::array::ord::compare_primitives::{{closure}}
             at /Users/baishen/.cargo/git/checkouts/arrow2-6249446b5f8db6f7/588e74f/src/array/ord.rs:61:53
   5: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/cd282d7f75da9080fda0f1740a729516e7fbec68/library/alloc/src/boxed.rs:1886:9
   6: arrow2::compute::sort::cmp_array
             at /Users/baishen/.cargo/git/checkouts/arrow2-6249446b5f8db6f7/588e74f/src/compute/sort/mod.rs:375:22
   7: arrow2::compute::sort::sort_list::{{closure}}
             at /Users/baishen/.cargo/git/checkouts/arrow2-6249446b5f8db6f7/588e74f/src/compute/sort/mod.rs:345:31
   8: alloc::slice::<impl [T]>::sort_by::{{closure}}
             at /rustc/cd282d7f75da9080fda0f1740a729516e7fbec68/library/alloc/src/slice.rs:332:33
   9: alloc::slice::insert_head
             at /rustc/cd282d7f75da9080fda0f1740a729516e7fbec68/library/alloc/src/slice.rs:890:24
  10: alloc::slice::merge_sort
             at /rustc/cd282d7f75da9080fda0f1740a729516e7fbec68/library/alloc/src/slice.rs:1099:17
  11: alloc::slice::<impl [T]>::sort_by
             at /rustc/cd282d7f75da9080fda0f1740a729516e7fbec68/library/alloc/src/slice.rs:332:9
  12: arrow2::compute::sort::sort_list
             at /Users/baishen/.cargo/git/checkouts/arrow2-6249446b5f8db6f7/588e74f/src/compute/sort/mod.rs:345:9
  13: arrow2::compute::sort::sort_to_indices
             at /Users/baishen/.cargo/git/checkouts/arrow2-6249446b5f8db6f7/588e74f/src/compute/sort/mod.rs:177:39
  14: arrow2::compute::sort::lex_sort::lexsort_to_indices_impl
             at /Users/baishen/.cargo/git/checkouts/arrow2-6249446b5f8db6f7/588e74f/src/compute/sort/lex_sort.rs:159:13
  15: common_datablocks::kernels::data_block_sort::<impl common_datablocks::data_block::DataBlock>::sort_block
             at ./src/kernels/data_block_sort.rs:66:23
  16: it::kernels::data_block_sort::test_data_block_sort
             at ./tests/it/kernels/data_block_sort.rs:189:23
  17: it::kernels::data_block_sort::test_data_block_sort::{{closure}}
             at ./tests/it/kernels/data_block_sort.rs:21:1
  18: core::ops::function::FnOnce::call_once
             at /rustc/cd282d7f75da9080fda0f1740a729516e7fbec68/library/core/src/ops/function.rs:248:5
  19: core::ops::function::FnOnce::call_once
             at /rustc/cd282d7f75da9080fda0f1740a729516e7fbec68/library/core/src/ops/function.rs:248:5
```