### PR TITLE
Panic-free read of IPC files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,8 @@ tokio-util = { version = "0.6", features = ["compat"] }
 # used to run formal property testing
 proptest = { version = "1", default_features = false, features = ["std"] }
 avro-rs = { version = "0.13", features = ["snappy"] }
+# use for flaky testing
+rand = "0.8"
 
 [package.metadata.docs.rs]
 features = ["full"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ indexmap = { version = "^1.6", optional = true }
 # used to print columns in a nice columnar format
 comfy-table = { version = "5.0", optional = true, default-features = false }
 
-arrow-format = { version = "0.6", optional = true, features = ["ipc"] }
+arrow-format = { version = "0.7", optional = true, features = ["ipc"] }
 
 hex = { version = "^0.4", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ Reading from untrusted data currently _may_ `panic!` on the following formats:
 
 * parquet
 * avro
-* Arrow IPC streams
-* compressed Arrow IPC files and streams
 
 We are actively addressing this.
 

--- a/README.md
+++ b/README.md
@@ -69,8 +69,14 @@ Most uses of `unsafe` fall into 3 categories:
 We actively monitor for vulnerabilities in Rust's advisory and either patch or mitigate
 them (see e.g. `.cargo/audit.yaml` and `.github/workflows/security.yaml`).
 
-Reading parquet and IPC currently `panic!` when they receive invalid. We are 
-actively addressing this.
+Reading from untrusted data currently _may_ `panic!` on the following formats:
+
+* parquet
+* avro
+* Arrow IPC streams
+* compressed Arrow IPC files and streams
+
+We are actively addressing this.
 
 ## Integration tests
 

--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -29,7 +29,7 @@ logging = ["tracing-subscriber"]
 
 [dependencies]
 arrow2 = { path = "../", features = ["io_ipc", "io_ipc_compression", "io_flight", "io_json_integration"] }
-arrow-format = { version = "0.6", features = ["full"] }
+arrow-format = { version = "0.7", features = ["full"] }
 async-trait = "0.1.41"
 clap = { version = "^3", features = ["derive"] }
 futures = "0.3"

--- a/integration-testing/src/flight_client_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_client_scenarios/integration_test.rs
@@ -274,8 +274,9 @@ async fn receive_batch_flight_data(
         .expect("Header to be valid flatbuffers")
         .expect("Header to be present")
     {
+        let length = data.data_body.len();
         let mut reader = std::io::Cursor::new(&data.data_body);
-        read::read_dictionary(batch, fields, ipc_schema, dictionaries, &mut reader, 0)
+        read::read_dictionary(batch, fields, ipc_schema, dictionaries, &mut reader, 0, length as u64)
             .expect("Error reading dictionary");
 
         data = resp.next().await?.ok()?;

--- a/integration-testing/src/flight_server_scenarios/integration_test.rs
+++ b/integration-testing/src/flight_server_scenarios/integration_test.rs
@@ -283,6 +283,7 @@ async fn record_batch_from_message(
     ipc_schema: &IpcSchema,
     dictionaries: &mut Dictionaries,
 ) -> Result<Chunk<Box<dyn Array>>, Status> {
+    let length = data_body.len();
     let mut reader = std::io::Cursor::new(data_body);
 
     let arrow_batch_result = ipc::read::read_record_batch(
@@ -294,6 +295,7 @@ async fn record_batch_from_message(
         arrow_format::ipc::MetadataVersion::V5,
         &mut reader,
         0,
+        length as u64,
     );
 
     arrow_batch_result.map_err(|e| Status::internal(format!("Could not convert to Chunk: {:?}", e)))
@@ -306,10 +308,11 @@ async fn dictionary_from_message(
     ipc_schema: &IpcSchema,
     dictionaries: &mut Dictionaries,
 ) -> Result<(), Status> {
+    let length = data_body.len();
     let mut reader = std::io::Cursor::new(data_body);
 
     let dictionary_batch_result =
-        ipc::read::read_dictionary(dict_batch, fields, ipc_schema, dictionaries, &mut reader, 0);
+        ipc::read::read_dictionary(dict_batch, fields, ipc_schema, dictionaries, &mut reader, 0, length as u64);
     dictionary_batch_result
         .map_err(|e| Status::internal(format!("Could not convert to Dictionary: {:?}", e)))
 }

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -228,7 +228,12 @@ impl FixedSizeBinaryArray {
 impl FixedSizeBinaryArray {
     pub(crate) fn maybe_get_size(data_type: &DataType) -> Result<usize, Error> {
         match data_type.to_logical_type() {
-            DataType::FixedSizeBinary(size) => Ok(*size),
+            DataType::FixedSizeBinary(size) => {
+                if *size == 0 {
+                    return Err(Error::oos("FixedSizeBinaryArray expects a positive size"));
+                }
+                Ok(*size)
+            }
             _ => Err(Error::oos(
                 "FixedSizeBinaryArray expects DataType::FixedSizeBinary",
             )),

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -213,7 +213,12 @@ impl FixedSizeListArray {
 impl FixedSizeListArray {
     pub(crate) fn try_child_and_size(data_type: &DataType) -> Result<(&Field, usize), Error> {
         match data_type.to_logical_type() {
-            DataType::FixedSizeList(child, size) => Ok((child.as_ref(), *size as usize)),
+            DataType::FixedSizeList(child, size) => {
+                if *size == 0 {
+                    return Err(Error::oos("FixedSizeBinaryArray expects a positive size"));
+                }
+                Ok((child.as_ref(), *size as usize))
+            }
             _ => Err(Error::oos(
                 "FixedSizeListArray expects DataType::FixedSizeList",
             )),

--- a/src/io/flight/mod.rs
+++ b/src/io/flight/mod.rs
@@ -118,6 +118,7 @@ pub fn deserialize_batch(
     let message = arrow_format::ipc::MessageRef::read_as_root(&data.data_header)
         .map_err(|err| Error::OutOfSpec(format!("Unable to get root as message: {:?}", err)))?;
 
+    let length = data.data_body.len();
     let mut reader = std::io::Cursor::new(&data.data_body);
 
     match message.header()?.ok_or_else(|| {
@@ -132,6 +133,7 @@ pub fn deserialize_batch(
             message.version()?,
             &mut reader,
             0,
+            length as u64,
         ),
         _ => Err(Error::nyi(
             "flight currently only supports reading RecordBatch messages",

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -73,8 +73,6 @@
 //! [2](https://github.com/jorgecarleitao/arrow2/blob/main/examples/ipc_file_write.rs),
 //! [3](https://github.com/jorgecarleitao/arrow2/tree/main/examples/ipc_pyarrow)).
 
-use crate::error::Error;
-
 mod compression;
 mod endianess;
 
@@ -102,10 +100,4 @@ pub struct IpcSchema {
     pub fields: Vec<IpcField>,
     /// Endianness of the file
     pub is_little_endian: bool,
-}
-
-impl From<arrow_format::ipc::planus::Error> for Error {
-    fn from(error: arrow_format::ipc::planus::Error) -> Self {
-        Error::OutOfSpec(error.to_string())
-    }
 }

--- a/src/io/ipc/read/array/binary.rs
+++ b/src/io/ipc/read/array/binary.rs
@@ -7,7 +7,7 @@ use crate::datatypes::DataType;
 use crate::error::{Error, Result};
 
 use super::super::read_basic::*;
-use super::super::{Compression, IpcBuffer, Node};
+use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
 
 pub fn read_binary<O: Offset, R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
@@ -34,9 +34,14 @@ pub fn read_binary<O: Offset, R: Read + Seek>(
         compression,
     )?;
 
+    let length: usize = field_node
+        .length()
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+
     let offsets: Buffer<O> = read_buffer(
         buffers,
-        1 + field_node.length() as usize,
+        1 + length,
         reader,
         block_offset,
         is_little_endian,

--- a/src/io/ipc/read/array/boolean.rs
+++ b/src/io/ipc/read/array/boolean.rs
@@ -6,7 +6,7 @@ use crate::datatypes::DataType;
 use crate::error::{Error, Result};
 
 use super::super::read_basic::*;
-use super::super::{Compression, IpcBuffer, Node};
+use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
 
 pub fn read_boolean<R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
@@ -24,7 +24,11 @@ pub fn read_boolean<R: Read + Seek>(
         ))
     })?;
 
-    let length = field_node.length() as usize;
+    let length: usize = field_node
+        .length()
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+
     let validity = read_validity(
         buffers,
         field_node,

--- a/src/io/ipc/read/array/list.rs
+++ b/src/io/ipc/read/array/list.rs
@@ -11,7 +11,7 @@ use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
 use super::super::Dictionaries;
-use super::super::{Compression, IpcBuffer, Node, Version};
+use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind, Version};
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_list<O: Offset, R: Read + Seek>(
@@ -45,9 +45,14 @@ where
         compression,
     )?;
 
+    let length: usize = field_node
+        .length()
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+
     let offsets = read_buffer::<O, _>(
         buffers,
-        1 + field_node.length() as usize,
+        1 + length,
         reader,
         block_offset,
         is_little_endian,

--- a/src/io/ipc/read/array/map.rs
+++ b/src/io/ipc/read/array/map.rs
@@ -10,7 +10,7 @@ use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
 use super::super::Dictionaries;
-use super::super::{Compression, IpcBuffer, Node, Version};
+use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind, Version};
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_map<R: Read + Seek>(
@@ -41,9 +41,14 @@ pub fn read_map<R: Read + Seek>(
         compression,
     )?;
 
+    let length: usize = field_node
+        .length()
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+
     let offsets = read_buffer::<i32, _>(
         buffers,
-        1 + field_node.length() as usize,
+        1 + length,
         reader,
         block_offset,
         is_little_endian,

--- a/src/io/ipc/read/array/null.rs
+++ b/src/io/ipc/read/array/null.rs
@@ -6,7 +6,7 @@ use crate::{
     error::{Error, Result},
 };
 
-use super::super::Node;
+use super::super::{Node, OutOfSpecKind};
 
 pub fn read_null(field_nodes: &mut VecDeque<Node>, data_type: DataType) -> Result<NullArray> {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
@@ -16,7 +16,12 @@ pub fn read_null(field_nodes: &mut VecDeque<Node>, data_type: DataType) -> Resul
         ))
     })?;
 
-    NullArray::try_new(data_type, field_node.length() as usize)
+    let length: usize = field_node
+        .length()
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+
+    NullArray::try_new(data_type, length)
 }
 
 pub fn skip_null(field_nodes: &mut VecDeque<Node>) -> Result<()> {

--- a/src/io/ipc/read/array/primitive.rs
+++ b/src/io/ipc/read/array/primitive.rs
@@ -6,7 +6,7 @@ use crate::error::{Error, Result};
 use crate::{array::PrimitiveArray, types::NativeType};
 
 use super::super::read_basic::*;
-use super::super::{Compression, IpcBuffer, Node};
+use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
 
 pub fn read_primitive<T: NativeType, R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
@@ -36,9 +36,14 @@ where
         compression,
     )?;
 
+    let length: usize = field_node
+        .length()
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+
     let values = read_buffer(
         buffers,
-        field_node.length() as usize,
+        length,
         reader,
         block_offset,
         is_little_endian,

--- a/src/io/ipc/read/array/utf8.rs
+++ b/src/io/ipc/read/array/utf8.rs
@@ -7,7 +7,7 @@ use crate::datatypes::DataType;
 use crate::error::{Error, Result};
 
 use super::super::read_basic::*;
-use super::super::{Compression, IpcBuffer, Node};
+use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
 
 pub fn read_utf8<O: Offset, R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
@@ -34,9 +34,14 @@ pub fn read_utf8<O: Offset, R: Read + Seek>(
         compression,
     )?;
 
+    let length: usize = field_node
+        .length()
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+
     let offsets: Buffer<O> = read_buffer(
         buffers,
-        1 + field_node.length() as usize,
+        1 + length,
         reader,
         block_offset,
         is_little_endian,

--- a/src/io/ipc/read/common.rs
+++ b/src/io/ipc/read/common.rs
@@ -7,6 +7,7 @@ use crate::array::*;
 use crate::chunk::Chunk;
 use crate::datatypes::{DataType, Field};
 use crate::error::{Error, Result};
+use crate::io::ipc::read::OutOfSpecKind;
 use crate::io::ipc::{IpcField, IpcSchema};
 
 use super::deserialize::{read, skip};
@@ -87,21 +88,33 @@ pub fn read_record_batch<R: Read + Seek>(
 ) -> Result<Chunk<Box<dyn Array>>> {
     assert_eq!(fields.len(), ipc_schema.fields.len());
     let buffers = batch
-        .buffers()?
-        .ok_or_else(|| Error::oos("IPC RecordBatch must contain buffers"))?;
+        .buffers()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferBuffers(err)))?
+        .ok_or_else(|| Error::from(OutOfSpecKind::MissingMessageBuffers))?;
     let mut buffers: VecDeque<arrow_format::ipc::BufferRef> = buffers.iter().collect();
 
-    for buffer in buffers.iter() {
-        if buffer.length() as u64 > file_size {
-            return Err(Error::oos(
-                "Any buffer's length must be smaller than the size of the file",
-            ));
-        }
+    // check that the sum of the sizes of all buffers is <= than the size of the file
+    let buffers_size = buffers
+        .iter()
+        .map(|buffer| {
+            let buffer_size: u64 = buffer
+                .length()
+                .try_into()
+                .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+            Ok(buffer_size)
+        })
+        .sum::<Result<u64>>()?;
+    if buffers_size > file_size {
+        return Err(Error::from(OutOfSpecKind::InvalidBuffersLength {
+            buffers_size,
+            file_size,
+        }));
     }
 
     let field_nodes = batch
-        .nodes()?
-        .ok_or_else(|| Error::oos("IPC RecordBatch must contain field nodes"))?;
+        .nodes()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferNodes(err)))?
+        .ok_or_else(|| Error::from(OutOfSpecKind::MissingMessageNodes))?;
     let mut field_nodes = field_nodes.iter().collect::<VecDeque<_>>();
 
     let columns = if let Some(projection) = projection {
@@ -119,7 +132,9 @@ pub fn read_record_batch<R: Read + Seek>(
                     dictionaries,
                     block_offset,
                     ipc_schema.is_little_endian,
-                    batch.compression()?,
+                    batch.compression().map_err(|err| {
+                        Error::from(OutOfSpecKind::InvalidFlatbufferCompression(err))
+                    })?,
                     version,
                 )?)),
                 ProjectionResult::NotSelected((field, _)) => {
@@ -143,7 +158,9 @@ pub fn read_record_batch<R: Read + Seek>(
                     dictionaries,
                     block_offset,
                     ipc_schema.is_little_endian,
-                    batch.compression()?,
+                    batch.compression().map_err(|err| {
+                        Error::from(OutOfSpecKind::InvalidFlatbufferCompression(err))
+                    })?,
                     version,
                 )
             })
@@ -199,10 +216,7 @@ fn first_dict_field<'a>(
             return Ok(field);
         }
     }
-    Err(Error::OutOfSpec(format!(
-        "dictionary id {} not found in schema",
-        id
-    )))
+    Err(Error::from(OutOfSpecKind::InvalidId { requested_id: id }))
 }
 
 /// Read the dictionary from the buffer and provided metadata,
@@ -216,23 +230,29 @@ pub fn read_dictionary<R: Read + Seek>(
     block_offset: u64,
     file_size: u64,
 ) -> Result<()> {
-    if batch.is_delta()? {
+    if batch
+        .is_delta()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferIsDelta(err)))?
+    {
         return Err(Error::NotYetImplemented(
             "delta dictionary batches not supported".to_string(),
         ));
     }
 
-    let id = batch.id()?;
+    let id = batch
+        .id()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferId(err)))?;
     let (first_field, first_ipc_field) = first_dict_field(id, fields, &ipc_schema.fields)?;
 
     // As the dictionary batch does not contain the type of the
     // values array, we need to retrieve this from the schema.
     // Get an array representing this dictionary's values.
-    let dictionary_values: Box<dyn Array> = match &first_field.data_type {
+    let dictionary_values: Box<dyn Array> = match first_field.data_type.to_logical_type() {
         DataType::Dictionary(_, ref value_type, _) => {
             let batch = batch
-                .data()?
-                .ok_or_else(|| Error::oos("The dictionary batch must have data."))?;
+                .data()
+                .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferData(err)))?
+                .ok_or_else(|| Error::from(OutOfSpecKind::MissingData))?;
 
             // Make a fake schema for the dictionary batch.
             let fields = vec![Field::new("", value_type.as_ref().clone(), false)];
@@ -252,11 +272,14 @@ pub fn read_dictionary<R: Read + Seek>(
                 file_size,
             )?;
             let mut arrays = columns.into_arrays();
-            Some(arrays.pop().unwrap())
+            arrays.pop().unwrap()
         }
-        _ => None,
-    }
-    .ok_or_else(|| Error::InvalidArgumentError("dictionary id not found in schema".to_string()))?;
+        _ => {
+            return Err(Error::from(OutOfSpecKind::InvalidIdDataType {
+                requested_id: id,
+            }))
+        }
+    };
 
     dictionaries.insert(id, dictionary_values);
 

--- a/src/io/ipc/read/error.rs
+++ b/src/io/ipc/read/error.rs
@@ -1,0 +1,110 @@
+use crate::error::Error;
+
+/// The different types of errors that reading from IPC can cause
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum OutOfSpecKind {
+    /// The IPC file does not start with [b'A', b'R', b'R', b'O', b'W', b'1']
+    InvalidHeader,
+    /// The IPC file does not end with [b'A', b'R', b'R', b'O', b'W', b'1']
+    InvalidFooter,
+    /// The first 4 bytes of the last 10 bytes is < 0
+    NegativeFooterLength,
+    /// The footer is an invalid flatbuffer
+    InvalidFlatbufferFooter(arrow_format::ipc::planus::Error),
+    /// The file's footer does not contain record batches
+    MissingRecordBatches,
+    /// The footer's record batches is an invalid flatbuffer
+    InvalidFlatbufferRecordBatches(arrow_format::ipc::planus::Error),
+    /// The file's footer does not contain a schema
+    MissingSchema,
+    /// The footer's schema is an invalid flatbuffer
+    InvalidFlatbufferSchema(arrow_format::ipc::planus::Error),
+    /// The file's schema does not contain fields
+    MissingFields,
+    /// The footer's dictionaries is an invalid flatbuffer
+    InvalidFlatbufferDictionaries(arrow_format::ipc::planus::Error),
+    /// The block is an invalid flatbuffer
+    InvalidFlatbufferBlock(arrow_format::ipc::planus::Error),
+    /// The dictionary message is an invalid flatbuffer
+    InvalidFlatbufferMessage(arrow_format::ipc::planus::Error),
+    /// The message does not contain a header
+    MissingMessageHeader,
+    /// The message's header is an invalid flatbuffer
+    InvalidFlatbufferHeader(arrow_format::ipc::planus::Error),
+    /// Relative positions in the file is < 0
+    UnexpectedNegativeInteger,
+    /// dictionaries can only contain dictionary messages; record batches can only contain records
+    UnexpectedMessageType,
+    /// RecordBatch messages do not contain buffers
+    MissingMessageBuffers,
+    /// The message's buffers is an invalid flatbuffer
+    InvalidFlatbufferBuffers(arrow_format::ipc::planus::Error),
+    /// RecordBatch messages does not contain nodes
+    MissingMessageNodes,
+    /// The message's nodes is an invalid flatbuffer
+    InvalidFlatbufferNodes(arrow_format::ipc::planus::Error),
+    /// The message's body length is an invalid flatbuffer
+    InvalidFlatbufferBodyLength(arrow_format::ipc::planus::Error),
+    /// The message does not contain data
+    MissingData,
+    /// The message's data is an invalid flatbuffer
+    InvalidFlatbufferData(arrow_format::ipc::planus::Error),
+    /// The version is an invalid flatbuffer
+    InvalidFlatbufferVersion(arrow_format::ipc::planus::Error),
+    /// The compression is an invalid flatbuffer
+    InvalidFlatbufferCompression(arrow_format::ipc::planus::Error),
+    /// The record contains a number of buffers that does not match the required number by the data type
+    ExpectedBuffer,
+    /// A buffer's size is smaller than the required for the number of elements
+    InvalidBuffer {
+        /// Declared number of elements in the buffer
+        length: usize,
+        /// The name of the `NativeType`
+        type_name: &'static str,
+        /// Bytes required for the `length` and `type`
+        required_number_of_bytes: usize,
+        /// The size of the IPC buffer
+        buffer_length: usize,
+    },
+    /// A buffer's size is larger than the file size
+    InvalidBuffersLength {
+        /// number of bytes of all buffers in the record
+        buffers_size: u64,
+        /// the size of the file
+        file_size: u64,
+    },
+    /// A bitmap's size is smaller than the required for the number of elements
+    InvalidBitmap {
+        /// Declared length of the bitmap
+        length: usize,
+        /// Number of bits on the IPC buffer
+        number_of_bits: usize,
+    },
+    /// The dictionary is_delta is an invalid flatbuffer
+    InvalidFlatbufferIsDelta(arrow_format::ipc::planus::Error),
+    /// The dictionary id is an invalid flatbuffer
+    InvalidFlatbufferId(arrow_format::ipc::planus::Error),
+    /// Invalid dictionary id
+    InvalidId {
+        /// The requested dictionary id
+        requested_id: i64,
+    },
+    /// Field id is not a dictionary
+    InvalidIdDataType {
+        /// The requested dictionary id
+        requested_id: i64,
+    },
+}
+
+impl From<OutOfSpecKind> for Error {
+    fn from(kind: OutOfSpecKind) -> Self {
+        Error::OutOfSpec(format!("{:?}", kind))
+    }
+}
+
+impl From<arrow_format::ipc::planus::Error> for Error {
+    fn from(error: arrow_format::ipc::planus::Error) -> Self {
+        Error::OutOfSpec(error.to_string())
+    }
+}

--- a/src/io/ipc/read/file_async.rs
+++ b/src/io/ipc/read/file_async.rs
@@ -144,7 +144,7 @@ where
     reader.seek(SeekFrom::End(-10 - footer_size as i64)).await?;
     reader.read_exact(&mut footer).await?;
 
-    deserialize_footer(&footer)
+    deserialize_footer(&footer, u64::MAX)
 }
 
 async fn read_batch<R>(
@@ -188,6 +188,7 @@ where
         message.version()?,
         &mut cursor,
         0,
+        metadata.size,
     )
 }
 
@@ -220,7 +221,15 @@ where
                 buffer.resize(length, 0);
                 reader.read_exact(&mut buffer).await?;
                 let mut cursor = std::io::Cursor::new(&mut buffer);
-                read_dictionary(batch, fields, ipc_schema, &mut dictionaries, &mut cursor, 0)?;
+                read_dictionary(
+                    batch,
+                    fields,
+                    ipc_schema,
+                    &mut dictionaries,
+                    &mut cursor,
+                    0,
+                    u64::MAX,
+                )?;
             }
             other => {
                 return Err(Error::OutOfSpec(format!(

--- a/src/io/ipc/read/mod.rs
+++ b/src/io/ipc/read/mod.rs
@@ -11,10 +11,14 @@ use crate::array::Array;
 mod array;
 mod common;
 mod deserialize;
+mod error;
 mod read_basic;
 pub(crate) mod reader;
 mod schema;
 mod stream;
+
+pub use error::OutOfSpecKind;
+
 #[cfg(feature = "io_ipc_read_async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "io_ipc_read_async")))]
 pub mod stream_async;

--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -12,6 +12,7 @@ use super::super::{ARROW_MAGIC, CONTINUATION_MARKER};
 use super::common::*;
 use super::schema::fb_to_schema;
 use super::Dictionaries;
+use super::OutOfSpecKind;
 use arrow_format::ipc::planus::ReadAsRoot;
 
 /// Metadata of an Arrow IPC file, written in the footer of the file.
@@ -59,9 +60,13 @@ fn read_dictionary_message<R: Read + Seek>(
     };
     let message_length = i32::from_le_bytes(message_size);
 
+    let message_length: usize = message_length
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+
     // prepare `data` to read the message
     data.clear();
-    data.resize(message_length as usize, 0);
+    data.resize(message_length, 0);
 
     reader.read_exact(data)?;
     Ok(())
@@ -74,16 +79,23 @@ fn read_dictionary_block<R: Read + Seek>(
     dictionaries: &mut Dictionaries,
     scratch: &mut Vec<u8>,
 ) -> Result<()> {
-    let offset = block.offset as u64;
-    let length = block.meta_data_length as u64;
+    let offset: u64 = block
+        .offset
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::UnexpectedNegativeInteger))?;
+    let length: u64 = block
+        .meta_data_length
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::UnexpectedNegativeInteger))?;
     read_dictionary_message(reader, offset, scratch)?;
 
     let message = arrow_format::ipc::MessageRef::read_as_root(scratch)
-        .map_err(|err| Error::OutOfSpec(format!("Unable to get root as message: {:?}", err)))?;
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferMessage(err)))?;
 
     let header = message
-        .header()?
-        .ok_or_else(|| Error::oos("Message must have an header"))?;
+        .header()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferHeader(err)))?
+        .ok_or_else(|| Error::from(OutOfSpecKind::MissingMessageHeader))?;
 
     match header {
         arrow_format::ipc::MessageHeaderRef::DictionaryBatch(batch) => {
@@ -96,16 +108,10 @@ fn read_dictionary_block<R: Read + Seek>(
                 reader,
                 block_offset,
                 metadata.size,
-            )?;
+            )
         }
