### PR TITLE
Expose share counts in `Buffer`

### DIFF
--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -168,6 +168,16 @@ impl<T: NativeType> Buffer<T> {
             Either::Right(data) => data,
         }
     }
+
+    /// Get the strong count of underlying `Arc` data buffer.
+    pub fn shared_count_strong(&self) -> usize {
+        Arc::strong_count(&self.data)
+    }
+
+    /// Get the weak count of underlying `Arc` data buffer.
+    pub fn shared_count_weak(&self) -> usize {
+        Arc::weak_count(&self.data)
+    }
 }
 
 impl<T: NativeType> From<Vec<T>> for Buffer<T> {


### PR DESCRIPTION
For polars extension types' dark unsafe magic I need to know how often underlying data is shared. This was possible when we `Arc`ed the arrays.

This exposes a method to get the shared count of the `Buffer`'s data.