### PR TITLE
Fixed wrong package name in examples

### DIFF
--- a/examples/parquet_read_parallel/Cargo.toml
+++ b/examples/parquet_read_parallel/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "parquet_write_parallel"
+name = "parquet_read_parallel"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
Cargo with the lastest nightly will report:

```shell
warning: skipping duplicate package `parquet_write_parallel` found at `/home/xuanwo/.cargo/git/checkouts/arrow2-6249446b5f8db6f7/6608071/examples/parquet_write_parallel`
```

This PR fixes it.

Signed-off-by: Xuanwo <github@xuanwo.io>