### PR TITLE
Avoid clone in `with_validity`

### DIFF
--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -219,17 +219,23 @@ impl<O: Offset> BinaryArray<O> {
         std::sync::Arc::new(self)
     }
 
-    /// Clones this [`BinaryArray`] with a different validity.
+    /// Returns this [`BinaryArray`] with a new validity.
     /// # Panic
     /// Panics iff `validity.len() != self.len()`.
     #[must_use]
-    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+    pub fn with_validity(mut self, validity: Option<Bitmap>) -> Self {
+        self.set_validity(validity);
+        self
+    }
+
+    /// Sets the validity of this [`BinaryArray`].
+    /// # Panics
+    /// This function panics iff `values.len() != self.len()`.
+    pub fn set_validity(&mut self, validity: Option<Bitmap>) {
         if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
-            panic!("validity's length must be equal to the array's length")
+            panic!("validity must be equal to the array's length")
         }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        arr
+        self.validity = validity;
     }
 
     /// Creates an empty [`BinaryArray`], i.e. whose `.len` is zero.
@@ -449,7 +455,7 @@ impl<O: Offset> Array for BinaryArray<O> {
         Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
-        Box::new(self.with_validity(validity))
+        Box::new(self.clone().with_validity(validity))
     }
     fn to_boxed(&self) -> Box<dyn Array> {
         Box::new(self.clone())

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -175,14 +175,13 @@ impl BooleanArray {
         }
     }
 
-    /// Clones this [`BooleanArray`], returning one with the provided validity.
+    /// Returns this [`BooleanArray`] with a new validity.
     /// # Panic
     /// This function panics iff `validity.len() != self.len()`.
     #[must_use]
-    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        let mut array = self.clone();
-        array.set_validity(validity);
-        array
+    pub fn with_validity(mut self, validity: Option<Bitmap>) -> Self {
+        self.set_validity(validity);
+        self
     }
 
     /// Sets the validity of this [`BooleanArray`].
@@ -412,7 +411,7 @@ impl Array for BooleanArray {
         Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
-        Box::new(self.with_validity(validity))
+        Box::new(self.clone().with_validity(validity))
     }
     fn to_boxed(&self) -> Box<dyn Array> {
         Box::new(self.clone())

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -109,16 +109,20 @@ impl<K: DictionaryKey> DictionaryArray<K> {
         }
     }
 
-    /// Sets the validity bitmap on this [`Array`].
+    /// Returns this [`DictionaryArray`] with a new validity.
     /// # Panic
     /// This function panics iff `validity.len() != self.len()`.
-    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
-        if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
-            panic!("validity should be as least as large as the array")
-        }
-        let mut arr = self.clone();
-        arr.values = arr.values.with_validity(validity);
-        arr
+    #[must_use]
+    pub fn with_validity(mut self, validity: Option<Bitmap>) -> Self {
+        self.set_validity(validity);
+        self
+    }
+
+    /// Sets the validity of the keys of this [`DictionaryArray`].
+    /// # Panics
+    /// This function panics iff `validity.len() != self.len()`.
+    pub fn set_validity(&mut self, validity: Option<Bitmap>) {
+        self.keys.set_validity(validity);
     }
 }
 
@@ -213,7 +217,7 @@ impl<K: DictionaryKey> Array for DictionaryArray<K> {
         Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
-        Box::new(self.with_validity(validity))
+        Box::new(self.clone().with_validity(validity))
     }
     fn to_boxed(&self) -> Box<dyn Array> {
         Box::new(self.clone())

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -144,17 +144,23 @@ impl FixedSizeBinaryArray {
         }
     }
 
-    /// Sets the validity bitmap on this [`FixedSizeBinaryArray`].
+    /// Returns this [`FixedSizeBinaryArray`] with a new validity.
     /// # Panic
     /// This function panics iff `validity.len() != self.len()`.
     #[must_use]
-    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+    pub fn with_validity(mut self, validity: Option<Bitmap>) -> Self {
+        self.set_validity(validity);
+        self
+    }
+
+    /// Sets the validity of this [`FixedSizeBinaryArray`].
+    /// # Panics
+    /// This function panics iff `validity.len() != self.len()`.
+    pub fn set_validity(&mut self, validity: Option<Bitmap>) {
         if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
-            panic!("validity should be as least as large as the array")
+            panic!("validity must be equal to the array's length")
         }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        arr
+        self.validity = validity;
     }
 }
 
@@ -273,12 +279,15 @@ impl Array for FixedSizeBinaryArray {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
+
     unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice_unchecked(offset, length))
     }
+
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
-        Box::new(self.with_validity(validity))
+        Box::new(self.clone().with_validity(validity))
     }
