### PR TITLE
Improved performance of deserializing JSON (2x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,7 @@ regex = { version = "^1.3", optional = true }
 streaming-iterator = { version = "0.1", optional = true }
 fallible-streaming-iterator = { version = "0.1", optional = true }
 
-serde = { version = "^1.0", features = ["rc"], optional = true }
-serde_derive = { version = "^1.0", optional = true }
-serde_json = { version = "^1.0", features = ["preserve_order"], optional = true }
+json-deserializer = { version = "0.3", optional = true }
 indexmap = { version = "^1.6", optional = true }
 
 # used to print columns in a nice columnar format
@@ -72,6 +70,9 @@ parquet2 = { version = "0.13", optional = true, default_features = false }
 
 # avro support
 avro-schema = { version = "0.2", optional = true }
+serde = { version = "^1.0", features = ["rc"], optional = true }
+serde_derive = { version = "^1.0", optional = true }
+serde_json = { version = "^1.0", features = ["preserve_order"], optional = true }
 # compression of avro
 libflate = { version = "1.1.1", optional = true }
 snap = { version = "1", optional = true }
@@ -134,7 +135,7 @@ io_csv_async = ["io_csv_read_async"]
 io_csv_read = ["csv", "lexical-core"]
 io_csv_read_async = ["csv-async", "lexical-core", "futures"]
 io_csv_write = ["csv-core", "streaming-iterator", "lexical-core"]
-io_json = ["serde", "serde_json", "streaming-iterator", "fallible-streaming-iterator", "indexmap", "lexical-core"]
+io_json = ["json-deserializer", "streaming-iterator", "fallible-streaming-iterator", "indexmap", "lexical-core"]
 io_ipc = ["arrow-format"]
 io_ipc_write_async = ["io_ipc", "futures"]
 io_ipc_read_async = ["io_ipc", "futures", "async-stream"]
@@ -156,9 +157,9 @@ io_avro_compression = [
     "crc",
 ]
 io_avro_async = ["io_avro", "futures", "async-stream"]
-# io_json: its dependencies + error handling
+# serde+serde_json: its dependencies + error handling
 # serde_derive: there is some derive around
-io_json_integration = ["io_json", "serde_derive", "hex"]
+io_json_integration = ["hex", "serde", "serde_derive", "serde_json", "io_ipc"]
 io_print = ["comfy-table"]
 # the compute kernels. Disabling this significantly reduces compile time.
 compute_aggregate = ["multiversion"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -314,5 +314,9 @@ name = "write_json"
 harness = false
 
 [[bench]]
+name = "read_json"
+harness = false
+
+[[bench]]
 name = "slices_iterator"
 harness = false

--- a/benches/read_json.rs
+++ b/benches/read_json.rs
@@ -1,0 +1,65 @@
+use arrow2::array::Array;
+use arrow2::datatypes::DataType;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use arrow2::io::json::{read, write};
+use arrow2::util::bench_util::*;
+
+fn prep(array: impl Array + 'static) -> (Vec<u8>, DataType) {
+    let mut data = vec![];
+    let blocks = write::Serializer::new(
+        vec![Ok(Box::new(array) as Box<dyn Array>)].into_iter(),
+        vec![],
+    );
+    // the operation of writing is IO-bounded.
+    write::write(&mut data, blocks).unwrap();
+
+    let dt = read::infer(&serde_json::from_slice(&data).unwrap()).unwrap();
+    (data, dt)
+}
+
+fn bench_read(data: &[u8], dt: &DataType) {
+    let json = serde_json::from_slice(data).unwrap();
+    read::deserialize(&json, dt.clone()).unwrap();
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+
+        let array = create_primitive_array::<i32>(size, 0.1);
+
+        let (data, dt) = prep(array);
+
+        c.bench_function(&format!("read i32 2^{}", log2_size), |b| {
+            b.iter(|| bench_read(&data, &dt))
+        });
+
+        let array = create_primitive_array::<f64>(size, 0.1);
+
+        let (data, dt) = prep(array);
+
+        c.bench_function(&format!("read f64 2^{}", log2_size), |b| {
+            b.iter(|| bench_read(&data, &dt))
+        });
+
+        let array = create_string_array::<i32>(size, 10, 0.1, 42);
+
+        let (data, dt) = prep(array);
+
+        c.bench_function(&format!("read utf8 2^{}", log2_size), |b| {
+            b.iter(|| bench_read(&data, &dt))
+        });
+
+        let array = create_boolean_array(size, 0.1, 0.1);
+
+        let (data, dt) = prep(array);
+
+        c.bench_function(&format!("read bool 2^{}", log2_size), |b| {
+            b.iter(|| bench_read(&data, &dt))
+        });
+    })
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/benches/read_json.rs
+++ b/benches/read_json.rs
@@ -14,13 +14,15 @@ fn prep(array: impl Array + 'static) -> (Vec<u8>, DataType) {
     // the operation of writing is IO-bounded.
     write::write(&mut data, blocks).unwrap();
 
-    let dt = read::infer(&serde_json::from_slice(&data).unwrap()).unwrap();
+    let value = read::json_deserializer::parse(&data).unwrap();
+
+    let dt = read::infer(&value).unwrap();
     (data, dt)
 }
 
 fn bench_read(data: &[u8], dt: &DataType) {
-    let json = serde_json::from_slice(data).unwrap();
-    read::deserialize(&json, dt.clone()).unwrap();
+    let value = read::json_deserializer::parse(data).unwrap();
+    read::deserialize(&value, dt.clone()).unwrap();
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/examples/json_read.rs
+++ b/examples/json_read.rs
@@ -1,5 +1,5 @@
-use std::fs::File;
-use std::io::BufReader;
+/// Example of reading a JSON file.
+use std::fs;
 use std::sync::Arc;
 
 use arrow2::array::Array;
@@ -7,12 +7,16 @@ use arrow2::error::Result;
 use arrow2::io::json::read;
 
 fn read_path(path: &str) -> Result<Arc<dyn Array>> {
-    // Example of reading a JSON file.
-    let reader = BufReader::new(File::open(path)?);
-    let json = serde_json::from_reader(reader)?;
+    // read the file into memory (IO-bounded)
+    let data = fs::read(path)?;
 
+    // create a non-owning struct of the data (CPU-bounded)
+    let json = read::json_deserializer::parse(&data)?;
+
+    // use it to infer an Arrow schema (CPU-bounded)
     let data_type = read::infer(&json)?;
 
+    // and deserialize it (CPU-bounded)
     read::deserialize(&json, data_type)
 }
 

--- a/src/io/avro/read/decompress.rs
+++ b/src/io/avro/read/decompress.rs
@@ -9,6 +9,7 @@ use super::super::{Block, CompressedBlock};
 use super::BlockStreamIterator;
 use super::Compression;
 
+#[cfg(feature = "io_avro_compression")]
 const CRC_TABLE: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
 
 /// Decompresses an Avro block.

--- a/src/io/avro/write/compress.rs
+++ b/src/io/avro/write/compress.rs
@@ -5,6 +5,7 @@ use crate::error::Result;
 use super::Compression;
 use super::{Block, CompressedBlock};
 
+#[cfg(feature = "io_avro_compression")]
 const CRC_TABLE: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_ISO_HDLC);
 
 /// Compresses a [`Block`] to a [`CompressedBlock`].

--- a/src/io/json/mod.rs
+++ b/src/io/json/mod.rs
@@ -5,8 +5,8 @@ pub mod write;
 
 use crate::error::Error;
 
-impl From<serde_json::error::Error> for Error {
-    fn from(error: serde_json::error::Error) -> Self {
-        Error::External("".to_string(), Box::new(error))
+impl From<json_deserializer::Error> for Error {
+    fn from(error: json_deserializer::Error) -> Self {
+        Error::ExternalFormat(error.to_string())
     }
 }

--- a/src/io/json/read/infer_schema.rs
+++ b/src/io/json/read/infer_schema.rs
@@ -1,8 +1,9 @@
 use std::borrow::Borrow;
+use std::collections::BTreeMap;
 
 use indexmap::map::IndexMap as HashMap;
 use indexmap::set::IndexSet as HashSet;
-use serde_json::Value;
+use json_deserializer::{Number, Value};
 
 use crate::datatypes::*;
 use crate::error::Result;
@@ -29,7 +30,7 @@ fn filter_map_nulls(dt: DataType) -> Option<DataType> {
     }
 }
 
-fn infer_object(inner: &serde_json::Map<String, Value>) -> Result<DataType> {
+fn infer_object(inner: &BTreeMap<String, Value>) -> Result<DataType> {
     let fields = inner
         .iter()
         .filter_map(|(key, value)| {
@@ -69,11 +70,10 @@ fn infer_array(values: &[Value]) -> Result<DataType> {
     })
 }
 
-fn infer_number(n: &serde_json::Number) -> DataType {
-    if n.is_f64() {
-        DataType::Float64
-    } else {
-        DataType::Int64
+fn infer_number(n: &Number) -> DataType {
+    match n {
+        Number::Float(..) => DataType::Float64,
+        Number::Integer(..) => DataType::Int64,
     }
 }
 

--- a/src/io/json/read/mod.rs
+++ b/src/io/json/read/mod.rs
@@ -6,3 +6,5 @@ pub(crate) use deserialize::_deserialize;
 pub use deserialize::deserialize;
 pub(crate) use infer_schema::coerce_data_type;
 pub use infer_schema::infer;
+
+pub use json_deserializer;

--- a/src/io/json/write/mod.rs
+++ b/src/io/json/write/mod.rs
@@ -1,5 +1,6 @@
 //! APIs to write to JSON
 mod serialize;
+mod utf8;
 
 pub use fallible_streaming_iterator::*;
 pub(crate) use serialize::new_serializer;

--- a/src/io/json/write/serialize.rs
+++ b/src/io/json/write/serialize.rs
@@ -13,6 +13,8 @@ use crate::temporal_conversions::{
 use crate::util::lexical_to_bytes_mut;
 use crate::{array::*, datatypes::DataType, types::NativeType};
 
+use super::utf8;
+
 fn boolean_serializer<'a>(
     array: &'a BooleanArray,
 ) -> Box<dyn StreamingIterator<Item = [u8]> + 'a + Send + Sync> {
@@ -73,7 +75,7 @@ fn utf8_serializer<'a, O: Offset>(
         array.iter(),
         |x, buf| {
             if let Some(x) = x {
-                serde_json::to_writer(buf, x).unwrap();
+                utf8::write_str(buf, x).unwrap();
             } else {
                 buf.extend_from_slice(b"null")
             }
@@ -256,7 +258,7 @@ fn serialize_item(buffer: &mut Vec<u8>, record: &[(&str, &[u8])], is_first_row: 
             buffer.push(b',');
         }
         first_item = false;
-        serde_json::to_writer(&mut *buffer, key).unwrap();
+        utf8::write_str(buffer, key).unwrap();
         buffer.push(b':');
         buffer.extend(*value);
     }

--- a/src/io/json/write/utf8.rs
+++ b/src/io/json/write/utf8.rs
@@ -1,0 +1,138 @@
+// Adapted from https://github.com/serde-rs/json/blob/f901012df66811354cb1d490ad59480d8fdf77b5/src/ser.rs
+use std::io;
+
+pub fn write_str<W>(writer: &mut W, value: &str) -> io::Result<()>
+where
+    W: io::Write,
+{
+    writer.write_all(b"\"")?;
+    let bytes = value.as_bytes();
+
+    let mut start = 0;
+
+    for (i, &byte) in bytes.iter().enumerate() {
+        let escape = ESCAPE[byte as usize];
+        if escape == 0 {
+            continue;
+        }
+
+        if start < i {
+            writer.write_all(&bytes[start..i])?;
+        }
+
+        let char_escape = CharEscape::from_escape_table(escape, byte);
+        write_char_escape(writer, char_escape)?;
+
+        start = i + 1;
+    }
+
+    if start != bytes.len() {
+        writer.write_all(&bytes[start..])?;
+    }
+    writer.write_all(b"\"")
+}
+
+const BB: u8 = b'b'; // \x08
+const TT: u8 = b't'; // \x09
+const NN: u8 = b'n'; // \x0A
+const FF: u8 = b'f'; // \x0C
+const RR: u8 = b'r'; // \x0D
+const QU: u8 = b'"'; // \x22
+const BS: u8 = b'\\'; // \x5C
+const UU: u8 = b'u'; // \x00...\x1F except the ones above
+const __: u8 = 0;
+
+// Lookup table of escape sequences. A value of b'x' at index i means that byte
+// i is escaped as "\x" in JSON. A value of 0 means that byte i is not escaped.
+static ESCAPE: [u8; 256] = [
+    //   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+    UU, UU, UU, UU, UU, UU, UU, UU, BB, TT, NN, UU, FF, RR, UU, UU, // 0
+    UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, // 1
+    __, __, QU, __, __, __, __, __, __, __, __, __, __, __, __, __, // 2
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 3
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 4
+    __, __, __, __, __, __, __, __, __, __, __, __, BS, __, __, __, // 5
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 6
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 7
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 8
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 9
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // A
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // B
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // C
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // D
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // E
+    __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
+];
+
+/// Represents a character escape code in a type-safe manner.
+pub enum CharEscape {
+    /// An escaped quote `"`
+    Quote,
+    /// An escaped reverse solidus `\`
+    ReverseSolidus,
+    // An escaped solidus `/`
+    //Solidus,
+    /// An escaped backspace character (usually escaped as `\b`)
+    Backspace,
+    /// An escaped form feed character (usually escaped as `\f`)
+    FormFeed,
+    /// An escaped line feed character (usually escaped as `\n`)
+    LineFeed,
+    /// An escaped carriage return character (usually escaped as `\r`)
+    CarriageReturn,
+    /// An escaped tab character (usually escaped as `\t`)
+    Tab,
+    /// An escaped ASCII plane control character (usually escaped as
+    /// `\u00XX` where `XX` are two hex characters)
+    AsciiControl(u8),
+}
+
+impl CharEscape {
+    #[inline]
+    fn from_escape_table(escape: u8, byte: u8) -> CharEscape {
+        match escape {
+            self::BB => CharEscape::Backspace,
+            self::TT => CharEscape::Tab,
+            self::NN => CharEscape::LineFeed,
+            self::FF => CharEscape::FormFeed,
+            self::RR => CharEscape::CarriageReturn,
+            self::QU => CharEscape::Quote,
+            self::BS => CharEscape::ReverseSolidus,
+            self::UU => CharEscape::AsciiControl(byte),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[inline]
+fn write_char_escape<W>(writer: &mut W, char_escape: CharEscape) -> io::Result<()>
+where
+    W: io::Write,
+{
+    use self::CharEscape::*;
+
+    let s = match char_escape {
+        Quote => b"\\\"",
+        ReverseSolidus => b"\\\\",
+        //Solidus => b"\\/",
+        Backspace => b"\\b",
+        FormFeed => b"\\f",
+        LineFeed => b"\\n",
+        CarriageReturn => b"\\r",
+        Tab => b"\\t",
+        AsciiControl(byte) => {
+            static HEX_DIGITS: [u8; 16] = *b"0123456789abcdef";
+            let bytes = &[
+                b'\\',
+                b'u',
+                b'0',
+                b'0',
+                HEX_DIGITS[(byte >> 4) as usize],
+                HEX_DIGITS[(byte & 0xF) as usize],
+            ];
+            return writer.write_all(bytes);
+        }
+    };
+
+    writer.write_all(s)
+}

--- a/src/io/json_integration/mod.rs
+++ b/src/io/json_integration/mod.rs
@@ -5,6 +5,8 @@
 use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::error::Error;
+
 pub mod read;
 pub mod write;
 
@@ -116,4 +118,10 @@ pub struct ArrowJsonColumn {
     pub type_id: Option<Vec<Value>>,
     /// the children
     pub children: Option<Vec<ArrowJsonColumn>>,
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Error::ExternalFormat(error.to_string())
+    }
 }

--- a/src/io/ndjson/read/file.rs
+++ b/src/io/ndjson/read/file.rs
@@ -2,8 +2,7 @@ use std::io::BufRead;
 
 use fallible_streaming_iterator::FallibleStreamingIterator;
 use indexmap::set::IndexSet as HashSet;
-use serde_json;
-use serde_json::Value;
+use json_deserializer::parse;
 
 use crate::{
     datatypes::DataType,
@@ -115,7 +114,7 @@ pub fn infer<R: std::io::BufRead>(
 
     let mut data_types = HashSet::new();
     while let Some(rows) = reader.next()? {
-        let value: Value = serde_json::from_str(&rows[0])?; // 0 because it is row by row
+        let value = parse(rows[0].as_bytes())?; // 0 because it is row by row
         let data_type = infer_json(&value)?;
         if data_type != DataType::Null {
             data_types.insert(data_type);
@@ -134,7 +133,7 @@ pub fn infer<R: std::io::BufRead>(
 pub fn infer_iter<A: AsRef<str>>(rows: impl Iterator<Item = A>) -> Result<DataType> {
     let mut data_types = HashSet::new();
     for row in rows {
-        let v: Value = serde_json::from_str(row.as_ref())?;
+        let v = parse(row.as_ref().as_bytes())?;
         let data_type = infer_json(&v)?;
         if data_type != DataType::Null {
             data_types.insert(data_type);

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -7,7 +7,7 @@ use super::*;
 
 #[test]
 fn read_json() -> Result<()> {
-    let data = r#"[
+    let data = br#"[
         {
             "a": 1
         },
@@ -19,7 +19,7 @@ fn read_json() -> Result<()> {
         }
     ]"#;
 
-    let json = serde_json::from_slice(data.as_bytes())?;
+    let json = json_deserializer::parse(data)?;
 
     let data_type = read::infer(&json)?;
 

--- a/tests/it/io/ndjson/read.rs
+++ b/tests/it/io/ndjson/read.rs
@@ -156,7 +156,7 @@ fn invalid_infer_schema() -> Result<()> {
     let re = ndjson_read::infer(&mut Cursor::new("city,lat,lng"), None);
     assert_eq!(
         re.err().unwrap().to_string(),
-        "External error: expected value at line 1 column 1",
+        "External format error: InvalidToken(99)",
     );
     Ok(())
 }
@@ -249,7 +249,7 @@ fn invalid_read_record() -> Result<()> {
 
     assert_eq!(
         arrays.err().unwrap().to_string(),
-        "External error: expected value at line 1 column 1",
+        "External format error: InvalidToken(99)",
     );
     Ok(())
 }


### PR DESCRIPTION
This PR replaces `serde_json` by `json_deserializer`, improving the performance of reading json strings by 2x and boolean by -30%, and +10% for floats:

```
read i32 2^20           time:   [68.065 ms 68.256 ms 68.444 ms]                          
                        change: [-0.8660% +1.5241% +3.8068%] (p = 0.20 > 0.05)

read f64 2^20           time:   [90.453 ms 90.682 ms 90.904 ms]                          
                        change: [+10.496% +10.879% +11.269%] (p = 0.00 < 0.05)

read utf8 2^20          time:   [51.573 ms 51.699 ms 51.825 ms]                           
                        change: [-56.883% -56.714% -56.550%] (p = 0.00 < 0.05)

read bool 2^20          time:   [33.284 ms 33.483 ms 33.837 ms]                           
                        change: [-30.126% -29.623% -28.852%] (p = 0.00 < 0.05)
```

Note that there is an API change: we now require to pass `json_deserializer::Value`, not `serde_json::Value`, to the deserializer. `json_deserializer` is exposed under `arrow2::io::json::read::json_deserializer` for convenience / version matching.
