### PR TITLE
Removed some panics reading invalid parquet files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ futures = { version = "0.3", optional = true }
 ahash = { version = "0.7", optional = true }
 
 # parquet support
-parquet2 = { version = "0.13.1", optional = true, default_features = false }
+parquet2 = { version = "0.14.0", optional = true, default_features = false }
 
 # avro support
 avro-schema = { version = "0.2", optional = true }

--- a/src/io/parquet/read/deserialize/primitive/nested.rs
+++ b/src/io/parquet/read/deserialize/primitive/nested.rs
@@ -92,19 +92,20 @@ where
         ) {
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, false) => {
                 let dict = dict.as_any().downcast_ref().unwrap();
-                Ok(State::RequiredDictionary(ValuesDictionary::new(page, dict)))
+                ValuesDictionary::try_new(page, dict).map(State::RequiredDictionary)
             }
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, false) => {
                 let dict = dict.as_any().downcast_ref().unwrap();
                 Ok(State::OptionalDictionary(
-                    Optional::new(page),
-                    ValuesDictionary::new(page, dict),
+                    Optional::try_new(page)?,
+                    ValuesDictionary::try_new(page, dict)?,
                 ))
             }
-            (Encoding::Plain, _, true, false) => {
-                Ok(State::Optional(Optional::new(page), Values::new::<P>(page)))
-            }
-            (Encoding::Plain, _, false, false) => Ok(State::Required(Values::new::<P>(page))),
+            (Encoding::Plain, _, true, false) => Ok(State::Optional(
+                Optional::try_new(page)?,
+                Values::try_new::<P>(page)?,
+            )),
+            (Encoding::Plain, _, false, false) => Ok(State::Required(Values::try_new::<P>(page)?)),
             _ => Err(utils::not_implemented(page)),
         }
     }


### PR DESCRIPTION
This PR removes common panics that emerge when reading parquet files.

This still does not shield us from all the panics - only from panics derived from invalid metadata, negative lengths, etc. - deserializing pages still panics.