### PR TITLE
Exposed utilities in `io::flight`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run
         # --skip io: miri can't handle opening of files, so we skip those
-        run: cargo miri test --features full -- --skip io::parquet --skip io::ipc
+        run: cargo miri test --features full -- --skip io::parquet --skip io::ipc --skip io::flight
 
   miri-checks-io:
     name: MIRI on IO IPC

--- a/src/io/flight/mod.rs
+++ b/src/io/flight/mod.rs
@@ -11,11 +11,13 @@ use crate::{
     error::{Error, Result},
     io::ipc::read,
     io::ipc::write,
-    io::ipc::write::common::{encode_chunk, DictionaryTracker, EncodedData, WriteOptions},
+    io::ipc::write::common::{encode_chunk, DictionaryTracker, EncodedData},
 };
 
-pub use super::ipc::write::default_ipc_fields;
 use super::ipc::{IpcField, IpcSchema};
+
+pub use super::ipc::write::default_ipc_fields;
+pub use crate::io::ipc::write::common::WriteOptions;
 
 /// Serializes [`Chunk`] to a vector of [`FlightData`] representing the serialized dictionaries
 /// and a [`FlightData`] representing the batch.

--- a/tests/it/io/flight/mod.rs
+++ b/tests/it/io/flight/mod.rs
@@ -1,0 +1,32 @@
+use arrow2::array::Array;
+use arrow2::chunk::Chunk;
+use arrow2::datatypes::Schema;
+use arrow2::error::Error;
+
+use arrow2::io::flight::*;
+use arrow2::io::ipc::write::{default_ipc_fields, WriteOptions};
+
+use super::ipc::read_gzip_json;
+
+fn round_trip(schema: Schema, chunk: Chunk<Box<dyn Array>>) -> Result<(), Error> {
+    let fields = default_ipc_fields(&schema.fields);
+    let serialized = serialize_schema(&schema, Some(&fields));
+    let (result, ipc_schema) = deserialize_schemas(&serialized.data_header)?;
+    assert_eq!(schema, result);
+
+    let (_, batch) = serialize_batch(&chunk, &fields, &WriteOptions { compression: None })?;
+
+    let result = deserialize_batch(&batch, &result.fields, &ipc_schema, &Default::default())?;
+    assert_eq!(result, chunk);
+    Ok(())
+}
+
+#[test]
+fn generated_nested_dictionary() -> Result<(), Error> {
+    let (schema, _, mut batches) =
+        read_gzip_json("1.0.0-littleendian", "generated_nested").unwrap();
+
+    round_trip(schema, batches.pop().unwrap())?;
+
+    Ok(())
+}

--- a/tests/it/io/mod.rs
+++ b/tests/it/io/mod.rs
@@ -22,3 +22,6 @@ mod avro;
     feature = "io_csv_read_async"
 ))]
 mod csv;
+
+#[cfg(feature = "io_flight")]
+mod flight;


### PR DESCRIPTION
Exposed some utilities from `io::ipc`  used in `io::flight` at `io::flight`.