### PR TITLE
Improved performance in lexical write (~5%)

### DIFF
--- a/src/util/lexical.rs
+++ b/src/util/lexical.rs
@@ -22,8 +22,16 @@ pub fn lexical_to_bytes_mut<N: lexical_core::ToLexical>(n: N, buf: &mut Vec<u8>)
 
         //  Safety:
         //  Omits an unneeded bound check as we just ensured that we reserved `N::FORMATTED_SIZE_DECIMAL`
-        let len = lexical_core::write_unchecked(n, slice).len();
-        buf.set_len(len);
+        #[cfg(debug_assertions)]
+        {
+            let len = lexical_core::write(n, slice).len();
+            buf.set_len(len);
+        }
+        #[cfg(not(debug_assertions))]
+        {
+            let len = lexical_core::write_unchecked(n, slice).len();
+            buf.set_len(len);
+        }
     }
 }
 

--- a/src/util/lexical.rs
+++ b/src/util/lexical.rs
@@ -19,7 +19,10 @@ pub fn lexical_to_bytes_mut<N: lexical_core::ToLexical>(n: N, buf: &mut Vec<u8>)
         //      Length of buf is set as written length afterwards. lexical_core
         //      creates a valid string, so doesn't need to be checked.
         let slice = std::slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.capacity());
-        let len = lexical_core::write(n, slice).len();
+
+        //  Safety:
+        //  Omits an unneeded bound check as we just ensured that we reserved `N::FORMATTED_SIZE_DECIMAL`
+        let len = lexical_core::write_unchecked(n, slice).len();
         buf.set_len(len);
     }
 }


### PR DESCRIPTION
It might be interesting to explore a slightly adapted version of `BufStreamingIterator`.

If I am correct it currently writes to an internal buffer, and then copies that buffer to the `W: Write` buffer. If we would accept that final buffer in the `next()` method as argument, we could directly write to that.

Will explore that idea later.