### PR TITLE
Change signature of PrimitiveScalar::value to return reference

### DIFF
--- a/src/compute/arithmetics/decimal/div.rs
+++ b/src/compute/arithmetics/decimal/div.rs
@@ -74,7 +74,7 @@ pub fn div(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveA
 pub fn div_scalar(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveScalar<i128>) -> PrimitiveArray<i128> {
     let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
-    let rhs = if let Some(rhs) = rhs.value() {
+    let rhs = if let Some(rhs) = *rhs.value() {
         rhs
     } else {
         return PrimitiveArray::<i128>::new_null(lhs.data_type().clone(), lhs.len());

--- a/src/compute/arithmetics/decimal/mul.rs
+++ b/src/compute/arithmetics/decimal/mul.rs
@@ -75,7 +75,7 @@ pub fn mul(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> PrimitiveA
 pub fn mul_scalar(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveScalar<i128>) -> PrimitiveArray<i128> {
     let (precision, scale) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
 
-    let rhs = if let Some(rhs) = rhs.value() {
+    let rhs = if let Some(rhs) = *rhs.value() {
         rhs
     } else {
         return PrimitiveArray::<i128>::new_null(lhs.data_type().clone(), lhs.len());

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -106,7 +106,7 @@ fn binary_scalar<T: NativeType, F: Fn(&PrimitiveArray<T>, &T) -> PrimitiveArray<
     rhs: &PrimitiveScalar<T>,
     op: F,
 ) -> PrimitiveArray<T> {
-    let rhs = if let Some(rhs) = rhs.value() {
+    let rhs = if let Some(rhs) = *rhs.value() {
         rhs
     } else {
         return PrimitiveArray::<T>::new_null(lhs.data_type().clone(), lhs.len());

--- a/src/compute/arithmetics/time.rs
+++ b/src/compute/arithmetics/time.rs
@@ -130,7 +130,7 @@ where
     T: NativeType + Add<T, Output = T>,
 {
     let scale = create_scale(time.data_type(), duration.data_type()).unwrap();
-    let duration = if let Some(duration) = duration.value() {
+    let duration = if let Some(duration) = *duration.value() {
         duration
     } else {
         return PrimitiveArray::<T>::new_null(time.data_type().clone(), time.len());
@@ -211,7 +211,7 @@ where
     T: NativeType + Sub<T, Output = T>,
 {
     let scale = create_scale(time.data_type(), duration.data_type()).unwrap();
-    let duration = if let Some(duration) = duration.value() {
+    let duration = if let Some(duration) = *duration.value() {
         duration
     } else {
         return PrimitiveArray::<T>::new_null(time.data_type().clone(), time.len());
@@ -297,7 +297,7 @@ pub fn sub_timestamps_scalar(
             ));
         };
 
-    let rhs = if let Some(value) = rhs.value() {
+    let rhs = if let Some(value) = *rhs.value() {
         value
     } else {
         return Ok(PrimitiveArray::<i64>::new_null(
@@ -374,7 +374,7 @@ pub fn add_interval_scalar(
     timestamp: &PrimitiveArray<i64>,
     interval: &PrimitiveScalar<months_days_ns>,
 ) -> Result<PrimitiveArray<i64>> {
-    let interval = if let Some(interval) = interval.value() {
+    let interval = if let Some(interval) = *interval.value() {
         interval
     } else {
         return Ok(PrimitiveArray::<i64>::new_null(

--- a/src/scalar/primitive.rs
+++ b/src/scalar/primitive.rs
@@ -27,8 +27,8 @@ impl<T: NativeType> PrimitiveScalar<T> {
 
     /// Returns the optional value.
     #[inline]
-    pub fn value(&self) -> Option<T> {
-        self.value
+    pub fn value(&self) -> &Option<T> {
+        &self.value
     }
 
     /// Returns a new `PrimitiveScalar` with the same value but different [`DataType`]

--- a/tests/it/array/union.rs
+++ b/tests/it/array/union.rs
@@ -106,11 +106,11 @@ fn iter_sparse() -> Result<()> {
 
     assert_eq!(
         next_unchecked::<PrimitiveScalar<i32>, _>(&mut iter).value(),
-        Some(1)
+        &Some(1)
     );
     assert_eq!(
         next_unchecked::<PrimitiveScalar<i32>, _>(&mut iter).value(),
-        None
+        &None
     );
     assert_eq!(
         next_unchecked::<Utf8Scalar<i32>, _>(&mut iter).value(),
@@ -140,11 +140,11 @@ fn iter_dense() -> Result<()> {
 
     assert_eq!(
         next_unchecked::<PrimitiveScalar<i32>, _>(&mut iter).value(),
-        Some(1)
+        &Some(1)
     );
     assert_eq!(
         next_unchecked::<PrimitiveScalar<i32>, _>(&mut iter).value(),
-        None
+        &None
     );
     assert_eq!(
         next_unchecked::<Utf8Scalar<i32>, _>(&mut iter).value(),
@@ -174,7 +174,7 @@ fn iter_sparse_slice() -> Result<()> {
 
     assert_eq!(
         next_unchecked::<PrimitiveScalar<i32>, _>(&mut iter).value(),
-        Some(3)
+        &Some(3)
     );
     assert_eq!(iter.next(), None);
 
@@ -201,7 +201,7 @@ fn iter_dense_slice() -> Result<()> {
 
     assert_eq!(
         next_unchecked::<PrimitiveScalar<i32>, _>(&mut iter).value(),
-        Some(3)
+        &Some(3)
     );
     assert_eq!(iter.next(), None);
 
@@ -233,7 +233,7 @@ fn scalar() -> Result<()> {
             .downcast_ref::<PrimitiveScalar<i32>>()
             .unwrap()
             .value(),
-        Some(1)
+        &Some(1)
     );
     assert_eq!(union_scalar.type_(), 0);
     let scalar = new_scalar(&array, 1);
@@ -245,7 +245,7 @@ fn scalar() -> Result<()> {
             .downcast_ref::<PrimitiveScalar<i32>>()
             .unwrap()
             .value(),
-        None
+        &None
     );
     assert_eq!(union_scalar.type_(), 0);
 

--- a/tests/it/scalar/primitive.rs
+++ b/tests/it/scalar/primitive.rs
@@ -20,7 +20,7 @@ fn equal() {
 fn basics() {
     let a = PrimitiveScalar::from(Some(2i32));
 
-    assert_eq!(a.value(), Some(2i32));
+    assert_eq!(a.value(), &Some(2i32));
     assert_eq!(a.data_type(), &DataType::Int32);
 
     let a = a.to(DataType::Date32);


### PR DESCRIPTION
The use-case is to be able to write generic code that uses scalars with `Array` iterators (for example in arrow2-convert for the deserialization path). This is much easier if the `PrimitiveScalar::value()` is consistent with the rest of scalars and returns a reference.

This could be too high risk of a change if too many downstream users will be affected, so alternately a new method `PrimitiveScalar::value_ref()` could be introduces that returns the reference. But that seemed less clean, so opted for this change to get feedback. There seems to be good test coverage around scalars, and all the tests are passing.