### PR TITLE
Bumped parquet2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ futures = { version = "0.3", optional = true }
 ahash = { version = "0.7", optional = true }
 
 # parquet support
-parquet2 = { version = "0.12", optional = true, default_features = false, features = ["stream"] }
+parquet2 = { version = "0.13", optional = true, default_features = false }
 
 # avro support
 avro-schema = { version = "0.2", optional = true }

--- a/arrow-parquet-integration-testing/src/main.rs
+++ b/arrow-parquet-integration-testing/src/main.rs
@@ -194,7 +194,6 @@ fn main() -> Result<()> {
 
     let mut writer = FileWriter::try_new(writer, schema, options)?;
 
-    writer.start()?;
     for group in row_groups {
         writer.write(group?)?;
     }

--- a/benches/write_parquet.rs
+++ b/benches/write_parquet.rs
@@ -32,7 +32,6 @@ fn write(array: &dyn Array, encoding: Encoding) -> Result<()> {
 
     let mut writer = FileWriter::try_new(writer, schema, options)?;
 
-    writer.start()?;
     for group in row_groups {
         writer.write(group?)?;
     }

--- a/examples/parquet_write.rs
+++ b/examples/parquet_write.rs
@@ -34,7 +34,6 @@ fn write_batch(path: &str, schema: Schema, columns: Chunk<Arc<dyn Array>>) -> Re
 
     let mut writer = FileWriter::try_new(file, schema, options)?;
 
-    writer.start()?;
     for group in row_groups {
         writer.write(group?)?;
     }

--- a/examples/parquet_write_parallel/src/main.rs
+++ b/examples/parquet_write_parallel/src/main.rs
@@ -97,7 +97,6 @@ fn parallel_write(path: &str, schema: &Schema, batches: &[Chunk]) -> Result<()> 
     let mut writer = FileWriter::try_new(file, schema, options)?;
 
     // Write the file.
-    writer.start()?;
     for group in row_groups {
         writer.write(group?)?;
     }

--- a/src/doc/lib.md
+++ b/src/doc/lib.md
@@ -60,7 +60,6 @@ fn main() -> Result<()> {
     let mut writer = FileWriter::try_new(file, schema, options)?;
 
     // Write the file.
-    writer.start()?;
     for group in row_groups {
         writer.write(group?)?;
     }

--- a/src/io/parquet/write/file.rs
+++ b/src/io/parquet/write/file.rs
@@ -72,11 +72,6 @@ impl<W: Write> FileWriter<W> {
         })
     }
 
-    /// Writes the header of the file
-    pub fn start(&mut self) -> Result<()> {
-        Ok(self.writer.start()?)
-    }
-
     /// Writes a row group to the file.
     pub fn write(&mut self, row_group: RowGroupIter<'_, Error>) -> Result<()> {
         Ok(self.writer.write(row_group)?)

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -815,7 +815,6 @@ fn integration_write(schema: &Schema, batches: &[Chunk<Arc<dyn Array>>]) -> Resu
 
     let mut writer = FileWriter::try_new(writer, schema.clone(), options)?;
 
-    writer.start()?;
     for group in row_groups {
         writer.write(group?)?;
     }

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -94,7 +94,6 @@ fn read_with_indexes(
     let writer = vec![];
     let mut writer = FileWriter::try_new(writer, schema, options)?;
 
-    writer.start()?;
     writer.write(row_group)?;
     writer.end(None)?;
     let data = writer.into_inner();

--- a/tests/it/io/parquet/write.rs
+++ b/tests/it/io/parquet/write.rs
@@ -47,7 +47,6 @@ fn round_trip(
     let writer = Cursor::new(vec![]);
     let mut writer = FileWriter::try_new(writer, schema, options)?;
 
-    writer.start()?;
     for group in row_groups {
         writer.write(group?)?;
     }


### PR DESCRIPTION
This adds a couple of improvements, including control of compression level to gzip and brotli.

# Backward incompatible change

The method `start` no longer exists nor is necessary - just remove it and all is good.