+
     fn to_boxed(&self) -> Box<dyn Array> {
         Box::new(self.clone())
     }

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -158,17 +158,23 @@ impl FixedSizeListArray {
         }
     }
 
-    /// Sets the validity bitmap on this [`FixedSizeListArray`].
+    /// Returns this [`FixedSizeListArray`] with a new validity.
     /// # Panic
     /// This function panics iff `validity.len() != self.len()`.
     #[must_use]
-    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+    pub fn with_validity(mut self, validity: Option<Bitmap>) -> Self {
+        self.set_validity(validity);
+        self
+    }
+
+    /// Sets the validity of this [`FixedSizeListArray`].
+    /// # Panics
+    /// This function panics iff `validity.len() != self.len()`.
+    pub fn set_validity(&mut self, validity: Option<Bitmap>) {
         if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
-            panic!("validity should be as least as large as the array")
+            panic!("validity must be equal to the array's length")
         }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        arr
+        self.validity = validity;
     }
 }
 
@@ -268,7 +274,7 @@ impl Array for FixedSizeListArray {
         Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
-        Box::new(self.with_validity(validity))
+        Box::new(self.clone().with_validity(validity))
     }
     fn to_boxed(&self) -> Box<dyn Array> {
         Box::new(self.clone())

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -231,16 +231,23 @@ impl<O: Offset> ListArray<O> {
         }
     }
 
-    /// Sets the validity bitmap on this [`ListArray`].
+    /// Returns this [`ListArray`] with a new validity.
     /// # Panic
     /// This function panics iff `validity.len() != self.len()`.
-    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+    #[must_use]
+    pub fn with_validity(mut self, validity: Option<Bitmap>) -> Self {
+        self.set_validity(validity);
+        self
+    }
+
+    /// Sets the validity of this [`ListArray`].
+    /// # Panics
+    /// This function panics iff `validity.len() != self.len()`.
+    pub fn set_validity(&mut self, validity: Option<Bitmap>) {
         if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
-            panic!("validity should be as least as large as the array")
+            panic!("validity must be equal to the array's length")
         }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        arr
+        self.validity = validity;
     }
 }
 
@@ -368,12 +375,15 @@ impl<O: Offset> Array for ListArray<O> {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
+
     unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice_unchecked(offset, length))
     }
+
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
-        Box::new(self.with_validity(validity))
+        Box::new(self.clone().with_validity(validity))
     }
+
     fn to_boxed(&self) -> Box<dyn Array> {
         Box::new(self.clone())
     }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -102,9 +102,9 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
     /// The caller must ensure that `offset + length <= self.len()`
     unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array>;
 
-    /// Sets the validity bitmap on this [`Array`].
+    /// Clones this [`Array`] with a new new assigned bitmap.
     /// # Panic
-    /// This function panics iff `validity.len() < self.len()`.
+    /// This function panics iff `validity.len() != self.len()`.
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array>;
 
     /// Clone a `&dyn Array` to an owned `Box<dyn Array>`.

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -114,6 +114,7 @@ impl Array for NullArray {
     fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {
         panic!("cannot set validity of a null array")
     }
+
     fn to_boxed(&self) -> Box<dyn Array> {
         Box::new(self.clone())
     }

--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -208,17 +208,23 @@ impl StructArray {
         }
     }
 
-    /// Sets the validity bitmap on this [`StructArray`].
-    /// # Panic
+    /// Returns this [`StructArray`] with a new validity.
+    /// # Panics
     /// This function panics iff `validity.len() != self.len()`.
     #[must_use]
-    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+    pub fn with_validity(mut self, validity: Option<Bitmap>) -> Self {
+        self.set_validity(validity);
+        self
+    }
+
+    /// Sets the validity of this [`StructArray`].
+    /// # Panics
+    /// This function panics iff `validity.len() != self.len()`.
+    pub fn set_validity(&mut self, validity: Option<Bitmap>) {
         if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
-            panic!("validity should be as least as large as the array")
+            panic!("validity's length must be equal to the array's length")
         }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        arr
+        self.validity = validity;
     }
 
     /// Boxes self into a [`Box<dyn Array>`].
@@ -302,12 +308,15 @@ impl Array for StructArray {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
+
     unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice_unchecked(offset, length))
     }
+
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
-        Box::new(self.with_validity(validity))
+        Box::new(self.clone().with_validity(validity))
     }
+
     fn to_boxed(&self) -> Box<dyn Array> {
         Box::new(self.clone())
     }

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -230,16 +230,23 @@ impl<O: Offset> Utf8Array<O> {
         std::sync::Arc::new(self)
     }
 
-    /// Clones this [`Utf8Array`] and assigns it a new validity
-    /// # Panic
+    /// Returns this [`Utf8Array`] with a new validity.
+    /// # Panics
     /// This function panics iff `validity.len() != self.len()`.
