### PR TITLE
Improved parquet read performance

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,12 @@ impl From<simdutf8::basic::Utf8Error> for Error {
     }
 }
 
+impl From<std::collections::TryReserveError> for Error {
+    fn from(_: std::collections::TryReserveError) -> Error {
+        Error::Overflow
+    }
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
See performance details [here](https://github.com/DataEngineeringLabs/bench-read-rs) and tip by [Kornel](https://users.rust-lang.org/u/kornel/summary) at https://users.rust-lang.org/t/how-to-efficiently-re-use-a-vec-u8-for-multiple-read-read/77628/6 

Essentially, we no longer zero the allocation when reading.