### PR TITLE
fix casting dictionary keys

### DIFF
--- a/src/compute/cast/dictionary_to.rs
+++ b/src/compute/cast/dictionary_to.rs
@@ -143,11 +143,9 @@ pub(super) fn dictionary_cast_dyn<K: DictionaryKey + num_traits::NumCast>(
 
             // Safety:
             // we return an error on overflow so the integers remain within bounds
-            unsafe {
-                match_integer_type!(to_keys_type, |$T| {
-                    key_cast!(keys, values, array, &to_key_type, $T, to_type.clone())
-                })
-            }
+            match_integer_type!(to_keys_type, |$T| {
+                key_cast!(keys, values, array, &to_key_type, $T, to_type.clone())
+            })
         }
         _ => unpack_dictionary::<K>(keys, values.as_ref(), to_type, options),
     }

--- a/src/compute/cast/dictionary_to.rs
+++ b/src/compute/cast/dictionary_to.rs
@@ -92,8 +92,7 @@ where
             Box::new(values.data_type().clone()),
             is_ordered,
         );
-        // Safety
-        // we errored if any cast overflowed
+        // Safety: this is safe because given a type `T` that fits in a `usize`, casting it to type `P` either overflows or also fits in a `usize`
         unsafe { DictionaryArray::try_new_unchecked(data_type, casted_keys, values.clone()) }
     }
 }

--- a/src/compute/cast/dictionary_to.rs
+++ b/src/compute/cast/dictionary_to.rs
@@ -15,7 +15,10 @@ macro_rules! key_cast {
         if cast_keys.null_count() > $keys.null_count() {
             return Err(Error::Overflow);
         }
-        DictionaryArray::try_new_unchecked($to_datatype, cast_keys, $values.clone())
+        // Safety: this is safe because given a type `T` that fits in a `usize`, casting it to type `P` either overflows or also fits in a `usize`
+        unsafe {
+             DictionaryArray::try_new_unchecked($to_datatype, cast_keys, $values.clone())
+        }
             .map(|x| x.boxed())
     }};
 }

--- a/tests/it/compute/cast.rs
+++ b/tests/it/compute/cast.rs
@@ -805,3 +805,27 @@ fn utf8_to_date64() {
 
     assert_eq!(&expected, c);
 }
+
+#[test]
+fn dict_keys() {
+    let mut array = MutableDictionaryArray::<u8, MutableUtf8Array<i32>>::new();
+    array
+        .try_extend([Some("one"), None, Some("three"), Some("one")])
+        .unwrap();
+    let array: DictionaryArray<u8> = array.into();
+
+    let result = cast(
+        &array,
+        &DataType::Dictionary(IntegerType::Int64, Box::new(DataType::Utf8), false),
+        CastOptions::default(),
+    )
+    .expect("cast failed");
+
+    let mut expected = MutableDictionaryArray::<i64, MutableUtf8Array<i32>>::new();
+    expected
+        .try_extend([Some("one"), None, Some("three"), Some("one")])
+        .unwrap();
+    let expected: DictionaryArray<i64> = expected.into();
+
+    assert_eq!(expected, result.as_ref());
+}


### PR DESCRIPTION
Updating arrow2 had some failed test in polars. It turned out that casting dictionary keys was a no-op. This PR fixes that and adds a test.