### PR TITLE
Removed unused `NativeType::to_ne_bytes`

### DIFF
--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -486,8 +486,7 @@ impl<O: Offset> Utf8Array<O> {
         P: AsRef<str>,
         I: TrustedLen<Item = Option<P>>,
     {
-        // soundness: I is `TrustedLen`
-        unsafe { Self::from_trusted_len_iter_unchecked(iterator) }
+        MutableUtf8Array::<O>::from_trusted_len_iter(iterator).into()
     }
 
     /// Creates a [`Utf8Array`] from an falible iterator of trusted length.
@@ -512,8 +511,7 @@ impl<O: Offset> Utf8Array<O> {
         P: AsRef<str>,
         I: TrustedLen<Item = std::result::Result<Option<P>, E>>,
     {
-        // soundness: I: TrustedLen
-        unsafe { Self::try_from_trusted_len_iter_unchecked(iter) }
+        MutableUtf8Array::<O>::try_from_trusted_len_iter(iter).map(|x| x.into())
     }
 
     /// Alias for `new`

--- a/tests/it/array/primitive/mod.rs
+++ b/tests/it/array/primitive/mod.rs
@@ -72,7 +72,7 @@ fn from() {
 }
 
 #[test]
-fn months_days_ns() {
+fn months_days_ns_from_slice() {
     let data = &[
         months_days_ns::new(1, 1, 2),
         months_days_ns::new(1, 1, 3),

--- a/tests/it/array/utf8/mod.rs
+++ b/tests/it/array/utf8/mod.rs
@@ -215,3 +215,21 @@ fn into_mut_4() {
     let array = Utf8Array::<i32>::new(DataType::Utf8, offsets, values, validity);
     assert!(array.into_mut().is_right());
 }
+
+#[test]
+fn rev_iter() {
+    let array = Utf8Array::<i32>::from(&[Some("hello"), Some(" "), None]);
+
+    assert_eq!(
+        array.into_iter().rev().collect::<Vec<_>>(),
+        vec![None, Some(" "), Some("hello")]
+    );
+}
+
+#[test]
+fn iter_nth() {
+    let array = Utf8Array::<i32>::from(&[Some("hello"), Some(" "), None]);
+
+    assert_eq!(array.iter().nth(1), Some(Some(" ")));
+    assert_eq!(array.iter().nth(10), None);
+}

--- a/tests/it/array/utf8/mutable.rs
+++ b/tests/it/array/utf8/mutable.rs
@@ -141,3 +141,29 @@ fn test_extend_values() {
     assert_eq!(array.offsets().as_slice(), &[0, 2, 7, 12, 17]);
     assert_eq!(array.validity(), None,);
 }
+
+#[test]
+fn test_extend() {
+    let mut array = MutableUtf8Array::<i32>::new();
+
+    array.extend([Some("hi"), None, Some("there"), None].into_iter());
+
+    let array: Utf8Array<i32> = array.into();
+
+    assert_eq!(
+        array,
+        Utf8Array::<i32>::from([Some("hi"), None, Some("there"), None])
+    );
+}
+
+#[test]
+fn as_arc() {
+    let mut array = MutableUtf8Array::<i32>::new();
+
+    array.extend([Some("hi"), None, Some("there"), None].into_iter());
+
+    assert_eq!(
+        Utf8Array::<i32>::from([Some("hi"), None, Some("there"), None]),
+        array.as_arc().as_ref()
+    );
+}

--- a/tests/it/types.rs
+++ b/tests/it/types.rs
@@ -1,4 +1,4 @@
-use arrow2::types::{BitChunkIter, BitChunkOnes};
+use arrow2::types::{days_ms, months_days_ns, BitChunkIter, BitChunkOnes, NativeType};
 
 #[test]
 fn test_basic1() {
@@ -17,4 +17,24 @@ fn test_ones() {
     assert_eq!(iter.size_hint(), (2, Some(2)));
     assert_eq!(iter.next(), Some(0));
     assert_eq!(iter.next(), Some(12));
+}
+
+#[test]
+fn months_days_ns_roundtrip() {
+    let a = months_days_ns(1, 2, 3);
+    let bytes = a.to_le_bytes();
+    assert_eq!(bytes, [1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0]);
+
+    let a = months_days_ns(1, 1, 1);
+    assert_eq!(a, months_days_ns::from_be_bytes(a.to_be_bytes()));
+}
+
+#[test]
+fn days_ms_roundtrip() {
+    let a = days_ms(1, 2);
+    let bytes = a.to_le_bytes();
+    assert_eq!(bytes, [1, 0, 0, 0, 2, 0, 0, 0]);
+
+    let a = days_ms(1, 2);
+    assert_eq!(a, days_ms::from_be_bytes(a.to_be_bytes()));
 }


### PR DESCRIPTION
This is an old function that is not really used nor needed (since `ne` does not take endianess into account).

Also added a bunch of tests covering from and to bytes of custom types.
