### PR TITLE
Improved dictionary invariants

### DIFF
--- a/src/array/dictionary/ffi.rs
+++ b/src/array/dictionary/ffi.rs
@@ -1,6 +1,6 @@
 use crate::{
     array::{FromFfi, PrimitiveArray, ToFfi},
-    error::Result,
+    error::Error,
     ffi,
 };
 
@@ -25,16 +25,20 @@ unsafe impl<K: DictionaryKey> ToFfi for DictionaryArray<K> {
 }
 
 impl<K: DictionaryKey, A: ffi::ArrowArrayRef> FromFfi<A> for DictionaryArray<K> {
-    unsafe fn try_from_ffi(array: A) -> Result<Self> {
+    unsafe fn try_from_ffi(array: A) -> Result<Self, Error> {
         // keys: similar to PrimitiveArray, but the datatype is the inner one
         let validity = unsafe { array.validity() }?;
         let values = unsafe { array.buffer::<K>(1) }?;
 
-        let data_type = K::PRIMITIVE.into();
-        let keys = PrimitiveArray::<K>::try_new(data_type, values, validity)?;
-        let values = array.dictionary()?.unwrap();
+        let data_type = array.data_type().clone();
+
+        let keys = PrimitiveArray::<K>::try_new(K::PRIMITIVE.into(), values, validity)?;
+        let values = array
+            .dictionary()?
+            .ok_or_else(|| Error::oos("Dictionary Array must contain a dictionary in ffi"))?;
         let values = ffi::try_from(values)?;
 
-        Ok(DictionaryArray::<K>::from_data(keys, values))
+        // the assumption of this trait
+        DictionaryArray::<K>::try_new_unchecked(data_type, keys, values)
     }
 }

--- a/src/array/dictionary/fmt.rs
+++ b/src/array/dictionary/fmt.rs
@@ -15,7 +15,7 @@ pub fn write_value<K: DictionaryKey, W: Write>(
     let values = array.values();
 
     if keys.is_valid(index) {
-        let key = keys.value(index).to_usize().unwrap();
+        let key = array.key_value(index);
         get_display(values.as_ref(), null)(f, key)
     } else {
         write!(f, "{}", null)

--- a/src/array/dictionary/iterator.rs
+++ b/src/array/dictionary/iterator.rs
@@ -1,4 +1,4 @@
-use crate::bitmap::utils::{zip_validity, ZipValidity};
+use crate::bitmap::utils::ZipValidity;
 use crate::scalar::Scalar;
 use crate::trusted_len::TrustedLen;
 
@@ -64,20 +64,5 @@ impl<'a, K: DictionaryKey> IntoIterator for &'a DictionaryArray<K> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
-    }
-}
-
-impl<'a, K: DictionaryKey> DictionaryArray<K> {
-    /// Returns an iterator of `Option<Box<dyn Array>>`
-    pub fn iter(&'a self) -> ZipIter<'a, K> {
-        zip_validity(
-            DictionaryValuesIter::new(self),
-            self.keys.validity().as_ref().map(|x| x.iter()),
-        )
-    }
-
-    /// Returns an iterator of `Box<dyn Array>`
-    pub fn values_iter(&'a self) -> ValuesIter<'a, K> {
-        DictionaryValuesIter::new(self)
     }
 }

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -1,7 +1,14 @@
+use std::hint::unreachable_unchecked;
+
 use crate::{
-    bitmap::Bitmap,
+    bitmap::{
+        utils::{zip_validity, ZipValidity},
+        Bitmap,
+    },
     datatypes::{DataType, IntegerType},
+    error::Error,
     scalar::{new_scalar, Scalar},
+    trusted_len::TrustedLen,
     types::NativeType,
 };
 
@@ -13,12 +20,23 @@ pub use iterator::*;
 pub use mutable::*;
 
 use super::{new_empty_array, primitive::PrimitiveArray, Array};
-use crate::scalar::NullScalar;
+use super::{new_null_array, specification::check_indexes};
 
 /// Trait denoting [`NativeType`]s that can be used as keys of a dictionary.
-pub trait DictionaryKey: NativeType + num_traits::NumCast + num_traits::FromPrimitive {
+pub trait DictionaryKey: NativeType + TryInto<usize> + TryFrom<usize> {
     /// The corresponding [`IntegerType`] of this key
     const KEY_TYPE: IntegerType;
+
+    /// Represents this key as a `usize`.
+    /// # Safety
+    /// The caller _must_ have checked that the value can be casted to `usize`.
+    #[inline]
+    unsafe fn as_usize(self) -> usize {
+        match self.try_into() {
+            Ok(v) => v,
+            Err(_) => unreachable_unchecked(),
+        }
+    }
 }
 
 impl DictionaryKey for i8 {
@@ -46,8 +64,13 @@ impl DictionaryKey for u64 {
     const KEY_TYPE: IntegerType = IntegerType::UInt64;
 }
 
-/// An [`Array`] whose values are encoded by keys. This [`Array`] is useful when the cardinality of
+/// An [`Array`] whose values are stored as indices. This [`Array`] is useful when the cardinality of
 /// values is low compared to the length of the [`Array`].
+///
+/// # Safety
+/// This struct guarantees that each item of [`DictionaryArray::keys`] is castable to `usize` and
+/// its value is smaller than [`DictionaryArray::values`]`.len()`. In other words, you can safely
+/// use `unchecked` calls to retrive the values
 #[derive(Clone)]
 pub struct DictionaryArray<K: DictionaryKey> {
     data_type: DataType,
@@ -55,36 +78,150 @@ pub struct DictionaryArray<K: DictionaryKey> {
     values: Box<dyn Array>,
 }
 
+fn check_data_type(
+    key_type: IntegerType,
+    data_type: &DataType,
+    values_data_type: &DataType,
+) -> Result<(), Error> {
+    if let DataType::Dictionary(key, value, _) = data_type.to_logical_type() {
+        if *key != key_type {
+            return Err(Error::oos(
+                "DictionaryArray must be initialized with a DataType::Dictionary whose integer is compatible to its keys",
+            ));
+        }
+        if value.as_ref().to_logical_type() != values_data_type.to_logical_type() {
+            return Err(Error::oos(
+                "DictionaryArray must be initialized with a DataType::Dictionary whose value is equal to its values",
+            ));
+        }
+    } else {
+        return Err(Error::oos(
+            "DictionaryArray must be initialized with logical DataType::Dictionary",
+        ));
+    }
+    Ok(())
+}
+
 impl<K: DictionaryKey> DictionaryArray<K> {
+    /// Returns a new [`DictionaryArray`].
+    /// # Implementation
+    /// This function is `O(N)` where `N` is the length of keys
+    /// # Errors
+    /// This function errors iff
+    /// * the `data_type`'s logical type is not a `DictionaryArray`
+    /// * the `data_type`'s keys is not compatible with `keys`
+    /// * the `data_type`'s values's data_type is not equal with `values.data_type()`
+    /// * any of the keys's values is not represented in `usize` or is `>= values.len()`
+    pub fn try_new(
+        data_type: DataType,
+        keys: PrimitiveArray<K>,
+        values: Box<dyn Array>,
+    ) -> Result<Self, Error> {
+        check_data_type(K::KEY_TYPE, &data_type, values.data_type())?;
+
+        check_indexes(keys.values(), values.len())?;
+
+        Ok(Self {
+            data_type,
+            keys,
+            values,
+        })
+    }
+
+    /// Returns a new [`DictionaryArray`].
+    /// # Implementation
+    /// This function is `O(N)` where `N` is the length of keys
+    /// # Errors
+    /// This function errors iff
+    /// * any of the keys's values is not represented in `usize` or is `>= values.len()`
+    pub fn try_from_keys(keys: PrimitiveArray<K>, values: Box<dyn Array>) -> Result<Self, Error> {
+        let data_type = Self::default_data_type(values.data_type().clone());
+        Self::try_new(data_type, keys, values)
+    }
+
+    /// Returns a new [`DictionaryArray`].
+    /// # Errors
+    /// This function errors iff
+    /// * the `data_type`'s logical type is not a `DictionaryArray`
+    /// * the `data_type`'s keys is not compatible with `keys`
+    /// * the `data_type`'s values's data_type is not equal with `values.data_type()`
+    /// # Safety
+    /// The caller must ensure that every keys's values is represented in `usize` and is `< values.len()`
+    pub unsafe fn try_new_unchecked(
+        data_type: DataType,
+        keys: PrimitiveArray<K>,
+        values: Box<dyn Array>,
+    ) -> Result<Self, Error> {
+        check_data_type(K::KEY_TYPE, &data_type, values.data_type())?;
+
+        Ok(Self {
+            data_type,
+            keys,
+            values,
+        })
+    }
+
     /// Returns a new empty [`DictionaryArray`].
     pub fn new_empty(data_type: DataType) -> Self {
-        let values = Self::get_child(&data_type);
+        let values = Self::try_get_child(&data_type).unwrap();
         let values = new_empty_array(values.clone());
-        let data_type = K::PRIMITIVE.into();
-        Self::from_data(PrimitiveArray::<K>::new_empty(data_type), values)
+        Self::try_new(
+            data_type,
+            PrimitiveArray::<K>::new_empty(K::PRIMITIVE.into()),
+            values,
+        )
+        .unwrap()
     }
 
     /// Returns an [`DictionaryArray`] whose all elements are null
     #[inline]
     pub fn new_null(data_type: DataType, length: usize) -> Self {
-        let values = Self::get_child(&data_type);
-        let data_type = K::PRIMITIVE.into();
-        Self::from_data(
-            PrimitiveArray::<K>::new_null(data_type, length),
-            new_empty_array(values.clone()),
+        let values = Self::try_get_child(&data_type).unwrap();
+        let values = new_null_array(values.clone(), 1);
+        Self::try_new(
+            data_type,
+            PrimitiveArray::<K>::new_null(K::PRIMITIVE.into(), length),
+            values,
+        )
+        .unwrap()
+    }
+
+    /// Returns an iterator of [`Option<Box<dyn Scalar>>`].
+    /// # Implementation
+    /// This function will allocate a new [`Scalar`] per item and is usually not performant.
+    /// Consider calling `keys_iter` and `values`, downcasting `values`, and iterating over that.
+    pub fn iter(&self) -> ZipValidity<Box<dyn Scalar>, DictionaryValuesIter<K>> {
+        zip_validity(
+            DictionaryValuesIter::new(self),
+            self.keys.validity().as_ref().map(|x| x.iter()),
         )
     }
 
-    /// The canonical method to create a new [`DictionaryArray`].
-    pub fn from_data(keys: PrimitiveArray<K>, values: Box<dyn Array>) -> Self {
-        let data_type =
-            DataType::Dictionary(K::KEY_TYPE, Box::new(values.data_type().clone()), false);
+    /// Returns an iterator of [`Box<dyn Scalar>`]
+    /// # Implementation
+    /// This function will allocate a new [`Scalar`] per item and is usually not performant.
+    /// Consider calling `keys_iter` and `values`, downcasting `values`, and iterating over that.
+    pub fn values_iter(&self) -> DictionaryValuesIter<K> {
+        DictionaryValuesIter::new(self)
+    }
 
-        Self {
-            data_type,
-            keys,
-            values,
+    /// Returns the [`DataType`] of this [`DictionaryArray`]
+    #[inline]
+    pub fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    /// Returns whether the values of this [`DictionaryArray`] are ordered
+    #[inline]
+    pub fn is_ordered(&self) -> bool {
+        match self.data_type.to_logical_type() {
+            DataType::Dictionary(_, _, is_ordered) => *is_ordered,
+            _ => unreachable!(),
         }
+    }
+
+    pub(crate) fn default_data_type(values_datatype: DataType) -> DataType {
+        DataType::Dictionary(K::KEY_TYPE, Box::new(values_datatype), false)
     }
 
     /// Creates a new [`DictionaryArray`] by slicing the existing [`DictionaryArray`].
@@ -124,10 +261,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     pub fn set_validity(&mut self, validity: Option<Bitmap>) {
         self.keys.set_validity(validity);
     }
-}
 
-// accessors
-impl<K: DictionaryKey> DictionaryArray<K> {
     /// Returns the length of this array
     #[inline]
     pub fn len(&self) -> usize {
@@ -147,6 +281,29 @@ impl<K: DictionaryKey> DictionaryArray<K> {
         &self.keys
     }
 
+    /// Returns an iterator of the keys' values of the [`DictionaryArray`] as `usize`
+    #[inline]
+    pub fn keys_values_iter(&self) -> impl TrustedLen<Item = usize> + Clone + '_ {
+        // safety - invariant of the struct
+        self.keys.values_iter().map(|x| unsafe { x.as_usize() })
+    }
+
+    /// Returns an iterator of the keys' of the [`DictionaryArray`] as `usize`
+    #[inline]
+    pub fn keys_iter(&self) -> impl TrustedLen<Item = Option<usize>> + Clone + '_ {
+        // safety - invariant of the struct
+        self.keys.iter().map(|x| x.map(|x| unsafe { x.as_usize() }))
+    }
+
+    /// Returns the keys' value of the [`DictionaryArray`] as `usize`
+    /// # Panics
+    /// This function panics iff `index >= self.len()`
+    #[inline]
+    pub fn key_value(&self, index: usize) -> usize {
+        // safety - invariant of the struct
+        unsafe { self.keys.values()[index].as_usize() }
+    }
+
     /// Returns the values of the [`DictionaryArray`].
     #[inline]
     pub fn values(&self) -> &Box<dyn Array> {
@@ -154,14 +311,16 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     }
 
     /// Returns the value of the [`DictionaryArray`] at position `i`.
+    /// # Implementation
+    /// This function will allocate a new [`Scalar`] and is usually not performant.
+    /// Consider calling `keys` and `values`, downcasting `values`, and iterating over that.
+    /// # Panic
+    /// This function panics iff `index >= self.len()`
     #[inline]
     pub fn value(&self, index: usize) -> Box<dyn Scalar> {
-        if self.keys.is_null(index) {
-            Box::new(NullScalar::new())
-        } else {
-            let index = self.keys.value(index).to_usize().unwrap();
-            new_scalar(self.values.as_ref(), index)
-        }
+        // safety - invariant of this struct
+        let index = unsafe { self.keys.value(index).as_usize() };
+        new_scalar(self.values.as_ref(), index)
     }
 
     /// Boxes self into a [`Box<dyn Array>`].
@@ -173,15 +332,16 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     pub fn arced(self) -> std::sync::Arc<dyn Array> {
         std::sync::Arc::new(self)
     }
-}
 
-impl<K: DictionaryKey> DictionaryArray<K> {
-    pub(crate) fn get_child(data_type: &DataType) -> &DataType {
-        match data_type {
+    pub(crate) fn try_get_child(data_type: &DataType) -> Result<&DataType, Error> {
+        Ok(match data_type.to_logical_type() {
             DataType::Dictionary(_, values, _) => values.as_ref(),
-            DataType::Extension(_, inner, _) => Self::get_child(inner),
-            _ => panic!("DictionaryArray must be initialized with DataType::Dictionary"),
-        }
+            _ => {
+                return Err(Error::oos(
+                    "Dictionaries must be initialized with DataType::Dictionary",
+                ))
+            }
+        })
     }
 }
 
@@ -213,12 +373,15 @@ impl<K: DictionaryKey> Array for DictionaryArray<K> {
     fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice(offset, length))
     }
+
     unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
         Box::new(self.slice_unchecked(offset, length))
     }
+
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
         Box::new(self.clone().with_validity(validity))
     }
+
     fn to_boxed(&self) -> Box<dyn Array> {
         Box::new(self.clone())
     }

--- a/src/array/equal/dictionary.rs
+++ b/src/array/equal/dictionary.rs
@@ -1,4 +1,4 @@
-use crate::array::{Array, DictionaryArray, DictionaryKey};
+use crate::array::{DictionaryArray, DictionaryKey};
 
 pub(super) fn equal<K: DictionaryKey>(lhs: &DictionaryArray<K>, rhs: &DictionaryArray<K>) -> bool {
     if !(lhs.data_type() == rhs.data_type() && lhs.len() == rhs.len()) {

--- a/src/array/equal/mod.rs
+++ b/src/array/equal/mod.rs
@@ -87,6 +87,12 @@ impl<O: Offset> PartialEq<&dyn Array> for Utf8Array<O> {
     }
 }
 
+impl<O: Offset> PartialEq<Utf8Array<O>> for &dyn Array {
+    fn eq(&self, other: &Utf8Array<O>) -> bool {
+        equal(*self, other)
+    }
+}
+
 impl<O: Offset> PartialEq<BinaryArray<O>> for BinaryArray<O> {
     fn eq(&self, other: &Self) -> bool {
         binary::equal(self, other)
@@ -96,6 +102,12 @@ impl<O: Offset> PartialEq<BinaryArray<O>> for BinaryArray<O> {
 impl<O: Offset> PartialEq<&dyn Array> for BinaryArray<O> {
     fn eq(&self, other: &&dyn Array) -> bool {
         equal(self, *other)
+    }
+}
+
+impl<O: Offset> PartialEq<BinaryArray<O>> for &dyn Array {
+    fn eq(&self, other: &BinaryArray<O>) -> bool {
+        equal(*self, other)
     }
 }
 

--- a/src/array/ord.rs
+++ b/src/array/ord.rs
@@ -141,8 +141,9 @@ where
     let comparator = build_compare(left.values().as_ref(), right.values().as_ref())?;
 
     Ok(Box::new(move |i: usize, j: usize| {
-        let key_left = left_keys[i].to_usize().unwrap();
-        let key_right = right_keys[j].to_usize().unwrap();
+        // safety: all dictionaries keys are guaranteed to be castable to usize
+        let key_left = unsafe { left_keys[i].as_usize() };
+        let key_right = unsafe { right_keys[j].as_usize() };
         (comparator)(key_left, key_right)
     }))
 }

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -97,6 +97,22 @@ pub fn try_check_offsets<O: Offset>(offsets: &[O], values_len: usize) -> Result<
     }
 }
 
+pub fn check_indexes<K>(keys: &[K], len: usize) -> Result<()>
+where
+    K: Copy + TryInto<usize>,
+{
+    keys.iter().try_for_each(|key| {
+        let key: usize = (*key)
+            .try_into()
+            .map_err(|_| Error::oos("The dictionary key must fit in a `usize`"))?;
+        if key >= len {
+            Err(Error::oos("The dictionary key must be smaller"))
+        } else {
+            Ok(())
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -434,9 +434,12 @@ pub fn neg(array: &dyn Array) -> Box<dyn Array> {
         Dictionary(key) => match_integer_type!(key, |$T| {
             let array = array.as_any().downcast_ref::<DictionaryArray<$T>>().unwrap();
 
-            let values = neg(array.values().as_ref()).into();
+            let values = neg(array.values().as_ref());
 
-            Box::new(DictionaryArray::<$T>::from_data(array.keys().clone(), values)) as Box<dyn Array>
+            // safety - this operation only applies to values and thus preserves the dictionary's invariant
+            unsafe{
+                DictionaryArray::<$T>::try_new_unchecked(array.data_type().clone(), array.keys().clone(), values).unwrap().boxed()
+            }
         }),
         _ => todo!(),
     }

--- a/src/compute/sort/utf8.rs
+++ b/src/compute/sort/utf8.rs
@@ -28,10 +28,13 @@ pub(super) fn indices_sorted_unstable_by_dictionary<I: Index, K: DictionaryKey, 
         .downcast_ref::<Utf8Array<O>>()
         .unwrap();
 
-    let get = |idx| unsafe {
-        let index = keys.value_unchecked(idx as usize);
-        // Note: there is no check that the keys are within bounds of the dictionary.
-        dict.value(index.to_usize().unwrap())
+    let get = |index| unsafe {
+        // safety: indices_sorted_unstable_by is guaranteed to get items in bounds
+        let index = keys.value_unchecked(index);
+        // safety: dictionaries are guaranteed to have valid usize keys
+        let index = index.as_usize();
+        // safety: dictionaries are guaranteed to have keys in bounds
+        dict.value_unchecked(index)
     };
 
     let cmp = |lhs: &&str, rhs: &&str| lhs.cmp(rhs);

--- a/src/compute/take/dict.rs
+++ b/src/compute/take/dict.rs
@@ -30,5 +30,13 @@ where
     I: Index,
 {
     let keys = take_primitive::<K, I>(values.keys(), indices);
-    DictionaryArray::<K>::from_data(keys, values.values().clone())
+    // safety - this operation takes a subset of keys and thus preserves the dictionary's invariant
+    unsafe {
+        DictionaryArray::<K>::try_new_unchecked(
+            values.data_type().clone(),
+            keys,
+            values.values().clone(),
+        )
+        .unwrap()
+    }
 }

--- a/src/io/avro/read/nested.rs
+++ b/src/io/avro/read/nested.rs
@@ -157,17 +157,25 @@ impl MutableArray for FixedItemsUtf8Dictionary {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(DictionaryArray::from_data(
-            std::mem::take(&mut self.keys).into(),
-            Box::new(self.values.clone()),
-        ))
+        Box::new(
+            DictionaryArray::try_new(
+                self.data_type.clone(),
+                std::mem::take(&mut self.keys).into(),
+                Box::new(self.values.clone()),
+            )
+            .unwrap(),
+        )
     }
 
     fn as_arc(&mut self) -> std::sync::Arc<dyn Array> {
-        std::sync::Arc::new(DictionaryArray::from_data(
-            std::mem::take(&mut self.keys).into(),
-            Box::new(self.values.clone()),
-        ))
+        std::sync::Arc::new(
+            DictionaryArray::try_new(
+                self.data_type.clone(),
+                std::mem::take(&mut self.keys).into(),
+                Box::new(self.values.clone()),
+            )
+            .unwrap(),
+        )
     }
 
     fn data_type(&self) -> &DataType {

--- a/src/io/csv/write/serialize.rs
+++ b/src/io/csv/write/serialize.rs
@@ -471,17 +471,15 @@ fn serialize_utf8_dict<'a, K: DictionaryKey, O: Offset>(
     array: &'a dyn Any,
 ) -> Box<dyn StreamingIterator<Item = [u8]> + 'a> {
     let array = array.downcast_ref::<DictionaryArray<K>>().unwrap();
-    let keys = array.keys();
     let values = array
         .values()
         .as_any()
         .downcast_ref::<Utf8Array<O>>()
         .unwrap();
     Box::new(BufStreamingIterator::new(
-        keys.iter(),
+        array.keys_iter(),
         move |x, buf| {
-            if let Some(x) = x {
-                let i = x.to_usize().unwrap();
+            if let Some(i) = x {
                 if !values.is_null(i) {
                     let val = values.value(i);
                     buf.extend_from_slice(val.as_bytes());

--- a/src/io/ipc/read/array/dictionary.rs
+++ b/src/io/ipc/read/array/dictionary.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 use std::io::{Read, Seek};
 
 use crate::array::{DictionaryArray, DictionaryKey};
+use crate::datatypes::DataType;
 use crate::error::{Error, Result};
 
 use super::super::Dictionaries;
@@ -12,6 +13,7 @@ use super::{read_primitive, skip_primitive};
 #[allow(clippy::too_many_arguments)]
 pub fn read_dictionary<T: DictionaryKey, R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
+    data_type: DataType,
     id: Option<i64>,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,
@@ -51,7 +53,7 @@ where
         scratch,
     )?;
 
-    Ok(DictionaryArray::<T>::from_data(keys, values))
+    DictionaryArray::<T>::try_new(data_type, keys, values)
 }
 
 pub fn skip_dictionary(

--- a/src/io/ipc/read/deserialize.rs
+++ b/src/io/ipc/read/deserialize.rs
@@ -180,6 +180,7 @@ pub fn read<R: Read + Seek>(
             match_integer_type!(key_type, |$T| {
                 read_dictionary::<$T, _>(
                     field_nodes,
+                    data_type,
                     ipc_field.dictionary_id,
                     buffers,
                     reader,

--- a/src/io/parquet/read/deserialize/binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/binary/dictionary.rs
@@ -23,6 +23,7 @@ where
 {
     iter: I,
     data_type: DataType,
+    values_data_type: DataType,
     values: Dict,
     items: VecDeque<(Vec<K>, MutableBitmap)>,
     chunk_size: Option<usize>,
@@ -36,13 +37,14 @@ where
     I: DataPages,
 {
     pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>) -> Self {
-        let data_type = match data_type {
+        let values_data_type = match &data_type {
             DataType::Dictionary(_, values, _) => values.as_ref().clone(),
             _ => unreachable!(),
         };
         Self {
             iter,
             data_type,
+            values_data_type,
             values: Dict::Empty,
             items: VecDeque::new(),
             chunk_size,
@@ -90,8 +92,9 @@ where
             &mut self.iter,
             &mut self.items,
             &mut self.values,
+            self.data_type.clone(),
             self.chunk_size,
-            |dict| read_dict::<O>(self.data_type.clone(), dict),
+            |dict| read_dict::<O>(self.values_data_type.clone(), dict),
         );
         match maybe_state {
             MaybeNext::Some(Ok(dict)) => Some(Ok(dict)),

--- a/src/io/parquet/read/deserialize/fixed_size_binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/dictionary.rs
@@ -22,6 +22,7 @@ where
 {
     iter: I,
     data_type: DataType,
+    values_data_type: DataType,
     values: Dict,
     items: VecDeque<(Vec<K>, MutableBitmap)>,
     chunk_size: Option<usize>,
@@ -33,13 +34,14 @@ where
     I: DataPages,
 {
     pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>) -> Self {
-        let data_type = match data_type {
+        let values_data_type = match &data_type {
             DataType::Dictionary(_, values, _) => values.as_ref().clone(),
             _ => unreachable!(),
         };
         Self {
             iter,
             data_type,
+            values_data_type,
             values: Dict::Empty,
             items: VecDeque::new(),
             chunk_size,
@@ -73,8 +75,9 @@ where
             &mut self.iter,
             &mut self.items,
             &mut self.values,
+            self.data_type.clone(),
             self.chunk_size,
-            |dict| read_dict(self.data_type.clone(), dict),
+            |dict| read_dict(self.values_data_type.clone(), dict),
         );
         match maybe_state {
             MaybeNext::Some(Ok(dict)) => Some(Ok(dict)),

--- a/src/io/parquet/read/statistics/dictionary.rs
+++ b/src/io/parquet/read/statistics/dictionary.rs
@@ -41,7 +41,7 @@ impl MutableArray for DynMutableDictionary {
         match self.data_type.to_physical_type() {
             PhysicalType::Dictionary(key) => match_integer_type!(key, |$T| {
                 let keys = PrimitiveArray::<$T>::from_iter((0..inner.len() as $T).map(Some));
-                Box::new(DictionaryArray::<$T>::from_data(keys, inner))
+                Box::new(DictionaryArray::<$T>::try_new(self.data_type.clone(), keys, inner).unwrap())
             }),
             _ => todo!(),
         }

--- a/tests/it/array/dictionary/mod.rs
+++ b/tests/it/array/dictionary/mod.rs
@@ -1,1 +1,153 @@
 mod mutable;
+
+use arrow2::{array::*, datatypes::DataType};
+
+#[test]
+fn try_new_ok() {
+    let values = Utf8Array::<i32>::from_slice(&["a", "aa"]);
+    let data_type =
+        DataType::Dictionary(i32::KEY_TYPE, Box::new(values.data_type().clone()), false);
+    let array = DictionaryArray::try_new(
+        data_type,
+        PrimitiveArray::from_vec(vec![1, 0]),
+        values.boxed(),
+    )
+    .unwrap();
+
+    assert_eq!(array.keys(), &PrimitiveArray::from_vec(vec![1i32, 0]));
+    assert_eq!(
+        &Utf8Array::<i32>::from_slice(&["a", "aa"]) as &dyn Array,
+        array.values().as_ref(),
+    );
+    assert!(!array.is_ordered());
+
+    assert_eq!(format!("{:?}", array), "DictionaryArray[aa, a]");
+}
+
+#[test]
+fn try_new_incorrect_key() {
+    let values = Utf8Array::<i32>::from_slice(&["a", "aa"]);
+    let data_type =
+        DataType::Dictionary(i16::KEY_TYPE, Box::new(values.data_type().clone()), false);
+
+    let r = DictionaryArray::try_new(
+        data_type,
+        PrimitiveArray::from_vec(vec![1, 0]),
+        values.boxed(),
+    )
+    .is_err();
+
+    assert!(r);
+}
+
+#[test]
+fn try_new_incorrect_dt() {
+    let values = Utf8Array::<i32>::from_slice(&["a", "aa"]);
+    let data_type = DataType::Int32;
+
+    let r = DictionaryArray::try_new(
+        data_type,
+        PrimitiveArray::from_vec(vec![1, 0]),
+        values.boxed(),
+    )
+    .is_err();
+
+    assert!(r);
+}
+
+#[test]
+fn try_new_incorrect_values_dt() {
+    let values = Utf8Array::<i32>::from_slice(&["a", "aa"]);
+    let data_type = DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::LargeUtf8), false);
+
+    let r = DictionaryArray::try_new(
+        data_type,
+        PrimitiveArray::from_vec(vec![1, 0]),
+        values.boxed(),
+    )
+    .is_err();
+
+    assert!(r);
+}
+
+#[test]
+fn try_new_out_of_bounds() {
+    let values = Utf8Array::<i32>::from_slice(&["a", "aa"]);
+
+    let r = DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![2, 0]), values.boxed())
+        .is_err();
+
+    assert!(r);
+}
+
+#[test]
+fn try_new_out_of_bounds_neg() {
+    let values = Utf8Array::<i32>::from_slice(&["a", "aa"]);
+
+    let r = DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![-1, 0]), values.boxed())
+        .is_err();
+
+    assert!(r);
+}
+
+#[test]
+fn new_null() {
+    let dt = DataType::Dictionary(i16::KEY_TYPE, Box::new(DataType::Int32), false);
+    let array = DictionaryArray::<i16>::new_null(dt, 2);
+
+    assert_eq!(format!("{:?}", array), "DictionaryArray[None, None]");
+}
+
+#[test]
+fn new_empty() {
+    let dt = DataType::Dictionary(i16::KEY_TYPE, Box::new(DataType::Int32), false);
+    let array = DictionaryArray::<i16>::new_empty(dt);
+
+    assert_eq!(format!("{:?}", array), "DictionaryArray[]");
+}
+
+#[test]
+fn with_validity() {
+    let values = Utf8Array::<i32>::from_slice(&["a", "aa"]);
+    let array =
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed())
+            .unwrap();
+
+    let array = array.with_validity(Some([true, false].into()));
+
+    assert_eq!(format!("{:?}", array), "DictionaryArray[aa, None]");
+}
+
+#[test]
+fn rev_iter() {
+    let values = Utf8Array::<i32>::from_slice(&["a", "aa"]);
+    let array =
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed())
+            .unwrap();
+
+    let mut iter = array.into_iter();
+    assert_eq!(iter.by_ref().rev().count(), 2);
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+}
+
+#[test]
+fn iter_values() {
+    let values = Utf8Array::<i32>::from_slice(&["a", "aa"]);
+    let array =
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed())
+            .unwrap();
+
+    let mut iter = array.values_iter();
+    assert_eq!(iter.by_ref().count(), 2);
+    assert_eq!(iter.size_hint(), (0, Some(0)));
+}
+
+#[test]
+fn keys_values_iter() {
+    let values = Utf8Array::<i32>::from_slice(&["a", "aa"]);
+    let array =
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0]), values.boxed())
+            .unwrap();
+
+    assert_eq!(array.keys_values_iter().collect::<Vec<_>>(), vec![1, 0]);
+}

--- a/tests/it/array/equal/dictionary.rs
+++ b/tests/it/array/equal/dictionary.rs
@@ -6,7 +6,7 @@ fn create_dictionary_array(values: &[Option<&str>], keys: &[Option<i16>]) -> Dic
     let keys = Int16Array::from(keys);
     let values = Utf8Array::<i32>::from(values);
 
-    DictionaryArray::from_data(keys, Box::new(values))
+    DictionaryArray::try_from_keys(keys, values.boxed()).unwrap()
 }
 
 #[test]

--- a/tests/it/array/growable/mod.rs
+++ b/tests/it/array/growable/mod.rs
@@ -38,9 +38,10 @@ fn test_make_growable() {
         FixedSizeBinaryArray::new(DataType::FixedSizeBinary(2), b"abcd".to_vec().into(), None);
     make_growable(&[&array], false, 2);
 
-    let array = DictionaryArray::<i32>::from_data(
-        Int32Array::from_slice([1, 2]),
-        Box::new(Int32Array::from_slice([1, 2])),
-    );
+    let array = DictionaryArray::try_from_keys(
+        Int32Array::from_slice([1, 0]),
+        Int32Array::from_slice([1, 2]).boxed(),
+    )
+    .unwrap();
     make_growable(&[&array], false, 2);
 }

--- a/tests/it/compute/arithmetics/mod.rs
+++ b/tests/it/compute/arithmetics/mod.rs
@@ -95,14 +95,16 @@ fn test_neg() {
 
 #[test]
 fn test_neg_dict() {
-    let a = DictionaryArray::<u8>::from_data(
+    let a = DictionaryArray::try_from_keys(
         UInt8Array::from_slice(&[0, 0, 1]),
-        Box::new(Int8Array::from_slice(&[1, 2])),
-    );
+        Int8Array::from_slice(&[1, 2]).boxed(),
+    )
+    .unwrap();
     let result = neg(&a);
-    let expected = DictionaryArray::<u8>::from_data(
+    let expected = DictionaryArray::try_from_keys(
         UInt8Array::from_slice(&[0, 0, 1]),
-        Box::new(Int8Array::from_slice(&[-1, -2])),
-    );
+        Int8Array::from_slice(&[-1, -2]).boxed(),
+    )
+    .unwrap();
     assert_eq!(expected, result.as_ref());
 }

--- a/tests/it/io/avro/read.rs
+++ b/tests/it/io/avro/read.rs
@@ -106,10 +106,11 @@ pub(super) fn data() -> Chunk<Box<dyn Array>> {
             None,
         )
         .boxed(),
-        DictionaryArray::<i32>::from_data(
+        DictionaryArray::try_from_keys(
             Int32Array::from_slice([1, 0]),
             Box::new(Utf8Array::<i32>::from_slice(["SPADES", "HEARTS"])),
         )
+        .unwrap()
         .boxed(),
         PrimitiveArray::<i128>::from_slice([12345678i128, -12345678i128])
             .to(DataType::Decimal(18, 5))

--- a/tests/it/io/csv/write.rs
+++ b/tests/it/io/csv/write.rs
@@ -16,7 +16,7 @@ fn data() -> Chunk<Box<dyn Array>> {
     let c6 = PrimitiveArray::<i32>::from_vec(vec![1234, 24680, 85563])
         .to(DataType::Time32(TimeUnit::Second));
     let keys = UInt32Array::from_slice(&[2, 0, 1]);
-    let c7 = DictionaryArray::from_data(keys, Box::new(c1.clone()));
+    let c7 = DictionaryArray::try_from_keys(keys, Box::new(c1.clone())).unwrap();
 
     Chunk::new(vec![
         Box::new(c1) as Box<dyn Array>,
@@ -256,13 +256,13 @@ fn data_array(column: &str) -> (Chunk<Box<dyn Array>>, Vec<&'static str>) {
         "dictionary[u32]" => {
             let keys = UInt32Array::from_slice(&[2, 1, 0]);
             let values = Utf8Array::<i64>::from_slice(["a b", "c", "d"]).boxed();
-            let array = DictionaryArray::from_data(keys, values);
+            let array = DictionaryArray::try_from_keys(keys, values).unwrap();
             (array.boxed(), vec!["d", "c", "a b"])
         }
         "dictionary[u64]" => {
             let keys = UInt64Array::from_slice(&[2, 1, 0]);
             let values = Utf8Array::<i64>::from_slice(["a b", "c", "d"]).boxed();
-            let array = DictionaryArray::from_data(keys, values);
+            let array = DictionaryArray::try_from_keys(keys, values).unwrap();
             (array.boxed(), vec!["d", "c", "a b"])
         }
         _ => todo!(),

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -359,7 +359,7 @@ pub fn pyarrow_nullable(column: &str) -> Box<dyn Array> {
         "int32_dict" => {
             let keys = PrimitiveArray::<i32>::from([Some(0), Some(1), None, Some(1)]);
             let values = Box::new(PrimitiveArray::<i32>::from_slice([10, 200]));
-            Box::new(DictionaryArray::<i32>::from_data(keys, values))
+            Box::new(DictionaryArray::try_from_keys(keys, values).unwrap())
         }
         "decimal_9" => {
             let values = i64_values
@@ -440,10 +440,7 @@ pub fn pyarrow_nullable_statistics(column: &str) -> Statistics {
         },
         "int32_dict" => {
             let new_dict = |array: Box<dyn Array>| -> Box<dyn Array> {
-                Box::new(DictionaryArray::<i32>::from_data(
-                    vec![Some(0)].into(),
-                    array,
-                ))
+                Box::new(DictionaryArray::try_from_keys(vec![Some(0)].into(), array).unwrap())
             };
 
             Statistics {
@@ -975,42 +972,45 @@ fn arrow_type() -> Result<()> {
     let array2 = Utf8Array::<i64>::from([Some("a"), None, Some("bb")]);
 
     let indices = PrimitiveArray::from_values((0..3u64).map(|x| x % 2));
-    let values = PrimitiveArray::from_slice([1.0f32, 3.0]);
-    let array3 = DictionaryArray::from_data(indices.clone(), Box::new(values));
+    let values = PrimitiveArray::from_slice([1.0f32, 3.0]).boxed();
+    let array3 = DictionaryArray::try_from_keys(indices.clone(), values).unwrap();
 
-    let values = BinaryArray::<i32>::from_slice([b"ab", b"ac"]);
-    let array4 = DictionaryArray::from_data(indices.clone(), Box::new(values));
+    let values = BinaryArray::<i32>::from_slice([b"ab", b"ac"]).boxed();
+    let array4 = DictionaryArray::try_from_keys(indices.clone(), values).unwrap();
 
     let values = FixedSizeBinaryArray::from_data(
         DataType::FixedSizeBinary(2),
         vec![b'a', b'b', b'a', b'c'].into(),
         None,
-    );
-    let array5 = DictionaryArray::from_data(indices.clone(), Box::new(values));
+    )
+    .boxed();
+    let array5 = DictionaryArray::try_from_keys(indices.clone(), values).unwrap();
 
-    let values = PrimitiveArray::from_slice([1i16, 3]);
-    let array6 = DictionaryArray::from_data(indices.clone(), Box::new(values));
+    let values = PrimitiveArray::from_slice([1i16, 3]).boxed();
+    let array6 = DictionaryArray::try_from_keys(indices.clone(), values).unwrap();
 
-    let values = PrimitiveArray::from_slice([1i64, 3]).to(DataType::Timestamp(
-        TimeUnit::Millisecond,
-        Some("UTC".to_string()),
-    ));
-    let array7 = DictionaryArray::from_data(indices.clone(), Box::new(values));
+    let values = PrimitiveArray::from_slice([1i64, 3])
+        .to(DataType::Timestamp(
+            TimeUnit::Millisecond,
+            Some("UTC".to_string()),
+        ))
+        .boxed();
+    let array7 = DictionaryArray::try_from_keys(indices.clone(), values).unwrap();
 
-    let values = PrimitiveArray::from_slice([1.0f64, 3.0]);
-    let array8 = DictionaryArray::from_data(indices.clone(), Box::new(values));
+    let values = PrimitiveArray::from_slice([1.0f64, 3.0]).boxed();
+    let array8 = DictionaryArray::try_from_keys(indices.clone(), values).unwrap();
 
-    let values = PrimitiveArray::from_slice([1u8, 3]);
-    let array9 = DictionaryArray::from_data(indices.clone(), Box::new(values));
+    let values = PrimitiveArray::from_slice([1u8, 3]).boxed();
+    let array9 = DictionaryArray::try_from_keys(indices.clone(), values).unwrap();
 
-    let values = PrimitiveArray::from_slice([1u16, 3]);
-    let array10 = DictionaryArray::from_data(indices.clone(), Box::new(values));
+    let values = PrimitiveArray::from_slice([1u16, 3]).boxed();
+    let array10 = DictionaryArray::try_from_keys(indices.clone(), values).unwrap();
 
-    let values = PrimitiveArray::from_slice([1u32, 3]);
-    let array11 = DictionaryArray::from_data(indices.clone(), Box::new(values));
+    let values = PrimitiveArray::from_slice([1u32, 3]).boxed();
+    let array11 = DictionaryArray::try_from_keys(indices.clone(), values).unwrap();
 
-    let values = PrimitiveArray::from_slice([1u64, 3]);
-    let array12 = DictionaryArray::from_data(indices, Box::new(values));
+    let values = PrimitiveArray::from_slice([1u64, 3]).boxed();
+    let array12 = DictionaryArray::try_from_keys(indices, values).unwrap();
 
     let array13 = PrimitiveArray::<i32>::from_slice([1, 2, 3])
         .to(DataType::Interval(IntervalUnit::YearMonth));

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -208,12 +208,12 @@ fn indexed_optional_boolean() -> Result<()> {
 #[test]
 fn indexed_dict() -> Result<()> {
     let indices = PrimitiveArray::from_values((0..6u64).map(|x| x % 2));
-    let values = PrimitiveArray::from_slice([4i32, 6i32]);
-    let array = DictionaryArray::from_data(indices, Box::new(values));
+    let values = PrimitiveArray::from_slice([4i32, 6i32]).boxed();
+    let array = DictionaryArray::try_from_keys(indices, values).unwrap();
 
     let indices = PrimitiveArray::from_slice(&[0u64]);
-    let values = PrimitiveArray::from_slice([4i32, 6i32]);
-    let expected = DictionaryArray::from_data(indices, Box::new(values));
+    let values = PrimitiveArray::from_slice([4i32, 6i32]).boxed();
+    let expected = DictionaryArray::try_from_keys(indices, values).unwrap();
 
     let expected = expected.boxed();
 

--- a/tests/it/io/print.rs
+++ b/tests/it/io/print.rs
@@ -97,7 +97,7 @@ fn write_dictionary() -> Result<()> {
 fn dictionary_validities() -> Result<()> {
     let keys = PrimitiveArray::<i32>::from([Some(1), None, Some(0)]);
     let values = PrimitiveArray::<i32>::from([None, Some(10)]);
-    let array = DictionaryArray::<i32>::from_data(keys, Box::new(values));
+    let array = DictionaryArray::try_from_keys(keys, Box::new(values)).unwrap();
 
     let columns = Chunk::new(vec![&array as &dyn Array]);
 


### PR DESCRIPTION
This PR changes the internal invariant from `DictionaryArray` to only contain keys that:
* can be casted to `usize`
* the maximum value is smaller than the values' length

This allows removing bound checks when iterating over the values via its keys.

# Backward incompatible changes

* `DictionaryArray::from_data` was replaced by `try_new`, `try_new_unchecked` and `try_from_keys`
* `DictionaryKey` now only implements `NativeType + TryFrom<usize> + TryInto<usize>`
