### PR TITLE
Renamed `Bitmap::null_count` to `Bitmap::unset_bits`

### DIFF
--- a/benches/bitmap_ops.rs
+++ b/benches/bitmap_ops.rs
@@ -4,7 +4,7 @@ use arrow2::bitmap::Bitmap;
 
 fn bench_arrow2(lhs: &Bitmap, rhs: &Bitmap) {
     let r = lhs | rhs;
-    assert!(r.null_count() > 0);
+    assert!(r.unset_bits() > 0);
 }
 
 fn add_benchmark(c: &mut Criterion) {
@@ -15,7 +15,7 @@ fn add_benchmark(c: &mut Criterion) {
         c.bench_function(&format!("bitmap aligned not 2^{}", log2_size), |b| {
             b.iter(|| {
                 let r = !&bitmap;
-                assert!(r.null_count() > 0);
+                assert!(r.unset_bits() > 0);
             })
         });
 
@@ -27,7 +27,7 @@ fn add_benchmark(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     let r = bitmap.clone().slice(offset, len);
-                    assert!(r.null_count() > 0);
+                    assert!(r.unset_bits() > 0);
                 })
             },
         );
@@ -40,7 +40,7 @@ fn add_benchmark(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     let r = bitmap.clone().slice(offset, len);
-                    assert!(r.null_count() > 0);
+                    assert!(r.unset_bits() > 0);
                 })
             },
         );
