### PR TITLE
Accept decoding parquet's `i64` into `u32` written by `pyarrow`

### DIFF
--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -130,9 +130,13 @@ fn v1_timestamp_ms_nullable() -> Result<()> {
 }
 
 #[test]
-#[ignore] // pyarrow issue; see https://issues.apache.org/jira/browse/ARROW-12201
 fn v1_u32_nullable() -> Result<()> {
     test_pyarrow_integration("uint32", 1, "basic", false, false, None)
+}
+
+#[test]
+fn v2_u32_nullable() -> Result<()> {
+    test_pyarrow_integration("uint32", 2, "basic", false, false, None)
 }
 
 #[test]


### PR DESCRIPTION
Despite [parquet's statement](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#unsigned-integers) that `uint32` are encoded as `i32`, `pyarrow` writes `UInt32` columns in `v1` files in parquet's `i64` physical type without logical annotations but with an arrow schema declared as `UInt32`.

This PR makes us accept this configuration when reading parquet (from `i64` to `u32`).

Thanks @mhtrinhLIC for reporting this at https://github.com/pola-rs/polars/issues/3754