-        t => {
-            return Err(Error::OutOfSpec(format!(
-                "Expecting DictionaryBatch in dictionary blocks, found {:?}.",
-                t
-            )));
-        }
-    };
-    Ok(())
+        _ => Err(Error::from(OutOfSpecKind::UnexpectedMessageType)),
+    }
 }
 
 /// Reads all file's dictionaries, if any
@@ -140,41 +146,50 @@ fn read_footer_len<R: Read + Seek>(reader: &mut R) -> Result<(u64, usize)> {
     let footer_len = i32::from_le_bytes(footer[..4].try_into().unwrap());
 
     if footer[4..] != ARROW_MAGIC {
-        return Err(Error::OutOfSpec(
-            "Arrow file does not contain correct footer".to_string(),
-        ));
+        return Err(Error::from(OutOfSpecKind::InvalidFooter));
     }
     let footer_len = footer_len
         .try_into()
-        .map_err(|_| Error::oos("The footer's lenght must be a positive number"))?;
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
 
     Ok((end, footer_len))
 }
 
 pub(super) fn deserialize_footer(footer_data: &[u8], size: u64) -> Result<FileMetadata> {
     let footer = arrow_format::ipc::FooterRef::read_as_root(footer_data)
-        .map_err(|err| Error::OutOfSpec(format!("Unable to get root as footer: {:?}", err)))?;
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferFooter(err)))?;
 
     let blocks = footer