@@ -49,7 +49,7 @@ fn add_benchmark(c: &mut Criterion) {
         c.bench_function(&format!("bitmap not 2^{}", log2_size), |b| {
             b.iter(|| {
                 let r = !&bitmap1;
-                assert!(r.null_count() > 0);
+                assert!(r.unset_bits() > 0);
             })
         });
 

--- a/benches/slices_iterator.rs
+++ b/benches/slices_iterator.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use arrow2::bitmap::{utils::SlicesIterator, Bitmap};
 
 fn bench_slices(lhs: &Bitmap) {
-    let set_count = lhs.len() - lhs.null_count();
+    let set_count = lhs.len() - lhs.unset_bits();
     let slices = SlicesIterator::new(lhs);
 
     let count = slices.fold(0usize, |acc, v| acc + v.1);

--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -306,7 +306,7 @@ impl<O: Offset> MutableBinaryArray<O> {
         // soundness: assumed trusted len
         let (mut validity, offsets, values) = try_trusted_len_unzip(iterator)?;
 
-        if validity.as_mut().unwrap().null_count() == 0 {
+        if validity.as_mut().unwrap().unset_bits() == 0 {
             validity = None;
         }
 
@@ -395,7 +395,7 @@ impl<O: Offset> MutableBinaryArray<O> {
             iterator,
         );
 
-        if self.validity.as_mut().unwrap().null_count() == 0 {
+        if self.validity.as_mut().unwrap().unset_bits() == 0 {
             self.validity = None;
         }
     }

--- a/src/array/boolean/mutable.rs
+++ b/src/array/boolean/mutable.rs
@@ -173,7 +173,7 @@ impl MutableBooleanArray {
 
             extend_trusted_len_unzip(iterator, &mut validity, &mut self.values);
 
-            if validity.null_count() > 0 {
+            if validity.unset_bits() > 0 {
                 self.validity = Some(validity);
             }
         }
@@ -299,7 +299,7 @@ impl MutableBooleanArray {
     {
         let (validity, values) = try_trusted_len_unzip(iterator)?;
 
-        let validity = if validity.null_count() > 0 {
+        let validity = if validity.unset_bits() > 0 {
             Some(validity)
         } else {
             None
@@ -344,7 +344,7 @@ where
 
     extend_trusted_len_unzip(iterator, &mut validity, &mut values);
 
-    let validity = if validity.null_count() > 0 {
+    let validity = if validity.unset_bits() > 0 {
         Some(validity)
     } else {
         None

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -63,7 +63,7 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
         };
         self.validity()
             .as_ref()
-            .map(|x| x.null_count())
+            .map(|x| x.unset_bits())
             .unwrap_or(0)
     }
 

--- a/src/array/physical_binary.rs
+++ b/src/array/physical_binary.rs
@@ -72,7 +72,7 @@ where
 
     extend_from_trusted_len_iter(&mut offsets, &mut values, &mut validity, iterator);
 
-    let validity = if validity.null_count() > 0 {
+    let validity = if validity.unset_bits() > 0 {
         Some(validity)
     } else {
         None

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -25,7 +25,7 @@ impl<T: NativeType> From<MutablePrimitiveArray<T>> for PrimitiveArray<T> {
     fn from(other: MutablePrimitiveArray<T>) -> Self {
         let validity = other.validity.and_then(|x| {
             let bitmap: Bitmap = x.into();
-            if bitmap.null_count() == 0 {
+            if bitmap.unset_bits() == 0 {
                 None
             } else {
                 Some(bitmap)

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -39,7 +39,7 @@ impl<O: Offset> From<MutableUtf8Array<O>> for Utf8Array<O> {
         // `Utf8Array` can be safely created from `MutableUtf8Array` without checks.
         let validity = other.validity.and_then(|x| {
             let bitmap: Bitmap = x.into();
-            if bitmap.null_count() == 0 {
+            if bitmap.unset_bits() == 0 {
                 None
             } else {
                 Some(bitmap)

--- a/src/bitmap/assign_ops.rs
+++ b/src/bitmap/assign_ops.rs
@@ -107,11 +107,11 @@ where
 #[inline]
 /// Compute bitwise OR operation in-place
 fn or_assign<T: BitChunk>(lhs: &mut MutableBitmap, rhs: &Bitmap) {
-    if rhs.null_count() == 0 {
+    if rhs.unset_bits() == 0 {
         assert_eq!(lhs.len(), rhs.len());
         lhs.clear();
         lhs.extend_constant(rhs.len(), true);
-    } else if rhs.null_count() == rhs.len() {
+    } else if rhs.unset_bits() == rhs.len() {
         // bitmap remains
     } else {
         binary_assign(lhs, rhs, |x: T, y| x | y)
@@ -138,10 +138,10 @@ impl<'a, 'b> std::ops::BitOr<&'a Bitmap> for MutableBitmap {
 #[inline]
 /// Compute bitwise `&` between `lhs` and `rhs`, assigning it to `lhs`
 fn and_assign<T: BitChunk>(lhs: &mut MutableBitmap, rhs: &Bitmap) {
-    if rhs.null_count() == 0 {
+    if rhs.unset_bits() == 0 {
         // bitmap remains
     }
-    if rhs.null_count() == rhs.len() {
+    if rhs.unset_bits() == rhs.len() {
         assert_eq!(lhs.len(), rhs.len());
         lhs.clear();
         lhs.extend_constant(rhs.len(), false);

--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -166,7 +166,7 @@ pub(crate) fn align(bitmap: &Bitmap, new_offset: usize) -> Bitmap {
 #[inline]
 /// Compute bitwise AND operation
 pub fn and(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
-    if lhs.null_count() == lhs.len() || rhs.null_count() == rhs.len() {
+    if lhs.unset_bits() == lhs.len() || rhs.unset_bits() == rhs.len() {
         assert_eq!(lhs.len(), rhs.len());
         Bitmap::new_zeroed(lhs.len())
     } else {
@@ -177,7 +177,7 @@ pub fn and(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
 #[inline]
 /// Compute bitwise OR operation
 pub fn or(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
-    if lhs.null_count() == 0 || rhs.null_count() == 0 {
+    if lhs.unset_bits() == 0 || rhs.unset_bits() == 0 {
         assert_eq!(lhs.len(), rhs.len());
         let mut mutable = MutableBitmap::with_capacity(lhs.len());
         mutable.extend_constant(lhs.len(), true);
@@ -190,8 +190,8 @@ pub fn or(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
 #[inline]
 /// Compute bitwise XOR operation
 pub fn xor(lhs: &Bitmap, rhs: &Bitmap) -> Bitmap {
-    let lhs_nulls = lhs.null_count();
-    let rhs_nulls = rhs.null_count();
+    let lhs_nulls = lhs.unset_bits();
+    let rhs_nulls = rhs.unset_bits();
 
     // all false or all true
     if lhs_nulls == rhs_nulls && rhs_nulls == rhs.len() || lhs_nulls == 0 && rhs_nulls == 0 {

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -224,9 +224,18 @@ impl MutableBitmap {
     }
 
     /// Returns the number of unset bits on this [`MutableBitmap`].
-    #[inline]
-    pub fn null_count(&self) -> usize {
+    ///
+    /// Guaranted to be `<= self.len()`.
+    /// # Implementation
+    /// This function is `O(N)`
+    pub fn unset_bits(&self) -> usize {
         count_zeros(&self.buffer, 0, self.length)
+    }
+
+    /// Returns the number of unset bits on this [`MutableBitmap`].
+    #[deprecated(since = "0.13.0", note = "use `unset_bits` instead")]
+    pub fn null_count(&self) -> usize {
+        self.unset_bits()
     }
 
     /// Returns the length of the [`MutableBitmap`].
@@ -327,7 +336,7 @@ impl From<MutableBitmap> for Bitmap {
 impl From<MutableBitmap> for Option<Bitmap> {
     #[inline]
     fn from(buffer: MutableBitmap) -> Self {
-        if buffer.null_count() > 0 {
+        if buffer.unset_bits() > 0 {
             Some(Bitmap::try_new(buffer.buffer, buffer.length).unwrap())
         } else {
             None

--- a/src/bitmap/utils/slice_iterator.rs
+++ b/src/bitmap/utils/slice_iterator.rs
@@ -39,7 +39,7 @@ impl<'a> SlicesIterator<'a> {
 
         Self {
             state,
-            count: values.len() - values.null_count(),
+            count: values.len() - values.unset_bits(),
             max_len: values.len(),
             values: iter,
             mask: 1u8.rotate_left(offset as u32),

--- a/src/compute/aggregate/min_max.rs
+++ b/src/compute/aggregate/min_max.rs
@@ -263,7 +263,7 @@ pub fn min_boolean(array: &BooleanArray) -> Option<bool> {
     if null_count == array.len() {
         None
     } else if null_count == 0 {
-        Some(array.values().null_count() == 0)
+        Some(array.values().unset_bits() == 0)
     } else {
         // Note the min bool is false (0), so short circuit as soon as we see it
         array
@@ -291,7 +291,7 @@ pub fn max_boolean(array: &BooleanArray) -> Option<bool> {
     if null_count == array.len() {
         None
     } else if null_count == 0 {
-        Some(array.values().null_count() < array.len())
+        Some(array.values().unset_bits() < array.len())
     } else {
         // Note the max bool is true (1), so short circuit as soon as we see it
         array

--- a/src/compute/boolean.rs
+++ b/src/compute/boolean.rs
@@ -194,7 +194,7 @@ pub fn any(array: &BooleanArray) -> bool {
         array.into_iter().any(|v| v == Some(true))
     } else {
         let vals = array.values();
-        vals.null_count() != vals.len()
+        vals.unset_bits() != vals.len()
     }
 }
 
@@ -204,6 +204,6 @@ pub fn all(array: &BooleanArray) -> bool {
         false
     } else {
         let vals = array.values();
-        vals.null_count() == 0
+        vals.unset_bits() == 0
     }
 }

--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -136,7 +136,7 @@ fn null_filter_simd<T: NativeType + Simd>(
     mask: &Bitmap,
 ) -> (Vec<T>, MutableBitmap) {
     assert_eq!(values.len(), mask.len());
-    let filter_count = mask.len() - mask.null_count();
+    let filter_count = mask.len() - mask.unset_bits();
 
     let (slice, offset, length) = mask.as_slice();
     if offset == 0 {
@@ -150,7 +150,7 @@ fn null_filter_simd<T: NativeType + Simd>(
 
 fn nonnull_filter_simd<T: NativeType + Simd>(values: &[T], mask: &Bitmap) -> Vec<T> {
     assert_eq!(values.len(), mask.len());
-    let filter_count = mask.len() - mask.null_count();
+    let filter_count = mask.len() - mask.unset_bits();
 
     let (slice, offset, length) = mask.as_slice();
     if offset == 0 {
@@ -264,7 +264,7 @@ pub fn filter(array: &dyn Array, filter: &BooleanArray) -> Result<Box<dyn Array>
         return crate::compute::filter::filter(array, &filter);
     }
 
-    let false_count = filter.values().null_count();
+    let false_count = filter.values().unset_bits();
     if false_count == filter.len() {
         assert_eq!(array.len(), filter.len());
         return Ok(array.slice(0, 0));

--- a/src/compute/sort/common.rs
+++ b/src/compute/sort/common.rs
@@ -105,7 +105,7 @@ where
                 .zip(I::range(0, length).unwrap())
                 .for_each(|(is_valid, index)| {
                     if is_valid {
-                        indices[validity.null_count() + valids] = index;
+                        indices[validity.unset_bits() + valids] = index;
                         valids += 1;
                     } else {
                         indices[nulls] = index;
@@ -113,18 +113,18 @@ where
                     }
                 });
 
-            if limit > validity.null_count() {
+            if limit > validity.unset_bits() {
                 // when limit is larger, we must sort values:
 
                 // Soundness:
                 // all indices in `indices` are by construction `< array.len() == values.len()`
                 // limit is by construction < indices.len()
-                let limit = limit.saturating_sub(validity.null_count());
-                let indices = &mut indices.as_mut_slice()[validity.null_count()..];
+                let limit = limit.saturating_sub(validity.unset_bits());
+                let indices = &mut indices.as_mut_slice()[validity.unset_bits()..];
                 sort_unstable_by(indices, get, cmp, options.descending, limit)
             }
         } else {
-            let last_valid_index = length.saturating_sub(validity.null_count());
+            let last_valid_index = length.saturating_sub(validity.unset_bits());
             let mut nulls = 0;
             let mut valids = 0;
             validity

--- a/src/io/parquet/write/binary/basic.rs
+++ b/src/io/parquet/write/binary/basic.rs
@@ -133,7 +133,7 @@ pub(crate) fn encode_delta<O: Offset>(
                 .map(|w| (w[1] - w[0]).to_usize() as i64)
                 .zip(validity.iter())
                 .flat_map(|(x, is_valid)| if is_valid { Some(x) } else { None });
-            let length = offsets.len() - 1 - validity.null_count();
+            let length = offsets.len() - 1 - validity.unset_bits();
             let lengths = utils::ExactSizedIter::new(lengths, length);
 
             delta_bitpacked::encode(lengths, buffer);

--- a/src/io/parquet/write/boolean/basic.rs
+++ b/src/io/parquet/write/boolean/basic.rs
@@ -28,7 +28,7 @@ pub(super) fn encode_plain(
             array
                 .validity()
                 .as_ref()
-                .map(|x| x.len() - x.null_count())
+                .map(|x| x.len() - x.unset_bits())
                 .unwrap_or_else(|| array.len()),
         );
         encode(iter, buffer)

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -42,7 +42,7 @@ fn encode_keys<K: DictionaryKey>(
         });
         let projected_val = Bitmap::from_trusted_len_iter(projected_validity);
 
-        let null_count = projected_val.null_count();
+        let null_count = projected_val.unset_bits();
 
         utils::write_def_levels(
             &mut buffer,

--- a/tests/it/array/primitive/mutable.rs
+++ b/tests/it/array/primitive/mutable.rs
@@ -133,7 +133,7 @@ fn from_iter() {
     let a = MutablePrimitiveArray::<i32>::from_iter((0..2).map(Some));
     assert_eq!(a.len(), 2);
     let validity = a.validity().unwrap();
-    assert_eq!(validity.null_count(), 0);
+    assert_eq!(validity.unset_bits(), 0);
 }
 
 #[test]
@@ -194,7 +194,7 @@ fn extend_trusted_len() {
     let mut a = MutablePrimitiveArray::<i32>::new();
     a.extend_trusted_len(vec![Some(1), Some(2)].into_iter());
     let validity = a.validity().unwrap();
-    assert_eq!(validity.null_count(), 0);
+    assert_eq!(validity.unset_bits(), 0);
     a.extend_trusted_len(vec![None, Some(4)].into_iter());
     assert_eq!(
         a.validity(),
@@ -285,7 +285,7 @@ fn set_validity() {
     let mut a = MutablePrimitiveArray::<i32>::new();
     a.extend_trusted_len(vec![Some(1), Some(2)].into_iter());
     let validity = a.validity().unwrap();
-    assert_eq!(validity.null_count(), 0);
+    assert_eq!(validity.unset_bits(), 0);
 
     // test that upon conversion to array the bitmap is set to None
     let arr: PrimitiveArray<_> = a.clone().into();

--- a/tests/it/bitmap/mod.rs
+++ b/tests/it/bitmap/mod.rs
@@ -113,13 +113,13 @@ fn not() {
 #[test]
 fn subslicing_gives_correct_null_count() {
     let base = Bitmap::from([false, true, true, false, false, true, true, true]);
-    assert_eq!(base.null_count(), 3);
+    assert_eq!(base.unset_bits(), 3);
 
     let view1 = base.clone().slice(0, 1);
     let view2 = base.slice(1, 7);
-    assert_eq!(view1.null_count(), 1);
-    assert_eq!(view2.null_count(), 2);
+    assert_eq!(view1.unset_bits(), 1);
+    assert_eq!(view2.unset_bits(), 2);
 
     let view3 = view2.slice(0, 1);
-    assert_eq!(view3.null_count(), 0);
+    assert_eq!(view3.unset_bits(), 0);
 }

--- a/tests/it/bitmap/mutable.rs
+++ b/tests/it/bitmap/mutable.rs
@@ -11,14 +11,14 @@ fn from_slice() {
 fn from_len_zeroed() {
     let a = MutableBitmap::from_len_zeroed(10);
     assert_eq!(a.len(), 10);
-    assert_eq!(a.null_count(), 10);
+    assert_eq!(a.unset_bits(), 10);
 }
 
 #[test]
 fn from_len_set() {
     let a = MutableBitmap::from_len_set(10);
     assert_eq!(a.len(), 10);
-    assert_eq!(a.null_count(), 0);
+    assert_eq!(a.unset_bits(), 0);
 }
 
 #[test]

--- a/tests/it/bitmap/utils/mod.rs
+++ b/tests/it/bitmap/utils/mod.rs
@@ -79,6 +79,6 @@ proptest! {
     #[cfg_attr(miri, ignore)] // miri and proptest do not work well :(
     fn null_count(bitmap in bitmap_strategy()) {
         let sum_of_sets: usize = (0..bitmap.len()).map(|x| (!bitmap.get_bit(x)) as usize).sum();
-        assert_eq!(bitmap.null_count(), sum_of_sets);
+        assert_eq!(bitmap.unset_bits(), sum_of_sets);
     }
 }

--- a/tests/it/bitmap/utils/slice_iterator.rs
+++ b/tests/it/bitmap/utils/slice_iterator.rs
@@ -17,7 +17,7 @@ proptest! {
 
         let slots = iter.slots();
 
-        assert_eq!(bitmap.len() - bitmap.null_count(), slots);
+        assert_eq!(bitmap.len() - bitmap.unset_bits(), slots);
 
         let slices = iter.collect::<Vec<_>>();
         let mut sum = 0;
@@ -110,7 +110,7 @@ fn bla() {
         .collect::<Bitmap>();
     let iter = SlicesIterator::new(&values);
     let count = iter.slots();
-    assert_eq!(values.null_count() + iter.slots(), values.len());
+    assert_eq!(values.unset_bits() + iter.slots(), values.len());
 
     let total = iter.into_iter().fold(0, |acc, x| acc + x.1);
 
@@ -122,7 +122,7 @@ fn past_end_should_not_be_returned() {
     let values = Bitmap::from_u8_slice(&[0b11111010], 3);
     let iter = SlicesIterator::new(&values);
     let count = iter.slots();
-    assert_eq!(values.null_count() + iter.slots(), values.len());
+    assert_eq!(values.unset_bits() + iter.slots(), values.len());
 
     let total = iter.into_iter().fold(0, |acc, x| acc + x.1);
 


### PR DESCRIPTION
`null_count` is not a very relatable name to a "bitmap", since the association `null <> unset_bit` only emerges in arrays - this PR renames the function (and marks the old as deprecated).
