### PR TITLE
Proposal: Migrate from `Arc<dyn Array>` to `Box<dyn Array>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ bench = false
 [dependencies]
 either = "1.6"
 num-traits = "0.2"
+dyn-clone = "1"
 bytemuck = { version = "1", features = ["derive"] }
 chrono = { version = "0.4", default_features = false, features = ["std"] }
 chrono-tz = { version = "0.6", optional = true }

--- a/arrow-parquet-integration-testing/src/main.rs
+++ b/arrow-parquet-integration-testing/src/main.rs
@@ -1,3 +1,6 @@
+use std::fs::File;
+use std::{collections::HashMap, io::Read};
+
 use arrow2::array::Array;
 use arrow2::io::ipc::IpcField;
 use arrow2::{
@@ -15,15 +18,12 @@ use arrow2::{
 };
 use clap::Parser;
 use flate2::read::GzDecoder;
-use std::fs::File;
-use std::sync::Arc;
-use std::{collections::HashMap, io::Read};
 
 /// Read gzipped JSON file
 pub fn read_gzip_json(
     version: &str,
     file_name: &str,
-) -> Result<(Schema, Vec<IpcField>, Vec<Chunk<Arc<dyn Array>>>)> {
+) -> Result<(Schema, Vec<IpcField>, Vec<Chunk<Box<dyn Array>>>)> {
     let path = format!(
         "../testing/arrow-testing/data/arrow-ipc-stream/integration/{}/{}.json.gz",
         version, file_name

--- a/arrow-pyarrow-integration-testing/src/c_stream.rs
+++ b/arrow-pyarrow-integration-testing/src/c_stream.rs
@@ -34,14 +34,12 @@ pub fn from_rust_iterator(py: Python) -> PyResult<PyObject> {
     let array = Int32Array::from(&[Some(2), None, Some(1), None]);
     let array = StructArray::from_data(
         DataType::Struct(vec![Field::new("a", array.data_type().clone(), true)]),
-        vec![Arc::new(array)],
+        vec![array.boxed()],
         None,
-    );
+    )
+    .boxed();
     // and a field with its datatype
     let field = Field::new("a", array.data_type().clone(), true);
-
-    // Arc it, since it will be shared with an external program
-    let array: Arc<dyn Array> = Arc::new(array.clone());
 
     // create an iterator of arrays
     let arrays = vec![array.clone(), array.clone(), array];

--- a/arrow-pyarrow-integration-testing/src/lib.rs
+++ b/arrow-pyarrow-integration-testing/src/lib.rs
@@ -4,7 +4,6 @@ mod c_stream;
 
 use std::error;
 use std::fmt;
-use std::sync::Arc;
 
 use pyo3::exceptions::PyOSError;
 use pyo3::ffi::Py_uintptr_t;
@@ -50,7 +49,7 @@ impl From<PyO3Error> for PyErr {
     }
 }
 
-fn to_rust_array(ob: PyObject, py: Python) -> PyResult<Arc<dyn Array>> {
+fn to_rust_array(ob: PyObject, py: Python) -> PyResult<Box<dyn Array>> {
     // prepare a pointer to receive the Array struct
     let array = Box::new(ffi::ArrowArray::empty());
     let schema = Box::new(ffi::ArrowSchema::empty());
@@ -73,7 +72,7 @@ fn to_rust_array(ob: PyObject, py: Python) -> PyResult<Arc<dyn Array>> {
     Ok(array.into())
 }
 
-fn to_py_array(array: Arc<dyn Array>, py: Python) -> PyResult<PyObject> {
+fn to_py_array(array: Box<dyn Array>, py: Python) -> PyResult<PyObject> {
     let array_ptr = Box::new(ffi::ArrowArray::empty());
     let schema_ptr = Box::new(ffi::ArrowSchema::empty());
 

--- a/benches/iter_list.rs
+++ b/benches/iter_list.rs
@@ -1,5 +1,4 @@
 use std::iter::FromIterator;
-use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 
@@ -28,7 +27,7 @@ fn add_benchmark(c: &mut Criterion) {
         let array = ListArray::<i32>::from_data(
             data_type,
             offsets.into(),
-            Arc::new(values),
+            Box::new(values),
             Some(validity),
         );
 

--- a/benches/write_csv.rs
+++ b/benches/write_csv.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use arrow2::array::*;
@@ -8,9 +6,9 @@ use arrow2::error::Result;
 use arrow2::io::csv::write;
 use arrow2::util::bench_util::*;
 
-type ChunkArc = Chunk<Arc<dyn Array>>;
+type ChunkBox = Chunk<Box<dyn Array>>;
 
-fn write_batch(columns: &ChunkArc) -> Result<()> {
+fn write_batch(columns: &ChunkBox) -> Result<()> {
     let mut writer = vec![];
 
     assert_eq!(columns.arrays().len(), 1);
@@ -20,8 +18,8 @@ fn write_batch(columns: &ChunkArc) -> Result<()> {
     write::write_chunk(&mut writer, columns, &options)
 }
 
-fn make_chunk(array: impl Array + 'static) -> Chunk<Arc<dyn Array>> {
-    Chunk::new(vec![Arc::new(array)])
+fn make_chunk(array: impl Array + 'static) -> Chunk<Box<dyn Array>> {
+    Chunk::new(vec![Box::new(array)])
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/benches/write_ipc.rs
+++ b/benches/write_ipc.rs
@@ -11,7 +11,7 @@ use arrow2::util::bench_util::{create_boolean_array, create_primitive_array, cre
 fn write(array: &dyn Array) -> Result<()> {
     let field = Field::new("c1", array.data_type().clone(), true);
     let schema = vec![field].into();
-    let columns = Chunk::try_new(vec![clone(array).into()])?;
+    let columns = Chunk::try_new(vec![clone(array)])?;
 
     let writer = Cursor::new(vec![]);
     let mut writer = FileWriter::try_new(writer, &schema, None, Default::default())?;

--- a/benches/write_parquet.rs
+++ b/benches/write_parquet.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use criterion::{criterion_group, criterion_main, Criterion};
 
 use arrow2::array::{clone, Array};
@@ -9,11 +7,11 @@ use arrow2::error::Result;
 use arrow2::io::parquet::write::*;
 use arrow2::util::bench_util::{create_boolean_array, create_primitive_array, create_string_array};
 
-type ChunkArc = Chunk<Arc<dyn Array>>;
+type ChunkBox = Chunk<Box<dyn Array>>;
 
 fn write(array: &dyn Array, encoding: Encoding) -> Result<()> {
     let schema = Schema::from(vec![Field::new("c1", array.data_type().clone(), true)]);
-    let columns: ChunkArc = Chunk::new(vec![clone(array).into()]);
+    let columns: ChunkBox = Chunk::new(vec![clone(array)]);
 
     let options = WriteOptions {
         write_statistics: false,

--- a/examples/avro_read_async.rs
+++ b/examples/avro_read_async.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use futures::pin_mut;
 use futures::StreamExt;
 use tokio::fs::File;
@@ -19,8 +17,8 @@ async fn main() -> Result<()> {
     let mut reader = File::open(file_path).await?.compat();
 
     let (avro_schemas, schema, compression, marker) = read_metadata(&mut reader).await?;
-    let avro_schemas = Arc::new(avro_schemas);
-    let projection = Arc::new(schema.fields.iter().map(|_| true).collect::<Vec<_>>());
+    let avro_schemas = Box::new(avro_schemas);
+    let projection = Box::new(schema.fields.iter().map(|_| true).collect::<Vec<_>>());
 
     let blocks = block_stream(&mut reader, marker).await;
 

--- a/examples/cow.rs
+++ b/examples/cow.rs
@@ -1,0 +1,20 @@
+// This example demos how to operate on arrays in-place.
+use arrow2::array::{Array, PrimitiveArray};
+
+fn main() {
+    // say we have have received an array
+    let mut array: Box<dyn Array> = PrimitiveArray::from_vec(vec![1i32, 2]).boxed();
+
+    // we can apply a transformation to its values without allocating a new array as follows:
+    // 1. downcast it to the correct type (known via `array.data_type().to_physical_type()`)
+    let array = array
+        .as_any_mut()
+        .downcast_mut::<PrimitiveArray<i32>>()
+        .unwrap();
+
+    // 2. call `apply_values` with the function to apply over the values
+    array.apply_values(|x| x.iter_mut().for_each(|x| *x *= 10));
+
+    // confirm that it gives the right result :)
+    assert_eq!(array, &PrimitiveArray::from_vec(vec![10i32, 20]));
+}

--- a/examples/csv_read.rs
+++ b/examples/csv_read.rs
@@ -1,11 +1,9 @@
-use std::sync::Arc;
-
 use arrow2::array::Array;
 use arrow2::chunk::Chunk;
 use arrow2::error::Result;
 use arrow2::io::csv::read;
 
-fn read_path(path: &str, projection: Option<&[usize]>) -> Result<Chunk<Arc<dyn Array>>> {
+fn read_path(path: &str, projection: Option<&[usize]>) -> Result<Chunk<Box<dyn Array>>> {
     // Create a CSV reader. This is typically created on the thread that reads the file and
     // thus owns the read head.
     let mut reader = read::ReaderBuilder::new().from_path(path)?;

--- a/examples/csv_read_parallel.rs
+++ b/examples/csv_read_parallel.rs
@@ -1,6 +1,5 @@
 use crossbeam_channel::unbounded;
 
-use std::sync::Arc;
 use std::thread;
 use std::time::SystemTime;
 
@@ -8,7 +7,7 @@ use arrow2::array::Array;
 use arrow2::chunk::Chunk;
 use arrow2::{error::Result, io::csv::read};
 
-fn parallel_read(path: &str) -> Result<Vec<Chunk<Arc<dyn Array>>>> {
+fn parallel_read(path: &str) -> Result<Vec<Chunk<Box<dyn Array>>>> {
     let batch_size = 100;
     let has_header = true;
     let projection = None;
@@ -19,7 +18,7 @@ fn parallel_read(path: &str) -> Result<Vec<Chunk<Arc<dyn Array>>>> {
     let mut reader = read::ReaderBuilder::new().from_path(path)?;
     let (fields, _) =
         read::infer_schema(&mut reader, Some(batch_size * 10), has_header, &read::infer)?;
-    let fields = Arc::new(fields);
+    let fields = Box::new(fields);
 
     let start = SystemTime::now();
     // spawn a thread to produce `Vec<ByteRecords>` (IO bounded)

--- a/examples/csv_write_parallel.rs
+++ b/examples/csv_write_parallel.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 use std::sync::mpsc;
 use std::sync::mpsc::{Receiver, Sender};
-use std::sync::Arc;
 use std::thread;
 
 use arrow2::{
@@ -11,7 +10,7 @@ use arrow2::{
     io::csv::write,
 };
 
-fn parallel_write(path: &str, batches: [Chunk<Arc<dyn Array>>; 2]) -> Result<()> {
+fn parallel_write(path: &str, batches: [Chunk<Box<dyn Array>>; 2]) -> Result<()> {
     let options = write::SerializeOptions::default();
 
     // write a header
@@ -59,7 +58,7 @@ fn main() -> Result<()> {
         Some(5),
         Some(6),
     ]);
-    let columns = Chunk::new(vec![array.arced()]);
+    let columns = Chunk::new(vec![array.boxed()]);
 
     parallel_write("example.csv", [columns.clone(), columns])
 }

--- a/examples/extension.rs
+++ b/examples/extension.rs
@@ -1,5 +1,4 @@
 use std::io::{Cursor, Seek, Write};
-use std::sync::Arc;
 
 use arrow2::array::*;
 use arrow2::chunk::Chunk;
@@ -40,7 +39,7 @@ fn write_ipc<W: Write + Seek>(writer: W, array: impl Array + 'static) -> Result<
     let options = write::WriteOptions { compression: None };
     let mut writer = write::FileWriter::new(writer, schema, None, options);
 
-    let batch = Chunk::try_new(vec![Arc::new(array) as Arc<dyn Array>])?;
+    let batch = Chunk::try_new(vec![Box::new(array) as Box<dyn Array>])?;
 
     writer.start()?;
     writer.write(&batch, None)?;
@@ -49,7 +48,7 @@ fn write_ipc<W: Write + Seek>(writer: W, array: impl Array + 'static) -> Result<
     Ok(writer.into_inner())
 }
 
-fn read_ipc(buf: &[u8]) -> Result<Chunk<Arc<dyn Array>>> {
+fn read_ipc(buf: &[u8]) -> Result<Chunk<Box<dyn Array>>> {
     let mut cursor = Cursor::new(buf);
     let metadata = read::read_file_metadata(&mut cursor)?;
     let mut reader = read::FileReader::new(cursor, metadata, None);

--- a/examples/ffi.rs
+++ b/examples/ffi.rs
@@ -2,10 +2,9 @@ use arrow2::array::{Array, PrimitiveArray};
 use arrow2::datatypes::Field;
 use arrow2::error::Result;
 use arrow2::ffi;
-use std::sync::Arc;
 
 unsafe fn export(
-    array: Arc<dyn Array>,
+    array: Box<dyn Array>,
     array_ptr: *mut ffi::ArrowArray,
     schema_ptr: *mut ffi::ArrowSchema,
 ) {
@@ -22,7 +21,7 @@ unsafe fn import(array: Box<ffi::ArrowArray>, schema: &ffi::ArrowSchema) -> Resu
 
 fn main() -> Result<()> {
     // let's assume that we have an array:
-    let array = PrimitiveArray::<i32>::from([Some(1), None, Some(123)]).arced();
+    let array = PrimitiveArray::<i32>::from([Some(1), None, Some(123)]).boxed();
 
     // the goal is to export this array and import it back via FFI.
     // to import, we initialize the structs that will receive the data

--- a/examples/ipc_file_read.rs
+++ b/examples/ipc_file_read.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::sync::Arc;
 
 use arrow2::array::Array;
 use arrow2::chunk::Chunk;
@@ -9,7 +8,7 @@ use arrow2::io::ipc::read;
 use arrow2::io::print;
 
 /// Simplest way: read all record batches from the file. This can be used e.g. for random access.
-fn read_batches(path: &str) -> Result<(Schema, Vec<Chunk<Arc<dyn Array>>>)> {
+fn read_batches(path: &str) -> Result<(Schema, Vec<Chunk<Box<dyn Array>>>)> {
     let mut file = File::open(path)?;
 
     // read the files' metadata. At this point, we can distribute the read whatever we like.
@@ -25,7 +24,7 @@ fn read_batches(path: &str) -> Result<(Schema, Vec<Chunk<Arc<dyn Array>>>)> {
 }
 
 /// Random access way: read a single record batch from the file. This can be used e.g. for random access.
-fn read_batch(path: &str) -> Result<(Schema, Chunk<Arc<dyn Array>>)> {
+fn read_batch(path: &str) -> Result<(Schema, Chunk<Box<dyn Array>>)> {
     let mut file = File::open(path)?;
 
     // read the files' metadata. At this point, we can distribute the read whatever we like.

--- a/examples/ipc_file_write.rs
+++ b/examples/ipc_file_write.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::sync::Arc;
 
 use arrow2::array::{Array, Int32Array, Utf8Array};
 use arrow2::chunk::Chunk;
@@ -7,7 +6,7 @@ use arrow2::datatypes::{DataType, Field, Schema};
 use arrow2::error::Result;
 use arrow2::io::ipc::write;
 
-fn write_batches(path: &str, schema: Schema, columns: &[Chunk<Arc<dyn Array>>]) -> Result<()> {
+fn write_batches(path: &str, schema: Schema, columns: &[Chunk<Box<dyn Array>>]) -> Result<()> {
     let file = File::create(path)?;
 
     let options = write::WriteOptions { compression: None };
@@ -35,7 +34,7 @@ fn main() -> Result<()> {
     let a = Int32Array::from_slice(&[1, 2, 3, 4, 5]);
     let b = Utf8Array::<i32>::from_slice(&["a", "b", "c", "d", "e"]);
 
-    let batch = Chunk::try_new(vec![a.arced(), b.arced()])?;
+    let batch = Chunk::try_new(vec![a.boxed(), b.boxed()])?;
 
     // write it
     write_batches(file_path, schema, &[batch])?;

--- a/examples/json_read.rs
+++ b/examples/json_read.rs
@@ -1,12 +1,11 @@
 /// Example of reading a JSON file.
 use std::fs;
-use std::sync::Arc;
 
 use arrow2::array::Array;
 use arrow2::error::Result;
 use arrow2::io::json::read;
 
-fn read_path(path: &str) -> Result<Arc<dyn Array>> {
+fn read_path(path: &str) -> Result<Box<dyn Array>> {
     // read the file into memory (IO-bounded)
     let data = fs::read(path)?;
 

--- a/examples/ndjson_read.rs
+++ b/examples/ndjson_read.rs
@@ -1,13 +1,12 @@
 use std::fs::File;
 use std::io::{BufReader, Seek};
-use std::sync::Arc;
 
 use arrow2::array::Array;
 use arrow2::error::Result;
 use arrow2::io::ndjson::read;
 use arrow2::io::ndjson::read::FallibleStreamingIterator;
 
-fn read_path(path: &str) -> Result<Vec<Arc<dyn Array>>> {
+fn read_path(path: &str) -> Result<Vec<Box<dyn Array>>> {
     let batch_size = 1024; // number of rows per array
     let mut reader = BufReader::new(File::open(path)?);
 

--- a/examples/parquet_read_async.rs
+++ b/examples/parquet_read_async.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::time::SystemTime;
 
 use futures::future::BoxFuture;
@@ -15,7 +14,7 @@ async fn main() -> Result<()> {
 
     use std::env;
     let args: Vec<String> = env::args().collect();
-    let file_path = Arc::new(args[1].clone());
+    let file_path = Box::new(args[1].clone());
 
     // # Read metadata
     let mut reader = BufReader::new(File::open(file_path.as_ref()).await?).compat();

--- a/examples/parquet_read_parallel/src/main.rs
+++ b/examples/parquet_read_parallel/src/main.rs
@@ -1,7 +1,6 @@
 //! Example demonstrating how to read from parquet in parallel using rayon
 use std::fs::File;
 use std::io::BufReader;
-use std::sync::Arc;
 use std::time::SystemTime;
 
 use log::trace;
@@ -18,7 +17,7 @@ mod logger;
 
 /// # Panic
 /// If the iterators are empty
-fn deserialize_parallel(columns: &mut [ArrayIter<'static>]) -> Result<Chunk<Arc<dyn Array>>> {
+fn deserialize_parallel(columns: &mut [ArrayIter<'static>]) -> Result<Chunk<Box<dyn Array>>> {
     // CPU-bounded
     let columns = columns
         .par_iter_mut()

--- a/examples/parquet_write.rs
+++ b/examples/parquet_write.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::sync::Arc;
 
 use arrow2::{
     array::{Array, Int32Array},
@@ -12,7 +11,7 @@ use arrow2::{
     },
 };
 
-fn write_batch(path: &str, schema: Schema, columns: Chunk<Arc<dyn Array>>) -> Result<()> {
+fn write_batch(path: &str, schema: Schema, columns: Chunk<Box<dyn Array>>) -> Result<()> {
     let options = WriteOptions {
         write_statistics: true,
         compression: CompressionOptions::Uncompressed,
@@ -53,7 +52,7 @@ fn main() -> Result<()> {
     ]);
     let field = Field::new("c1", array.data_type().clone(), true);
     let schema = Schema::from(vec![field]);
-    let columns = Chunk::new(vec![array.arced()]);
+    let columns = Chunk::new(vec![array.boxed()]);
 
     write_batch("test.parquet", schema, columns)
 }

--- a/examples/parquet_write_parallel/src/main.rs
+++ b/examples/parquet_write_parallel/src/main.rs
@@ -1,6 +1,5 @@
 //! Example demonstrating how to write to parquet in parallel.
 use std::collections::VecDeque;
-use std::sync::Arc;
 
 use rayon::prelude::*;
 
@@ -12,7 +11,7 @@ use arrow2::{
     io::parquet::{read::ParquetError, write::*},
 };
 
-type Chunk = AChunk<Arc<dyn Array>>;
+type Chunk = AChunk<Box<dyn Array>>;
 
 struct Bla {
     columns: VecDeque<CompressedPage>,
@@ -134,7 +133,14 @@ fn create_batch(size: usize) -> Result<Chunk> {
         })
         .collect();
 
+<<<<<<< HEAD
     Chunk::try_new(vec![c1.arced(), c2.arced()])
+=======
+    Chunk::try_new(vec![
+        Box::new(c1) as Box<dyn Array>,
+        Box::new(c2) as Box<dyn Array>,
+    ])
+>>>>>>> 619252ff0 (Arc->Box)
 }
 
 fn main() -> Result<()> {

--- a/guide/src/high_level.md
+++ b/guide/src/high_level.md
@@ -268,3 +268,16 @@ Some notes:
    and cloned its validity. This approach is suitable for operations whose branching off
    is more expensive than operating over all values. If the operation is expensive,
    then using `PrimitiveArray::<O>::from_trusted_len_iter` is likely faster.
+
+## Clone on write semantics
+
+We support the mutation of arrays in-place via clone-on-write semantics.
+Essentially, all data is under an `Arc`, but it can be taken via `Arc::get_mut`
+and operated in place.
+
+Below is a complete example of how to operate on a `Box<dyn Array>` without 
+extra allocations.
+
+```rust,ignore
+{{#include ../examples/cow.rs}}
+```

--- a/integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -62,7 +62,7 @@ pub async fn scenario_setup(port: u16) -> Result {
 struct IntegrationDataset {
     schema: Schema,
     ipc_schema: IpcSchema,
-    chunks: Vec<Chunk<Arc<dyn Array>>>,
+    chunks: Vec<Chunk<Box<dyn Array>>>,
 }
 
 #[derive(Clone, Default)]
@@ -282,7 +282,7 @@ async fn record_batch_from_message(
     fields: &[Field],
     ipc_schema: &IpcSchema,
     dictionaries: &mut Dictionaries,
-) -> Result<Chunk<Arc<dyn Array>>, Status> {
+) -> Result<Chunk<Box<dyn Array>>, Status> {
     let mut reader = std::io::Cursor::new(data_body);
 
     let arrow_batch_result = ipc::read::read_record_batch(

--- a/integration-testing/src/lib.rs
+++ b/integration-testing/src/lib.rs
@@ -29,7 +29,6 @@ use arrow2::io::json_integration::{read, ArrowJsonBatch, ArrowJsonDictionaryBatc
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufReader;
-use std::sync::Arc;
 
 /// The expected username for the basic auth integration test.
 pub const AUTH_USERNAME: &str = "arrow";
@@ -45,7 +44,7 @@ pub struct ArrowFile {
     // we can evolve this into a concrete Arrow type
     // this is temporarily not being read from
     pub _dictionaries: HashMap<i64, ArrowJsonDictionaryBatch>,
-    pub batches: Vec<Chunk<Arc<dyn Array>>>,
+    pub batches: Vec<Chunk<Box<dyn Array>>>,
 }
 
 pub fn read_json_file(json_name: &str) -> Result<ArrowFile> {

--- a/src/array/README.md
+++ b/src/array/README.md
@@ -20,7 +20,7 @@ This document describes the overall design of this module.
 
 * The trait `Array` MUST only be implemented by structs in this module.
 
-* Every child array on the struct MUST be `Arc<dyn Array>`. This enables the struct to be clonable.
+* Every child array on the struct MUST be `Box<dyn Array>`.
 
 * An array MUST implement `try_new(...) -> Self`. This method MUST error iff
   the data does not follow the arrow specification, including any sentinel types such as utf8.

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -424,6 +424,11 @@ impl<O: Offset> Array for BinaryArray<O> {
     }
 
     #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
     fn len(&self) -> usize {
         self.len()
     }

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -258,6 +258,11 @@ impl Array for BooleanArray {
     }
 
     #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
     fn len(&self) -> usize {
         self.len()
     }

--- a/src/array/dictionary/ffi.rs
+++ b/src/array/dictionary/ffi.rs
@@ -33,7 +33,7 @@ impl<K: DictionaryKey, A: ffi::ArrowArrayRef> FromFfi<A> for DictionaryArray<K> 
         let data_type = K::PRIMITIVE.into();
         let keys = PrimitiveArray::<K>::try_new(data_type, values, validity)?;
         let values = array.dictionary()?.unwrap();
-        let values = ffi::try_from(values)?.into();
+        let values = ffi::try_from(values)?;
 
         Ok(DictionaryArray::<K>::from_data(keys, values))
     }

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -37,7 +37,7 @@ pub struct MutableDictionaryArray<K: DictionaryKey, M: MutableArray> {
 
 impl<K: DictionaryKey, M: MutableArray> From<MutableDictionaryArray<K, M>> for DictionaryArray<K> {
     fn from(mut other: MutableDictionaryArray<K, M>) -> Self {
-        DictionaryArray::<K>::from_data(other.keys.into(), other.values.as_arc())
+        DictionaryArray::<K>::from_data(other.keys.into(), other.values.as_box())
     }
 }
 
@@ -155,14 +155,14 @@ impl<K: DictionaryKey, M: 'static + MutableArray> MutableArray for MutableDictio
     fn as_box(&mut self) -> Box<dyn Array> {
         Box::new(DictionaryArray::<K>::from_data(
             std::mem::take(&mut self.keys).into(),
-            self.values.as_arc(),
+            self.values.as_box(),
         ))
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
         Arc::new(DictionaryArray::<K>::from_data(
             std::mem::take(&mut self.keys).into(),
-            self.values.as_arc(),
+            self.values.as_box(),
         ))
     }
 

--- a/src/array/equal/mod.rs
+++ b/src/array/equal/mod.rs
@@ -21,7 +21,7 @@ impl PartialEq for dyn Array + '_ {
     }
 }
 
-impl PartialEq<dyn Array> for Arc<dyn Array + '_> {
+impl PartialEq<dyn Array> for std::sync::Arc<dyn Array + '_> {
     fn eq(&self, that: &dyn Array) -> bool {
         equal(&**self, that)
     }
@@ -48,6 +48,12 @@ impl PartialEq<&dyn Array> for NullArray {
 impl<T: NativeType> PartialEq<&dyn Array> for PrimitiveArray<T> {
     fn eq(&self, other: &&dyn Array) -> bool {
         equal(self, *other)
+    }
+}
+
+impl<T: NativeType> PartialEq<PrimitiveArray<T>> for &dyn Array {
+    fn eq(&self, other: &PrimitiveArray<T>) -> bool {
+        equal(*self, other)
     }
 }
 

--- a/src/array/ffi.rs
+++ b/src/array/ffi.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::datatypes::PhysicalType;
 use crate::{array::*, ffi};
 
@@ -14,7 +12,7 @@ pub(crate) unsafe trait ToFfi {
     fn buffers(&self) -> Vec<Option<std::ptr::NonNull<u8>>>;
 
     /// The children
-    fn children(&self) -> Vec<Arc<dyn Array>> {
+    fn children(&self) -> Vec<Box<dyn Array>> {
         vec![]
     }
 
@@ -50,8 +48,8 @@ macro_rules! ffi_dyn {
 type BuffersChildren = (
     usize,
     Vec<Option<std::ptr::NonNull<u8>>>,
-    Vec<Arc<dyn Array>>,
-    Option<Arc<dyn Array>>,
+    Vec<Box<dyn Array>>,
+    Option<Box<dyn Array>>,
 );
 
 pub fn offset_buffers_children_dictionary(array: &dyn Array) -> BuffersChildren {

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -247,6 +247,11 @@ impl Array for FixedSizeBinaryArray {
     }
 
     #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
     fn len(&self) -> usize {
         self.len()
     }

--- a/src/array/fixed_size_list/ffi.rs
+++ b/src/array/fixed_size_list/ffi.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use super::FixedSizeListArray;
 use crate::{
     array::{
@@ -15,8 +13,8 @@ unsafe impl ToFfi for FixedSizeListArray {
         vec![self.validity.as_ref().map(|x| x.as_ptr())]
     }
 
-    fn children(&self) -> Vec<Arc<dyn Array>> {
-        vec![self.values().clone()]
+    fn children(&self) -> Vec<Box<dyn Array>> {
+        vec![self.values.clone()]
     }
 
     fn offset(&self) -> Option<usize> {
@@ -38,7 +36,7 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for FixedSizeListArray {
         let data_type = array.data_type().clone();
         let validity = unsafe { array.validity() }?;
         let child = unsafe { array.child(0)? };
-        let values = ffi::try_from(child)?.into();
+        let values = ffi::try_from(child)?;
 
         Self::try_new(data_type, values, validity)
     }

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -22,7 +22,7 @@ impl<M: MutableArray> From<MutableFixedSizeListArray<M>> for FixedSizeListArray 
     fn from(mut other: MutableFixedSizeListArray<M>) -> Self {
         FixedSizeListArray::new(
             other.data_type,
-            other.values.as_arc(),
+            other.values.as_box(),
             other.validity.map(|x| x.into()),
         )
     }
@@ -117,7 +117,7 @@ impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
     fn as_box(&mut self) -> Box<dyn Array> {
         Box::new(FixedSizeListArray::new(
             self.data_type.clone(),
-            self.values.as_arc(),
+            self.values.as_box(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
         ))
     }
@@ -125,7 +125,7 @@ impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
     fn as_arc(&mut self) -> Arc<dyn Array> {
         Arc::new(FixedSizeListArray::new(
             self.data_type.clone(),
-            self.values.as_arc(),
+            self.values.as_box(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
         ))
     }

--- a/src/array/growable/fixed_size_list.rs
+++ b/src/array/growable/fixed_size_list.rs
@@ -67,7 +67,7 @@ impl<'a> GrowableFixedSizeList<'a> {
 
     fn to(&mut self) -> FixedSizeListArray {
         let validity = std::mem::take(&mut self.validity);
-        let values = self.values.as_arc();
+        let values = self.values.as_box();
 
         FixedSizeListArray::new(self.arrays[0].data_type().clone(), values, validity.into())
     }
@@ -97,7 +97,7 @@ impl<'a> Growable<'a> for GrowableFixedSizeList<'a> {
 impl<'a> From<GrowableFixedSizeList<'a>> for FixedSizeListArray {
     fn from(val: GrowableFixedSizeList<'a>) -> Self {
         let mut values = val.values;
-        let values = values.as_arc();
+        let values = values.as_box();
 
         Self::new(
             val.arrays[0].data_type().clone(),

--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -102,7 +102,7 @@ impl<'a, O: Offset> GrowableList<'a, O> {
     fn to(&mut self) -> ListArray<O> {
         let validity = std::mem::take(&mut self.validity);
         let offsets = std::mem::take(&mut self.offsets);
-        let values = self.values.as_arc();
+        let values = self.values.as_box();
 
         ListArray::<O>::new(
             self.arrays[0].data_type().clone(),
@@ -137,7 +137,7 @@ impl<'a, O: Offset> Growable<'a> for GrowableList<'a, O> {
 impl<'a, O: Offset> From<GrowableList<'a, O>> for ListArray<O> {
     fn from(val: GrowableList<'a, O>) -> Self {
         let mut values = val.values;
-        let values = values.as_arc();
+        let values = values.as_box();
 
         ListArray::<O>::new(
             val.arrays[0].data_type().clone(),

--- a/src/array/growable/structure.rs
+++ b/src/array/growable/structure.rs
@@ -66,7 +66,7 @@ impl<'a> GrowableStruct<'a> {
     fn to(&mut self) -> StructArray {
         let validity = std::mem::take(&mut self.validity);
         let values = std::mem::take(&mut self.values);
-        let values = values.into_iter().map(|mut x| x.as_arc()).collect();
+        let values = values.into_iter().map(|mut x| x.as_box()).collect();
 
         StructArray::new(
             DataType::Struct(self.arrays[0].fields().to_vec()),
@@ -118,7 +118,7 @@ impl<'a> Growable<'a> for GrowableStruct<'a> {
 
 impl<'a> From<GrowableStruct<'a>> for StructArray {
     fn from(val: GrowableStruct<'a>) -> Self {
-        let values = val.values.into_iter().map(|mut x| x.as_arc()).collect();
+        let values = val.values.into_iter().map(|mut x| x.as_box()).collect();
 
         StructArray::new(
             DataType::Struct(val.arrays[0].fields().to_vec()),

--- a/src/array/growable/union.rs
+++ b/src/array/growable/union.rs
@@ -53,7 +53,7 @@ impl<'a> GrowableUnion<'a> {
         let types = std::mem::take(&mut self.types);
         let fields = std::mem::take(&mut self.fields);
         let offsets = std::mem::take(&mut self.offsets);
-        let fields = fields.into_iter().map(|mut x| x.as_arc()).collect();
+        let fields = fields.into_iter().map(|mut x| x.as_box()).collect();
 
         UnionArray::new(
             self.arrays[0].data_type().clone(),
@@ -99,7 +99,7 @@ impl<'a> Growable<'a> for GrowableUnion<'a> {
 
 impl<'a> From<GrowableUnion<'a>> for UnionArray {
     fn from(val: GrowableUnion<'a>) -> Self {
-        let fields = val.fields.into_iter().map(|mut x| x.as_arc()).collect();
+        let fields = val.fields.into_iter().map(|mut x| x.as_box()).collect();
 
         UnionArray::new(
             val.arrays[0].data_type().clone(),

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::{array::FromFfi, bitmap::align, error::Result, ffi};
 
 use super::super::{ffi::ToFfi, Array, Offset};
@@ -13,7 +11,7 @@ unsafe impl<O: Offset> ToFfi for ListArray<O> {
         ]
     }
 
-    fn children(&self) -> Vec<Arc<dyn Array>> {
+    fn children(&self) -> Vec<Box<dyn Array>> {
         vec![self.values.clone()]
     }
 
@@ -56,7 +54,7 @@ impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for ListArray<O> {
         let validity = unsafe { array.validity() }?;
         let offsets = unsafe { array.buffer::<O>(1) }?;
         let child = unsafe { array.child(0)? };
-        let values = ffi::try_from(child)?.into();
+        let values = ffi::try_from(child)?;
 
         Ok(Self::from_data(data_type, offsets, values, validity))
     }

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -56,7 +56,7 @@ impl<O: Offset, M: MutableArray> From<MutableListArray<O, M>> for ListArray<O> {
             ListArray::new_unchecked(
                 other.data_type,
                 other.offsets.into(),
-                other.values.as_arc(),
+                other.values.as_box(),
                 other.validity.map(|x| x.into()),
             )
         }
@@ -215,27 +215,27 @@ impl<O: Offset, M: MutableArray + Default + 'static> MutableArray for MutableLis
     fn as_box(&mut self) -> Box<dyn Array> {
         // Safety:
         // MutableListArray has monotonically increasing offsets
-        unsafe {
-            Box::new(ListArray::new_unchecked(
+        Box::new(unsafe {
+            ListArray::new_unchecked(
                 self.data_type.clone(),
                 std::mem::take(&mut self.offsets).into(),
-                self.values.as_arc(),
+                self.values.as_box(),
                 std::mem::take(&mut self.validity).map(|x| x.into()),
-            ))
-        }
+            )
+        })
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
         // Safety:
         // MutableListArray has monotonically increasing offsets
-        unsafe {
-            Arc::new(ListArray::new_unchecked(
+        Arc::new(unsafe {
+            ListArray::new_unchecked(
                 self.data_type.clone(),
                 std::mem::take(&mut self.offsets).into(),
-                self.values.as_arc(),
+                self.values.as_box(),
                 std::mem::take(&mut self.validity).map(|x| x.into()),
-            ))
-        }
+            )
+        })
     }
 
     fn data_type(&self) -> &DataType {

--- a/src/array/map/ffi.rs
+++ b/src/array/map/ffi.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::{array::FromFfi, bitmap::align, error::Result, ffi};
 
 use super::super::{ffi::ToFfi, Array};
@@ -13,7 +11,7 @@ unsafe impl ToFfi for MapArray {
         ]
     }
 
-    fn children(&self) -> Vec<Arc<dyn Array>> {
+    fn children(&self) -> Vec<Box<dyn Array>> {
         vec![self.field.clone()]
     }
 
@@ -56,7 +54,7 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for MapArray {
         let validity = unsafe { array.validity() }?;
         let offsets = unsafe { array.buffer::<i32>(1) }?;
         let child = array.child(0)?;
-        let values = ffi::try_from(child)?.into();
+        let values = ffi::try_from(child)?;
 
         Self::try_new(data_type, offsets, values, validity)
     }

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -85,6 +85,11 @@ impl Array for NullArray {
     }
 
     #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
     fn len(&self) -> usize {
         self.len()
     }

--- a/src/array/struct_/ffi.rs
+++ b/src/array/struct_/ffi.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use super::super::{ffi::ToFfi, Array, FromFfi};
 use super::StructArray;
 use crate::{error::Result, ffi};
@@ -9,7 +7,7 @@ unsafe impl ToFfi for StructArray {
         vec![self.validity.as_ref().map(|x| x.as_ptr())]
     }
 
-    fn children(&self) -> Vec<Arc<dyn Array>> {
+    fn children(&self) -> Vec<Box<dyn Array>> {
         self.values.clone()
     }
 
@@ -36,9 +34,9 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for StructArray {
         let values = (0..fields.len())
             .map(|index| {
                 let child = array.child(index)?;
-                Ok(ffi::try_from(child)?.into())
+                ffi::try_from(child)
             })
-            .collect::<Result<Vec<Arc<dyn Array>>>>()?;
+            .collect::<Result<Vec<Box<dyn Array>>>>()?;
 
         Self::try_new(data_type, values, validity)
     }

--- a/src/array/union/ffi.rs
+++ b/src/array/union/ffi.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::{array::FromFfi, error::Result, ffi};
 
 use super::super::{ffi::ToFfi, Array};
@@ -17,7 +15,7 @@ unsafe impl ToFfi for UnionArray {
         }
     }
 
-    fn children(&self) -> Vec<Arc<dyn Array>> {
+    fn children(&self) -> Vec<Box<dyn Array>> {
         self.fields.clone()
     }
 
@@ -47,9 +45,9 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for UnionArray {
         let fields = (0..fields.len())
             .map(|index| {
                 let child = array.child(index)?;
-                Ok(ffi::try_from(child)?.into())
+                ffi::try_from(child)
             })
-            .collect::<Result<Vec<Arc<dyn Array>>>>()?;
+            .collect::<Result<Vec<Box<dyn Array>>>>()?;
 
         if offset > 0 {
             types = types.slice(offset, length);

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -555,6 +555,11 @@ impl<O: Offset> Array for Utf8Array<O> {
     }
 
     #[inline]
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
     fn len(&self) -> usize {
         self.len()
     }

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -137,7 +137,7 @@ impl<T: NativeType> Buffer<T> {
         self.offset
     }
 
-    /// Converts this [`Buffer`] to [`Vec`], returning itself if the conversion
+    /// Converts this [`Buffer`] to either a [`Buffer`] or a [`Vec`], returning itself if the conversion
     /// is not possible
     ///
     /// This operation returns a [`Vec`] iff this [`Buffer`]:

--- a/src/compute/cast/dictionary_to.rs
+++ b/src/compute/cast/dictionary_to.rs
@@ -32,7 +32,7 @@ pub fn dictionary_to_dictionary_values<K: DictionaryKey>(
     let keys = from.keys();
     let values = from.values();
 
-    let values = cast(values.as_ref(), values_type, CastOptions::default())?.into();
+    let values = cast(values.as_ref(), values_type, CastOptions::default())?;
     Ok(DictionaryArray::from_data(keys.clone(), values))
 }
 
@@ -51,8 +51,7 @@ pub fn wrapping_dictionary_to_dictionary_values<K: DictionaryKey>(
             wrapped: true,
             partial: false,
         },
-    )?
-    .into();
+    )?;
     Ok(DictionaryArray::from_data(keys.clone(), values))
 }
 
@@ -111,7 +110,7 @@ pub(super) fn dictionary_cast_dyn<K: DictionaryKey>(
 
     match to_type {
         DataType::Dictionary(to_keys_type, to_values_type, _) => {
-            let values = cast(values.as_ref(), to_values_type, options)?.into();
+            let values = cast(values.as_ref(), to_values_type, options)?;
 
             // create the appropriate array type
             let data_type = (*to_keys_type).into();

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -296,8 +296,7 @@ fn cast_list<O: Offset>(
         values.as_ref(),
         ListArray::<O>::get_child_type(to_type),
         options,
-    )?
-    .into();
+    )?;
 
     Ok(ListArray::<O>::new(
         to_type.clone(),
@@ -398,7 +397,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
 
         (_, List(to)) => {
             // cast primitive to list's primitive
-            let values = cast(array, &to.data_type, options)?.into();
+            let values = cast(array, &to.data_type, options)?;
             // create offsets, where if array.len() = 2, we have [0,1,2]
             let offsets = (0..=array.len() as i32).collect::<Vec<_>>();
 

--- a/src/compute/take/structure.rs
+++ b/src/compute/take/structure.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::sync::Arc;
-
 use crate::{
     array::{Array, PrimitiveArray, StructArray},
     bitmap::{Bitmap, MutableBitmap},
@@ -54,10 +52,10 @@ fn take_validity<I: Index>(
 }
 
 pub fn take<I: Index>(array: &StructArray, indices: &PrimitiveArray<I>) -> Result<StructArray> {
-    let values: Vec<Arc<dyn Array>> = array
+    let values: Vec<Box<dyn Array>> = array
         .values()
         .iter()
-        .map(|a| super::take(a.as_ref(), indices).map(|x| x.into()))
+        .map(|a| super::take(a.as_ref(), indices))
         .collect::<Result<_>>()?;
     let validity = take_validity(array.validity(), indices)?;
     Ok(StructArray::new(

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -85,7 +85,7 @@ unsafe extern "C" fn c_release_array(array: *mut ArrowArray) {
 
 #[allow(dead_code)]
 struct PrivateData {
-    array: Arc<dyn Array>,
+    array: Box<dyn Array>,
     buffers_ptr: Box<[*const std::os::raw::c_void]>,
     children_ptr: Box<[*mut ArrowArray]>,
     dictionary_ptr: Option<*mut ArrowArray>,
@@ -96,7 +96,7 @@ impl ArrowArray {
     /// # Safety
     /// This method releases `buffers`. Consumers of this struct *must* call `release` before
     /// releasing this struct, or contents in `buffers` leak.
-    pub(crate) fn new(array: Arc<dyn Array>) -> Self {
+    pub(crate) fn new(array: Box<dyn Array>) -> Self {
         let (offset, buffers, children, dictionary) =
             offset_buffers_children_dictionary(array.as_ref());
 

--- a/src/ffi/bridge.rs
+++ b/src/ffi/bridge.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::array::*;
 
 macro_rules! ffi_dyn {
@@ -8,12 +6,12 @@ macro_rules! ffi_dyn {
         if a.offset().is_some() {
             $array
         } else {
-            Arc::new(a.to_ffi_aligned())
+            Box::new(a.to_ffi_aligned())
         }
     }};
 }
 
-pub fn align_to_c_data_interface(array: Arc<dyn Array>) -> Arc<dyn Array> {
+pub fn align_to_c_data_interface(array: Box<dyn Array>) -> Box<dyn Array> {
     use crate::datatypes::PhysicalType::*;
     match array.data_type().to_physical_type() {
         Null => ffi_dyn!(array, NullArray),

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -20,10 +20,10 @@ use self::schema::to_field;
 pub use generated::{ArrowArray, ArrowArrayStream, ArrowSchema};
 pub use stream::{export_iterator, ArrowArrayStreamReader};
 
-/// Exports an [`Arc<dyn Array>`] to the C data interface.
+/// Exports an [`Box<dyn Array>`] to the C data interface.
 /// # Safety
 /// The pointer `ptr` must be allocated and valid
-pub unsafe fn export_array_to_c(array: Arc<dyn Array>, ptr: *mut ArrowArray) {
+pub unsafe fn export_array_to_c(array: Box<dyn Array>, ptr: *mut ArrowArray) {
     let array = bridge::align_to_c_data_interface(array);
 
     std::ptr::write_unaligned(ptr, ArrowArray::new(array));

--- a/src/ffi/stream.rs
+++ b/src/ffi/stream.rs
@@ -1,5 +1,4 @@
 use std::ffi::{CStr, CString};
-use std::sync::Arc;
 
 use crate::{array::Array, datatypes::Field, error::Error};
 
@@ -125,7 +124,7 @@ impl ArrowArrayStreamReader {
 }
 
 struct PrivateData {
-    iter: Box<dyn Iterator<Item = Result<Arc<dyn Array>, Error>>>,
+    iter: Box<dyn Iterator<Item = Result<Box<dyn Array>, Error>>>,
     field: Field,
     error: Option<CString>,
 }
@@ -199,7 +198,7 @@ unsafe extern "C" fn release(iter: *mut ArrowArrayStream) {
 /// # Safety
 /// The pointer `consumer` must be allocated
 pub unsafe fn export_iterator(
-    iter: Box<dyn Iterator<Item = Result<Arc<dyn Array>, Error>>>,
+    iter: Box<dyn Iterator<Item = Result<Box<dyn Array>, Error>>>,
     field: Field,
     consumer: *mut ArrowArrayStream,
 ) {

--- a/src/io/avro/read/deserialize.rs
+++ b/src/io/avro/read/deserialize.rs
@@ -1,5 +1,4 @@
 use std::convert::TryInto;
-use std::sync::Arc;
 
 use avro_schema::Record;
 use avro_schema::{Enum, Schema as AvroSchema};
@@ -444,7 +443,7 @@ pub fn deserialize(
     fields: &[Field],
     avro_schemas: &[AvroSchema],
     projection: &[bool],
-) -> Result<Chunk<Arc<dyn Array>>> {
+) -> Result<Chunk<Box<dyn Array>>> {
     let rows = block.number_of_rows;
     let mut block = block.data.as_ref();
 
@@ -484,7 +483,7 @@ pub fn deserialize(
             .iter_mut()
             .zip(projection.iter())
             .filter_map(|x| if *x.1 { Some(x.0) } else { None })
-            .map(|array| array.as_arc())
+            .map(|array| array.as_box())
             .collect(),
     )
 }

--- a/src/io/avro/read/mod.rs
+++ b/src/io/avro/read/mod.rs
@@ -1,6 +1,5 @@
 //! APIs to read from Avro format to arrow.
 use std::io::Read;
-use std::sync::Arc;
 
 use avro_schema::{Record, Schema as AvroSchema};
 use fallible_streaming_iterator::FallibleStreamingIterator;
@@ -75,7 +74,7 @@ impl<R: Read> Reader<R> {
 }
 
 impl<R: Read> Iterator for Reader<R> {
-    type Item = Result<Chunk<Arc<dyn Array>>>;
+    type Item = Result<Chunk<Box<dyn Array>>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let fields = &self.fields[..];

--- a/src/io/avro/read/nested.rs
+++ b/src/io/avro/read/nested.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::array::*;
 use crate::bitmap::*;
 use crate::datatypes::*;
@@ -83,16 +81,16 @@ impl<O: Offset> MutableArray for DynMutableListArray<O> {
         Box::new(ListArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.offsets).into(),
-            self.values.as_arc(),
+            self.values.as_box(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
         ))
     }
 
-    fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(ListArray::new(
+    fn as_arc(&mut self) -> std::sync::Arc<dyn Array> {
+        std::sync::Arc::new(ListArray::new(
             self.data_type.clone(),
             std::mem::take(&mut self.offsets).into(),
-            self.values.as_arc(),
+            self.values.as_box(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
         ))
     }
@@ -161,14 +159,14 @@ impl MutableArray for FixedItemsUtf8Dictionary {
     fn as_box(&mut self) -> Box<dyn Array> {
         Box::new(DictionaryArray::from_data(
             std::mem::take(&mut self.keys).into(),
-            Arc::new(self.values.clone()),
+            Box::new(self.values.clone()),
         ))
     }
 
-    fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(DictionaryArray::from_data(
+    fn as_arc(&mut self) -> std::sync::Arc<dyn Array> {
+        std::sync::Arc::new(DictionaryArray::from_data(
             std::mem::take(&mut self.keys).into(),
-            Arc::new(self.values.clone()),
+            Box::new(self.values.clone()),
         ))
     }
 
@@ -245,7 +243,7 @@ impl MutableArray for DynMutableStructArray {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        let values = self.values.iter_mut().map(|x| x.as_arc()).collect();
+        let values = self.values.iter_mut().map(|x| x.as_box()).collect();
 
         Box::new(StructArray::new(
             self.data_type.clone(),
@@ -254,10 +252,10 @@ impl MutableArray for DynMutableStructArray {
         ))
     }
 
-    fn as_arc(&mut self) -> Arc<dyn Array> {
-        let values = self.values.iter_mut().map(|x| x.as_arc()).collect();
+    fn as_arc(&mut self) -> std::sync::Arc<dyn Array> {
+        let values = self.values.iter_mut().map(|x| x.as_box()).collect();
 
-        Arc::new(StructArray::new(
+        std::sync::Arc::new(StructArray::new(
             self.data_type.clone(),
             values,
             std::mem::take(&mut self.validity).map(|x| x.into()),

--- a/src/io/csv/read/deserialize.rs
+++ b/src/io/csv/read/deserialize.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use csv::ByteRecord;
 
 use crate::{
@@ -27,7 +25,7 @@ pub fn deserialize_column(
     column: usize,
     datatype: DataType,
     line_number: usize,
-) -> Result<Arc<dyn Array>> {
+) -> Result<Box<dyn Array>> {
     deserialize_column_gen(rows, column, datatype, line_number)
 }
 
@@ -40,9 +38,9 @@ pub fn deserialize_batch<F>(
     projection: Option<&[usize]>,
     line_number: usize,
     deserialize_column: F,
-) -> Result<Chunk<Arc<dyn Array>>>
+) -> Result<Chunk<Box<dyn Array>>>
 where
-    F: Fn(&[ByteRecord], usize, DataType, usize) -> Result<Arc<dyn Array>>,
+    F: Fn(&[ByteRecord], usize, DataType, usize) -> Result<Box<dyn Array>>,
 {
     deserialize_batch_gen(rows, fields, projection, line_number, deserialize_column)
 }

--- a/src/io/csv/read_async/deserialize.rs
+++ b/src/io/csv/read_async/deserialize.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use csv_async::ByteRecord;
 
 use crate::{
@@ -27,7 +25,7 @@ pub fn deserialize_column(
     column: usize,
     datatype: DataType,
     line_number: usize,
-) -> Result<Arc<dyn Array>> {
+) -> Result<Box<dyn Array>> {
     deserialize_column_gen(rows, column, datatype, line_number)
 }
 
@@ -40,9 +38,9 @@ pub fn deserialize_batch<F>(
     projection: Option<&[usize]>,
     line_number: usize,
     deserialize_column: F,
-) -> Result<Chunk<Arc<dyn Array>>>
+) -> Result<Chunk<Box<dyn Array>>>
 where
-    F: Fn(&[ByteRecord], usize, DataType, usize) -> Result<Arc<dyn Array>>,
+    F: Fn(&[ByteRecord], usize, DataType, usize) -> Result<Box<dyn Array>>,
 {
     deserialize_batch_gen(rows, fields, projection, line_number, deserialize_column)
 }

--- a/src/io/flight/mod.rs
+++ b/src/io/flight/mod.rs
@@ -1,5 +1,4 @@
 //! Serialization and deserialization to Arrow's flight protocol
-use std::sync::Arc;
 
 use arrow_format::flight::data::{FlightData, SchemaResult};
 use arrow_format::ipc;
@@ -21,7 +20,7 @@ use super::ipc::{IpcField, IpcSchema};
 /// Serializes [`Chunk`] to a vector of [`FlightData`] representing the serialized dictionaries
 /// and a [`FlightData`] representing the batch.
 pub fn serialize_batch(
-    columns: &Chunk<Arc<dyn Array>>,
+    columns: &Chunk<Box<dyn Array>>,
     fields: &[IpcField],
     options: &WriteOptions,
 ) -> (Vec<FlightData>, FlightData) {
@@ -114,7 +113,7 @@ pub fn deserialize_batch(
     fields: &[Field],
     ipc_schema: &IpcSchema,
     dictionaries: &read::Dictionaries,
-) -> Result<Chunk<Arc<dyn Array>>> {
+) -> Result<Chunk<Box<dyn Array>>> {
     // check that the data_header is a record batch message
     let message = arrow_format::ipc::MessageRef::read_as_root(&data.data_header)
         .map_err(|err| Error::OutOfSpec(format!("Unable to get root as message: {:?}", err)))?;

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -31,7 +31,6 @@
 //! ```
 //! use arrow2::io::ipc::{{read::{FileReader, read_file_metadata}}, {write::{FileWriter, WriteOptions}}};
 //! # use std::fs::File;
-//! # use std::sync::Arc;
 //! # use arrow2::datatypes::{Field, Schema, DataType};
 //! # use arrow2::array::{Int32Array, Array};
 //! # use arrow2::chunk::Chunk;
@@ -48,7 +47,7 @@
 //! // Setup the data
 //! let x_data = Int32Array::from_slice([-1i32, 1]);
 //! let y_data = Int32Array::from_slice([1i32, -1]);
-//! let chunk = Chunk::try_new(vec![x_data.arced(), y_data.arced()])?;
+//! let chunk = Chunk::try_new(vec![x_data.boxed(), y_data.boxed()])?;
 //!
 //! // Write the messages and finalize the stream
 //! for _ in 0..5 {

--- a/src/io/ipc/read/file_async.rs
+++ b/src/io/ipc/read/file_async.rs
@@ -1,7 +1,6 @@
 //! Async reader for Arrow IPC files
 use std::collections::HashMap;
 use std::io::SeekFrom;
-use std::sync::Arc;
 
 use arrow_format::ipc::{planus::ReadAsRoot, Block, MessageHeaderRef, MessageRef};
 use futures::{
@@ -21,7 +20,7 @@ use super::FileMetadata;
 
 /// Async reader for Arrow IPC files
 pub struct FileStream<'a> {
-    stream: BoxStream<'a, Result<Chunk<Arc<dyn Array>>>>,
+    stream: BoxStream<'a, Result<Chunk<Box<dyn Array>>>>,
     schema: Option<Schema>,
     metadata: FileMetadata,
 }
@@ -69,7 +68,7 @@ impl<'a> FileStream<'a> {
         mut dictionaries: Option<Dictionaries>,
         metadata: FileMetadata,
         projection: Option<(Vec<usize>, HashMap<usize, usize>)>,
-    ) -> BoxStream<'a, Result<Chunk<Arc<dyn Array>>>>
+    ) -> BoxStream<'a, Result<Chunk<Box<dyn Array>>>>
     where
         R: AsyncRead + AsyncSeek + Unpin + Send + 'a,
     {
@@ -105,7 +104,7 @@ impl<'a> FileStream<'a> {
 }
 
 impl<'a> Stream for FileStream<'a> {
-    type Item = Result<Chunk<Arc<dyn Array>>>;
+    type Item = Result<Chunk<Box<dyn Array>>>;
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,
@@ -156,7 +155,7 @@ async fn read_batch<R>(
     block: usize,
     meta_buffer: &mut Vec<u8>,
     block_buffer: &mut Vec<u8>,
-) -> Result<Chunk<Arc<dyn Array>>>
+) -> Result<Chunk<Box<dyn Array>>>
 where
     R: AsyncRead + AsyncSeek + Unpin,
 {

--- a/src/io/ipc/read/mod.rs
+++ b/src/io/ipc/read/mod.rs
@@ -5,7 +5,6 @@
 //! [`StreamReader`](stream::StreamReader), which only supports reading
 //! data in the order it was written in.
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::array::Array;
 
@@ -32,7 +31,7 @@ pub use schema::deserialize_schema;
 pub use stream::{read_stream_metadata, StreamMetadata, StreamReader, StreamState};
 
 /// how dictionaries are tracked in this crate
-pub type Dictionaries = HashMap<i64, Arc<dyn Array>>;
+pub type Dictionaries = HashMap<i64, Box<dyn Array>>;
 
 pub(crate) type Node<'a> = arrow_format::ipc::FieldNodeRef<'a>;
 pub(crate) type IpcBuffer<'a> = arrow_format::ipc::BufferRef<'a>;

--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::io::{Read, Seek, SeekFrom};
-use std::sync::Arc;
 
 use crate::array::Array;
 use crate::chunk::Chunk;
@@ -234,7 +233,7 @@ pub fn read_batch<R: Read + Seek>(
     projection: Option<&[usize]>,
     index: usize,
     stratch: &mut Vec<u8>,
-) -> Result<Chunk<Arc<dyn Array>>> {
+) -> Result<Chunk<Box<dyn Array>>> {
     let block = metadata.blocks[index];
 
     // read length
@@ -318,7 +317,7 @@ impl<R: Read + Seek> FileReader<R> {
 }
 
 impl<R: Read + Seek> Iterator for FileReader<R> {
-    type Item = Result<Chunk<Arc<dyn Array>>>;
+    type Item = Result<Chunk<Box<dyn Array>>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // get current block

--- a/src/io/ipc/read/stream.rs
+++ b/src/io/ipc/read/stream.rs
@@ -1,5 +1,4 @@
 use std::io::Read;
-use std::sync::Arc;
 
 use arrow_format;
 use arrow_format::ipc::planus::ReadAsRoot;
@@ -61,7 +60,7 @@ pub enum StreamState {
     /// A live stream without data
     Waiting,
     /// Next item in the stream
-    Some(Chunk<Arc<dyn Array>>),
+    Some(Chunk<Box<dyn Array>>),
 }
 
 impl StreamState {
@@ -70,7 +69,7 @@ impl StreamState {
     /// # Panics
     ///
     /// If the `StreamState` was `Waiting`.
-    pub fn unwrap(self) -> Chunk<Arc<dyn Array>> {
+    pub fn unwrap(self) -> Chunk<Box<dyn Array>> {
         if let StreamState::Some(batch) = self {
             batch
         } else {

--- a/src/io/ipc/read/stream_async.rs
+++ b/src/io/ipc/read/stream_async.rs
@@ -1,5 +1,4 @@
 //! APIs to read Arrow streams asynchronously
-use std::sync::Arc;
 
 use arrow_format::ipc::planus::ReadAsRoot;
 use futures::future::BoxFuture;
@@ -33,7 +32,7 @@ enum StreamState<R> {
     /// The stream does not contain new chunks (and it has not been closed)
     Waiting(ReadState<R>),
     /// The stream contain a new chunk
-    Some((ReadState<R>, Chunk<Arc<dyn Array>>)),
+    Some((ReadState<R>, Chunk<Box<dyn Array>>)),
 }
 
 /// Reads the [`StreamMetadata`] of the Arrow stream asynchronously
@@ -140,7 +139,7 @@ async fn maybe_next<R: AsyncRead + Unpin + Send>(
                 0,
             )?;
 
-            // read the next message until we encounter a Chunk<Arc<dyn Array>> message
+            // read the next message until we encounter a Chunk<Box<dyn Array>> message
             Ok(Some(StreamState::Waiting(state)))
         }
         t => Err(Error::OutOfSpec(format!(
@@ -177,7 +176,7 @@ impl<'a, R: AsyncRead + Unpin + Send + 'a> AsyncStreamReader<'a, R> {
 }
 
 impl<'a, R: AsyncRead + Unpin + Send> Stream for AsyncStreamReader<'a, R> {
-    type Item = Result<Chunk<Arc<dyn Array>>>;
+    type Item = Result<Chunk<Box<dyn Array>>>;
 
     fn poll_next(
         self: std::pin::Pin<&mut Self>,

--- a/src/io/ipc/write/file_async.rs
+++ b/src/io/ipc/write/file_async.rs
@@ -23,7 +23,6 @@ type WriteOutput<W> = (usize, Option<Block>, Vec<Block>, Option<W>);
 /// # Examples
 ///
 /// ```
-/// use std::sync::Arc;
 /// use futures::{SinkExt, TryStreamExt, io::Cursor};
 /// use arrow2::array::{Array, Int32Array};
 /// use arrow2::datatypes::{DataType, Field, Schema};
@@ -46,7 +45,7 @@ type WriteOutput<W> = (usize, Option<Block>, Vec<Block>, Option<W>);
 /// // Write chunks to file
 /// for i in 0..3 {
 ///     let values = Int32Array::from(&[Some(i), None]);
-///     let chunk = Chunk::new(vec![values.arced()]);
+///     let chunk = Chunk::new(vec![values.boxed()]);
 ///     sink.feed(chunk.into()).await?;
 /// }
 /// sink.close().await?;

--- a/src/io/ipc/write/stream.rs
+++ b/src/io/ipc/write/stream.rs
@@ -4,7 +4,6 @@
 //! however the `FileWriter` expects a reader that supports `Seek`ing
 
 use std::io::Write;
-use std::sync::Arc;
 
 use super::super::IpcField;
 use super::common::{encode_chunk, DictionaryTracker, EncodedData, WriteOptions};
@@ -70,7 +69,7 @@ impl<W: Write> StreamWriter<W> {
     /// Writes [`Chunk`] to the stream
     pub fn write(
         &mut self,
-        columns: &Chunk<Arc<dyn Array>>,
+        columns: &Chunk<Box<dyn Array>>,
         ipc_fields: Option<&[IpcField]>,
     ) -> Result<()> {
         if self.finished {

--- a/src/io/ipc/write/stream_async.rs
+++ b/src/io/ipc/write/stream_async.rs
@@ -20,7 +20,6 @@ use crate::error::{Error, Result};
 /// # Examples
 ///
 /// ```
-/// use std::sync::Arc;
 /// use futures::SinkExt;
 /// use arrow2::array::{Array, Int32Array};
 /// use arrow2::datatypes::{DataType, Field, Schema};
@@ -41,7 +40,7 @@ use crate::error::{Error, Result};
 ///
 /// for i in 0..3 {
 ///     let values = Int32Array::from(&[Some(i), None]);
-///     let chunk = Chunk::new(vec![values.arced()]);
+///     let chunk = Chunk::new(vec![values.boxed()]);
 ///     sink.feed(chunk.into()).await?;
 /// }
 /// sink.close().await?;

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, sync::Arc};
+use std::io::Write;
 
 use arrow_format::ipc::planus::Builder;
 
@@ -118,7 +118,7 @@ impl<W: Write> FileWriter<W> {
     /// Writes [`Chunk`] to the file
     pub fn write(
         &mut self,
-        columns: &Chunk<Arc<dyn Array>>,
+        columns: &Chunk<Box<dyn Array>>,
         ipc_fields: Option<&[IpcField]>,
     ) -> Result<()> {
         if self.state != State::Started {

--- a/src/io/json_integration/write/array.rs
+++ b/src/io/json_integration/write/array.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::{
     array::{Array, PrimitiveArray},
     chunk::Chunk,
@@ -10,7 +8,7 @@ use super::super::{ArrowJsonBatch, ArrowJsonColumn};
 
 /// Serializes a [`Chunk`] to [`ArrowJsonBatch`].
 pub fn serialize_chunk<A: ToString>(
-    columns: &Chunk<Arc<dyn Array>>,
+    columns: &Chunk<Box<dyn Array>>,
     names: &[A],
 ) -> ArrowJsonBatch {
     let count = columns.len();

--- a/src/io/ndjson/read/deserialize.rs
+++ b/src/io/ndjson/read/deserialize.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use json_deserializer::parse;
 
 use crate::array::Array;
@@ -14,7 +12,7 @@ use super::super::super::json::read::_deserialize;
 /// This function is guaranteed to return an array of length equal to `rows.len()`.
 /// # Errors
 /// This function errors iff any of the rows is not a valid JSON (i.e. the format is not valid NDJSON).
-pub fn deserialize(rows: &[String], data_type: DataType) -> Result<Arc<dyn Array>, Error> {
+pub fn deserialize(rows: &[String], data_type: DataType) -> Result<Box<dyn Array>, Error> {
     if rows.is_empty() {
         return Err(Error::ExternalFormat(
             "Cannot deserialize 0 NDJSON rows because empty string is not a valid JSON value"
@@ -34,7 +32,7 @@ pub fn deserialize(rows: &[String], data_type: DataType) -> Result<Arc<dyn Array
 pub fn deserialize_iter<'a>(
     rows: impl Iterator<Item = &'a str>,
     data_type: DataType,
-) -> Result<Arc<dyn Array>, Error> {
+) -> Result<Box<dyn Array>, Error> {
     // deserialize strings to `Value`s
     let rows = rows
         .map(|row| parse(row.as_bytes()).map_err(Error::from))

--- a/src/io/parquet/read/deserialize/binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/binary/dictionary.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::collections::VecDeque;
 
 use parquet2::page::{BinaryPageDict, DictPage};
 
@@ -51,7 +51,7 @@ where
     }
 }
 
-fn read_dict<O: Offset>(data_type: DataType, dict: &dyn DictPage) -> Arc<dyn Array> {
+fn read_dict<O: Offset>(data_type: DataType, dict: &dyn DictPage) -> Box<dyn Array> {
     let dict = dict.as_any().downcast_ref::<BinaryPageDict>().unwrap();
     let offsets = dict
         .offsets()
@@ -61,13 +61,13 @@ fn read_dict<O: Offset>(data_type: DataType, dict: &dyn DictPage) -> Arc<dyn Arr
     let values = dict.values().to_vec();
 
     match data_type.to_physical_type() {
-        PhysicalType::Utf8 | PhysicalType::LargeUtf8 => Arc::new(Utf8Array::<O>::from_data(
+        PhysicalType::Utf8 | PhysicalType::LargeUtf8 => Box::new(Utf8Array::<O>::from_data(
             data_type,
             offsets.into(),
             values.into(),
             None,
         )) as _,
-        PhysicalType::Binary | PhysicalType::LargeBinary => Arc::new(BinaryArray::<O>::from_data(
+        PhysicalType::Binary | PhysicalType::LargeBinary => Box::new(BinaryArray::<O>::from_data(
             data_type,
             offsets.into(),
             values.into(),

--- a/src/io/parquet/read/deserialize/binary/mod.rs
+++ b/src/io/parquet/read/deserialize/binary/mod.rs
@@ -3,8 +3,6 @@ mod dictionary;
 mod nested;
 mod utils;
 
-use std::sync::Arc;
-
 use crate::{
     array::{Array, Offset},
     datatypes::DataType,
@@ -36,7 +34,7 @@ where
         ArrayIterator::<O, A, I>::new(iter, init, data_type, chunk_size).map(|x| {
             x.map(|(mut nested, array)| {
                 let _ = nested.nested.pop().unwrap(); // the primitive
-                let values = Arc::new(array) as Arc<dyn Array>;
+                let values = Box::new(array) as Box<dyn Array>;
                 (nested, values)
             })
         }),

--- a/src/io/parquet/read/deserialize/boolean/mod.rs
+++ b/src/io/parquet/read/deserialize/boolean/mod.rs
@@ -21,7 +21,7 @@ where
     Box::new(ArrayIterator::new(iter, init, chunk_size).map(|x| {
         x.map(|(mut nested, array)| {
             let _ = nested.nested.pop().unwrap(); // the primitive
-            let values = array.arced();
+            let values = array.boxed();
             (nested, values)
         })
     }))

--- a/src/io/parquet/read/deserialize/dictionary.rs
+++ b/src/io/parquet/read/deserialize/dictionary.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::collections::VecDeque;
 
 use parquet2::{
     deserialize::SliceFilteredIter,
@@ -190,11 +190,11 @@ where
 #[derive(Debug)]
 pub enum Dict {
     Empty,
-    Complete(Arc<dyn Array>),
+    Complete(Box<dyn Array>),
 }
 
 impl Dict {
-    pub fn unwrap(&self) -> Arc<dyn Array> {
+    pub fn unwrap(&self) -> Box<dyn Array> {
         match self {
             Self::Empty => panic!(),
             Self::Complete(array) => array.clone(),
@@ -211,7 +211,7 @@ pub(super) fn next_dict<
     'a,
     K: DictionaryKey,
     I: DataPages,
-    F: Fn(&dyn DictPage) -> Arc<dyn Array>,
+    F: Fn(&dyn DictPage) -> Box<dyn Array>,
 >(
     iter: &'a mut I,
     items: &mut VecDeque<(Vec<K>, MutableBitmap)>,

--- a/src/io/parquet/read/deserialize/fixed_size_binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/dictionary.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::collections::VecDeque;
 
 use parquet2::page::{DictPage, FixedLenByteArrayPageDict};
 
@@ -47,14 +47,14 @@ where
     }
 }
 
-fn read_dict(data_type: DataType, dict: &dyn DictPage) -> Arc<dyn Array> {
+fn read_dict(data_type: DataType, dict: &dyn DictPage) -> Box<dyn Array> {
     let dict = dict
         .as_any()
         .downcast_ref::<FixedLenByteArrayPageDict>()
         .unwrap();
     let values = dict.values().to_vec();
 
-    Arc::new(FixedSizeBinaryArray::from_data(
+    Box::new(FixedSizeBinaryArray::from_data(
         data_type,
         values.into(),
         None,

--- a/src/io/parquet/read/deserialize/mod.rs
+++ b/src/io/parquet/read/deserialize/mod.rs
@@ -40,15 +40,15 @@ pub fn get_page_iterator<R: Read + Seek>(
 fn create_list(
     data_type: DataType,
     nested: &mut NestedState,
-    values: Arc<dyn Array>,
-) -> Arc<dyn Array> {
+    values: Box<dyn Array>,
+) -> Box<dyn Array> {
     let (mut offsets, validity) = nested.nested.pop().unwrap().inner();
     match data_type.to_logical_type() {
         DataType::List(_) => {
             offsets.push(values.len() as i64);
 
             let offsets = offsets.iter().map(|x| *x as i32).collect::<Vec<_>>();
-            Arc::new(ListArray::<i32>::new(
+            Box::new(ListArray::<i32>::new(
                 data_type,
                 offsets.into(),
                 values,
@@ -58,14 +58,14 @@ fn create_list(
         DataType::LargeList(_) => {
             offsets.push(values.len() as i64);
 
-            Arc::new(ListArray::<i64>::new(
+            Box::new(ListArray::<i64>::new(
                 data_type,
                 offsets.into(),
                 values,
                 validity.and_then(|x| x.into()),
             ))
         }
-        DataType::FixedSizeList(_, _) => Arc::new(FixedSizeListArray::new(
+        DataType::FixedSizeList(_, _) => Box::new(FixedSizeListArray::new(
             data_type,
             values,
             validity.and_then(|x| x.into()),
@@ -317,7 +317,7 @@ where
                     inner,
                     None,
                 );
-                Ok((nested, array.arced()))
+                Ok((nested, array.boxed()))
             }))
         }
         other => {

--- a/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/src/io/parquet/read/deserialize/nested_utils.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::collections::VecDeque;
 
 use parquet2::{
     encoding::hybrid_rle::HybridRleDecoder, page::DataPage, read::levels::get_bit_width,
@@ -529,4 +529,4 @@ where
 }
 
 pub type NestedArrayIter<'a> =
-    Box<dyn Iterator<Item = Result<(NestedState, Arc<dyn Array>)>> + Send + Sync + 'a>;
+    Box<dyn Iterator<Item = Result<(NestedState, Box<dyn Array>)>> + Send + Sync + 'a>;

--- a/src/io/parquet/read/deserialize/null.rs
+++ b/src/io/parquet/read/deserialize/null.rs
@@ -20,11 +20,11 @@ where
     let remainder = chunk_size % len;
     let i_data_type = data_type.clone();
     let complete = (0..complete_chunks)
-        .map(move |_| Ok(NullArray::new(i_data_type.clone(), chunk_size).arced()));
+        .map(move |_| Ok(NullArray::new(i_data_type.clone(), chunk_size).boxed()));
     if len % chunk_size == 0 {
         Box::new(complete)
     } else {
         let array = NullArray::new(data_type, remainder);
-        Box::new(complete.chain(std::iter::once(Ok(array.arced()))))
+        Box::new(complete.chain(std::iter::once(Ok(array.boxed()))))
     }
 }

--- a/src/io/parquet/read/deserialize/primitive/dictionary.rs
+++ b/src/io/parquet/read/deserialize/primitive/dictionary.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::collections::VecDeque;
 
 use parquet2::{
     page::{DictPage, PrimitivePageDict},
@@ -18,7 +18,7 @@ use super::super::utils::MaybeNext;
 use super::super::DataPages;
 
 #[inline]
-fn read_dict<P, T, F>(data_type: DataType, op: F, dict: &dyn DictPage) -> Arc<dyn Array>
+fn read_dict<P, T, F>(data_type: DataType, op: F, dict: &dyn DictPage) -> Box<dyn Array>
 where
     T: NativeType,
     P: ParquetNativeType,
@@ -30,7 +30,7 @@ where
         .unwrap();
     let values = dict.values().iter().map(|x| (op)(*x)).collect::<Vec<_>>();
 
-    Arc::new(PrimitiveArray::new(data_type, values.into(), None))
+    Box::new(PrimitiveArray::new(data_type, values.into(), None))
 }
 
 /// An iterator adapter over [`DataPages`] assumed to be encoded as boolean arrays

--- a/src/io/parquet/read/deserialize/primitive/mod.rs
+++ b/src/io/parquet/read/deserialize/primitive/mod.rs
@@ -29,7 +29,7 @@ where
         ArrayIterator::<T, I, P, F>::new(iter, init, data_type, chunk_size, op).map(|x| {
             x.map(|(mut nested, array)| {
                 let _ = nested.nested.pop().unwrap(); // the primitive
-                (nested, array.arced())
+                (nested, array.boxed())
             })
         }),
     )

--- a/src/io/parquet/read/deserialize/simple.rs
+++ b/src/io/parquet/read/deserialize/simple.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use parquet2::{
     schema::types::{
         PhysicalType, PrimitiveLogicalType, PrimitiveType, TimeUnit as ParquetTimeUnit,
@@ -25,10 +23,10 @@ use super::primitive;
 #[inline]
 fn dyn_iter<'a, A, I>(iter: I) -> ArrayIter<'a>
 where
-    A: Array + 'static,
+    A: Array,
     I: Iterator<Item = Result<A>> + Send + Sync + 'a,
 {
-    Box::new(iter.map(|x| x.map(|x| Arc::new(x) as Arc<dyn Array>)))
+    Box::new(iter.map(|x| x.map(|x| Box::new(x) as Box<dyn Array>)))
 }
 
 /// Converts an iterator of [MutablePrimitiveArray] into an iterator of [PrimitiveArray]
@@ -165,7 +163,7 @@ pub fn page_iter_to_arrays<'a, I: 'a + DataPages>(
                     PrimitiveArray::<i128>::try_new(data_type.clone(), values.into(), validity)
                 });
 
-                let arrays = pages.map(|x| x.map(|x| x.arced()));
+                let arrays = pages.map(|x| x.map(|x| x.boxed()));
 
                 Box::new(arrays) as _
             }

--- a/src/io/parquet/read/deserialize/struct_.rs
+++ b/src/io/parquet/read/deserialize/struct_.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::array::{Array, StructArray};
 use crate::datatypes::{DataType, Field};
 use crate::error::Error;
@@ -19,7 +17,7 @@ impl<'a> StructIterator<'a> {
 }
 
 impl<'a> Iterator for StructIterator<'a> {
-    type Item = Result<(NestedState, Arc<dyn Array>), Error>;
+    type Item = Result<(NestedState, Box<dyn Array>), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let values = self
@@ -49,7 +47,7 @@ impl<'a> Iterator for StructIterator<'a> {
 
         Some(Ok((
             nested,
-            Arc::new(StructArray::from_data(
+            Box::new(StructArray::from_data(
                 DataType::Struct(self.fields.clone()),
                 new_values,
                 validity.and_then(|x| x.into()),

--- a/src/io/parquet/read/file.rs
+++ b/src/io/parquet/read/file.rs
@@ -129,7 +129,7 @@ impl<R: Read + Seek> FileReader<R> {
 }
 
 impl<R: Read + Seek> Iterator for FileReader<R> {
-    type Item = Result<Chunk<Arc<dyn Array>>>;
+    type Item = Result<Chunk<Box<dyn Array>>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining_rows == 0 {

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -8,10 +8,7 @@ mod row_group;
 pub mod schema;
 pub mod statistics;
 
-use std::{
-    io::{Read, Seek},
-    sync::Arc,
-};
+use std::io::{Read, Seek};
 
 use futures::{AsyncRead, AsyncSeek};
 
@@ -56,7 +53,7 @@ impl<I: FallibleStreamingIterator<Item = DataPage, Error = ParquetError> + Send 
 }
 
 /// Type def for a sharable, boxed dyn [`Iterator`] of arrays
-pub type ArrayIter<'a> = Box<dyn Iterator<Item = Result<Arc<dyn Array>>> + Send + Sync + 'a>;
+pub type ArrayIter<'a> = Box<dyn Iterator<Item = Result<Box<dyn Array>>> + Send + Sync + 'a>;
 
 /// Reads parquets' metadata syncronously.
 pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {

--- a/src/io/parquet/read/row_group.rs
+++ b/src/io/parquet/read/row_group.rs
@@ -1,7 +1,4 @@
-use std::{
-    io::{Read, Seek},
-    sync::Arc,
-};
+use std::io::{Read, Seek};
 
 use futures::{
     future::{try_join_all, BoxFuture},
@@ -59,7 +56,7 @@ impl RowGroupDeserializer {
 }
 
 impl Iterator for RowGroupDeserializer {
-    type Item = Result<Chunk<Arc<dyn Array>>>;
+    type Item = Result<Chunk<Box<dyn Array>>>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining_rows == 0 {
@@ -71,7 +68,7 @@ impl Iterator for RowGroupDeserializer {
             .map(|iter| {
                 let array = iter.next().unwrap()?;
                 Ok(if array.len() > self.remaining_rows {
-                    array.slice(0, array.len() - self.remaining_rows).into()
+                    array.slice(0, array.len() - self.remaining_rows)
                 } else {
                     array
                 })
@@ -186,7 +183,7 @@ pub fn to_deserializer<'a>(
             let pages = PageReader::new(
                 std::io::Cursor::new(chunk),
                 column_meta,
-                Arc::new(|_, _| true),
+                std::sync::Arc::new(|_, _| true),
                 vec![],
             );
             (

--- a/src/io/parquet/read/statistics/dictionary.rs
+++ b/src/io/parquet/read/statistics/dictionary.rs
@@ -37,7 +37,7 @@ impl MutableArray for DynMutableDictionary {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        let inner = self.inner.as_arc();
+        let inner = self.inner.as_box();
         match self.data_type.to_physical_type() {
             PhysicalType::Dictionary(key) => match_integer_type!(key, |$T| {
                 let keys = PrimitiveArray::<$T>::from_iter((0..inner.len() as $T).map(Some));

--- a/src/io/parquet/read/statistics/list.rs
+++ b/src/io/parquet/read/statistics/list.rs
@@ -36,7 +36,7 @@ impl MutableArray for DynMutableListArray {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        let inner = self.inner.as_arc();
+        let inner = self.inner.as_box();
 
         match self.data_type.to_logical_type() {
             DataType::List(_) => {

--- a/src/io/parquet/read/statistics/map.rs
+++ b/src/io/parquet/read/statistics/map.rs
@@ -41,7 +41,7 @@ impl MutableArray for DynMutableMapArray {
         Box::new(MapArray::new(
             self.data_type.clone(),
             vec![0, self.inner.len() as i32].into(),
-            self.inner.as_arc(),
+            self.inner.as_box(),
             None,
         ))
     }

--- a/src/io/parquet/read/statistics/struct_.rs
+++ b/src/io/parquet/read/statistics/struct_.rs
@@ -38,7 +38,7 @@ impl MutableArray for DynMutableStructArray {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        let inner = self.inner.iter_mut().map(|x| x.as_arc()).collect();
+        let inner = self.inner.iter_mut().map(|x| x.as_box()).collect();
 
         Box::new(StructArray::new(self.data_type.clone(), inner, None))
     }

--- a/src/io/parquet/write/pages.rs
+++ b/src/io/parquet/write/pages.rs
@@ -234,8 +234,8 @@ mod tests {
 
     #[test]
     fn test_struct() {
-        let boolean = BooleanArray::from_slice(&[false, false, true, true]).arced();
-        let int = Int32Array::from_slice(&[42, 28, 19, 31]).arced();
+        let boolean = BooleanArray::from_slice(&[false, false, true, true]).boxed();
+        let int = Int32Array::from_slice(&[42, 28, 19, 31]).boxed();
 
         let fields = vec![
             Field::new("b", DataType::Boolean, false),
@@ -298,9 +298,8 @@ mod tests {
 
     #[test]
     fn test_struct_struct() {
-        use std::sync::Arc;
-        let boolean = BooleanArray::from_slice(&[false, false, true, true]).arced();
-        let int = Int32Array::from_slice(&[42, 28, 19, 31]).arced();
+        let boolean = BooleanArray::from_slice(&[false, false, true, true]).boxed();
+        let int = Int32Array::from_slice(&[42, 28, 19, 31]).boxed();
 
         let fields = vec![
             Field::new("b", DataType::Boolean, false),
@@ -320,7 +319,7 @@ mod tests {
 
         let array = StructArray::from_data(
             DataType::Struct(fields),
-            vec![Arc::new(array.clone()), Arc::new(array)],
+            vec![Box::new(array.clone()), Box::new(array)],
             None,
         );
 
@@ -402,9 +401,8 @@ mod tests {
 
     #[test]
     fn test_list_struct() {
-        use std::sync::Arc;
-        let boolean = BooleanArray::from_slice(&[false, false, true, true]).arced();
-        let int = Int32Array::from_slice(&[42, 28, 19, 31]).arced();
+        let boolean = BooleanArray::from_slice(&[false, false, true, true]).boxed();
+        let int = Int32Array::from_slice(&[42, 28, 19, 31]).boxed();
 
         let fields = vec![
             Field::new("b", DataType::Boolean, false),
@@ -420,7 +418,7 @@ mod tests {
         let array = ListArray::new(
             DataType::List(Box::new(Field::new("l", array.data_type().clone(), true))),
             vec![0i32, 2, 4].into(),
-            Arc::new(array),
+            Box::new(array),
             None,
         );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 #![allow(unused_unsafe)]
 //
 #![allow(clippy::len_without_is_empty)]
+// Trait objects must be returned as a &Box<dyn Array> so that they can be cloned
+#![allow(clippy::borrowed_box)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "simd", feature(portable_simd))]
 

--- a/src/scalar/dictionary.rs
+++ b/src/scalar/dictionary.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::sync::Arc;
 
 use crate::{array::*, datatypes::DataType};
 
@@ -8,7 +7,7 @@ use super::Scalar;
 /// The [`DictionaryArray`] equivalent of [`Array`] for [`Scalar`].
 #[derive(Debug, Clone)]
 pub struct DictionaryScalar<K: DictionaryKey> {
-    value: Option<Arc<dyn Scalar>>,
+    value: Option<Box<dyn Scalar>>,
     phantom: std::marker::PhantomData<K>,
     data_type: DataType,
 }
@@ -26,7 +25,7 @@ impl<K: DictionaryKey> DictionaryScalar<K> {
     /// * the `data_type` is not `List` or `LargeList` (depending on this scalar's offset `O`)
     /// * the child of the `data_type` is not equal to the `values`
     #[inline]
-    pub fn new(data_type: DataType, value: Option<Arc<dyn Scalar>>) -> Self {
+    pub fn new(data_type: DataType, value: Option<Box<dyn Scalar>>) -> Self {
         Self {
             value,
             phantom: std::marker::PhantomData,
@@ -35,7 +34,7 @@ impl<K: DictionaryKey> DictionaryScalar<K> {
     }
 
     /// The values of the [`DictionaryScalar`]
-    pub fn value(&self) -> Option<&Arc<dyn Scalar>> {
+    pub fn value(&self) -> Option<&Box<dyn Scalar>> {
         self.value.as_ref()
     }
 }

--- a/src/scalar/fixed_size_list.rs
+++ b/src/scalar/fixed_size_list.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::sync::Arc;
 
 use crate::{array::*, datatypes::DataType};
 
@@ -9,7 +8,7 @@ use super::Scalar;
 /// [`Array`]. The only difference is that this has only one element.
 #[derive(Debug, Clone)]
 pub struct FixedSizeListScalar {
-    values: Option<Arc<dyn Array>>,
+    values: Option<Box<dyn Array>>,
     data_type: DataType,
 }
 
@@ -29,7 +28,7 @@ impl FixedSizeListScalar {
     /// * the child of the `data_type` is not equal to the `values`
     /// * the size of child array is not equal
     #[inline]
-    pub fn new(data_type: DataType, values: Option<Arc<dyn Array>>) -> Self {
+    pub fn new(data_type: DataType, values: Option<Box<dyn Array>>) -> Self {
         let (field, size) = FixedSizeListArray::get_child_and_size(&data_type);
         let inner_data_type = field.data_type();
         let values = values.map(|x| {
@@ -41,7 +40,7 @@ impl FixedSizeListScalar {
     }
 
     /// The values of the [`FixedSizeListScalar`]
-    pub fn values(&self) -> Option<&Arc<dyn Array>> {
+    pub fn values(&self) -> Option<&Box<dyn Array>> {
         self.values.as_ref()
     }
 }

--- a/src/scalar/list.rs
+++ b/src/scalar/list.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::sync::Arc;
 
 use crate::{array::*, datatypes::DataType};
 
@@ -9,7 +8,7 @@ use super::Scalar;
 /// [`Array`]. The only difference is that this has only one element.
 #[derive(Debug, Clone)]
 pub struct ListScalar<O: Offset> {
-    values: Arc<dyn Array>,
+    values: Box<dyn Array>,
     is_valid: bool,
     phantom: std::marker::PhantomData<O>,
     data_type: DataType,
@@ -30,14 +29,14 @@ impl<O: Offset> ListScalar<O> {
     /// * the `data_type` is not `List` or `LargeList` (depending on this scalar's offset `O`)
     /// * the child of the `data_type` is not equal to the `values`
     #[inline]
-    pub fn new(data_type: DataType, values: Option<Arc<dyn Array>>) -> Self {
+    pub fn new(data_type: DataType, values: Option<Box<dyn Array>>) -> Self {
         let inner_data_type = ListArray::<O>::get_child_type(&data_type);
         let (is_valid, values) = match values {
             Some(values) => {
                 assert_eq!(inner_data_type, values.data_type());
                 (true, values)
             }
-            None => (false, new_empty_array(inner_data_type.clone()).into()),
+            None => (false, new_empty_array(inner_data_type.clone())),
         };
         Self {
             values,
@@ -48,7 +47,7 @@ impl<O: Offset> ListScalar<O> {
     }
 
     /// The values of the [`ListScalar`]
-    pub fn values(&self) -> &Arc<dyn Array> {
+    pub fn values(&self) -> &Box<dyn Array> {
         &self.values
     }
 }

--- a/src/scalar/struct_.rs
+++ b/src/scalar/struct_.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::datatypes::DataType;
 
 use super::Scalar;
@@ -7,7 +5,7 @@ use super::Scalar;
 /// A single entry of a [`crate::array::StructArray`].
 #[derive(Debug, Clone)]
 pub struct StructScalar {
-    values: Vec<Arc<dyn Scalar>>,
+    values: Vec<Box<dyn Scalar>>,
     is_valid: bool,
     data_type: DataType,
 }
@@ -23,7 +21,7 @@ impl PartialEq for StructScalar {
 impl StructScalar {
     /// Returns a new [`StructScalar`]
     #[inline]
-    pub fn new(data_type: DataType, values: Option<Vec<Arc<dyn Scalar>>>) -> Self {
+    pub fn new(data_type: DataType, values: Option<Vec<Box<dyn Scalar>>>) -> Self {
         let is_valid = values.is_some();
         Self {
             values: values.unwrap_or_default(),
@@ -34,7 +32,7 @@ impl StructScalar {
 
     /// Returns the values irrespectively of the validity.
     #[inline]
-    pub fn values(&self) -> &[Arc<dyn Scalar>] {
+    pub fn values(&self) -> &[Box<dyn Scalar>] {
         &self.values
     }
 }

--- a/src/scalar/union.rs
+++ b/src/scalar/union.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::datatypes::DataType;
 
 use super::Scalar;
@@ -7,7 +5,7 @@ use super::Scalar;
 /// A single entry of a [`crate::array::UnionArray`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct UnionScalar {
-    value: Arc<dyn Scalar>,
+    value: Box<dyn Scalar>,
     type_: i8,
     data_type: DataType,
 }
@@ -15,7 +13,7 @@ pub struct UnionScalar {
 impl UnionScalar {
     /// Returns a new [`UnionScalar`]
     #[inline]
-    pub fn new(data_type: DataType, type_: i8, value: Arc<dyn Scalar>) -> Self {
+    pub fn new(data_type: DataType, type_: i8, value: Box<dyn Scalar>) -> Self {
         Self {
             value,
             type_,
@@ -25,7 +23,7 @@ impl UnionScalar {
 
     /// Returns the inner value
     #[inline]
-    pub fn value(&self) -> &Arc<dyn Scalar> {
+    pub fn value(&self) -> &Box<dyn Scalar> {
         &self.value
     }
 

--- a/tests/it/array/equal/dictionary.rs
+++ b/tests/it/array/equal/dictionary.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::array::*;
 
 use super::test_equal;
@@ -8,7 +6,7 @@ fn create_dictionary_array(values: &[Option<&str>], keys: &[Option<i16>]) -> Dic
     let keys = Int16Array::from(keys);
     let values = Utf8Array::<i32>::from(values);
 
-    DictionaryArray::from_data(keys, Arc::new(values))
+    DictionaryArray::from_data(keys, Box::new(values))
 }
 
 #[test]

--- a/tests/it/array/equal/list.rs
+++ b/tests/it/array/equal/list.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::array::{Int32Array, ListArray, MutableListArray, MutablePrimitiveArray, TryExtend};
 use arrow2::bitmap::Bitmap;
 use arrow2::buffer::Buffer;
@@ -71,7 +69,7 @@ fn test_list_offsets() {
 fn test_bla() {
     let offsets = Buffer::from(vec![0, 3, 3, 6]);
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-    let values = Arc::new(Int32Array::from([
+    let values = Box::new(Int32Array::from([
         Some(1),
         Some(2),
         Some(3),
@@ -85,7 +83,7 @@ fn test_bla() {
 
     let offsets = Buffer::from(vec![0, 0, 3]);
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-    let values = Arc::new(Int32Array::from([Some(4), None, Some(6)]));
+    let values = Box::new(Int32Array::from([Some(4), None, Some(6)]));
     let validity = Bitmap::from([false, true]);
     let rhs = ListArray::<i32>::from_data(data_type, offsets, values, Some(validity));
 

--- a/tests/it/array/growable/dictionary.rs
+++ b/tests/it/array/growable/dictionary.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::array::growable::{Growable, GrowableDictionary};
 use arrow2::array::*;
 use arrow2::datatypes::DataType;
@@ -17,7 +15,7 @@ fn test_single() -> Result<()> {
     // same values, less keys
     let expected = DictionaryArray::<i32>::from_data(
         PrimitiveArray::from(vec![Some(1), Some(0)]),
-        Arc::new(Utf8Array::<i32>::from(&original_data)),
+        Box::new(Utf8Array::<i32>::from(&original_data)),
     );
 
     let mut growable = GrowableDictionary::new(&[&array], false, 0);
@@ -41,7 +39,7 @@ fn test_negative_keys() {
         Some(vec![true, true, true, false].into()),
     );
 
-    let arr = DictionaryArray::from_data(keys, Arc::new(Utf8Array::<i32>::from(vals)));
+    let arr = DictionaryArray::from_data(keys, Box::new(Utf8Array::<i32>::from(vals)));
     // check that we don't panic with negative keys to usize conversion
     let mut growable = GrowableDictionary::new(&[&arr], false, 0);
     growable.extend(0, 0, 4);
@@ -69,7 +67,7 @@ fn test_multi() -> Result<()> {
     original_data1.extend(original_data2.iter().cloned());
     let expected = DictionaryArray::<i32>::from_data(
         PrimitiveArray::from(vec![Some(1), None, Some(3), None]),
-        Arc::new(Utf8Array::<i32>::from_slice(&["a", "b", "c", "b", "a"])),
+        Box::new(Utf8Array::<i32>::from_slice(&["a", "b", "c", "b", "a"])),
     );
 
     let mut growable = GrowableDictionary::new(&[&array1, &array2], false, 0);

--- a/tests/it/array/growable/mod.rs
+++ b/tests/it/array/growable/mod.rs
@@ -40,7 +40,7 @@ fn test_make_growable() {
 
     let array = DictionaryArray::<i32>::from_data(
         Int32Array::from_slice([1, 2]),
-        std::sync::Arc::new(Int32Array::from_slice([1, 2])),
+        Box::new(Int32Array::from_slice([1, 2])),
     );
     make_growable(&[&array], false, 2);
 }

--- a/tests/it/array/growable/struct_.rs
+++ b/tests/it/array/growable/struct_.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::array::{
     growable::{Growable, GrowableStruct},
     Array, PrimitiveArray, StructArray, Utf8Array,
@@ -7,15 +5,15 @@ use arrow2::array::{
 use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::{DataType, Field};
 
-fn some_values() -> (DataType, Vec<Arc<dyn Array>>) {
-    let strings: Arc<dyn Array> = Arc::new(Utf8Array::<i32>::from(&[
+fn some_values() -> (DataType, Vec<Box<dyn Array>>) {
+    let strings: Box<dyn Array> = Box::new(Utf8Array::<i32>::from(&[
         Some("a"),
         Some("aa"),
         None,
         Some("mark"),
         Some("doe"),
     ]));
-    let ints: Arc<dyn Array> = Arc::new(PrimitiveArray::<i32>::from(&[
+    let ints: Box<dyn Array> = Box::new(PrimitiveArray::<i32>::from(&[
         Some(1),
         Some(2),
         Some(3),
@@ -42,7 +40,7 @@ fn basic() {
 
     let expected = StructArray::from_data(
         fields,
-        vec![values[0].slice(1, 2).into(), values[1].slice(1, 2).into()],
+        vec![values[0].slice(1, 2), values[1].slice(1, 2)],
         None,
     );
     assert_eq!(result, expected)
@@ -61,7 +59,7 @@ fn offset() {
 
     let expected = StructArray::from_data(
         fields,
-        vec![values[0].slice(2, 2).into(), values[1].slice(2, 2).into()],
+        vec![values[0].slice(2, 2), values[1].slice(2, 2)],
         None,
     );
 
@@ -85,7 +83,7 @@ fn nulls() {
 
     let expected = StructArray::from_data(
         fields,
-        vec![values[0].slice(1, 2).into(), values[1].slice(1, 2).into()],
+        vec![values[0].slice(1, 2), values[1].slice(1, 2)],
         Some(Bitmap::from_u8_slice(&[0b00000010], 5).slice(1, 2)),
     );
 
@@ -105,14 +103,14 @@ fn many() {
     mutable.extend_validity(1);
     let result = mutable.as_box();
 
-    let expected_string: Arc<dyn Array> = Arc::new(Utf8Array::<i32>::from(&[
+    let expected_string: Box<dyn Array> = Box::new(Utf8Array::<i32>::from(&[
         Some("aa"),
         None,
         Some("a"),
         Some("aa"),
         None,
     ]));
-    let expected_int: Arc<dyn Array> = Arc::new(PrimitiveArray::<i32>::from(vec![
+    let expected_int: Box<dyn Array> = Box::new(PrimitiveArray::<i32>::from(vec![
         Some(2),
         Some(3),
         Some(1),

--- a/tests/it/array/growable/union.rs
+++ b/tests/it/array/growable/union.rs
@@ -16,8 +16,8 @@ fn sparse() -> Result<()> {
     let data_type = DataType::Union(fields, None, UnionMode::Sparse);
     let types = vec![0, 0, 1].into();
     let fields = vec![
-        Int32Array::from(&[Some(1), None, Some(2)]).arced(),
-        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).arced(),
+        Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
+        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).boxed(),
     ];
     let array = UnionArray::from_data(data_type, types, fields, None);
 
@@ -46,8 +46,8 @@ fn dense() -> Result<()> {
     let data_type = DataType::Union(fields, None, UnionMode::Dense);
     let types = vec![0, 0, 1].into();
     let fields = vec![
-        Int32Array::from(&[Some(1), None, Some(2)]).arced(),
-        Utf8Array::<i32>::from(&[Some("c")]).arced(),
+        Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
+        Utf8Array::<i32>::from(&[Some("c")]).boxed(),
     ];
     let offsets = Some(vec![0, 1, 0].into());
 

--- a/tests/it/array/list/mod.rs
+++ b/tests/it/array/list/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::array::*;
 use arrow2::buffer::Buffer;
 use arrow2::datatypes::DataType;
@@ -15,7 +13,7 @@ fn debug() {
     let array = ListArray::<i32>::from_data(
         data_type,
         Buffer::from(vec![0, 2, 2, 3, 5]),
-        Arc::new(values),
+        Box::new(values),
         None,
     );
 
@@ -32,7 +30,7 @@ fn test_nested_panic() {
     let array = ListArray::<i32>::from_data(
         data_type.clone(),
         Buffer::from(vec![0, 2, 2, 3, 5]),
-        Arc::new(values),
+        Box::new(values),
         None,
     );
 
@@ -41,7 +39,7 @@ fn test_nested_panic() {
     let _ = ListArray::<i32>::from_data(
         data_type,
         Buffer::from(vec![0, 2, 4]),
-        Arc::new(array),
+        Box::new(array),
         None,
     );
 }
@@ -55,7 +53,7 @@ fn test_nested_display() {
     let array = ListArray::<i32>::from_data(
         data_type,
         Buffer::from(vec![0, 2, 4, 7, 7, 8, 10]),
-        Arc::new(values),
+        Box::new(values),
         None,
     );
 
@@ -63,7 +61,7 @@ fn test_nested_display() {
     let nested = ListArray::<i32>::from_data(
         data_type,
         Buffer::from(vec![0, 2, 5, 6]),
-        Arc::new(array),
+        Box::new(array),
         None,
     );
 

--- a/tests/it/array/list/mutable.rs
+++ b/tests/it/array/list/mutable.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::{array::*, bitmap::Bitmap, buffer::Buffer, datatypes::DataType};
 
 #[test]
@@ -24,7 +22,7 @@ fn basics() {
     let expected = ListArray::<i32>::from_data(
         data_type,
         Buffer::from(vec![0, 3, 3, 6]),
-        Arc::new(values),
+        Box::new(values),
         Some(Bitmap::from([true, false, true])),
     );
     assert_eq!(expected, array);

--- a/tests/it/array/map/mod.rs
+++ b/tests/it/array/map/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::{
     array::*,
     datatypes::{DataType, Field},
@@ -16,21 +14,21 @@ fn basics() {
     let field = StructArray::new(
         dt.clone(),
         vec![
-            Arc::new(Utf8Array::<i32>::from_slice(["a", "aa", "aaa"])) as _,
-            Arc::new(Utf8Array::<i32>::from_slice(["b", "bb", "bbb"])),
+            Box::new(Utf8Array::<i32>::from_slice(["a", "aa", "aaa"])) as _,
+            Box::new(Utf8Array::<i32>::from_slice(["b", "bb", "bbb"])),
         ],
         None,
     );
 
-    let array = MapArray::new(data_type, vec![0, 1, 2].into(), Arc::new(field), None);
+    let array = MapArray::new(data_type, vec![0, 1, 2].into(), Box::new(field), None);
 
     assert_eq!(
         array.value(0),
         Box::new(StructArray::new(
             dt.clone(),
             vec![
-                Arc::new(Utf8Array::<i32>::from_slice(["a"])) as _,
-                Arc::new(Utf8Array::<i32>::from_slice(["b"])),
+                Box::new(Utf8Array::<i32>::from_slice(["a"])) as _,
+                Box::new(Utf8Array::<i32>::from_slice(["b"])),
             ],
             None,
         )) as Box<dyn Array>
@@ -42,8 +40,8 @@ fn basics() {
         Box::new(StructArray::new(
             dt,
             vec![
-                Arc::new(Utf8Array::<i32>::from_slice(["aa"])) as _,
-                Arc::new(Utf8Array::<i32>::from_slice(["bb"])),
+                Box::new(Utf8Array::<i32>::from_slice(["aa"])) as _,
+                Box::new(Utf8Array::<i32>::from_slice(["bb"])),
             ],
             None,
         )) as Box<dyn Array>

--- a/tests/it/array/mod.rs
+++ b/tests/it/array/mod.rs
@@ -102,5 +102,5 @@ fn test_with_validity() {
 // check that `PartialEq` can be derived
 #[derive(PartialEq)]
 struct A {
-    array: std::sync::Arc<dyn Array>,
+    array: Box<dyn Array>,
 }

--- a/tests/it/array/struct_/iterator.rs
+++ b/tests/it/array/struct_/iterator.rs
@@ -4,8 +4,8 @@ use arrow2::scalar::new_scalar;
 
 #[test]
 fn test_simple_iter() {
-    let boolean = BooleanArray::from_slice(&[false, false, true, true]).arced();
-    let int = Int32Array::from_slice(&[42, 28, 19, 31]).arced();
+    let boolean = BooleanArray::from_slice(&[false, false, true, true]).boxed();
+    let int = Int32Array::from_slice(&[42, 28, 19, 31]).boxed();
 
     let fields = vec![
         Field::new("b", DataType::Boolean, false),

--- a/tests/it/array/struct_/mod.rs
+++ b/tests/it/array/struct_/mod.rs
@@ -6,8 +6,8 @@ use arrow2::datatypes::*;
 
 #[test]
 fn debug() {
-    let boolean = BooleanArray::from_slice(&[false, false, true, true]).arced();
-    let int = Int32Array::from_slice(&[42, 28, 19, 31]).arced();
+    let boolean = BooleanArray::from_slice(&[false, false, true, true]).boxed();
+    let int = Int32Array::from_slice(&[42, 28, 19, 31]).boxed();
 
     let fields = vec![
         Field::new("b", DataType::Boolean, false),

--- a/tests/it/array/union.rs
+++ b/tests/it/array/union.rs
@@ -28,8 +28,8 @@ fn sparse_debug() -> Result<()> {
     let data_type = DataType::Union(fields, None, UnionMode::Sparse);
     let types = vec![0, 0, 1].into();
     let fields = vec![
-        Int32Array::from(&[Some(1), None, Some(2)]).arced(),
-        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).arced(),
+        Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
+        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).boxed(),
     ];
 
     let array = UnionArray::from_data(data_type, types, fields, None);
@@ -48,8 +48,8 @@ fn dense_debug() -> Result<()> {
     let data_type = DataType::Union(fields, None, UnionMode::Dense);
     let types = vec![0, 0, 1].into();
     let fields = vec![
-        Int32Array::from(&[Some(1), None, Some(2)]).arced(),
-        Utf8Array::<i32>::from(&[Some("c")]).arced(),
+        Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
+        Utf8Array::<i32>::from(&[Some("c")]).boxed(),
     ];
     let offsets = Some(vec![0, 1, 0].into());
 
@@ -69,8 +69,8 @@ fn slice() -> Result<()> {
     let data_type = DataType::Union(fields, None, UnionMode::Sparse);
     let types = Buffer::from(vec![0, 0, 1]);
     let fields = vec![
-        Int32Array::from(&[Some(1), None, Some(2)]).arced(),
-        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).arced(),
+        Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
+        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).boxed(),
     ];
 
     let array = UnionArray::from_data(data_type.clone(), types, fields.clone(), None);
@@ -79,8 +79,8 @@ fn slice() -> Result<()> {
 
     let sliced_types = Buffer::from(vec![0, 1]);
     let sliced_fields = vec![
-        Int32Array::from(&[None, Some(2)]).arced(),
-        Utf8Array::<i32>::from(&[Some("b"), Some("c")]).arced(),
+        Int32Array::from(&[None, Some(2)]).boxed(),
+        Utf8Array::<i32>::from(&[Some("b"), Some("c")]).boxed(),
     ];
     let expected = UnionArray::from_data(data_type, sliced_types, sliced_fields, None);
 
@@ -97,8 +97,8 @@ fn iter_sparse() -> Result<()> {
     let data_type = DataType::Union(fields, None, UnionMode::Sparse);
     let types = Buffer::from(vec![0, 0, 1]);
     let fields = vec![
-        Int32Array::from(&[Some(1), None, Some(2)]).arced(),
-        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).arced(),
+        Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
+        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).boxed(),
     ];
 
     let array = UnionArray::from_data(data_type, types, fields.clone(), None);
@@ -131,8 +131,8 @@ fn iter_dense() -> Result<()> {
     let types = Buffer::from(vec![0, 0, 1]);
     let offsets = Buffer::<i32>::from(vec![0, 1, 0]);
     let fields = vec![
-        Int32Array::from(&[Some(1), None]).arced(),
-        Utf8Array::<i32>::from(&[Some("c")]).arced(),
+        Int32Array::from(&[Some(1), None]).boxed(),
+        Utf8Array::<i32>::from(&[Some("c")]).boxed(),
     ];
 
     let array = UnionArray::from_data(data_type, types, fields.clone(), Some(offsets));
@@ -164,8 +164,8 @@ fn iter_sparse_slice() -> Result<()> {
     let data_type = DataType::Union(fields, None, UnionMode::Sparse);
     let types = Buffer::from(vec![0, 0, 1]);
     let fields = vec![
-        Int32Array::from(&[Some(1), Some(3), Some(2)]).arced(),
-        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).arced(),
+        Int32Array::from(&[Some(1), Some(3), Some(2)]).boxed(),
+        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).boxed(),
     ];
 
     let array = UnionArray::from_data(data_type, types, fields.clone(), None);
@@ -191,8 +191,8 @@ fn iter_dense_slice() -> Result<()> {
     let types = Buffer::from(vec![0, 0, 1]);
     let offsets = Buffer::<i32>::from(vec![0, 1, 0]);
     let fields = vec![
-        Int32Array::from(&[Some(1), Some(3)]).arced(),
-        Utf8Array::<i32>::from(&[Some("c")]).arced(),
+        Int32Array::from(&[Some(1), Some(3)]).boxed(),
+        Utf8Array::<i32>::from(&[Some("c")]).boxed(),
     ];
 
     let array = UnionArray::from_data(data_type, types, fields.clone(), Some(offsets));
@@ -218,8 +218,8 @@ fn scalar() -> Result<()> {
     let types = Buffer::from(vec![0, 0, 1]);
     let offsets = Buffer::<i32>::from(vec![0, 1, 0]);
     let fields = vec![
-        Int32Array::from(&[Some(1), None]).arced(),
-        Utf8Array::<i32>::from(&[Some("c")]).arced(),
+        Int32Array::from(&[Some(1), None]).boxed(),
+        Utf8Array::<i32>::from(&[Some("c")]).boxed(),
     ];
 
     let array = UnionArray::from_data(data_type, types, fields.clone(), Some(offsets));

--- a/tests/it/compute/arithmetics/mod.rs
+++ b/tests/it/compute/arithmetics/mod.rs
@@ -97,12 +97,12 @@ fn test_neg() {
 fn test_neg_dict() {
     let a = DictionaryArray::<u8>::from_data(
         UInt8Array::from_slice(&[0, 0, 1]),
-        std::sync::Arc::new(Int8Array::from_slice(&[1, 2])),
+        Box::new(Int8Array::from_slice(&[1, 2])),
     );
     let result = neg(&a);
     let expected = DictionaryArray::<u8>::from_data(
         UInt8Array::from_slice(&[0, 0, 1]),
-        std::sync::Arc::new(Int8Array::from_slice(&[-1, -2])),
+        Box::new(Int8Array::from_slice(&[-1, -2])),
     );
     assert_eq!(expected, result.as_ref());
 }

--- a/tests/it/compute/take.rs
+++ b/tests/it/compute/take.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::compute::take::{can_take, take};
 use arrow2::datatypes::{DataType, Field, IntervalUnit};
 use arrow2::error::Result;
@@ -75,7 +73,7 @@ fn create_test_struct() -> StructArray {
     ];
     StructArray::from_data(
         DataType::Struct(fields),
-        vec![boolean.arced(), int.arced()],
+        vec![boolean.boxed(), int.boxed()],
         validity,
     )
 }
@@ -96,7 +94,7 @@ fn test_struct_with_nulls() {
         .into();
     let expected = StructArray::from_data(
         array.data_type().clone(),
-        vec![boolean.arced(), int.arced()],
+        vec![boolean.boxed(), int.boxed()],
         validity,
     );
     assert_eq!(expected, output.as_ref());
@@ -179,7 +177,7 @@ fn list_with_no_none() {
     let array = ListArray::<i32>::from_data(
         data_type,
         Buffer::from(vec![0, 2, 2, 6, 9, 10]),
-        Arc::new(values),
+        Box::new(values),
         None,
     );
 
@@ -192,7 +190,7 @@ fn list_with_no_none() {
     let expected = ListArray::<i32>::from_data(
         expected_type,
         Buffer::from(vec![0, 1, 1, 4]),
-        Arc::new(expected_values),
+        Box::new(expected_values),
         None,
     );
 
@@ -211,7 +209,7 @@ fn list_with_none() {
     let array = ListArray::<i32>::from_data(
         data_type,
         Buffer::from(vec![0, 2, 2, 6, 9, 10]),
-        Arc::new(values),
+        Box::new(values),
         Some(validity),
     );
 
@@ -270,7 +268,7 @@ fn test_nested() {
     let array = ListArray::<i32>::from_data(
         data_type,
         Buffer::from(vec![0, 2, 4, 7, 7, 8, 10]),
-        Arc::new(values),
+        Box::new(values),
         None,
     );
 
@@ -278,7 +276,7 @@ fn test_nested() {
     let nested = ListArray::<i32>::from_data(
         data_type,
         Buffer::from(vec![0, 2, 5, 6]),
-        Arc::new(array),
+        Box::new(array),
         None,
     );
 
@@ -293,7 +291,7 @@ fn test_nested() {
     let expected_array = ListArray::<i32>::from_data(
         expected_data_type,
         Buffer::from(vec![0, 2, 4, 7, 7, 8]),
-        Arc::new(expected_values),
+        Box::new(expected_values),
         None,
     );
 
@@ -301,7 +299,7 @@ fn test_nested() {
     let expected = ListArray::<i32>::from_data(
         expected_data_type,
         Buffer::from(vec![0, 2, 5]),
-        Arc::new(expected_array),
+        Box::new(expected_array),
         None,
     );
 

--- a/tests/it/ffi/stream.rs
+++ b/tests/it/ffi/stream.rs
@@ -1,10 +1,8 @@
-use std::sync::Arc;
-
 use arrow2::array::*;
 use arrow2::datatypes::Field;
 use arrow2::{error::Result, ffi};
 
-fn _test_round_trip(arrays: Vec<Arc<dyn Array>>) -> Result<()> {
+fn _test_round_trip(arrays: Vec<Box<dyn Array>>) -> Result<()> {
     let field = Field::new("a", arrays[0].data_type().clone(), true);
     let iter = Box::new(arrays.clone().into_iter().map(Ok)) as _;
 
@@ -14,9 +12,9 @@ fn _test_round_trip(arrays: Vec<Arc<dyn Array>>) -> Result<()> {
 
     let mut stream = unsafe { ffi::ArrowArrayStreamReader::try_new(stream)? };
 
-    let mut produced_arrays: Vec<Arc<dyn Array>> = vec![];
+    let mut produced_arrays: Vec<Box<dyn Array>> = vec![];
     while let Some(array) = unsafe { stream.next() } {
-        produced_arrays.push(array?.into());
+        produced_arrays.push(array?);
     }
 
     assert_eq!(produced_arrays, arrays);
@@ -27,7 +25,7 @@ fn _test_round_trip(arrays: Vec<Arc<dyn Array>>) -> Result<()> {
 #[test]
 fn round_trip() -> Result<()> {
     let array = Int32Array::from(&[Some(2), None, Some(1), None]);
-    let array: Arc<dyn Array> = Arc::new(array);
+    let array: Box<dyn Array> = Box::new(array);
 
     _test_round_trip(vec![array.clone(), array.clone(), array])
 }

--- a/tests/it/io/avro/write.rs
+++ b/tests/it/io/avro/write.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::array::*;
 use arrow2::chunk::Chunk;
 use arrow2::datatypes::*;
@@ -82,7 +80,7 @@ pub(super) fn data() -> Chunk<Box<dyn Array>> {
         Box::new(ListArray::<i32>::new(
             list_dt,
             vec![0, 2, 5].into(),
-            Arc::new(PrimitiveArray::<i32>::from([
+            Box::new(PrimitiveArray::<i32>::from([
                 None,
                 Some(1),
                 None,
@@ -94,7 +92,7 @@ pub(super) fn data() -> Chunk<Box<dyn Array>> {
         Box::new(ListArray::<i32>::new(
             list_dt1,
             vec![0, 2, 2].into(),
-            Arc::new(PrimitiveArray::<i32>::from([None, Some(1)])),
+            Box::new(PrimitiveArray::<i32>::from([None, Some(1)])),
             Some([true, false].into()),
         )),
     ];
@@ -262,16 +260,16 @@ fn struct_data() -> Chunk<Box<dyn Array>> {
         Box::new(StructArray::new(
             struct_dt.clone(),
             vec![
-                Arc::new(PrimitiveArray::<i32>::from_slice([1, 2])),
-                Arc::new(PrimitiveArray::<i32>::from([None, Some(1)])),
+                Box::new(PrimitiveArray::<i32>::from_slice([1, 2])),
+                Box::new(PrimitiveArray::<i32>::from([None, Some(1)])),
             ],
             None,
         )),
         Box::new(StructArray::new(
             struct_dt,
             vec![
-                Arc::new(PrimitiveArray::<i32>::from_slice([1, 2])),
-                Arc::new(PrimitiveArray::<i32>::from([None, Some(1)])),
+                Box::new(PrimitiveArray::<i32>::from_slice([1, 2])),
+                Box::new(PrimitiveArray::<i32>::from([None, Some(1)])),
             ],
             Some([true, false].into()),
         )),

--- a/tests/it/io/csv/read.rs
+++ b/tests/it/io/csv/read.rs
@@ -1,7 +1,6 @@
 use proptest::prelude::*;
 
 use std::io::Cursor;
-use std::sync::Arc;
 
 use arrow2::array::*;
 use arrow2::datatypes::*;
@@ -89,7 +88,7 @@ fn infer_ints() -> Result<()> {
     Ok(())
 }
 
-fn test_deserialize(input: &str, data_type: DataType) -> Result<Arc<dyn Array>> {
+fn test_deserialize(input: &str, data_type: DataType) -> Result<Box<dyn Array>> {
     let reader = std::io::Cursor::new(input);
     let mut reader = ReaderBuilder::new().has_headers(false).from_reader(reader);
 

--- a/tests/it/io/csv/write.rs
+++ b/tests/it/io/csv/write.rs
@@ -1,5 +1,4 @@
 use std::io::Cursor;
-use std::sync::Arc;
 
 use arrow2::array::*;
 use arrow2::chunk::Chunk;
@@ -17,7 +16,7 @@ fn data() -> Chunk<Box<dyn Array>> {
     let c6 = PrimitiveArray::<i32>::from_vec(vec![1234, 24680, 85563])
         .to(DataType::Time32(TimeUnit::Second));
     let keys = UInt32Array::from_slice(&[2, 0, 1]);
-    let c7 = DictionaryArray::from_data(keys, Arc::new(c1.clone()));
+    let c7 = DictionaryArray::from_data(keys, Box::new(c1.clone()));
 
     Chunk::new(vec![
         Box::new(c1) as Box<dyn Array>,
@@ -85,57 +84,57 @@ d|-556132.25|1||2019-04-18 02:45:55.555|11:46:03 PM|c
     Ok(())
 }
 
-fn data_array(column: usize) -> (Chunk<Arc<dyn Array>>, Vec<&'static str>) {
+fn data_array(column: usize) -> (Chunk<Box<dyn Array>>, Vec<&'static str>) {
     let (array, expected) = match column {
         0 => (
-            Utf8Array::<i64>::from_slice(["a b", "c", "d"]).arced(),
+            Utf8Array::<i64>::from_slice(["a b", "c", "d"]).boxed(),
             vec!["a b", "c", "d"],
         ),
         1 => (
-            BinaryArray::<i32>::from_slice(["a b", "c", "d"]).arced(),
+            BinaryArray::<i32>::from_slice(["a b", "c", "d"]).boxed(),
             vec!["a b", "c", "d"],
         ),
         2 => (
-            BinaryArray::<i64>::from_slice(["a b", "c", "d"]).arced(),
+            BinaryArray::<i64>::from_slice(["a b", "c", "d"]).boxed(),
             vec!["a b", "c", "d"],
         ),
         3 => (
-            Int8Array::from_slice(&[3, 2, 1]).arced(),
+            Int8Array::from_slice(&[3, 2, 1]).boxed(),
             vec!["3", "2", "1"],
         ),
         4 => (
-            Int16Array::from_slice(&[3, 2, 1]).arced(),
+            Int16Array::from_slice(&[3, 2, 1]).boxed(),
             vec!["3", "2", "1"],
         ),
         5 => (
-            Int32Array::from_slice(&[3, 2, 1]).arced(),
+            Int32Array::from_slice(&[3, 2, 1]).boxed(),
             vec!["3", "2", "1"],
         ),
         6 => (
-            Int64Array::from_slice(&[3, 2, 1]).arced(),
+            Int64Array::from_slice(&[3, 2, 1]).boxed(),
             vec!["3", "2", "1"],
         ),
         7 => (
-            UInt8Array::from_slice(&[3, 2, 1]).arced(),
+            UInt8Array::from_slice(&[3, 2, 1]).boxed(),
             vec!["3", "2", "1"],
         ),
         8 => (
-            UInt16Array::from_slice(&[3, 2, 1]).arced(),
+            UInt16Array::from_slice(&[3, 2, 1]).boxed(),
             vec!["3", "2", "1"],
         ),
         9 => (
-            UInt32Array::from_slice(&[3, 2, 1]).arced(),
+            UInt32Array::from_slice(&[3, 2, 1]).boxed(),
             vec!["3", "2", "1"],
         ),
         10 => (
-            UInt64Array::from_slice(&[3, 2, 1]).arced(),
+            UInt64Array::from_slice(&[3, 2, 1]).boxed(),
             vec!["3", "2", "1"],
         ),
         11 => {
             let array = PrimitiveArray::<i32>::from_vec(vec![1_234_001, 24_680_001, 85_563_001])
                 .to(DataType::Time32(TimeUnit::Millisecond));
             (
-                array.arced(),
+                array.boxed(),
                 vec!["00:20:34.001", "06:51:20.001", "23:46:03.001"],
             )
         }
@@ -147,7 +146,7 @@ fn data_array(column: usize) -> (Chunk<Arc<dyn Array>>, Vec<&'static str>) {
             ])
             .to(DataType::Time64(TimeUnit::Microsecond));
             (
-                array.arced(),
+                array.boxed(),
                 vec!["00:20:34.000001", "06:51:20.000001", "23:46:03.000001"],
             )
         }
@@ -159,7 +158,7 @@ fn data_array(column: usize) -> (Chunk<Arc<dyn Array>>, Vec<&'static str>) {
             ])
             .to(DataType::Time64(TimeUnit::Nanosecond));
             (
-                array.arced(),
+                array.boxed(),
                 vec![
                     "00:20:34.000000001",
                     "06:51:20.000000001",
@@ -174,7 +173,7 @@ fn data_array(column: usize) -> (Chunk<Arc<dyn Array>>, Vec<&'static str>) {
             ])
             .to(DataType::Timestamp(TimeUnit::Nanosecond, None));
             (
-                array.arced(),
+                array.boxed(),
                 vec![
                     "2019-04-18 10:54:47.378000001",
                     "2019-04-18 02:45:55.555000001",
@@ -191,7 +190,7 @@ fn data_array(column: usize) -> (Chunk<Arc<dyn Array>>, Vec<&'static str>) {
                 Some("+01:00".to_string()),
             ));
             (
-                array.arced(),
+                array.boxed(),
                 vec![
                     "2019-04-18 11:54:47.378000001 +01:00",
                     "2019-04-18 03:45:55.555000001 +01:00",
@@ -200,9 +199,9 @@ fn data_array(column: usize) -> (Chunk<Arc<dyn Array>>, Vec<&'static str>) {
         }
         16 => {
             let keys = UInt32Array::from_slice(&[2, 1, 0]);
-            let values = Utf8Array::<i64>::from_slice(["a b", "c", "d"]).arced();
+            let values = Utf8Array::<i64>::from_slice(["a b", "c", "d"]).boxed();
             let array = DictionaryArray::from_data(keys, values);
-            (array.arced(), vec!["d", "c", "a b"])
+            (array.boxed(), vec!["d", "c", "a b"])
         }
         17 => {
             let array = PrimitiveArray::<i64>::from_slice([
@@ -214,7 +213,7 @@ fn data_array(column: usize) -> (Chunk<Arc<dyn Array>>, Vec<&'static str>) {
                 Some("Europe/Lisbon".to_string()),
             ));
             (
-                array.arced(),
+                array.boxed(),
                 vec![
                     "2019-04-18 11:54:47.378000001 WEST",
                     "2019-04-18 03:45:55.555000001 WEST",
@@ -228,7 +227,7 @@ fn data_array(column: usize) -> (Chunk<Arc<dyn Array>>, Vec<&'static str>) {
 }
 
 fn test_array(
-    columns: Chunk<Arc<dyn Array>>,
+    columns: Chunk<Box<dyn Array>>,
     data: Vec<&'static str>,
     options: SerializeOptions,
 ) -> Result<()> {
@@ -276,7 +275,7 @@ fn write_tz_timezone_formatted_offset() -> Result<()> {
                 Some("+01:00".to_string()),
             ));
 
-    let columns = Chunk::new(vec![array.arced()]);
+    let columns = Chunk::new(vec![array.boxed()]);
     let expected = vec![
         "2019-04-18T11:54:47.378000001+01:00",
         "2019-04-18T03:45:55.555000001+01:00",
@@ -301,7 +300,7 @@ fn write_tz_timezone_formatted_tz() -> Result<()> {
                 Some("Europe/Lisbon".to_string()),
             ));
 
-    let columns = Chunk::new(vec![array.arced()]);
+    let columns = Chunk::new(vec![array.boxed()]);
     let expected = vec![
         "2019-04-18T11:54:47.378000001+01:00",
         "2019-04-18T03:45:55.555000001+01:00",
@@ -320,7 +319,7 @@ fn write_tz_timezone_formatted_tz() -> Result<()> {
 fn write_empty_and_missing() {
     let a = Utf8Array::<i32>::from(&[Some(""), None]);
     let b = Utf8Array::<i32>::from(&[None, Some("")]);
-    let columns = Chunk::new(vec![a.arced(), b.arced()]);
+    let columns = Chunk::new(vec![a.boxed(), b.boxed()]);
 
     let mut writer = vec![];
     let options = SerializeOptions::default();
@@ -333,7 +332,7 @@ fn write_empty_and_missing() {
 #[test]
 fn write_escaping() {
     let a = Utf8Array::<i32>::from_slice(&["Acme co., Ltd."]);
-    let columns = Chunk::new(vec![a.arced()]);
+    let columns = Chunk::new(vec![a.boxed()]);
 
     let mut writer = vec![];
     let options = SerializeOptions::default();
@@ -353,7 +352,7 @@ fn write_escaping_resize_local_buf() {
         let a = Utf8Array::<i32>::from_slice(&[
             payload
         ]);
-        let columns = Chunk::new(vec![a.arced()]);
+        let columns = Chunk::new(vec![a.boxed()]);
 
         let mut writer = vec![];
         let options = SerializeOptions::default();

--- a/tests/it/io/ipc/common.rs
+++ b/tests/it/io/ipc/common.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs::File, io::Read, sync::Arc};
+use std::{collections::HashMap, fs::File, io::Read};
 
 use arrow2::{
     array::Array, chunk::Chunk, datatypes::Schema, error::Result,
@@ -8,7 +8,7 @@ use arrow2::{
 
 use flate2::read::GzDecoder;
 
-type IpcRead = (Schema, Vec<IpcField>, Vec<Chunk<Arc<dyn Array>>>);
+type IpcRead = (Schema, Vec<IpcField>, Vec<Chunk<Box<dyn Array>>>);
 
 /// Read gzipped JSON file
 pub fn read_gzip_json(version: &str, file_name: &str) -> Result<IpcRead> {

--- a/tests/it/io/ipc/write/file_append.rs
+++ b/tests/it/io/ipc/write/file_append.rs
@@ -10,7 +10,7 @@ use super::file::write;
 #[test]
 fn basic() -> Result<()> {
     // prepare some data
-    let array = BooleanArray::from([Some(true), Some(false), None, Some(true)]).arced();
+    let array = BooleanArray::from([Some(true), Some(false), None, Some(true)]).boxed();
     let schema = Schema::from(vec![Field::new("a", array.data_type().clone(), true)]);
     let columns = Chunk::try_new(vec![array])?;
 

--- a/tests/it/io/ipc/write/stream.rs
+++ b/tests/it/io/ipc/write/stream.rs
@@ -1,5 +1,4 @@
 use std::io::Cursor;
-use std::sync::Arc;
 
 use arrow2::array::Array;
 use arrow2::chunk::Chunk;
@@ -16,7 +15,7 @@ use crate::io::ipc::common::read_gzip_json;
 fn write_(
     schema: &Schema,
     ipc_fields: Option<Vec<IpcField>>,
-    batches: &[Chunk<Arc<dyn Array>>],
+    batches: &[Chunk<Box<dyn Array>>],
 ) -> Vec<u8> {
     let mut result = vec![];
 

--- a/tests/it/io/ipc/write_file_async.rs
+++ b/tests/it/io/ipc/write_file_async.rs
@@ -1,5 +1,4 @@
 use std::io::Cursor;
-use std::sync::Arc;
 
 use arrow2::array::Array;
 use arrow2::chunk::Chunk;
@@ -18,7 +17,7 @@ use crate::io::ipc::common::read_gzip_json;
 async fn write_(
     schema: &Schema,
     ipc_fields: &[IpcField],
-    batches: &[Chunk<Arc<dyn Array>>],
+    batches: &[Chunk<Box<dyn Array>>],
 ) -> Result<Vec<u8>> {
     let mut result = AsyncCursor::new(vec![]);
 

--- a/tests/it/io/ipc/write_stream_async.rs
+++ b/tests/it/io/ipc/write_stream_async.rs
@@ -1,5 +1,4 @@
 use std::io::Cursor;
-use std::sync::Arc;
 
 use arrow2::array::Array;
 use arrow2::chunk::Chunk;
@@ -18,7 +17,7 @@ use crate::io::ipc::common::read_gzip_json;
 async fn write_(
     schema: &Schema,
     ipc_fields: &[IpcField],
-    batches: &[Chunk<Arc<dyn Array>>],
+    batches: &[Chunk<Box<dyn Array>>],
 ) -> Result<Vec<u8>> {
     let mut result = AsyncCursor::new(vec![]);
 

--- a/tests/it/io/json/mod.rs
+++ b/tests/it/io/json/mod.rs
@@ -1,8 +1,6 @@
 mod read;
 mod write;
 
-use std::sync::Arc;
-
 use arrow2::array::*;
 use arrow2::error::Result;
 use arrow2::io::json::write as json_write;

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -3,8 +3,6 @@ use arrow2::datatypes::*;
 use arrow2::error::Result;
 use arrow2::io::json::read;
 
-use super::*;
-
 #[test]
 fn read_json() -> Result<()> {
     let data = br#"[
@@ -27,7 +25,7 @@ fn read_json() -> Result<()> {
 
     let expected = StructArray::from_data(
         DataType::Struct(vec![Field::new("a", DataType::Int64, true)]),
-        vec![Arc::new(Int64Array::from_slice([1, 2, 3])) as _],
+        vec![Box::new(Int64Array::from_slice([1, 2, 3])) as _],
         None,
     );
 

--- a/tests/it/io/json/write.rs
+++ b/tests/it/io/json/write.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::{
     array::*,
     bitmap::Bitmap,
@@ -64,7 +62,7 @@ fn struct_() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Arc::new(c1) as _, Arc::new(c2)], None);
+    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
 
     let expected = r#"[{"c1":1,"c2":"a"},{"c1":2,"c2":"b"},{"c1":3,"c2":"c"},{"c1":null,"c2":"d"},{"c1":5,"c2":null}]"#;
 
@@ -85,12 +83,12 @@ fn nested_struct_with_validity() -> Result<()> {
     let c1 = StructArray::from_data(
         DataType::Struct(fields),
         vec![
-            Arc::new(Int32Array::from(&[Some(1), None, Some(5)])),
-            Arc::new(StructArray::from_data(
+            Box::new(Int32Array::from(&[Some(1), None, Some(5)])),
+            Box::new(StructArray::from_data(
                 DataType::Struct(inner),
                 vec![
-                    Arc::new(Utf8Array::<i32>::from(&vec![None, Some("f"), Some("g")])),
-                    Arc::new(Int32Array::from(&[Some(20), None, Some(43)])),
+                    Box::new(Utf8Array::<i32>::from(&vec![None, Some("f"), Some("g")])),
+                    Box::new(Int32Array::from(&[Some(20), None, Some(43)])),
                 ],
                 Some(Bitmap::from([false, true, true])),
             )),
@@ -103,7 +101,7 @@ fn nested_struct_with_validity() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Arc::new(c1) as _, Arc::new(c2)], None);
+    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
 
     let expected = r#"[{"c1":{"c11":1,"c12":null},"c2":"a"},{"c1":{"c11":null,"c12":{"c121":"f","c122":null}},"c2":"b"},{"c1":null,"c2":"c"}]"#;
 
@@ -121,10 +119,10 @@ fn nested_struct() -> Result<()> {
     let c1 = StructArray::from_data(
         DataType::Struct(fields),
         vec![
-            Arc::new(Int32Array::from(&[Some(1), None, Some(5)])),
-            Arc::new(StructArray::from_data(
+            Box::new(Int32Array::from(&[Some(1), None, Some(5)])),
+            Box::new(StructArray::from_data(
                 DataType::Struct(vec![c121]),
-                vec![Arc::new(Utf8Array::<i32>::from(&vec![
+                vec![Box::new(Utf8Array::<i32>::from(&vec![
                     Some("e"),
                     Some("f"),
                     Some("g"),
@@ -141,7 +139,7 @@ fn nested_struct() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Arc::new(c1) as _, Arc::new(c2)], None);
+    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
 
     let expected = r#"[{"c1":{"c11":1,"c12":{"c121":"e"}},"c2":"a"},{"c1":{"c11":null,"c12":{"c121":"f"}},"c2":"b"},{"c1":{"c11":5,"c12":{"c121":"g"}},"c2":"c"}]"#;
 
@@ -170,7 +168,7 @@ fn struct_with_list_field() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Arc::new(c1) as _, Arc::new(c2)], None);
+    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
 
     let expected = r#"[{"c1":["a","a1"],"c2":1},{"c1":["b"],"c2":2},{"c1":["c"],"c2":3},{"c1":["d"],"c2":4},{"c1":["e"],"c2":5}]"#;
 
@@ -205,7 +203,7 @@ fn nested_list() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Arc::new(c1) as _, Arc::new(c2)], None);
+    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
 
     let expected =
         r#"[{"c1":[[1,2],[3]],"c2":"foo"},{"c1":[],"c2":"bar"},{"c1":[[4,5,6]],"c2":null}]"#;
@@ -229,10 +227,10 @@ fn list_of_struct() -> Result<()> {
     let s = StructArray::from_data(
         DataType::Struct(fields),
         vec![
-            Arc::new(Int32Array::from(&[Some(1), None, Some(5)])),
-            Arc::new(StructArray::from_data(
+            Box::new(Int32Array::from(&[Some(1), None, Some(5)])),
+            Box::new(StructArray::from_data(
                 DataType::Struct(inner),
-                vec![Arc::new(Utf8Array::<i32>::from(&vec![
+                vec![Box::new(Utf8Array::<i32>::from(&vec![
                     Some("e"),
                     Some("f"),
                     Some("g"),
@@ -250,7 +248,7 @@ fn list_of_struct() -> Result<()> {
     let c1 = ListArray::<i32>::from_data(
         c1_datatype,
         Buffer::from(vec![0, 2, 2, 3]),
-        Arc::new(s),
+        Box::new(s),
         Some(Bitmap::from_u8_slice([0b00000101], 3)),
     );
 
@@ -260,7 +258,7 @@ fn list_of_struct() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Arc::new(c1) as _, Arc::new(c2)], None);
+    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
 
     let expected = r#"[{"c1":[{"c11":1,"c12":null},{"c11":null,"c12":{"c121":"f"}}],"c2":1},{"c1":null,"c2":2},{"c1":[null],"c2":3}]"#;
 

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -1,5 +1,4 @@
 use std::io::{Cursor, Read, Seek};
-use std::sync::Arc;
 
 use arrow2::{
     array::*, bitmap::Bitmap, buffer::Buffer, chunk::Chunk, datatypes::*, error::Result,
@@ -13,7 +12,7 @@ mod read_indexes;
 mod write;
 mod write_async;
 
-type ArrayStats = (Arc<dyn Array>, Statistics);
+type ArrayStats = (Box<dyn Array>, Statistics);
 
 pub fn read_column<R: Read + Seek>(mut reader: R, column: &str) -> Result<ArrayStats> {
     let metadata = read_metadata(&mut reader)?;
@@ -87,7 +86,7 @@ pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
                 Some(9),
                 Some(10),
             ])
-            .arced()
+            .boxed()
         }
         "list_int64_required" | "list_int64_optional_required" | "list_int64_required_required" => {
             // [[0, 1], None, [2, 0, 3], [4, 5, 6], [], [7, 8, 9], None, [10]]
@@ -105,7 +104,7 @@ pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
                 Some(9),
                 Some(10),
             ])
-            .arced()
+            .boxed()
         }
         "list_int16" => PrimitiveArray::<i16>::from(&[
             Some(0),
@@ -121,7 +120,7 @@ pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
             Some(9),
             Some(10),
         ])
-        .arced(),
+        .boxed(),
         "list_bool" => BooleanArray::from(&[
             Some(false),
             Some(true),
@@ -136,7 +135,7 @@ pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
             Some(false),
             Some(true),
         ])
-        .arced(),
+        .boxed(),
         /*
             string = [
                 ["Hello", "bbb"],
@@ -149,7 +148,7 @@ pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
                 [""],
             ]
         */
-        "list_utf8" => Arc::new(Utf8Array::<i32>::from(&[
+        "list_utf8" => Box::new(Utf8Array::<i32>::from(&[
             Some("Hello".to_string()),
             Some("bbb".to_string()),
             Some("aa".to_string()),
@@ -163,7 +162,7 @@ pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
             Some("bbb".to_string()),
             Some("".to_string()),
         ])),
-        "list_large_binary" => Arc::new(BinaryArray::<i64>::from(&[
+        "list_large_binary" => Box::new(BinaryArray::<i64>::from(&[
             Some(b"Hello".to_vec()),
             Some(b"bbb".to_vec()),
             Some(b"aa".to_vec()),
@@ -180,7 +179,7 @@ pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
         "list_nested_i64"
         | "list_nested_inner_required_i64"
         | "list_nested_inner_required_required_i64" => {
-            Arc::new(NullArray::from_data(DataType::Null, 1))
+            Box::new(NullArray::from_data(DataType::Null, 1))
         }
         other => unreachable!("{}", other),
     };
@@ -351,7 +350,7 @@ pub fn pyarrow_nullable(column: &str) -> Box<dyn Array> {
         "uint32" => Box::new(PrimitiveArray::<u32>::from(u32_values)),
         "int32_dict" => {
             let keys = PrimitiveArray::<i32>::from([Some(0), Some(1), None, Some(1)]);
-            let values = Arc::new(PrimitiveArray::<i32>::from_slice([10, 200]));
+            let values = Box::new(PrimitiveArray::<i32>::from_slice([10, 200]));
             Box::new(DictionaryArray::<i32>::from_data(keys, values))
         }
         "decimal_9" => {
@@ -432,7 +431,7 @@ pub fn pyarrow_nullable_statistics(column: &str) -> Statistics {
             max_value: Box::new(UInt32Array::from_slice([9])),
         },
         "int32_dict" => {
-            let new_dict = |array: Arc<dyn Array>| -> Box<dyn Array> {
+            let new_dict = |array: Box<dyn Array>| -> Box<dyn Array> {
                 Box::new(DictionaryArray::<i32>::from_data(
                     vec![Some(0)].into(),
                     array,
@@ -442,8 +441,8 @@ pub fn pyarrow_nullable_statistics(column: &str) -> Statistics {
             Statistics {
                 distinct_count: Count::Single(UInt64Array::from([None])),
                 null_count: Count::Single(UInt64Array::from([Some(0)])),
-                min_value: new_dict(Arc::new(Int32Array::from_slice([10]))),
-                max_value: new_dict(Arc::new(Int32Array::from_slice([200]))),
+                min_value: new_dict(Box::new(Int32Array::from_slice([10]))),
+                max_value: new_dict(Box::new(Int32Array::from_slice([200]))),
             }
         }
         "decimal_9" => Statistics {
@@ -555,7 +554,7 @@ pub fn pyarrow_required_statistics(column: &str) -> Statistics {
 }
 
 pub fn pyarrow_nested_nullable_statistics(column: &str) -> Statistics {
-    let new_list = |array: Arc<dyn Array>, nullable: bool| {
+    let new_list = |array: Box<dyn Array>, nullable: bool| {
         Box::new(ListArray::<i32>::new(
             DataType::List(Box::new(Field::new(
                 "item",
@@ -572,87 +571,69 @@ pub fn pyarrow_nested_nullable_statistics(column: &str) -> Statistics {
         "list_int16" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single(UInt64Array::from([Some(1)])),
-            min_value: new_list(Arc::new(Int16Array::from_slice([0])), true),
-            max_value: new_list(Arc::new(Int16Array::from_slice([10])), true),
+            min_value: new_list(Box::new(Int16Array::from_slice([0])), true),
+            max_value: new_list(Box::new(Int16Array::from_slice([10])), true),
         },
         "list_bool" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single(UInt64Array::from([Some(1)])),
-            min_value: new_list(Arc::new(BooleanArray::from_slice([false])), true),
-            max_value: new_list(Arc::new(BooleanArray::from_slice([true])), true),
+            min_value: new_list(Box::new(BooleanArray::from_slice([false])), true),
+            max_value: new_list(Box::new(BooleanArray::from_slice([true])), true),
         },
         "list_utf8" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single([Some(1)].into()),
-            min_value: new_list(Arc::new(Utf8Array::<i32>::from_slice([""])), true),
-            max_value: new_list(Arc::new(Utf8Array::<i32>::from_slice(["ccc"])), true),
+            min_value: new_list(Box::new(Utf8Array::<i32>::from_slice([""])), true),
+            max_value: new_list(Box::new(Utf8Array::<i32>::from_slice(["ccc"])), true),
         },
         "list_large_binary" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single([Some(1)].into()),
-            min_value: new_list(Arc::new(BinaryArray::<i64>::from_slice([b""])), true),
-            max_value: new_list(Arc::new(BinaryArray::<i64>::from_slice([b"ccc"])), true),
+            min_value: new_list(Box::new(BinaryArray::<i64>::from_slice([b""])), true),
+            max_value: new_list(Box::new(BinaryArray::<i64>::from_slice([b"ccc"])), true),
         },
         "list_int64" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single([Some(1)].into()),
-            min_value: new_list(Arc::new(Int64Array::from_slice([0])), true),
-            max_value: new_list(Arc::new(Int64Array::from_slice([10])), true),
+            min_value: new_list(Box::new(Int64Array::from_slice([0])), true),
+            max_value: new_list(Box::new(Int64Array::from_slice([10])), true),
         },
         "list_int64_required" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single([Some(1)].into()),
-            min_value: new_list(Arc::new(Int64Array::from_slice([0])), false),
-            max_value: new_list(Arc::new(Int64Array::from_slice([10])), false),
+            min_value: new_list(Box::new(Int64Array::from_slice([0])), false),
+            max_value: new_list(Box::new(Int64Array::from_slice([10])), false),
         },
         "list_int64_required_required" | "list_int64_optional_required" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single([Some(0)].into()),
-            min_value: new_list(Arc::new(Int64Array::from_slice([0])), false),
-            max_value: new_list(Arc::new(Int64Array::from_slice([10])), false),
+            min_value: new_list(Box::new(Int64Array::from_slice([0])), false),
+            max_value: new_list(Box::new(Int64Array::from_slice([10])), false),
         },
         "list_nested_i64" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single([Some(2)].into()),
-            min_value: new_list(
-                new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
-                true,
-            ),
-            max_value: new_list(
-                new_list(Arc::new(Int64Array::from_slice([10])), true).into(),
-                true,
-            ),
+            min_value: new_list(new_list(Box::new(Int64Array::from_slice([0])), true), true),
+            max_value: new_list(new_list(Box::new(Int64Array::from_slice([10])), true), true),
         },
         "list_nested_inner_required_required_i64" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single([Some(0)].into()),
-            min_value: new_list(
-                new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
-                true,
-            ),
-            max_value: new_list(
-                new_list(Arc::new(Int64Array::from_slice([10])), true).into(),
-                true,
-            ),
+            min_value: new_list(new_list(Box::new(Int64Array::from_slice([0])), true), true),
+            max_value: new_list(new_list(Box::new(Int64Array::from_slice([10])), true), true),
         },
         "list_nested_inner_required_i64" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single([Some(0)].into()),
-            min_value: new_list(
-                new_list(Arc::new(Int64Array::from_slice([0])), true).into(),
-                true,
-            ),
-            max_value: new_list(
-                new_list(Arc::new(Int64Array::from_slice([10])), true).into(),
-                true,
-            ),
+            min_value: new_list(new_list(Box::new(Int64Array::from_slice([0])), true), true),
+            max_value: new_list(new_list(Box::new(Int64Array::from_slice([10])), true), true),
         },
         other => todo!("{}", other),
     }
 }
 
 pub fn pyarrow_nested_edge_statistics(column: &str) -> Statistics {
-    let new_list = |array: Arc<dyn Array>| {
+    let new_list = |array: Box<dyn Array>| {
         Box::new(ListArray::<i32>::new(
             DataType::List(Box::new(Field::new(
                 "item",
@@ -669,14 +650,14 @@ pub fn pyarrow_nested_edge_statistics(column: &str) -> Statistics {
         "simple" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single(UInt64Array::from([Some(0)])),
-            min_value: new_list(Arc::new(Int64Array::from([Some(0)]))),
-            max_value: new_list(Arc::new(Int64Array::from([Some(1)]))),
+            min_value: new_list(Box::new(Int64Array::from([Some(0)]))),
+            max_value: new_list(Box::new(Int64Array::from([Some(1)]))),
         },
         "null" => Statistics {
             distinct_count: Count::Single(UInt64Array::from([None])),
             null_count: Count::Single(UInt64Array::from([Some(1)])),
-            min_value: new_list(Arc::new(Int64Array::from([None]))),
-            max_value: new_list(Arc::new(Int64Array::from([None]))),
+            min_value: new_list(Box::new(Int64Array::from([None]))),
+            max_value: new_list(Box::new(Int64Array::from([None]))),
         },
         _ => unreachable!(),
     }
@@ -695,7 +676,7 @@ pub fn pyarrow_struct(column: &str) -> Box<dyn Array> {
         Some(true),
         Some(true),
     ];
-    let boolean = BooleanArray::from(boolean).arced();
+    let boolean = BooleanArray::from(boolean).boxed();
     let fields = vec![
         Field::new("f1", DataType::Utf8, true),
         Field::new("f2", DataType::Boolean, true),
@@ -714,15 +695,11 @@ pub fn pyarrow_struct(column: &str) -> Box<dyn Array> {
                 Some("def"),
                 Some("aaa"),
             ];
-            let values = vec![Utf8Array::<i32>::from(string).arced(), boolean];
-            Box::new(StructArray::from_data(
-                DataType::Struct(fields),
-                values,
-                None,
-            ))
+            let values = vec![Utf8Array::<i32>::from(string).boxed(), boolean];
+            StructArray::from_data(DataType::Struct(fields), values, None).boxed()
         }
         "struct_struct" => {
-            let struct_ = pyarrow_struct("struct").into();
+            let struct_ = pyarrow_struct("struct");
             let values = vec![struct_, boolean];
             Box::new(StructArray::from_data(
                 DataType::Struct(vec![
@@ -738,7 +715,7 @@ pub fn pyarrow_struct(column: &str) -> Box<dyn Array> {
 }
 
 pub fn pyarrow_struct_statistics(column: &str) -> Statistics {
-    let new_struct = |arrays: Vec<Arc<dyn Array>>, names: Vec<String>| {
+    let new_struct = |arrays: Vec<Box<dyn Array>>, names: Vec<String>| {
         let fields = names
             .into_iter()
             .zip(arrays.iter())
@@ -753,29 +730,29 @@ pub fn pyarrow_struct_statistics(column: &str) -> Statistics {
         "struct" => Statistics {
             distinct_count: Count::Struct(new_struct(
                 vec![
-                    Arc::new(UInt64Array::from([None])),
-                    Arc::new(UInt64Array::from([None])),
+                    Box::new(UInt64Array::from([None])),
+                    Box::new(UInt64Array::from([None])),
                 ],
                 names.clone(),
             )),
             null_count: Count::Struct(new_struct(
                 vec![
-                    Arc::new(UInt64Array::from([Some(4)])),
-                    Arc::new(UInt64Array::from([Some(4)])),
+                    Box::new(UInt64Array::from([Some(4)])),
+                    Box::new(UInt64Array::from([Some(4)])),
                 ],
                 names.clone(),
             )),
             min_value: Box::new(new_struct(
                 vec![
-                    Arc::new(Utf8Array::<i32>::from_slice([""])),
-                    Arc::new(BooleanArray::from_slice([false])),
+                    Box::new(Utf8Array::<i32>::from_slice([""])),
+                    Box::new(BooleanArray::from_slice([false])),
                 ],
                 names.clone(),
             )),
             max_value: Box::new(new_struct(
                 vec![
-                    Arc::new(Utf8Array::<i32>::from_slice(["def"])),
-                    Arc::new(BooleanArray::from_slice([true])),
+                    Box::new(Utf8Array::<i32>::from_slice(["def"])),
+                    Box::new(BooleanArray::from_slice([true])),
                 ],
                 names,
             )),
@@ -805,13 +782,13 @@ pub fn pyarrow_map(column: &str) -> Box<dyn Array> {
                 StructArray::try_new(
                     dt,
                     vec![
-                        Utf8Array::<i32>::from(s1).arced(),
-                        Utf8Array::<i32>::from(s2).arced(),
+                        Utf8Array::<i32>::from(s1).boxed(),
+                        Utf8Array::<i32>::from(s2).boxed(),
                     ],
                     None,
                 )
                 .unwrap()
-                .arced(),
+                .boxed(),
                 None,
             )
             .unwrap()
@@ -830,13 +807,13 @@ pub fn pyarrow_map(column: &str) -> Box<dyn Array> {
                 StructArray::try_new(
                     dt,
                     vec![
-                        Utf8Array::<i32>::from(s1).arced(),
-                        Utf8Array::<i32>::from(s2).arced(),
+                        Utf8Array::<i32>::from(s1).boxed(),
+                        Utf8Array::<i32>::from(s2).boxed(),
                     ],
                     None,
                 )
                 .unwrap()
-                .arced(),
+                .boxed(),
                 None,
             )
             .unwrap()
@@ -847,7 +824,7 @@ pub fn pyarrow_map(column: &str) -> Box<dyn Array> {
 }
 
 pub fn pyarrow_map_statistics(column: &str) -> Statistics {
-    let new_map = |arrays: Vec<Arc<dyn Array>>, names: Vec<String>| {
+    let new_map = |arrays: Vec<Box<dyn Array>>, names: Vec<String>| {
         let fields = names
             .into_iter()
             .zip(arrays.iter())
@@ -859,7 +836,7 @@ pub fn pyarrow_map_statistics(column: &str) -> Statistics {
                 false,
             ),
             vec![0, arrays[0].len() as i32].into(),
-            StructArray::new(DataType::Struct(fields), arrays, None).arced(),
+            StructArray::new(DataType::Struct(fields), arrays, None).boxed(),
             None,
         )
     };
@@ -870,29 +847,29 @@ pub fn pyarrow_map_statistics(column: &str) -> Statistics {
         "map" => Statistics {
             distinct_count: Count::Map(new_map(
                 vec![
-                    Arc::new(UInt64Array::from([None])),
-                    Arc::new(UInt64Array::from([None])),
+                    UInt64Array::from([None]).boxed(),
+                    UInt64Array::from([None]).boxed(),
                 ],
                 names.clone(),
             )),
             null_count: Count::Map(new_map(
                 vec![
-                    Arc::new(UInt64Array::from([Some(0)])),
-                    Arc::new(UInt64Array::from([Some(0)])),
+                    UInt64Array::from([Some(0)]).boxed(),
+                    UInt64Array::from([Some(0)]).boxed(),
                 ],
                 names.clone(),
             )),
             min_value: Box::new(new_map(
                 vec![
-                    Arc::new(Utf8Array::<i32>::from_slice(["a1"])),
-                    Arc::new(Utf8Array::<i32>::from_slice(["b1"])),
+                    Utf8Array::<i32>::from_slice(["a1"]).boxed(),
+                    Utf8Array::<i32>::from_slice(["b1"]).boxed(),
                 ],
                 names.clone(),
             )),
             max_value: Box::new(new_map(
                 vec![
-                    Arc::new(Utf8Array::<i32>::from_slice(["a2"])),
-                    Arc::new(Utf8Array::<i32>::from_slice(["b2"])),
+                    Utf8Array::<i32>::from_slice(["a2"]).boxed(),
+                    Utf8Array::<i32>::from_slice(["b2"]).boxed(),
                 ],
                 names,
             )),
@@ -900,29 +877,29 @@ pub fn pyarrow_map_statistics(column: &str) -> Statistics {
         "map_nullable" => Statistics {
             distinct_count: Count::Map(new_map(
                 vec![
-                    Arc::new(UInt64Array::from([None])),
-                    Arc::new(UInt64Array::from([None])),
+                    UInt64Array::from([None]).boxed(),
+                    UInt64Array::from([None]).boxed(),
                 ],
                 names.clone(),
             )),
             null_count: Count::Map(new_map(
                 vec![
-                    Arc::new(UInt64Array::from([Some(0)])),
-                    Arc::new(UInt64Array::from([Some(1)])),
+                    UInt64Array::from([Some(0)]).boxed(),
+                    UInt64Array::from([Some(1)]).boxed(),
                 ],
                 names.clone(),
             )),
             min_value: Box::new(new_map(
                 vec![
-                    Arc::new(Utf8Array::<i32>::from_slice(["a1"])),
-                    Arc::new(Utf8Array::<i32>::from_slice(["b1"])),
+                    Utf8Array::<i32>::from_slice(["a1"]).boxed(),
+                    Utf8Array::<i32>::from_slice(["b1"]).boxed(),
                 ],
                 names.clone(),
             )),
             max_value: Box::new(new_map(
                 vec![
-                    Arc::new(Utf8Array::<i32>::from_slice(["a2"])),
-                    Arc::new(Utf8Array::<i32>::from_slice(["b1"])),
+                    Utf8Array::<i32>::from_slice(["a2"]).boxed(),
+                    Utf8Array::<i32>::from_slice(["b1"]).boxed(),
                 ],
                 names,
             )),
@@ -931,7 +908,7 @@ pub fn pyarrow_map_statistics(column: &str) -> Statistics {
     }
 }
 
-fn integration_write(schema: &Schema, batches: &[Chunk<Arc<dyn Array>>]) -> Result<Vec<u8>> {
+fn integration_write(schema: &Schema, batches: &[Chunk<Box<dyn Array>>]) -> Result<Vec<u8>> {
     let options = WriteOptions {
         write_statistics: true,
         compression: CompressionOptions::Uncompressed,
@@ -965,7 +942,7 @@ fn integration_write(schema: &Schema, batches: &[Chunk<Arc<dyn Array>>]) -> Resu
     Ok(writer.into_inner().into_inner())
 }
 
-type IntegrationRead = (Schema, Vec<Chunk<Arc<dyn Array>>>);
+type IntegrationRead = (Schema, Vec<Chunk<Box<dyn Array>>>);
 
 fn integration_read(data: &[u8]) -> Result<IntegrationRead> {
     let reader = Cursor::new(data);
@@ -991,17 +968,17 @@ fn arrow_type() -> Result<()> {
 
     let indices = PrimitiveArray::from_values((0..3u64).map(|x| x % 2));
     let values = PrimitiveArray::from_slice([1.0f32, 3.0]);
-    let array3 = DictionaryArray::from_data(indices.clone(), std::sync::Arc::new(values));
+    let array3 = DictionaryArray::from_data(indices.clone(), Box::new(values));
 
     let values = BinaryArray::<i32>::from_slice([b"ab", b"ac"]);
-    let array4 = DictionaryArray::from_data(indices.clone(), std::sync::Arc::new(values));
+    let array4 = DictionaryArray::from_data(indices.clone(), Box::new(values));
 
     let values = FixedSizeBinaryArray::from_data(
         DataType::FixedSizeBinary(2),
         vec![b'a', b'b', b'a', b'c'].into(),
         None,
     );
-    let array5 = DictionaryArray::from_data(indices, std::sync::Arc::new(values));
+    let array5 = DictionaryArray::from_data(indices, Box::new(values));
 
     let schema = Schema::from(vec![
         Field::new("a1", dt1, true),
@@ -1012,12 +989,12 @@ fn arrow_type() -> Result<()> {
         Field::new("a6", array5.data_type().clone(), false),
     ]);
     let batch = Chunk::try_new(vec![
-        array.arced(),
-        Arc::new(array2),
-        Arc::new(array3),
-        Arc::new(array4),
-        Arc::new(array5.clone()),
-        Arc::new(array5),
+        array.boxed(),
+        array2.boxed(),
+        array3.boxed(),
+        array4.boxed(),
+        array5.clone().boxed(),
+        array5.boxed(),
     ])?;
 
     let r = integration_write(&schema, &[batch.clone()])?;
@@ -1057,7 +1034,7 @@ fn list_array_generic(inner_is_nullable: bool, is_nullable: bool) -> Result<()> 
         array.data_type().clone(),
         is_nullable,
     )]);
-    let batch = Chunk::try_new(vec![array.arced()])?;
+    let batch = Chunk::try_new(vec![array.boxed()])?;
 
     let r = integration_write(&schema, &[batch.clone()])?;
 

--- a/tests/it/io/parquet/write.rs
+++ b/tests/it/io/parquet/write.rs
@@ -28,7 +28,6 @@ fn round_trip(
         "struct" => (pyarrow_struct(column), pyarrow_struct_statistics(column)),
         _ => unreachable!(),
     };
-    let array: Arc<dyn Array> = array.into();
 
     let field = Field::new("a1", array.data_type().clone(), true);
     let schema = Schema::from(vec![field]);

--- a/tests/it/io/parquet/write_async.rs
+++ b/tests/it/io/parquet/write_async.rs
@@ -20,7 +20,7 @@ async fn test_parquet_async_roundtrip() {
     for i in 0..5 {
         let a1 = Int32Array::from(&[Some(i), None, Some(i + 1)]);
         let a2 = Float32Array::from(&[None, Some(i as f32), None]);
-        let chunk = Chunk::new(vec![a1.arced(), a2.arced()]);
+        let chunk = Chunk::new(vec![a1.boxed(), a2.boxed()]);
         data.push(chunk);
     }
     let schema = Schema::from(vec![

--- a/tests/it/io/print.rs
+++ b/tests/it/io/print.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::{
     array::*,
     bitmap::Bitmap,
@@ -99,7 +97,7 @@ fn write_dictionary() -> Result<()> {
 fn dictionary_validities() -> Result<()> {
     let keys = PrimitiveArray::<i32>::from([Some(1), None, Some(0)]);
     let values = PrimitiveArray::<i32>::from([None, Some(10)]);
-    let array = DictionaryArray::<i32>::from_data(keys, Arc::new(values));
+    let array = DictionaryArray::<i32>::from_data(keys, Box::new(values));
 
     let columns = Chunk::new(vec![&array as &dyn Array]);
 
@@ -323,8 +321,8 @@ fn write_struct() -> Result<()> {
         Field::new("b", DataType::Utf8, true),
     ];
     let values = vec![
-        Int32Array::from(&[Some(1), None, Some(2)]).arced(),
-        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).arced(),
+        Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
+        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).boxed(),
     ];
 
     let validity = Some(Bitmap::from(&[true, false, true]));
@@ -361,8 +359,8 @@ fn write_union() -> Result<()> {
     let data_type = DataType::Union(fields, None, UnionMode::Sparse);
     let types = Buffer::from(vec![0, 0, 1]);
     let fields = vec![
-        Int32Array::from(&[Some(1), None, Some(2)]).arced(),
-        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).arced(),
+        Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
+        Utf8Array::<i32>::from(&[Some("a"), Some("b"), Some("c")]).boxed(),
     ];
 
     let array = UnionArray::from_data(data_type, types, fields, None);

--- a/tests/it/scalar/fixed_size_list.rs
+++ b/tests/it/scalar/fixed_size_list.rs
@@ -10,7 +10,7 @@ fn equal() {
     let dt = DataType::FixedSizeList(Box::new(Field::new("a", DataType::Boolean, true)), 2);
     let a = FixedSizeListScalar::new(
         dt.clone(),
-        Some(BooleanArray::from_slice([true, false]).arced()),
+        Some(BooleanArray::from_slice([true, false]).boxed()),
     );
 
     let b = FixedSizeListScalar::new(dt.clone(), None);
@@ -19,7 +19,7 @@ fn equal() {
     assert_eq!(b, b);
     assert!(a != b);
 
-    let b = FixedSizeListScalar::new(dt, Some(BooleanArray::from_slice([true, true]).arced()));
+    let b = FixedSizeListScalar::new(dt, Some(BooleanArray::from_slice([true, true]).boxed()));
     assert!(a != b);
     assert_eq!(b, b);
 }
@@ -29,7 +29,7 @@ fn basics() {
     let dt = DataType::FixedSizeList(Box::new(Field::new("a", DataType::Boolean, true)), 2);
     let a = FixedSizeListScalar::new(
         dt.clone(),
-        Some(BooleanArray::from_slice([true, false]).arced()),
+        Some(BooleanArray::from_slice([true, false]).boxed()),
     );
 
     assert_eq!(

--- a/tests/it/scalar/list.rs
+++ b/tests/it/scalar/list.rs
@@ -10,13 +10,13 @@ fn equal() {
     let dt = DataType::List(Box::new(Field::new("a", DataType::Boolean, true)));
     let a = ListScalar::<i32>::new(
         dt.clone(),
-        Some(BooleanArray::from_slice([true, false]).arced()),
+        Some(BooleanArray::from_slice([true, false]).boxed()),
     );
     let b = ListScalar::<i32>::new(dt.clone(), None);
     assert_eq!(a, a);
     assert_eq!(b, b);
     assert!(a != b);
-    let b = ListScalar::<i32>::new(dt, Some(BooleanArray::from_slice([true, true]).arced()));
+    let b = ListScalar::<i32>::new(dt, Some(BooleanArray::from_slice([true, true]).boxed()));
     assert!(a != b);
     assert_eq!(b, b);
 }
@@ -26,7 +26,7 @@ fn basics() {
     let dt = DataType::List(Box::new(Field::new("a", DataType::Boolean, true)));
     let a = ListScalar::<i32>::new(
         dt.clone(),
-        Some(BooleanArray::from_slice([true, false]).arced()),
+        Some(BooleanArray::from_slice([true, false]).boxed()),
     );
 
     assert_eq!(BooleanArray::from_slice([true, false]), a.values().as_ref());

--- a/tests/it/scalar/mod.rs
+++ b/tests/it/scalar/mod.rs
@@ -11,5 +11,5 @@ mod utf8;
 // check that `PartialEq` can be derived
 #[derive(PartialEq)]
 struct A {
-    array: std::sync::Arc<dyn arrow2::scalar::Scalar>,
+    array: Box<dyn arrow2::scalar::Scalar>,
 }

--- a/tests/it/scalar/struct_.rs
+++ b/tests/it/scalar/struct_.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use arrow2::{
     datatypes::{DataType, Field},
     scalar::{BooleanScalar, Scalar, StructScalar},
@@ -12,7 +10,7 @@ fn equal() {
     let a = StructScalar::new(
         dt.clone(),
         Some(vec![
-            Arc::new(BooleanScalar::from(Some(true))) as Arc<dyn Scalar>
+            Box::new(BooleanScalar::from(Some(true))) as Box<dyn Scalar>
         ]),
     );
     let b = StructScalar::new(dt.clone(), None);
@@ -22,7 +20,7 @@ fn equal() {
     let b = StructScalar::new(
         dt,
         Some(vec![
-            Arc::new(BooleanScalar::from(Some(false))) as Arc<dyn Scalar>
+            Box::new(BooleanScalar::from(Some(false))) as Box<dyn Scalar>
         ]),
     );
     assert!(a != b);
@@ -33,7 +31,7 @@ fn equal() {
 fn basics() {
     let dt = DataType::Struct(vec![Field::new("a", DataType::Boolean, true)]);
 
-    let values = vec![Arc::new(BooleanScalar::from(Some(true))) as Arc<dyn Scalar>];
+    let values = vec![Box::new(BooleanScalar::from(Some(true))) as Box<dyn Scalar>];
 
     let a = StructScalar::new(dt.clone(), Some(values.clone()));
 


### PR DESCRIPTION
This PR is a backward incompatible change to extend the support for clone-on-write semantics
initially added by @ritchie46 on #794 to arrays.

The migration is simple - replace `Arc<dyn Array>` by `Box<dyn Array>`.

# Background

`Arc` main goal is to enable sharing of data, typically because cloning is expensive. The tradeoff is that `Arc`s usually represent immutable data.

All our arrays are quite small structs. Their underlying data is usually a `DataType` and one or two `Arc`s that store the data itself.

Thus, `Arc`ing `Array` does not add much value. OTOH, it makes the API clumsy, since we need to remember to arc everything. It also aludes users to the immutable nature of the Array. Furthermore, it makes it challenging to offer a good support for clone-on-write semantics to arrays since we need to check if the array is being shared, and clone its internals if yes.

Currently,
* all our nested/child arrays are stored as `Arc<dyn Array>`
* all our IO interfaces, including FFI, received and output an `Arc<dyn Array>`

My understanding is that there three main reasons for us to be in this situation:

1. Rust support for cloning `Box<dyn T>` where `T: Clone` is not great - it is essentially not possible in `std`.
2. historically `arrow-rs` used to store everything under `Arc` (e.g. `ArrayData`, `Array`, data itself).
3. The C++ implementation, which `arrow-rs` is inspired on, seems to use `Arc` (`shared_ptr`)

# This PR

This PR makes
* child arrays to be `Box<dyn Array>` instead of `Arc<dyn Array>`
* all IO consume and return `Box<dyn Array>` instead of `Arc<dyn Array>`

The major benefit of this behavior is that it makes it quite easy to add first class support clone-on-write semantics to the different Array APIs. As an example, with this PR we can now more easily:

* read a primitive array from parquet (`Box<dyn Array>`)
* evaluate a complex runtime expression on it (e.g. `((a * 10) + 2) * exp(-10 * a))`) without any extra allocation

This PR also adds an example illustrating how the API is used.