-    pub fn with_validity(&self, validity: Option<Bitmap>) -> Self {
+    #[must_use]
+    pub fn with_validity(mut self, validity: Option<Bitmap>) -> Self {
+        self.set_validity(validity);
+        self
+    }
+
+    /// Sets the validity of this [`Utf8Array`].
+    /// # Panics
+    /// This function panics iff `validity.len() != self.len()`.
+    pub fn set_validity(&mut self, validity: Option<Bitmap>) {
         if matches!(&validity, Some(bitmap) if bitmap.len() != self.len()) {
-            panic!("validity's len must be equal to the array")
+            panic!("validity's length must be equal to the array's length")
         }
-        let mut arr = self.clone();
-        arr.validity = validity;
-        arr
+        self.validity = validity;
     }
 
     /// Try to convert this `Utf8Array` to a `MutableUtf8Array`
@@ -566,7 +573,7 @@ impl<O: Offset> Array for Utf8Array<O> {
         Box::new(self.slice_unchecked(offset, length))
     }
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
-        Box::new(self.with_validity(validity))
+        Box::new(self.clone().with_validity(validity))
     }
 
     fn to_boxed(&self) -> Box<dyn Array> {

--- a/src/compute/comparison/binary.rs
+++ b/src/compute/comparison/binary.rs
@@ -56,8 +56,8 @@ pub fn eq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> BooleanArray
 pub fn eq_and_validity<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> BooleanArray {
     let validity_lhs = lhs.validity().cloned();
     let validity_rhs = rhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
-    let rhs = rhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
+    let rhs = rhs.clone().with_validity(None);
     let out = compare_op(&lhs, &rhs, |a, b| a == b);
 
     finish_eq_validities(out, validity_lhs, validity_rhs)
@@ -71,7 +71,7 @@ pub fn eq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
 /// Perform `lhs == rhs` operation on [`BinaryArray`] and a scalar and include validities in comparison.
 pub fn eq_scalar_and_validity<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
     let validity = lhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
     let out = compare_op_scalar(&lhs, rhs, |a, b| a == b);
 
     finish_eq_validities(out, validity, None)
@@ -90,8 +90,8 @@ pub fn neq<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> BooleanArra
 pub fn neq_and_validity<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> BooleanArray {
     let validity_lhs = lhs.validity().cloned();
     let validity_rhs = rhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
-    let rhs = rhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
+    let rhs = rhs.clone().with_validity(None);
 
     let out = compare_op(&lhs, &rhs, |a, b| a != b);
     finish_neq_validities(out, validity_lhs, validity_rhs)
@@ -105,7 +105,7 @@ pub fn neq_scalar<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
 /// Perform `lhs != rhs` operation on [`BinaryArray`] and a scalar and include validities in comparison.
 pub fn neq_scalar_and_validity<O: Offset>(lhs: &BinaryArray<O>, rhs: &[u8]) -> BooleanArray {
     let validity = lhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
     let out = compare_op_scalar(&lhs, rhs, |a, b| a != b);
 
     finish_neq_validities(out, validity, None)

--- a/src/compute/comparison/boolean.rs
+++ b/src/compute/comparison/boolean.rs
@@ -43,8 +43,8 @@ pub fn eq(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
 pub fn eq_and_validity(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
     let validity_lhs = lhs.validity().cloned();
     let validity_rhs = rhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
-    let rhs = rhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
+    let rhs = rhs.clone().with_validity(None);
     let out = compare_op(&lhs, &rhs, |a, b| !(a ^ b));
 
     finish_eq_validities(out, validity_lhs, validity_rhs)
@@ -62,7 +62,7 @@ pub fn eq_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
 /// Perform `lhs == rhs` operation on a [`BooleanArray`] and a scalar value and include validities in comparison.
 pub fn eq_scalar_and_validity(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
     let validity = lhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
     if rhs {
         finish_eq_validities(lhs, validity, None)
     } else {
@@ -83,8 +83,8 @@ pub fn neq(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
 pub fn neq_and_validity(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
     let validity_lhs = lhs.validity().cloned();
     let validity_rhs = rhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
-    let rhs = rhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
+    let rhs = rhs.clone().with_validity(None);
     let out = compare_op(&lhs, &rhs, |a, b| a ^ b);
 
     finish_neq_validities(out, validity_lhs, validity_rhs)
@@ -98,7 +98,7 @@ pub fn neq_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
 /// Perform `left != right` operation on an array and a scalar value.
 pub fn neq_scalar_and_validity(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
     let validity = lhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
     let out = eq_scalar(&lhs, !rhs);
     finish_neq_validities(out, validity, None)
 }

--- a/src/compute/comparison/primitive.rs
+++ b/src/compute/comparison/primitive.rs
@@ -108,8 +108,8 @@ where
 {
     let validity_lhs = lhs.validity().cloned();
     let validity_rhs = rhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
-    let rhs = rhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
+    let rhs = rhs.clone().with_validity(None);
     let out = compare_op(&lhs, &rhs, |a, b| a.eq(b));
 
     finish_eq_validities(out, validity_lhs, validity_rhs)
@@ -131,7 +131,7 @@ where
     T::Simd: Simd8PartialEq,
 {
     let validity = lhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
     let out = compare_op_scalar(&lhs, rhs, |a, b| a.eq(b));
 
     finish_eq_validities(out, validity, None)
@@ -154,8 +154,8 @@ where
 {
     let validity_lhs = lhs.validity().cloned();
     let validity_rhs = rhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
-    let rhs = rhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
+    let rhs = rhs.clone().with_validity(None);
     let out = compare_op(&lhs, &rhs, |a, b| a.neq(b));
 
     finish_neq_validities(out, validity_lhs, validity_rhs)
@@ -177,7 +177,7 @@ where
     T::Simd: Simd8PartialEq,
 {
     let validity = lhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
     let out = compare_op_scalar(&lhs, rhs, |a, b| a.neq(b));
 
     finish_neq_validities(out, validity, None)

--- a/src/compute/comparison/utf8.rs
+++ b/src/compute/comparison/utf8.rs
@@ -51,8 +51,8 @@ pub fn eq<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> BooleanArray {
 pub fn eq_and_validity<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> BooleanArray {
     let validity_lhs = lhs.validity().cloned();
     let validity_rhs = rhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
-    let rhs = rhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
+    let rhs = rhs.clone().with_validity(None);
     let out = compare_op(&lhs, &rhs, |a, b| a == b);
 
     finish_eq_validities(out, validity_lhs, validity_rhs)
@@ -62,8 +62,8 @@ pub fn eq_and_validity<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> Boo
 pub fn neq_and_validity<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> BooleanArray {
     let validity_lhs = lhs.validity().cloned();
     let validity_rhs = rhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
-    let rhs = rhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
+    let rhs = rhs.clone().with_validity(None);
     let out = compare_op(&lhs, &rhs, |a, b| a != b);
 
     finish_neq_validities(out, validity_lhs, validity_rhs)
@@ -77,7 +77,7 @@ pub fn eq_scalar<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
 /// Perform `lhs == rhs` operation on [`Utf8Array`] and a scalar. Also includes null values in comparisson.
 pub fn eq_scalar_and_validity<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     let validity = lhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
     let out = compare_op_scalar(&lhs, rhs, |a, b| a == b);
 
     finish_eq_validities(out, validity, None)
@@ -86,7 +86,7 @@ pub fn eq_scalar_and_validity<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> Boole
 /// Perform `lhs != rhs` operation on [`Utf8Array`] and a scalar. Also includes null values in comparisson.
 pub fn neq_scalar_and_validity<O: Offset>(lhs: &Utf8Array<O>, rhs: &str) -> BooleanArray {
     let validity = lhs.validity().cloned();
-    let lhs = lhs.with_validity(None);
+    let lhs = lhs.clone().with_validity(None);
     let out = compare_op_scalar(&lhs, rhs, |a, b| a != b);
 
     finish_neq_validities(out, validity, None)

--- a/tests/it/compute/comparison.rs
+++ b/tests/it/compute/comparison.rs
@@ -265,7 +265,7 @@ fn compare_no_propagating_nulls_eq() {
 
     // now mask with a null
     let mask = Bitmap::from_iter([false, true, true]);
-    let a_masked = a.with_validity(Some(mask));
+    let a_masked = a.clone().with_validity(Some(mask));
     let out = comparison::utf8::eq_and_validity(&a, &a_masked);
     check_mask(&out, &[false, true, true]);
 
@@ -306,7 +306,7 @@ fn compare_no_propagating_nulls_neq() {
 
     // now mask with a null
     let mask = Bitmap::from_iter([false, true, true]);
-    let a_masked = a.with_validity(Some(mask));
+    let a_masked = a.clone().with_validity(Some(mask));
     let out = comparison::utf8::neq_and_validity(&a, &a_masked);
     check_mask(&out, &[true, false, false]);
 


### PR DESCRIPTION
This PR modifies the concrete implementations of `with_validity` to not clone the arrays unless explicitly requires.

The motivation is that when an array is cloned, it becomes immutable (an `O(N)` clone of the data is required to mutate it). Thus, we should only clone when the user needs to clone.

# Migration

To migrate, use `array.clone().with_validity(...)` instead of `array.with_validity(...)` when clone is required.

