### PR TITLE
Added support for random access reads to IPC

### DIFF
--- a/src/io/ipc/append/mod.rs
+++ b/src/io/ipc/append/mod.rs
@@ -32,16 +32,7 @@ impl<R: Read + Seek + Write> FileWriter<R> {
             ));
         }
 
-        let dictionaries = if let Some(blocks) = &metadata.dictionaries {
-            read::reader::read_dictionaries(
-                &mut writer,
-                &metadata.schema.fields,
-                &metadata.ipc_schema,
-                blocks,
-            )?
-        } else {
-            Default::default()
-        };
+        let dictionaries = read::read_file_dictionaries(&mut writer, &metadata)?;
 
         let last_block = metadata.blocks.last().ok_or_else(|| {
             Error::oos("An Arrow IPC file must have at least 1 message (the schema message)")

--- a/src/io/ipc/read/mod.rs
+++ b/src/io/ipc/read/mod.rs
@@ -25,7 +25,9 @@ pub mod stream_async;
 pub mod file_async;
 
 pub use common::{read_dictionary, read_record_batch};
-pub use reader::{read_file_metadata, FileMetadata, FileReader};
+pub use reader::{
+    read_batch, read_file_dictionaries, read_file_metadata, FileMetadata, FileReader,
+};
 pub use schema::deserialize_schema;
 pub use stream::{read_stream_metadata, StreamMetadata, StreamReader, StreamState};
 


### PR DESCRIPTION
This exposes an API to read from IPC on a random-access fashion, i.e. read record batch at position `i`.
