### PR TITLE
Reduced bound checks

### DIFF
--- a/src/array/growable/utf8.rs
+++ b/src/array/growable/utf8.rs
@@ -55,13 +55,19 @@ impl<'a, O: Offset> GrowableUtf8<'a, O> {
         let offsets = std::mem::take(&mut self.offsets);
         let values = std::mem::take(&mut self.values);
 
+        #[cfg(debug_assertions)]
+        {
+            crate::array::specification::try_check_offsets_and_utf8(&offsets, &values).unwrap();
+        }
+
         unsafe {
-            Utf8Array::<O>::from_data_unchecked(
+            Utf8Array::<O>::try_new_unchecked(
                 self.arrays[0].data_type().clone(),
                 offsets.into(),
                 values.into(),
                 validity.into(),
             )
+            .unwrap()
         }
     }
 }
@@ -99,14 +105,7 @@ impl<'a, O: Offset> Growable<'a> for GrowableUtf8<'a, O> {
 }
 
 impl<'a, O: Offset> From<GrowableUtf8<'a, O>> for Utf8Array<O> {
-    fn from(val: GrowableUtf8<'a, O>) -> Self {
-        unsafe {
-            Utf8Array::<O>::from_data_unchecked(
-                val.arrays[0].data_type().clone(),
-                val.offsets.into(),
-                val.values.into(),
-                val.validity.into(),
-            )
-        }
+    fn from(mut val: GrowableUtf8<'a, O>) -> Self {
+        val.to()
     }
 }


### PR DESCRIPTION
In line to what we already do for `Utf8` this PR omits bound checks for `Dictionary` and `List` types when converting from a `Growable` to arrays. The bound checks can be removed because of the invariants of the `Growable` struct.

I added assertions for debug builds for all the data types where we removed the bounds checks so that implementation bugs will be caught.

Finally I dispatched the `From` impls to `Struct::to` to make the code more dry.