### PR TITLE
implement default for PrimitiveArray

### DIFF
--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -511,3 +511,9 @@ pub type UInt16Vec = MutablePrimitiveArray<u16>;
 pub type UInt32Vec = MutablePrimitiveArray<u32>;
 /// A type definition [`MutablePrimitiveArray`] for `u64`
 pub type UInt64Vec = MutablePrimitiveArray<u64>;
+
+impl<T: NativeType> Default for PrimitiveArray<T> {
+    fn default() -> Self {
+        PrimitiveArray::new(DataType::Null, vec![].into(), None)
+    }
+}


### PR DESCRIPTION
When dealing with mutable access, which we are improving currently. It is often ergonomic to use `std::mem::take` to take ownership of a value. When `Default` is implemented, something cheap is put in the original place.

This PR adds a `Default` impl for `PrimitiveArray` that does not allocate.