-        .record_batches()?
-        .ok_or_else(|| Error::OutOfSpec("Unable to get record batches from footer".to_string()))?;
+        .record_batches()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferRecordBatches(err)))?
+        .ok_or_else(|| Error::from(OutOfSpecKind::MissingRecordBatches))?;
 
     let blocks = blocks
         .iter()
-        .map(|block| Ok(block.try_into()?))
+        .map(|block| {
+            block
+                .try_into()
+                .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferRecordBatches(err)))
+        })
         .collect::<Result<Vec<_>>>()?;
 
     let ipc_schema = footer
-        .schema()?
-        .ok_or_else(|| Error::OutOfSpec("Unable to get the schema from footer".to_string()))?;
+        .schema()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferSchema(err)))?
+        .ok_or_else(|| Error::from(OutOfSpecKind::MissingSchema))?;
     let (schema, ipc_schema) = fb_to_schema(ipc_schema)?;
 
     let dictionaries = footer
-        .dictionaries()?
+        .dictionaries()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferDictionaries(err)))?
         .map(|dictionaries| {
             dictionaries
                 .into_iter()
-                .map(|x| Ok(x.try_into()?))
+                .map(|block| {
+                    block.try_into().map_err(|err| {
+                        Error::from(OutOfSpecKind::InvalidFlatbufferRecordBatches(err))
+                    })
+                })
                 .collect::<Result<Vec<_>>>()
         })
         .transpose()?;
