### PR TITLE
parquet: Don't take ownership of `Vec<Eccoding>`

### DIFF
--- a/src/io/parquet/write/pages.rs
+++ b/src/io/parquet/write/pages.rs
@@ -198,7 +198,7 @@ pub fn array_to_columns<A: AsRef<dyn Array> + Send + Sync>(
     array: A,
     type_: ParquetType,
     options: WriteOptions,
-    encoding: Vec<Encoding>,
+    encoding: &[Encoding],
 ) -> Result<Vec<DynIter<'static, Result<EncodedPage>>>> {
     let array = array.as_ref();
     let nested = to_nested(array, &type_)?;
@@ -213,9 +213,9 @@ pub fn array_to_columns<A: AsRef<dyn Array> + Send + Sync>(
         .iter()
         .zip(nested.into_iter())
         .zip(types.into_iter())
-        .zip(encoding.into_iter())
+        .zip(encoding.iter())
         .map(|(((values, nested), type_), encoding)| {
-            array_to_pages(*values, type_, nested, options, encoding)
+            array_to_pages(*values, type_, nested, options, *encoding)
         })
         .collect()
 }

--- a/src/io/parquet/write/row_group.rs
+++ b/src/io/parquet/write/row_group.rs
@@ -36,7 +36,7 @@ pub fn row_group_iter<A: AsRef<dyn Array> + 'static + Send + Sync>(
             .zip(fields.into_iter())
             .zip(encodings.into_iter())
             .flat_map(move |((array, type_), encoding)| {
-                let encoded_columns = array_to_columns(array, type_, options, encoding).unwrap();
+                let encoded_columns = array_to_columns(array, type_, options, &encoding).unwrap();
                 encoded_columns
                     .into_iter()
                     .map(|encoded_pages| {


### PR DESCRIPTION
array_to_columns could do with a slice as `Encoding`
is `Copy`