### PR TITLE
Removed un-necessary allocation in `assign_ops`

### DIFF
--- a/benches/assign_ops.rs
+++ b/benches/assign_ops.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use arrow2::compute::arity_assign::binary;
+use arrow2::compute::arity_assign::{binary, unary};
 use arrow2::{
     compute::arithmetics::basic::{mul, mul_scalar},
     util::bench_util::*,
@@ -13,8 +13,7 @@ fn add_benchmark(c: &mut Criterion) {
         let mut arr_a = create_primitive_array::<f32>(size, 0.2);
         c.bench_function(&format!("apply_mul 2^{}", log2_size), |b| {
             b.iter(|| {
-                criterion::black_box(&mut arr_a)
-                    .apply_values_mut(|x| x.iter_mut().for_each(|x| *x *= 1.01));
+                unary(criterion::black_box(&mut arr_a), |x| x * 1.01);
                 assert!(!arr_a.value(10).is_nan());
             })
         });
@@ -30,7 +29,7 @@ fn add_benchmark(c: &mut Criterion) {
         let mut arr_a = create_primitive_array::<f32>(size, 0.2);
         let mut arr_b = create_primitive_array_with_seed::<f32>(size, 0.2, 10);
         // convert to be close to 1.01
-        arr_b.apply_values_mut(|x| x.iter_mut().for_each(|x| *x = 1.01 + *x / 20.0));
+        unary(&mut arr_b, |x| 1.01 + x / 20.0);
 
         c.bench_function(&format!("apply_mul null 2^{}", log2_size), |b| {
             b.iter(|| {

--- a/examples/cow.rs
+++ b/examples/cow.rs
@@ -1,19 +1,21 @@
 // This example demos how to operate on arrays in-place.
 use arrow2::array::{Array, PrimitiveArray};
+use arrow2::compute::arity_assign;
 
 fn main() {
-    // say we have have received an array
+    // say we have have received an `Array`
     let mut array: Box<dyn Array> = PrimitiveArray::from_vec(vec![1i32, 2]).boxed();
 
     // we can apply a transformation to its values without allocating a new array as follows:
+
     // 1. downcast it to the correct type (known via `array.data_type().to_physical_type()`)
     let array = array
         .as_any_mut()
         .downcast_mut::<PrimitiveArray<i32>>()
         .unwrap();
 
-    // 2. call `apply_values` with the function to apply over the values
-    array.apply_values_mut(|x| x.iter_mut().for_each(|x| *x *= 10));
+    // 2. call `unary` with the function to apply to each value
+    arity_assign::unary(array, |x| x * 10);
 
     // confirm that it gives the right result :)
     assert_eq!(array, &PrimitiveArray::from_vec(vec![10i32, 20]));

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -236,25 +236,6 @@ impl BooleanArray {
         self.values = values.into();
     }
 
-    /// Applies a function `f` to the validity of this array, cloning it
-    /// iff it is being shared.
-    ///
-    /// This is an API to leverage clone-on-write
-    /// # Implementation
-    /// This function is `O(f)` if the data is not being shared, and `O(N) + O(f)`
-    /// if it is being shared (since it results in a `O(N)` memcopy).
-    /// # Panics
-    /// This function panics if the function modifies the length of the [`MutableBitmap`].
-    pub fn apply_validity_mut<F: Fn(&mut MutableBitmap)>(&mut self, f: F) {
-        if let Some(validity) = self.validity.as_mut() {
-            let owned_validity = std::mem::take(validity);
-            let mut mut_bitmap = owned_validity.make_mut();
-            f(&mut mut_bitmap);
-            assert_eq!(mut_bitmap.len(), self.values.len());
-            *validity = mut_bitmap.into();
-        }
-    }
-
     /// Try to convert this [`BooleanArray`] to a [`MutableBooleanArray`]
     pub fn into_mut(self) -> Either<Self, MutableBooleanArray> {
         use Either::*;

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -90,27 +90,9 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     /// This function is `O(f)` if the data is not being shared, and `O(N) + O(f)`
     /// if it is being shared (since it results in a `O(N)` memcopy).
     /// # Panics
-    /// This function panics, if `f` modifies the length of `&mut [T]`
+    /// This function panics iff `f` panics
     pub fn apply_values<F: Fn(&mut [T])>(&mut self, f: F) {
-        let len = self.values.len();
         f(&mut self.values);
-        assert_eq!(len, self.values.len(), "values length must remain the same")
-    }
-
-    /// Applies a function `f` to the validity of this array, cloning it
-    /// iff it is being shared.
-    ///
-    /// This is an API to leverage clone-on-write
-    /// # Implementation
-    /// This function is `O(f)` if the data is not being shared, and `O(N) + O(f)`
-    /// if it is being shared (since it results in a `O(N)` memcopy).
-    /// # Panics
-    /// This function panics if the function modifies the length of the [`MutableBitmap`].
-    pub fn apply_validity<F: Fn(&mut MutableBitmap)>(&mut self, f: F) {
-        if let Some(validity) = &mut self.validity {
-            f(validity);
-            assert_eq!(validity.len(), self.values.len());
-        }
     }
 }
 

--- a/tests/it/array/boolean/mod.rs
+++ b/tests/it/array/boolean/mod.rs
@@ -131,27 +131,3 @@ fn from_iter() {
     let a: BooleanArray = iter.collect();
     assert_eq!(a.len(), 2);
 }
-
-#[test]
-fn apply_values() {
-    let mut a = BooleanArray::from([Some(true), Some(false), None]);
-    a.apply_values_mut(|x| {
-        let mut a = std::mem::take(x);
-        a = !a;
-        *x = a;
-    });
-    let expected = BooleanArray::from([Some(false), Some(true), None]);
-    assert_eq!(a, expected);
-}
-
-#[test]
-fn apply_validity() {
-    let mut a = BooleanArray::from([Some(true), Some(false), None]);
-    a.apply_validity_mut(|x| {
-        let mut a = std::mem::take(x);
-        a = !a;
-        *x = a;
-    });
-    let expected = BooleanArray::from([None, None, Some(false)]);
-    assert_eq!(a, expected);
-}

--- a/tests/it/array/primitive/mod.rs
+++ b/tests/it/array/primitive/mod.rs
@@ -124,25 +124,3 @@ fn into_mut_3() {
     let array = PrimitiveArray::new(DataType::Int32, values, validity);
     assert!(array.into_mut().is_right());
 }
-
-#[test]
-fn apply_values() {
-    let mut a = PrimitiveArray::from([Some(1), Some(2), None]);
-    a.apply_values_mut(|x| {
-        x[0] = 10;
-    });
-    let expected = PrimitiveArray::from([Some(10), Some(2), None]);
-    assert_eq!(a, expected);
-}
-
-#[test]
-fn apply_validity() {
-    let mut a = PrimitiveArray::from([Some(1), Some(2), None]);
-    a.apply_validity_mut(|x| {
-        let mut a = std::mem::take(x);
-        a = !a;
-        *x = a;
-    });
-    let expected = PrimitiveArray::from([None, None, Some(0)]);
-    assert_eq!(a, expected);
-}


### PR DESCRIPTION
This PR removes unnecessary allocation on `assign_ops`.

When converting `PrimitiveArray -> MutablePrimitiveArray`, we need to check that both the values and validities are unique refs. However, when operating over values and validities independently, we do not need a mutable ref to both at the same time.

A common case where this was hitting was when `rhs` had a validity and `lhs` did not. In this case, we first cloned the `rhs`'s validity for `lhs`, but them tried to get a mut ref to both the validity and the values (to only use the values). This would naturally fail, causing us to have to re-use the `lhs`.

This PR adds `PrimitiveArray::get_mut_values` and removes (un-released) functions from `PrimitiveArray`, since the function `get_mut_values` is more generic.