@@ -188,43 +203,36 @@ pub(super) fn deserialize_footer(footer_data: &[u8], size: u64) -> Result<FileMe
     })
 }
 
-/// Read the IPC file's metadata
+/// Read the Arrow IPC file's metadata
 pub fn read_file_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetadata> {
     // check if header contain the correct magic bytes
     let mut magic_buffer: [u8; 6] = [0; 6];
     let start = reader.seek(SeekFrom::Current(0))?;
     reader.read_exact(&mut magic_buffer)?;
     if magic_buffer != ARROW_MAGIC {
-        return Err(Error::OutOfSpec(
-            "Arrow file does not contain correct header".to_string(),
-        ));
+        return Err(Error::from(OutOfSpecKind::InvalidHeader));
     }
 
     let (end, footer_len) = read_footer_len(reader)?;
 
     // read footer
-    let mut footer_data = vec![0; footer_len];
+    let mut serialized_footer = vec![0; footer_len];
     reader.seek(SeekFrom::End(-10 - footer_len as i64))?;
-    reader.read_exact(&mut footer_data)?;
+    reader.read_exact(&mut serialized_footer)?;
 
-    deserialize_footer(&footer_data, end - start)
+    deserialize_footer(&serialized_footer, end - start)
 }
 
 pub(super) fn get_serialized_batch<'a>(
     message: &'a arrow_format::ipc::MessageRef,
 ) -> Result<arrow_format::ipc::RecordBatchRef<'a>> {
