### PR TITLE
Removed `Buffer::into_mut` and `make_mut` functions

### DIFF
--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -66,10 +66,9 @@ impl<O: Offset> Default for MutableUtf8Array<O> {
 impl<O: Offset> MutableUtf8Array<O> {
     /// Initializes a new empty [`MutableUtf8Array`].
     pub fn new() -> Self {
-        let offsets = vec![O::default()];
         Self {
             data_type: Self::default_data_type(),
-            offsets,
+            offsets: vec![O::default()],
             values: Vec::<u8>::new(),
             validity: None,
         }

--- a/src/buffer/bytes.rs
+++ b/src/buffer/bytes.rs
@@ -31,10 +31,8 @@ impl Debug for Deallocation {
 
 /// A continuous, fixed-size, immutable memory region that knows how to de-allocate itself.
 ///
-/// In the most common case, this buffer is allocated using [`allocate_aligned`](alloc::allocate_aligned)
-/// and deallocated accordingly [`free_aligned`](alloc::free_aligned).
-/// When the region is allocated by a foreign allocator, [Deallocation::Foreign], this calls the
-/// foreign deallocator to deallocate the region when it is no longer needed.
+/// In the most common case, this buffer is allocated using Rust's native allocator.
+/// However, it may also be allocated by a foreign allocator, [Deallocation::Foreign].
 pub struct Bytes<T: NativeType> {
     /// inner data
     data: MaybeForeign<T>,

--- a/src/compute/arity_assign.rs
+++ b/src/compute/arity_assign.rs
@@ -66,11 +66,9 @@ where
                         // alloc new region
                         &immutable & rhs
                     }
-                    Either::Right(mut mutable) => {
+                    Either::Right(mutable) => {
                         // mutate in place
-                        let mut mutable_ref = &mut mutable;
-                        mutable_ref &= rhs;
-                        mutable.into()
+                        (mutable & rhs).into()
                     }
                 }
             });


### PR DESCRIPTION
The function `get_mut` covers both cases, making it the entry point for `cow` semantics.
