### PR TITLE
Removed unneeded `Default` constraint

### DIFF
--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -203,7 +203,7 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
     }
 }
 
-impl<O: Offset, M: MutableArray + Default + 'static> MutableArray for MutableListArray<O, M> {
+impl<O: Offset, M: MutableArray + 'static> MutableArray for MutableListArray<O, M> {
     fn len(&self) -> usize {
         self.offsets.len() - 1
     }


### PR DESCRIPTION
I was trying to use `MutableListArray` with a type that doesn't implement `Default`, and ran into an error caused by this constraint. It looks unnecessary, and removing it doesn't seem to break anything.