-    let header = message.header()?.ok_or_else(|| {
-        Error::oos("IPC: unable to fetch the message header. The file or stream is corrupted.")
-    })?;
+    let header = message
+        .header()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferHeader(err)))?
+        .ok_or_else(|| Error::from(OutOfSpecKind::MissingMessageHeader))?;
     match header {
-        arrow_format::ipc::MessageHeaderRef::Schema(_) => Err(Error::OutOfSpec(
-            "Not expecting a schema when messages are read".to_string(),
-        )),
         arrow_format::ipc::MessageHeaderRef::RecordBatch(batch) => Ok(batch),
-        t => Err(Error::OutOfSpec(format!(
-            "Reading types other than record batches not yet supported, unable to read {:?}",
-            t
-        ))),
+        _ => Err(Error::from(OutOfSpecKind::UnexpectedMessageType)),
     }
 }
 
@@ -245,24 +253,41 @@ pub fn read_batch<R: Read + Seek>(
 ) -> Result<Chunk<Box<dyn Array>>> {
     let block = metadata.blocks[index];
 
+    let offset: u64 = block
+        .offset
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+
     // read length
-    reader.seek(SeekFrom::Start(block.offset as u64))?;
+    reader.seek(SeekFrom::Start(offset))?;
     let mut meta_buf = [0; 4];
     reader.read_exact(&mut meta_buf)?;
     if meta_buf == CONTINUATION_MARKER {
         // continuation marker encountered, read message next
         reader.read_exact(&mut meta_buf)?;
     }
-    let meta_len = i32::from_le_bytes(meta_buf) as usize;
+    let meta_len = i32::from_le_bytes(meta_buf)
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::UnexpectedNegativeInteger))?;
 
     stratch.clear();
     stratch.resize(meta_len, 0);
     reader.read_exact(stratch)?;
 
     let message = arrow_format::ipc::MessageRef::read_as_root(stratch)
