### PR TITLE
Added more tests (increase coverage)

### DIFF
--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -163,6 +163,7 @@ impl<O: Offset> MutableBinaryArray<O> {
         let a: BinaryArray<O> = self.into();
         Arc::new(a)
     }
+
     /// Shrinks the capacity of the [`MutableBinaryArray`] to fit its current length.
     pub fn shrink_to_fit(&mut self) {
         self.values.shrink_to_fit();

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -125,7 +125,7 @@ impl FixedSizeBinaryArray {
         let values = self
             .values
             .clone()
-            .slice_unchecked(offset * self.size as usize, length * self.size as usize);
+            .slice_unchecked(offset * self.size, length * self.size);
         Self {
             data_type: self.data_type.clone(),
             size: self.size,

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -243,6 +243,13 @@ fn buffer_offset(array: &ArrowArray, data_type: &DataType, i: usize) -> usize {
     use PhysicalType::*;
     match (data_type.to_physical_type(), i) {
         (LargeUtf8, 2) | (LargeBinary, 2) | (Utf8, 2) | (Binary, 2) => 0,
+        (FixedSizeBinary, 1) => {
+            if let DataType::FixedSizeBinary(size) = data_type.to_logical_type() {
+                (array.offset as usize) * *size
+            } else {
+                unreachable!()
+            }
+        }
         _ => array.offset as usize,
     }
 }

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -306,6 +306,7 @@ unsafe fn to_data_type(schema: &ArrowSchema) -> Result<DataType> {
                     let size = size_raw
                         .parse::<usize>()
                         .map_err(|_| Error::OutOfSpec("size is not a valid integer".to_string()))?;
+                    println!("schema: {}", size);
                     DataType::FixedSizeBinary(size)
                 }
                 ["+w", size_raw] => {

--- a/src/trusted_len.rs
+++ b/src/trusted_len.rs
@@ -21,6 +21,12 @@ where
     T: Copy,
 {
 }
+unsafe impl<'a, I, T: 'a> TrustedLen for std::iter::Cloned<I>
+where
+    I: TrustedLen<Item = &'a T>,
+    T: Clone,
+{
+}
 
 unsafe impl<I> TrustedLen for std::iter::Enumerate<I> where I: TrustedLen {}
 

--- a/tests/it/array/binary/mod.rs
+++ b/tests/it/array/binary/mod.rs
@@ -67,6 +67,16 @@ fn from_trusted_len_iter() {
 }
 
 #[test]
+fn try_from_trusted_len_iter() {
+    let iter = std::iter::repeat(b"hello".as_ref())
+        .take(2)
+        .map(Some)
+        .map(arrow2::error::Result::Ok);
+    let a = BinaryArray::<i32>::try_from_trusted_len_iter(iter).unwrap();
+    assert_eq!(a.len(), 2);
+}
+
+#[test]
 fn from_iter() {
     let iter = std::iter::repeat(b"hello").take(2).map(Some);
     let a: BinaryArray<i32> = iter.collect();

--- a/tests/it/array/binary/mutable.rs
+++ b/tests/it/array/binary/mutable.rs
@@ -35,30 +35,26 @@ fn from_iter() {
 
 #[test]
 fn from_trusted_len_iter() {
-    let iter = (0..3u8).map(|x| vec![x; x as usize]);
-    let a: MutableBinaryArray<i32> = iter.clone().map(Some).collect();
+    let data = vec![vec![0; 0], vec![1; 1], vec![2; 2]];
+    let a: MutableBinaryArray<i32> = data.iter().cloned().map(Some).collect();
     assert_eq!(a.values().deref(), &[1u8, 2, 2]);
     assert_eq!(a.offsets().deref(), &[0, 0, 1, 3]);
     assert_eq!(a.validity(), None);
 
-    let a = unsafe {
-        MutableBinaryArray::<i32>::from_trusted_len_iter_unchecked(iter.clone().map(Some))
-    };
+    let a = MutableBinaryArray::<i32>::from_trusted_len_iter(data.iter().cloned().map(Some));
     assert_eq!(a.values().deref(), &[1u8, 2, 2]);
     assert_eq!(a.offsets().deref(), &[0, 0, 1, 3]);
     assert_eq!(a.validity(), None);
 
-    let a = unsafe {
-        MutableBinaryArray::<i32>::try_from_trusted_len_iter_unchecked::<Error, _, _>(
-            iter.clone().map(Some).map(Ok),
-        )
-    }
+    let a = MutableBinaryArray::<i32>::try_from_trusted_len_iter::<Error, _, _>(
+        data.iter().cloned().map(Some).map(Ok),
+    )
     .unwrap();
     assert_eq!(a.values().deref(), &[1u8, 2, 2]);
     assert_eq!(a.offsets().deref(), &[0, 0, 1, 3]);
     assert_eq!(a.validity(), None);
 
-    let a = unsafe { MutableBinaryArray::<i32>::from_trusted_len_values_iter_unchecked(iter) };
+    let a = MutableBinaryArray::<i32>::from_trusted_len_values_iter(data.iter().cloned());
     assert_eq!(a.values().deref(), &[1u8, 2, 2]);
     assert_eq!(a.offsets().deref(), &[0, 0, 1, 3]);
     assert_eq!(a.validity(), None);

--- a/tests/it/array/boolean/mod.rs
+++ b/tests/it/array/boolean/mod.rs
@@ -40,6 +40,15 @@ fn basics() {
 }
 
 #[test]
+fn try_new_invalid() {
+    assert!(BooleanArray::try_new(DataType::Int32, [true].into(), None).is_err());
+    assert!(
+        BooleanArray::try_new(DataType::Boolean, [true].into(), Some([false, true].into()))
+            .is_err()
+    );
+}
+
+#[test]
 fn with_validity() {
     let bitmap = Bitmap::from([true, false, true]);
     let a = BooleanArray::from_data(DataType::Boolean, bitmap, None);
@@ -58,13 +67,24 @@ fn into_mut_valid() {
     let bitmap = Bitmap::from([true, false, true]);
     let a = BooleanArray::from_data(DataType::Boolean, bitmap, None);
     let _ = a.into_mut().right().unwrap();
+
+    let bitmap = Bitmap::from([true, false, true]);
+    let validity = Bitmap::from([true, false, true]);
+    let a = BooleanArray::from_data(DataType::Boolean, bitmap, Some(validity));
+    let _ = a.into_mut().right().unwrap();
 }
 
 #[test]
 fn into_mut_invalid() {
     let bitmap = Bitmap::from([true, false, true]);
-    let _other = bitmap.clone(); // values are shared
+    let _other = bitmap.clone(); // values is shared
     let a = BooleanArray::from_data(DataType::Boolean, bitmap, None);
+    let _ = a.into_mut().left().unwrap();
+
+    let bitmap = Bitmap::from([true, false, true]);
+    let validity = Bitmap::from([true, false, true]);
+    let _other = validity.clone(); // validity is shared
+    let a = BooleanArray::from_data(DataType::Boolean, bitmap, Some(validity));
     let _ = a.into_mut().left().unwrap();
 }
 
@@ -78,7 +98,30 @@ fn empty() {
 #[test]
 fn from_trusted_len_iter() {
     let iter = std::iter::repeat(true).take(2).map(Some);
-    let a = BooleanArray::from_trusted_len_iter(iter);
+    let a = BooleanArray::from_trusted_len_iter(iter.clone());
+    assert_eq!(a.len(), 2);
+    let a = unsafe { BooleanArray::from_trusted_len_iter_unchecked(iter) };
+    assert_eq!(a.len(), 2);
+}
+
+#[test]
+fn try_from_trusted_len_iter() {
+    let iter = std::iter::repeat(true)
+        .take(2)
+        .map(Some)
+        .map(arrow2::error::Result::Ok);
+    let a = BooleanArray::try_from_trusted_len_iter(iter.clone()).unwrap();
+    assert_eq!(a.len(), 2);
+    let a = unsafe { BooleanArray::try_from_trusted_len_iter_unchecked(iter).unwrap() };
+    assert_eq!(a.len(), 2);
+}
+
+#[test]
+fn from_trusted_len_values_iter() {
+    let iter = std::iter::repeat(true).take(2);
+    let a = BooleanArray::from_trusted_len_values_iter(iter.clone());
+    assert_eq!(a.len(), 2);
+    let a = unsafe { BooleanArray::from_trusted_len_values_iter_unchecked(iter) };
     assert_eq!(a.len(), 2);
 }
 

--- a/tests/it/array/boolean/mutable.rs
+++ b/tests/it/array/boolean/mutable.rs
@@ -142,3 +142,23 @@ fn extend_trusted_len_values() {
     );
     assert_eq!(a.values(), &MutableBitmap::from([false, true, false]));
 }
+
+#[test]
+fn into_iter() {
+    let ve = MutableBitmap::from([true, false])
+        .into_iter()
+        .collect::<Vec<_>>();
+    assert_eq!(ve, vec![true, false]);
+    let ve = MutableBitmap::from([true, false])
+        .iter()
+        .collect::<Vec<_>>();
+    assert_eq!(ve, vec![true, false]);
+}
+
+#[test]
+fn shrink_to_fit() {
+    let mut a = MutableBitmap::with_capacity(100);
+    a.push(true);
+    a.shrink_to_fit();
+    assert_eq!(a.capacity(), 8);
+}

--- a/tests/it/bitmap/mutable.rs
+++ b/tests/it/bitmap/mutable.rs
@@ -8,6 +8,32 @@ fn from_slice() {
 }
 
 #[test]
+fn from_len_zeroed() {
+    let a = MutableBitmap::from_len_zeroed(10);
+    assert_eq!(a.len(), 10);
+    assert_eq!(a.null_count(), 10);
+}
+
+#[test]
+fn from_len_set() {
+    let a = MutableBitmap::from_len_set(10);
+    assert_eq!(a.len(), 10);
+    assert_eq!(a.null_count(), 0);
+}
+
+#[test]
+fn try_new_invalid() {
+    assert!(MutableBitmap::try_new(vec![], 2).is_err());
+}
+
+#[test]
+fn clear() {
+    let mut a = MutableBitmap::from_len_zeroed(10);
+    a.clear();
+    assert_eq!(a.len(), 0);
+}
+
+#[test]
 fn trusted_len() {
     let data = vec![true; 65];
     let bitmap = MutableBitmap::from_trusted_len_iter(data.into_iter());

--- a/tests/it/ffi/data.rs
+++ b/tests/it/ffi/data.rs
@@ -82,6 +82,18 @@ fn u32() -> Result<()> {
 }
 
 #[test]
+fn decimal() -> Result<()> {
+    let data = Int128Array::from_slice(&[1, 0, 2, 0]);
+    test_round_trip(data)
+}
+
+#[test]
+fn decimal_nullable() -> Result<()> {
+    let data = Int128Array::from(&[Some(1), None, Some(2), None]);
+    test_round_trip(data)
+}
+
+#[test]
 fn timestamp_tz() -> Result<()> {
     let data = Int64Array::from(&vec![Some(2), None, None]).to(DataType::Timestamp(
         TimeUnit::Second,
@@ -129,6 +141,26 @@ fn large_binary() -> Result<()> {
 }
 
 #[test]
+fn fixed_size_binary() -> Result<()> {
+    let data = FixedSizeBinaryArray::new(
+        DataType::FixedSizeBinary(2),
+        vec![1, 2, 3, 4, 5, 6].into(),
+        None,
+    );
+    test_round_trip(data)
+}
+
+#[test]
+fn fixed_size_binary_nullable() -> Result<()> {
+    let data = FixedSizeBinaryArray::new(
+        DataType::FixedSizeBinary(2),
+        vec![1, 2, 3, 4, 5, 6].into(),
+        Some([true, true, false].into()),
+    );
+    test_round_trip(data)
+}
+
+#[test]
 fn list() -> Result<()> {
     let data = vec![
         Some(vec![Some(1i32), Some(2), Some(3)]),
@@ -140,6 +172,22 @@ fn list() -> Result<()> {
     array.try_extend(data)?;
 
     let array: ListArray<i32> = array.into();
+
+    test_round_trip(array)
+}
+
+#[test]
+fn large_list() -> Result<()> {
+    let data = vec![
+        Some(vec![Some(1i32), Some(2), Some(3)]),
+        None,
+        Some(vec![Some(4), None, Some(6)]),
+    ];
+
+    let mut array = MutableListArray::<i64, MutablePrimitiveArray<i32>>::new();
+    array.try_extend(data)?;
+
+    let array: ListArray<i64> = array.into();
 
     test_round_trip(array)
 }
@@ -231,7 +279,11 @@ fn schema() -> Result<()> {
 fn extension() -> Result<()> {
     let field = Field::new(
         "a",
-        DataType::Extension("a".to_string(), Box::new(DataType::Int32), None),
+        DataType::Extension(
+            "a".to_string(),
+            Box::new(DataType::Int32),
+            Some("bla".to_string()),
+        ),
         true,
     );
     test_round_trip_schema(field)


### PR DESCRIPTION
Also implemented `TrustedLen` for `iter.cloned()` when `iter` is trusted len.