### PR TITLE
Removed un-needed indirection

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -4,6 +4,6 @@ mod immutable;
 
 use crate::ffi::InternalArrowArray;
 
-pub(crate) type Bytes<T> = foreign_vec::ForeignVec<Box<InternalArrowArray>, T>;
+pub(crate) type Bytes<T> = foreign_vec::ForeignVec<InternalArrowArray, T>;
 
 pub use immutable::Buffer;


### PR DESCRIPTION
Essentially replaced `Box<InternalArrowArray>` by `InternalArrowArray`, since the box was not needed.