-        .map_err(|err| Error::oos(format!("Unable parse message: {:?}", err)))?;
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferMessage(err)))?;
 
     let batch = get_serialized_batch(&message)?;
+
+    let offset: u64 = block
+        .offset
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+
+    let length: u64 = block
+        .meta_data_length
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
 
     read_record_batch(
         batch,
@@ -270,9 +295,11 @@ pub fn read_batch<R: Read + Seek>(
         &metadata.ipc_schema,
         projection,
         dictionaries,
-        message.version()?,
+        message
+            .version()
+            .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferVersion(err)))?,
         reader,
-        block.offset as u64 + block.meta_data_length as u64,
+        offset + length,
         metadata.size,
     )
 }

--- a/src/io/ipc/read/stream_async.rs
+++ b/src/io/ipc/read/stream_async.rs
@@ -4,6 +4,7 @@ use arrow_format::ipc::planus::ReadAsRoot;
 use futures::future::BoxFuture;
 use futures::AsyncRead;
 use futures::AsyncReadExt;
+use futures::FutureExt;
 use futures::Stream;
 
 use crate::array::*;
@@ -14,6 +15,7 @@ use super::super::CONTINUATION_MARKER;
 use super::common::{read_dictionary, read_record_batch};
 use super::schema::deserialize_stream_metadata;
 use super::Dictionaries;
