### PR TITLE
Fixed reading arrays from parquet with required children

### DIFF
--- a/parquet_integration/bench_compute.py
+++ b/parquet_integration/bench_compute.py
@@ -26,7 +26,7 @@ assert sum([x for x in get_f32(1000, 0.9)[1] if x]) > 750
 
 
 def bench_add_f32_pyarrow(log2_size, null_density):
-    size = 2 ** log2_size
+    size = 2**log2_size
 
     values, validity = get_f32(size, null_density)
     array1 = pa.array(values, pa.float32(), mask=validity)
@@ -50,7 +50,7 @@ def bench_add_f32_pyarrow(log2_size, null_density):
 
 
 def bench_add_f32_numpy(log2_size):
-    size = 2 ** log2_size
+    size = 2**log2_size
 
     array1, _ = get_f32(size, 0)
     array2, _ = get_f32(size, 0)
@@ -71,7 +71,7 @@ def bench_add_f32_numpy(log2_size):
 
 
 def _bench_unary_f32_pyarrow(log2_size, null_density, name, op):
-    size = 2 ** log2_size
+    size = 2**log2_size
 
     values, validity = get_f32(size, null_density)
     array = pa.array(values, pa.float32(), mask=validity)
@@ -100,7 +100,7 @@ def bench_min_f32_pyarrow(log2_size, null_density):
 
 
 def _bench_unary_f32_numpy(log2_size, name, op):
-    size = 2 ** log2_size
+    size = 2**log2_size
 
     values, _ = get_f32(size, 0)
 
@@ -128,7 +128,7 @@ def bench_min_f32_numpy(log2_size):
 
 
 def bench_sort_f32_pyarrow(log2_size, null_density):
-    size = 2 ** log2_size
+    size = 2**log2_size
 
     values, validity = get_f32(size, null_density)
     array = pa.array(values, pa.float32(), mask=validity)
@@ -151,7 +151,7 @@ def bench_sort_f32_pyarrow(log2_size, null_density):
 
 def bench_sort_f32_numpy(log2_size):
     null_density = 0
-    size = 2 ** log2_size
+    size = 2**log2_size
 
     array, _ = get_f32(size, null_density)
 
@@ -171,7 +171,7 @@ def bench_sort_f32_numpy(log2_size):
 
 
 def bench_filter_f32_pyarrow(log2_size, null_density):
-    size = 2 ** log2_size
+    size = 2**log2_size
 
     values, validity = get_f32(size, null_density)
     _, mask = get_f32(size, 0.9)
@@ -198,7 +198,7 @@ def bench_filter_f32_pyarrow(log2_size, null_density):
 
 def bench_filter_f32_numpy(log2_size):
     null_density = 0
-    size = 2 ** log2_size
+    size = 2**log2_size
 
     array, _ = get_f32(size, null_density)
     _, mask = get_f32(size, 0.1)

--- a/src/io/parquet/read/deserialize/primitive/basic.rs
+++ b/src/io/parquet/read/deserialize/primitive/basic.rs
@@ -148,7 +148,7 @@ where
     }
 }
 
-impl<'a, T> utils::DecodedState<'a> for (Vec<T>, MutableBitmap) {
+impl<'a, T: std::fmt::Debug> utils::DecodedState<'a> for (Vec<T>, MutableBitmap) {
     fn len(&self) -> usize {
         self.0.len()
     }

--- a/src/io/parquet/read/deserialize/utils.rs
+++ b/src/io/parquet/read/deserialize/utils.rs
@@ -343,7 +343,8 @@ pub(super) trait PageState<'a>: std::fmt::Debug {
 }
 
 /// The state of a partially deserialized page
-pub(super) trait DecodedState<'a> {
+pub(super) trait DecodedState<'a>: std::fmt::Debug {
+    // the number of values that this decoder already consumed
     fn len(&self) -> usize;
 }
 

--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -65,6 +65,7 @@ fn test_pyarrow_integration(
         "list_bool",
         "list_nested_inner_required_required_i64",
         "list_nested_inner_required_i64",
+        "struct_nullable", // it counts null struct items as nulls
         // pyarrow reports an incorrect min/max for MapArray
         "map",
         "map_nullable",
@@ -447,14 +448,18 @@ fn v2_decimal_26_required_dict() -> Result<()> {
 }
 
 #[test]
-fn v1_struct_optional() -> Result<()> {
+fn v1_struct_required_optional() -> Result<()> {
     test_pyarrow_integration("struct", 1, "struct", false, false, None)
 }
 
 #[test]
-#[ignore]
-fn v1_struct_struct_optional() -> Result<()> {
+fn v1_struct_struct() -> Result<()> {
     test_pyarrow_integration("struct_struct", 1, "struct", false, false, None)
+}
+
+#[test]
+fn v1_struct_optional_optional() -> Result<()> {
+    test_pyarrow_integration("struct_nullable", 1, "struct", false, false, None)
 }
 
 #[test]


### PR DESCRIPTION
Some structs in arrow whose slots are nulls still require the underlying children to be populated (such as `Struct` and `FixedSizeList`). The current reading design does not support this.

This PR fixes this.

Closes #937
