### PR TITLE
Made `chunk_size` optional in parquet's `column_iter_to_arrays`

### DIFF
--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -423,12 +423,12 @@ pub struct Iter<O: Offset, A: TraitBinaryArray<O>, I: DataPages> {
     iter: I,
     data_type: DataType,
     items: VecDeque<(Binary<O>, MutableBitmap)>,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
     phantom_a: std::marker::PhantomData<A>,
 }
 
 impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> Iter<O, A, I> {
-    pub fn new(iter: I, data_type: DataType, chunk_size: usize) -> Self {
+    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>) -> Self {
         Self {
             iter,
             data_type,

--- a/src/io/parquet/read/deserialize/binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/binary/dictionary.rs
@@ -25,7 +25,7 @@ where
     data_type: DataType,
     values: Dict,
     items: VecDeque<(Vec<K>, MutableBitmap)>,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
     phantom: std::marker::PhantomData<O>,
 }
 
@@ -35,7 +35,7 @@ where
     O: Offset,
     I: DataPages,
 {
-    pub fn new(iter: I, data_type: DataType, chunk_size: usize) -> Self {
+    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>) -> Self {
         let data_type = match data_type {
             DataType::Dictionary(_, values, _) => values.as_ref().clone(),
             _ => unreachable!(),

--- a/src/io/parquet/read/deserialize/binary/mod.rs
+++ b/src/io/parquet/read/deserialize/binary/mod.rs
@@ -25,7 +25,7 @@ pub fn iter_to_arrays_nested<'a, O, A, I>(
     iter: I,
     init: Vec<InitNested>,
     data_type: DataType,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
 ) -> NestedArrayIter<'a>
 where
     I: 'a + DataPages,

--- a/src/io/parquet/read/deserialize/binary/nested.rs
+++ b/src/io/parquet/read/deserialize/binary/nested.rs
@@ -146,12 +146,17 @@ pub struct ArrayIterator<O: Offset, A: TraitBinaryArray<O>, I: DataPages> {
     init: Vec<InitNested>,
     items: VecDeque<(Binary<O>, MutableBitmap)>,
     nested: VecDeque<NestedState>,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
     phantom_a: std::marker::PhantomData<A>,
 }
 
 impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> ArrayIterator<O, A, I> {
-    pub fn new(iter: I, init: Vec<InitNested>, data_type: DataType, chunk_size: usize) -> Self {
+    pub fn new(
+        iter: I,
+        init: Vec<InitNested>,
+        data_type: DataType,
+        chunk_size: Option<usize>,
+    ) -> Self {
         Self {
             iter,
             data_type,

--- a/src/io/parquet/read/deserialize/boolean/basic.rs
+++ b/src/io/parquet/read/deserialize/boolean/basic.rs
@@ -188,11 +188,11 @@ pub struct Iter<I: DataPages> {
     iter: I,
     data_type: DataType,
     items: VecDeque<(MutableBitmap, MutableBitmap)>,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
 }
 
 impl<I: DataPages> Iter<I> {
-    pub fn new(iter: I, data_type: DataType, chunk_size: usize) -> Self {
+    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>) -> Self {
         Self {
             iter,
             data_type,

--- a/src/io/parquet/read/deserialize/boolean/mod.rs
+++ b/src/io/parquet/read/deserialize/boolean/mod.rs
@@ -13,7 +13,7 @@ pub use self::basic::Iter;
 pub fn iter_to_arrays_nested<'a, I: 'a>(
     iter: I,
     init: Vec<InitNested>,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
 ) -> NestedArrayIter<'a>
 where
     I: DataPages,

--- a/src/io/parquet/read/deserialize/boolean/nested.rs
+++ b/src/io/parquet/read/deserialize/boolean/nested.rs
@@ -118,11 +118,11 @@ pub struct ArrayIterator<I: DataPages> {
     // invariant: items.len() == nested.len()
     items: VecDeque<(MutableBitmap, MutableBitmap)>,
     nested: VecDeque<NestedState>,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
 }
 
 impl<I: DataPages> ArrayIterator<I> {
-    pub fn new(iter: I, init: Vec<InitNested>, chunk_size: usize) -> Self {
+    pub fn new(iter: I, init: Vec<InitNested>, chunk_size: Option<usize>) -> Self {
         Self {
             iter,
             init,

--- a/src/io/parquet/read/deserialize/dictionary.rs
+++ b/src/io/parquet/read/deserialize/dictionary.rs
@@ -216,7 +216,7 @@ pub(super) fn next_dict<
     iter: &'a mut I,
     items: &mut VecDeque<(Vec<K>, MutableBitmap)>,
     dict: &mut Dict,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
     read_dict: F,
 ) -> MaybeNext<Result<DictionaryArray<K>>> {
     if items.len() > 1 {
@@ -249,7 +249,7 @@ pub(super) fn next_dict<
 
             utils::extend_from_new_page(page, chunk_size, items, &PrimitiveDecoder::<K>::default());
 
-            if items.front().unwrap().len() < chunk_size {
+            if items.front().unwrap().len() < chunk_size.unwrap_or(usize::MAX) {
                 MaybeNext::More
             } else {
                 let (values, validity) = items.pop_front().unwrap();
@@ -262,7 +262,7 @@ pub(super) fn next_dict<
             if let Some((values, validity)) = items.pop_front() {
                 // we have a populated item and no more pages
                 // the only case where an item's length may be smaller than chunk_size
-                debug_assert!(values.len() <= chunk_size);
+                debug_assert!(values.len() <= chunk_size.unwrap_or(usize::MAX));
 
                 let keys = finish_key(values, validity);
 

--- a/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
@@ -289,11 +289,11 @@ pub struct Iter<I: DataPages> {
     data_type: DataType,
     size: usize,
     items: VecDeque<(FixedSizeBinary, MutableBitmap)>,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
 }
 
 impl<I: DataPages> Iter<I> {
-    pub fn new(iter: I, data_type: DataType, chunk_size: usize) -> Self {
+    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>) -> Self {
         let size = FixedSizeBinaryArray::get_size(&data_type);
         Self {
             iter,

--- a/src/io/parquet/read/deserialize/fixed_size_binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/dictionary.rs
@@ -24,7 +24,7 @@ where
     data_type: DataType,
     values: Dict,
     items: VecDeque<(Vec<K>, MutableBitmap)>,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
 }
 
 impl<K, I> DictIter<K, I>
@@ -32,7 +32,7 @@ where
     K: DictionaryKey,
     I: DataPages,
 {
-    pub fn new(iter: I, data_type: DataType, chunk_size: usize) -> Self {
+    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>) -> Self {
         let data_type = match data_type {
             DataType::Dictionary(_, values, _) => values.as_ref().clone(),
             _ => unreachable!(),

--- a/src/io/parquet/read/deserialize/null.rs
+++ b/src/io/parquet/read/deserialize/null.rs
@@ -3,7 +3,11 @@ use crate::{array::NullArray, datatypes::DataType};
 use super::super::{ArrayIter, DataPages};
 
 /// Converts [`DataPages`] to an [`Iterator`] of [`Array`]
-pub fn iter_to_arrays<'a, I>(mut iter: I, data_type: DataType, chunk_size: usize) -> ArrayIter<'a>
+pub fn iter_to_arrays<'a, I>(
+    mut iter: I,
+    data_type: DataType,
+    chunk_size: Option<usize>,
+) -> ArrayIter<'a>
 where
     I: 'a + DataPages,
 {
@@ -12,6 +16,8 @@ where
     while let Ok(Some(x)) = iter.next() {
         len += x.num_values()
     }
+
+    let chunk_size = chunk_size.unwrap_or(len);
 
     let complete_chunks = chunk_size / len;
     let remainder = chunk_size % len;

--- a/src/io/parquet/read/deserialize/primitive/basic.rs
+++ b/src/io/parquet/read/deserialize/primitive/basic.rs
@@ -296,7 +296,7 @@ where
     iter: I,
     data_type: DataType,
     items: VecDeque<(Vec<T>, MutableBitmap)>,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
     op: F,
     phantom: std::marker::PhantomData<P>,
 }
@@ -309,7 +309,7 @@ where
     P: ParquetNativeType,
     F: Copy + Fn(P) -> T,
 {
-    pub fn new(iter: I, data_type: DataType, chunk_size: usize, op: F) -> Self {
+    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>, op: F) -> Self {
         Self {
             iter,
             data_type,

--- a/src/io/parquet/read/deserialize/primitive/dictionary.rs
+++ b/src/io/parquet/read/deserialize/primitive/dictionary.rs
@@ -47,7 +47,7 @@ where
     data_type: DataType,
     values: Dict,
     items: VecDeque<(Vec<K>, MutableBitmap)>,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
     op: F,
     phantom: std::marker::PhantomData<P>,
 }
@@ -61,7 +61,7 @@ where
     P: ParquetNativeType,
     F: Copy + Fn(P) -> T,
 {
-    pub fn new(iter: I, data_type: DataType, chunk_size: usize, op: F) -> Self {
+    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>, op: F) -> Self {
         let data_type = match data_type {
             DataType::Dictionary(_, values, _) => *values,
             _ => data_type,

--- a/src/io/parquet/read/deserialize/primitive/mod.rs
+++ b/src/io/parquet/read/deserialize/primitive/mod.rs
@@ -16,7 +16,7 @@ pub fn iter_to_arrays_nested<'a, I, T, P, F>(
     iter: I,
     init: Vec<InitNested>,
     data_type: DataType,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
     op: F,
 ) -> NestedArrayIter<'a>
 where

--- a/src/io/parquet/read/deserialize/primitive/nested.rs
+++ b/src/io/parquet/read/deserialize/primitive/nested.rs
@@ -179,7 +179,7 @@ where
     // invariant: items.len() == nested.len()
     items: VecDeque<(Vec<T>, MutableBitmap)>,
     nested: VecDeque<NestedState>,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
     decoder: PrimitiveDecoder<T, P, F>,
 }
 
@@ -195,7 +195,7 @@ where
         iter: I,
         init: Vec<InitNested>,
         data_type: DataType,
-        chunk_size: usize,
+        chunk_size: Option<usize>,
         op: F,
     ) -> Self {
         Self {

--- a/src/io/parquet/read/deserialize/simple.rs
+++ b/src/io/parquet/read/deserialize/simple.rs
@@ -62,7 +62,7 @@ pub fn page_iter_to_arrays<'a, I: 'a + DataPages>(
     pages: I,
     type_: &PrimitiveType,
     data_type: DataType,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
 ) -> Result<ArrayIter<'a>> {
     use DataType::*;
 
@@ -232,7 +232,7 @@ fn timestamp<'a, I: 'a + DataPages>(
     physical_type: &PhysicalType,
     logical_type: &Option<PrimitiveLogicalType>,
     data_type: DataType,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
     time_unit: TimeUnit,
 ) -> Result<ArrayIter<'a>> {
     if physical_type == &PhysicalType::Int96 {
@@ -291,7 +291,7 @@ fn timestamp_dict<'a, K: DictionaryKey, I: 'a + DataPages>(
     physical_type: &PhysicalType,
     logical_type: &Option<PrimitiveLogicalType>,
     data_type: DataType,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
     time_unit: TimeUnit,
 ) -> Result<ArrayIter<'a>> {
     if physical_type == &PhysicalType::Int96 {
@@ -426,7 +426,7 @@ fn dict_read<'a, K: DictionaryKey, I: 'a + DataPages>(
     physical_type: &PhysicalType,
     logical_type: &Option<PrimitiveLogicalType>,
     data_type: DataType,
-    chunk_size: usize,
+    chunk_size: Option<usize>,
 ) -> Result<ArrayIter<'a>> {
     use DataType::*;
     let values_data_type = if let Dictionary(_, v, _) = &data_type {

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -22,11 +22,11 @@ pub use parquet2::{
     metadata::{ColumnChunkMetaData, ColumnDescriptor, RowGroupMetaData},
     page::{CompressedDataPage, DataPage, DataPageHeader},
     read::{
-        decompress, get_column_iterator, get_page_iterator as _get_page_iterator,
-        get_page_stream as _get_page_stream, read_columns_indexes as _read_columns_indexes,
-        read_metadata as _read_metadata, read_metadata_async as _read_metadata_async,
-        read_pages_locations, BasicDecompressor, ColumnChunkIter, Decompressor,
-        MutStreamingIterator, PageFilter, PageReader, ReadColumnIterator, State,
+        decompress, get_column_iterator, get_page_stream,
+        read_columns_indexes as _read_columns_indexes, read_metadata as _read_metadata,
+        read_metadata_async as _read_metadata_async, read_pages_locations, BasicDecompressor,
+        ColumnChunkIter, Decompressor, MutStreamingIterator, PageFilter, PageReader,
+        ReadColumnIterator, State,
     },
     schema::types::{
         GroupLogicalType, ParquetType, PhysicalType, PrimitiveConvertedType, PrimitiveLogicalType,

--- a/src/io/parquet/read/row_group.rs
+++ b/src/io/parquet/read/row_group.rs
@@ -196,7 +196,7 @@ pub fn to_deserializer<'a>(
         })
         .unzip();
 
-    column_iter_to_arrays(columns, types, field, chunk_size)
+    column_iter_to_arrays(columns, types, field, Some(chunk_size))
 }
 
 /// Returns a vector of iterators of [`Array`] ([`ArrayIter`]) corresponding to the top

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -125,7 +125,7 @@ fn read_with_indexes(
         vec![pages],
         vec![&c1.descriptor().descriptor.primitive_type],
         schema.fields[1].clone(),
-        row_group.num_rows() as usize,
+        Some(row_group.num_rows() as usize),
     )?;
 
     let arrays = arrays.collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
This allows reading incomplete column chunks, e.g. when the user wants to read page by page.