+use super::OutOfSpecKind;
 use super::StreamMetadata;
 
 /// A (private) state of stream messages
@@ -51,7 +53,11 @@ pub async fn read_stream_metadata_async<R: AsyncRead + Unpin + Send>(
         i32::from_le_bytes(meta_size)
     };
 
-    let mut meta_buffer = vec![0; meta_len as usize];
+    let meta_len: usize = meta_len
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+
+    let mut meta_buffer = vec![0; meta_len];
     reader.read_exact(&mut meta_buffer).await?;
 
     deserialize_stream_metadata(&meta_buffer)
@@ -85,8 +91,12 @@ async fn maybe_next<R: AsyncRead + Unpin + Send>(
         if meta_length == CONTINUATION_MARKER {
             state.reader.read_exact(&mut meta_length).await?;
         }
-        i32::from_le_bytes(meta_length) as usize
+        i32::from_le_bytes(meta_length)
     };
+
+    let meta_length: usize = meta_length
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
 
     if meta_length == 0 {
         // the stream has ended, mark the reader as finished
@@ -98,23 +108,23 @@ async fn maybe_next<R: AsyncRead + Unpin + Send>(
     state.reader.read_exact(&mut state.message_buffer).await?;
 
     let message = arrow_format::ipc::MessageRef::read_as_root(&state.message_buffer)
-        .map_err(|err| Error::OutOfSpec(format!("Unable to get root as message: {:?}", err)))?;
-    let header = message.header()?.ok_or_else(|| {
-        Error::oos("IPC: unable to fetch the message header. The file or stream is corrupted.")
-    })?;
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferMessage(err)))?;
+
+    let header = message
+        .header()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferHeader(err)))?
+        .ok_or_else(|| Error::from(OutOfSpecKind::MissingMessageHeader))?;
+
+    let block_length: usize = message
+        .body_length()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferBodyLength(err)))?
+        .try_into()
+        .map_err(|_| Error::from(OutOfSpecKind::UnexpectedNegativeInteger))?;
 
     match header {
-        arrow_format::ipc::MessageHeaderRef::Schema(_) => {
-            Err(Error::oos("A stream cannot contain a schema message"))
-        }
         arrow_format::ipc::MessageHeaderRef::RecordBatch(batch) => {
-            // read the block that makes up the record batch into a buffer
-            let length: usize = message
-                .body_length()?
-                .try_into()
-                .map_err(|_| Error::oos("The body length of a header must be larger than zero"))?;
             state.data_buffer.clear();
-            state.data_buffer.resize(length, 0);
+            state.data_buffer.resize(block_length, 0);
             state.reader.read_exact(&mut state.data_buffer).await?;
 
             read_record_batch(
@@ -131,12 +141,7 @@ async fn maybe_next<R: AsyncRead + Unpin + Send>(
             .map(|chunk| Some(StreamState::Some((state, chunk))))
         }
         arrow_format::ipc::MessageHeaderRef::DictionaryBatch(batch) => {
-            // read the block that makes up the dictionary batch into a buffer
-            let length: usize = message
-                .body_length()?
-                .try_into()
-                .map_err(|_| Error::oos("The body length of a header must be larger than zero"))?;
-            let mut body = vec![0; length];
+            let mut body = vec![0; block_length];
             state.reader.read_exact(&mut body).await?;
 
             let file_size = body.len() as u64;
@@ -156,10 +161,7 @@ async fn maybe_next<R: AsyncRead + Unpin + Send>(
             // read the next message until we encounter a Chunk<Box<dyn Array>> message
             Ok(Some(StreamState::Waiting(state)))
         }
-        t => Err(Error::OutOfSpec(format!(
-            "Reading types other than record batches not yet supported, unable to read {:?} ",
-            t
-        ))),
+        _ => Err(Error::from(OutOfSpecKind::UnexpectedMessageType)),
     }
 }
 
@@ -179,7 +181,7 @@ impl<'a, R: AsyncRead + Unpin + Send + 'a> AsyncStreamReader<'a, R> {
             data_buffer: Default::default(),
             message_buffer: Default::default(),
         };
-        let future = Some(Box::pin(maybe_next(state)) as _);
+        let future = Some(maybe_next(state).boxed());
         Self { metadata, future }
     }
 

