### PR TITLE
Improve `arity_assign`: `~2x` improvement if we share data.

### DIFF
--- a/benches/assign_ops.rs
+++ b/benches/assign_ops.rs
@@ -14,7 +14,7 @@ fn add_benchmark(c: &mut Criterion) {
         c.bench_function(&format!("apply_mul 2^{}", log2_size), |b| {
             b.iter(|| {
                 criterion::black_box(&mut arr_a)
-                    .apply_values(|x| x.iter_mut().for_each(|x| *x *= 1.01));
+                    .apply_values_mut(|x| x.iter_mut().for_each(|x| *x *= 1.01));
                 assert!(!arr_a.value(10).is_nan());
             })
         });
@@ -30,7 +30,7 @@ fn add_benchmark(c: &mut Criterion) {
         let mut arr_a = create_primitive_array::<f32>(size, 0.2);
         let mut arr_b = create_primitive_array_with_seed::<f32>(size, 0.2, 10);
         // convert to be close to 1.01
-        arr_b.apply_values(|x| x.iter_mut().for_each(|x| *x = 1.01 + *x / 20.0));
+        arr_b.apply_values_mut(|x| x.iter_mut().for_each(|x| *x = 1.01 + *x / 20.0));
 
         c.bench_function(&format!("apply_mul null 2^{}", log2_size), |b| {
             b.iter(|| {

--- a/examples/cow.rs
+++ b/examples/cow.rs
@@ -13,7 +13,7 @@ fn main() {
         .unwrap();
 
     // 2. call `apply_values` with the function to apply over the values
-    array.apply_values(|x| x.iter_mut().for_each(|x| *x *= 10));
+    array.apply_values_mut(|x| x.iter_mut().for_each(|x| *x *= 10));
 
     // confirm that it gives the right result :)
     assert_eq!(array, &PrimitiveArray::from_vec(vec![10i32, 20]));

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -102,7 +102,7 @@ impl BooleanArray {
     /// if it is being shared (since it results in a `O(N)` memcopy).
     /// # Panics
     /// This function panics if the function modifies the length of the [`MutableBitmap`].
-    pub fn apply_values<F: Fn(&mut MutableBitmap)>(&mut self, f: F) {
+    pub fn apply_values_mut<F: Fn(&mut MutableBitmap)>(&mut self, f: F) {
         let values = std::mem::take(&mut self.values);
         let mut values = values.make_mut();
         f(&mut values);
@@ -121,7 +121,7 @@ impl BooleanArray {
     /// if it is being shared (since it results in a `O(N)` memcopy).
     /// # Panics
     /// This function panics if the function modifies the length of the [`MutableBitmap`].
-    pub fn apply_validity<F: Fn(&mut MutableBitmap)>(&mut self, f: F) {
+    pub fn apply_validity_mut<F: Fn(&mut MutableBitmap)>(&mut self, f: F) {
         if let Some(validity) = self.validity.as_mut() {
             let values = std::mem::take(validity);
             let mut bitmap = values.make_mut();

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -511,3 +511,9 @@ pub type UInt16Vec = MutablePrimitiveArray<u16>;
 pub type UInt32Vec = MutablePrimitiveArray<u32>;
 /// A type definition [`MutablePrimitiveArray`] for `u64`
 pub type UInt64Vec = MutablePrimitiveArray<u64>;
+
+impl<T: NativeType> Default for PrimitiveArray<T> {
+    fn default() -> Self {
+        PrimitiveArray::new(DataType::Null, vec![].into(), None)
+    }
+}

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -245,12 +245,41 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// This function panics iff `validity.len() != self.len()`.
     #[must_use]
     pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+        let mut out = self.clone();
+        out.set_validity(validity);
+        out
+    }
+
+    /// Update the validity buffer of this [`PrimitiveArray`].
+    /// # Panics
+    /// This function panics iff `values.len() != self.len()`.
+    pub fn set_validity(&mut self, validity: Option<Bitmap>) {
         if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
             panic!("validity should be as least as large as the array")
         }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        arr
+        self.validity = validity;
+    }
+
+    /// Returns a clone of this [`PrimitiveArray`] with a new values.
+    /// # Panics
+    /// This function panics iff `values.len() != self.len()`.
+    #[must_use]
+    pub fn with_values(&self, values: Vec<T>) -> Self {
+        let mut out = self.clone();
+        out.set_values(values);
+        out
+    }
+
+    /// Update the values buffer of this [`PrimitiveArray`].
+    /// # Panics
+    /// This function panics iff `values.len() != self.len()`.
+    pub fn set_values(&mut self, values: Vec<T>) {
+        assert_eq!(
+            values.len(),
+            self.len(),
+            "values length should be equal to this arrays length"
+        );
+        self.values = values.into();
     }
 
     /// Applies a function `f` to the values of this array, cloning the values

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -279,7 +279,7 @@ impl<T: NativeType> PrimitiveArray<T> {
             self.len(),
             "values length should be equal to this arrays length"
         );
-        self.values = values.into();
+        self.values = values;
     }
 
     /// Applies a function `f` to the values of this array, cloning the values

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -273,7 +273,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// Update the values buffer of this [`PrimitiveArray`].
     /// # Panics
     /// This function panics iff `values.len() != self.len()`.
-    pub fn set_values(&mut self, values: Vec<T>) {
+    pub fn set_values(&mut self, values: Buffer<T>) {
         assert_eq!(
             values.len(),
             self.len(),

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -264,7 +264,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// # Panics
     /// This function panics iff `values.len() != self.len()`.
     #[must_use]
-    pub fn with_values(&self, values: Vec<T>) -> Self {
+    pub fn with_values(&self, values: Buffer<T>) -> Self {
         let mut out = self.clone();
         out.set_values(values);
         out
@@ -289,10 +289,14 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// # Implementation
     /// This function is `O(f)` if the data is not being shared, and `O(N) + O(f)`
     /// if it is being shared (since it results in a `O(N)` memcopy).
+    /// # Panics
+    /// This function panics, if `f` modifies the length of `&mut [T]`
     pub fn apply_values<F: Fn(&mut [T])>(&mut self, f: F) {
         let values = std::mem::take(&mut self.values);
         let mut values = values.make_mut();
+        let len = values.len();
         f(&mut values);
+        assert_eq!(values.len(), len, "values length must remain the same");
         self.values = values.into();
     }
 

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -514,6 +514,6 @@ pub type UInt64Vec = MutablePrimitiveArray<u64>;
 
 impl<T: NativeType> Default for PrimitiveArray<T> {
     fn default() -> Self {
-        PrimitiveArray::new(DataType::Null, vec![].into(), None)
+        PrimitiveArray::new(T::PRIMITIVE.into(), Default::default(), None)
     }
 }

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -81,6 +81,32 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     pub fn into_data(self) -> (DataType, Vec<T>, Option<MutableBitmap>) {
         (self.data_type, self.values, self.validity)
     }
+
+    /// Applies a function `f` to the values of this array, cloning the values
+    /// iff they are being shared with others
+    ///
+    /// This is an API to use clone-on-write
+    /// # Implementation
+    /// This function is `O(f)` if the data is not being shared, and `O(N) + O(f)`
+    /// if it is being shared (since it results in a `O(N)` memcopy).
+    pub fn apply_values<F: Fn(&mut [T])>(&mut self, f: F) {
+        f(&mut self.values);
+    }
+
+    /// Applies a function `f` to the validity of this array, cloning it
+    /// iff it is being shared.
+    ///
+    /// This is an API to leverage clone-on-write
+    /// # Implementation
+    /// This function is `O(f)` if the data is not being shared, and `O(N) + O(f)`
+    /// if it is being shared (since it results in a `O(N)` memcopy).
+    /// # Panics
+    /// This function panics if the function modifies the length of the [`MutableBitmap`].
+    pub fn apply_validity<F: Fn(&mut MutableBitmap)>(&mut self, f: F) {
+        if let Some(validity) = &mut self.validity {
+            f(validity);
+        }
+    }
 }
 
 impl<T: NativeType> Default for MutablePrimitiveArray<T> {

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -89,8 +89,12 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     /// # Implementation
     /// This function is `O(f)` if the data is not being shared, and `O(N) + O(f)`
     /// if it is being shared (since it results in a `O(N)` memcopy).
+    /// # Panics
+    /// This function panics, if `f` modifies the length of `&mut [T]`
     pub fn apply_values<F: Fn(&mut [T])>(&mut self, f: F) {
+        let len = self.values.len();
         f(&mut self.values);
+        assert_eq!(len, self.values.len(), "values length must remain the same")
     }
 
     /// Applies a function `f` to the validity of this array, cloning it
@@ -105,6 +109,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     pub fn apply_validity<F: Fn(&mut MutableBitmap)>(&mut self, f: F) {
         if let Some(validity) = &mut self.validity {
             f(validity);
+            assert_eq!(validity.len(), self.values.len());
         }
     }
 }

--- a/src/compute/arity_assign.rs
+++ b/src/compute/arity_assign.rs
@@ -61,7 +61,7 @@ where
                 .zip(rhs.values().iter())
                 .map(|(l, r)| op(*l, *r))
                 .collect::<Vec<_>>();
-            immutable.set_values(values);
+            immutable.set_values(values.into());
             *lhs = immutable;
         }
         Either::Right(mut mutable) => {

--- a/tests/it/array/boolean/mod.rs
+++ b/tests/it/array/boolean/mod.rs
@@ -135,7 +135,7 @@ fn from_iter() {
 #[test]
 fn apply_values() {
     let mut a = BooleanArray::from([Some(true), Some(false), None]);
-    a.apply_values(|x| {
+    a.apply_values_mut(|x| {
         let mut a = std::mem::take(x);
         a = !a;
         *x = a;
@@ -147,7 +147,7 @@ fn apply_values() {
 #[test]
 fn apply_validity() {
     let mut a = BooleanArray::from([Some(true), Some(false), None]);
-    a.apply_validity(|x| {
+    a.apply_validity_mut(|x| {
         let mut a = std::mem::take(x);
         a = !a;
         *x = a;

--- a/tests/it/array/primitive/mod.rs
+++ b/tests/it/array/primitive/mod.rs
@@ -128,7 +128,7 @@ fn into_mut_3() {
 #[test]
 fn apply_values() {
     let mut a = PrimitiveArray::from([Some(1), Some(2), None]);
-    a.apply_values(|x| {
+    a.apply_values_mut(|x| {
         x[0] = 10;
     });
     let expected = PrimitiveArray::from([Some(10), Some(2), None]);
@@ -138,7 +138,7 @@ fn apply_values() {
 #[test]
 fn apply_validity() {
     let mut a = PrimitiveArray::from([Some(1), Some(2), None]);
-    a.apply_validity(|x| {
+    a.apply_validity_mut(|x| {
         let mut a = std::mem::take(x);
         a = !a;
         *x = a;


### PR DESCRIPTION
This continues upon #1073 (you may close that one if you prefer in one PR, otherwise I rebase).

I did a local benchmark to see what the cost of the new `arity_assign` would be in the case we share data. In polars expressions that is every first operation:

```
Gnuplot not found, using plotters backend
bench_1                 time:   [608.34 us 609.30 us 610.73 us]                    
                        change: [+44.741% +45.228% +45.698%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
```

This showed, that in case of shared data, we first do a `memcpy` and this is `~2x` slower than the kernels where we allocate a new memory buffer.

Luckily we can have best of both worlds. :)

This PR branches depending on the shared state:

* in case we share state -> we alloc (and thus choose the fastest path possible)
* in case we own -> we mutate in place (and thus choose the fastest path possible)

I also added a distinction between `set_validity` and `with_validity` as we now have mutable data, it is not always logical return a new `PrimitiveArray`.