### PR TITLE
Fixed using lower limit than size of first parquet row group

### DIFF
--- a/src/io/parquet/read/file.rs
+++ b/src/io/parquet/read/file.rs
@@ -80,7 +80,7 @@ impl<R: Read + Seek> FileReader<R> {
             metadata: schema_metadata,
         };
 
-        let row_groups = RowGroupReader::new(
+        let mut row_groups = RowGroupReader::new(
             reader,
             schema,
             groups_filter,
@@ -88,12 +88,13 @@ impl<R: Read + Seek> FileReader<R> {
             chunk_size,
             limit,
         );
+        let current_row_group = row_groups.next().transpose()?;
 
         Ok(Self {
             row_groups,
             metadata,
             remaining_rows: limit.unwrap_or(usize::MAX),
-            current_row_group: None,
+            current_row_group,
         })
     }
 

--- a/src/io/parquet/read/row_group.rs
+++ b/src/io/parquet/read/row_group.rs
@@ -78,10 +78,11 @@ impl Iterator for RowGroupDeserializer {
             })
             .collect::<Result<Vec<_>>>()
             .map(Chunk::new);
-        self.remaining_rows -= chunk
+        self.remaining_rows = self.remaining_rows.saturating_sub(chunk
             .as_ref()
             .map(|x| x.len())
-            .unwrap_or(self.remaining_rows);
+            .unwrap_or(self.remaining_rows)
+        );
 
         Some(chunk)
     }

--- a/src/io/parquet/read/row_group.rs
+++ b/src/io/parquet/read/row_group.rs
@@ -78,10 +78,11 @@ impl Iterator for RowGroupDeserializer {
             })
             .collect::<Result<Vec<_>>>()
             .map(Chunk::new);
-        self.remaining_rows = self.remaining_rows.saturating_sub(chunk
-            .as_ref()
-            .map(|x| x.len())
-            .unwrap_or(self.remaining_rows)
+        self.remaining_rows = self.remaining_rows.saturating_sub(
+            chunk
+                .as_ref()
+                .map(|x| x.len())
+                .unwrap_or(self.remaining_rows),
         );
 
         Some(chunk)


### PR DESCRIPTION
If the first row-group of parquet data had more rows than the limit, no data would be returned even if the chunk size was available in that limit and first row group