--- a/tests/it/io/ipc/read/file.rs
+++ b/tests/it/io/ipc/read/file.rs
@@ -219,13 +219,11 @@ fn test_does_not_panic() {
     );
     let original = std::fs::read(path).unwrap();
 
-    for errors in 0..1000 {
+    for _ in 0..1000 {
         let mut data = original.clone();
-        for _ in 0..errors {
-            let position: usize = rand::thread_rng().gen_range(0..data.len());
-            let new_byte: u8 = rand::thread_rng().gen_range(0..u8::MAX);
-            data[position] = new_byte
-        }
+        let position: usize = rand::thread_rng().gen_range(0..data.len());
+        let new_byte: u8 = rand::thread_rng().gen_range(0..u8::MAX);
+        data[position] = new_byte;
         let _ = read_corrupted_ipc(data);
     }
 }

--- a/tests/it/io/ipc/read/file.rs
+++ b/tests/it/io/ipc/read/file.rs
@@ -191,3 +191,41 @@ fn read_projected() -> Result<()> {
 
     test_projection("1.0.0-littleendian", "generated_primitive", vec![2, 1])
 }
+
+fn read_corrupted_ipc(data: Vec<u8>) -> Result<()> {
+    let mut file = std::io::Cursor::new(data);
+
+    let metadata = read_file_metadata(&mut file)?;
+    let mut reader = FileReader::new(file, metadata, None);
+
+    reader.try_for_each(|rhs| {
+        rhs?;
+        Result::Ok(())
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn test_does_not_panic() {
+    use rand::Rng; // 0.8.0
+
+    let version = "1.0.0-littleendian";
+    let file_name = "generated_primitive";
+    let testdata = crate::test_util::arrow_test_data();
+    let path = format!(
+        "{}/arrow-ipc-stream/integration/{}/{}.arrow_file",
+        testdata, version, file_name
+    );
+    let original = std::fs::read(path).unwrap();
+
+    for errors in 0..1000 {
+        let mut data = original.clone();
+        for _ in 0..errors {
+            let position: usize = rand::thread_rng().gen_range(0..data.len());
+            let new_byte: u8 = rand::thread_rng().gen_range(0..u8::MAX);
+            data[position] = new_byte
+        }
+        let _ = read_corrupted_ipc(data);
+    }
+}


### PR DESCRIPTION
This PR safeguards the IPC interface from panicking or aborting (OOM) on invalid data.

* All number casts (e.g. `i32` to `usize`) and operations (e.g. `*`) are now protected to avoid overflow and thus trigger OOM
* Many of the errors were converted to an enum for more clarity over what failed exactly
* the sum of size of all IPC buffers can no longer be larger than the size of the file, thus protecting us from OOM attacks