### PR TITLE
Added support to write parquet `_metadata` sidecar

### DIFF
--- a/src/io/parquet/write/file.rs
+++ b/src/io/parquet/write/file.rs
@@ -8,7 +8,7 @@ use parquet2::write::WriteOptions as FileWriteOptions;
 use crate::datatypes::Schema;
 use crate::error::{Error, Result};
 
-use super::{schema::schema_to_metadata_key, to_parquet_schema, WriteOptions};
+use super::{schema::schema_to_metadata_key, to_parquet_schema, ThriftFileMetaData, WriteOptions};
 
 /// Attaches [`Schema`] to `key_value_metadata`
 pub fn add_arrow_schema(
@@ -86,5 +86,12 @@ impl<W: Write> FileWriter<W> {
     /// Consumes this writer and returns the inner writer
     pub fn into_inner(self) -> W {
         self.writer.into_inner()
+    }
+
+    /// Returns the underlying writer and [`ThriftFileMetaData`]
+    /// # Panics
+    /// This function panics if [`Self::end`] has not yet been called
+    pub fn into_inner_and_metadata(self) -> (W, ThriftFileMetaData) {
+        self.writer.into_inner_and_metadata()
     }
 }

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -24,10 +24,13 @@ pub use parquet2::{
     compression::{BrotliLevel, CompressionLevel, CompressionOptions, GzipLevel, ZstdLevel},
     encoding::Encoding,
     fallible_streaming_iterator,
-    metadata::{Descriptor, KeyValue, SchemaDescriptor},
+    metadata::{Descriptor, FileMetaData, KeyValue, SchemaDescriptor, ThriftFileMetaData},
     page::{CompressedDataPage, CompressedPage, EncodedPage},
     schema::types::{FieldInfo, ParquetType, PhysicalType as ParquetPhysicalType},
-    write::{compress, Compressor, DynIter, DynStreamingIterator, RowGroupIter, Version},
+    write::{
+        compress, write_metadata_sidecar, Compressor, DynIter, DynStreamingIterator, RowGroupIter,
+        Version,
+    },
     FallibleStreamingIterator,
 };
 


### PR DESCRIPTION
This PR exposes parquet2's API to write partitioned parquet files' metadata on a sidecar, `_common_metadata` and `_metadata`. See https://github.com/jorgecarleitao/parquet2/issues/146 for context within `parquet2` and [pyarrow documentation](https://arrow.apache.org/docs/python/generated/pyarrow.parquet.write_to_dataset.html). Thanks to @kylebarron for the idea and thorough explanation!
