### PR TITLE
Replaced `Result` by `panic` in boolean comparison

### DIFF
--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -515,21 +515,20 @@ fn finish_eq_validities(
         (Some(lhs), None) => compute::boolean::and(
             &BooleanArray::new(DataType::Boolean, lhs, None),
             &output_without_validities,
-        )
-        .unwrap(),
+        ),
         (None, Some(rhs)) => compute::boolean::and(
             &output_without_validities,
             &BooleanArray::new(DataType::Boolean, rhs, None),
-        )
-        .unwrap(),
+        ),
         (Some(lhs), Some(rhs)) => {
             let lhs = BooleanArray::new(DataType::Boolean, lhs, None);
             let rhs = BooleanArray::new(DataType::Boolean, rhs, None);
             let eq_validities = compute::comparison::boolean::eq(&lhs, &rhs);
-            compute::boolean::and(&output_without_validities, &eq_validities).unwrap()
+            compute::boolean::and(&output_without_validities, &eq_validities)
         }
     }
 }
+
 fn finish_neq_validities(
     output_without_validities: BooleanArray,
     validity_lhs: Option<Bitmap>,
@@ -540,18 +539,18 @@ fn finish_neq_validities(
         (Some(lhs), None) => {
             let lhs_negated =
                 compute::boolean::not(&BooleanArray::new(DataType::Boolean, lhs, None));
-            compute::boolean::or(&lhs_negated, &output_without_validities).unwrap()
+            compute::boolean::or(&lhs_negated, &output_without_validities)
         }
         (None, Some(rhs)) => {
             let rhs_negated =
                 compute::boolean::not(&BooleanArray::new(DataType::Boolean, rhs, None));
-            compute::boolean::or(&output_without_validities, &rhs_negated).unwrap()
+            compute::boolean::or(&output_without_validities, &rhs_negated)
         }
         (Some(lhs), Some(rhs)) => {
             let lhs = BooleanArray::new(DataType::Boolean, lhs, None);
             let rhs = BooleanArray::new(DataType::Boolean, rhs, None);
             let neq_validities = compute::comparison::boolean::neq(&lhs, &rhs);
-            compute::boolean::or(&output_without_validities, &neq_validities).unwrap()
+            compute::boolean::or(&output_without_validities, &neq_validities)
         }
     }
 }

--- a/tests/it/compute/boolean.rs
+++ b/tests/it/compute/boolean.rs
@@ -7,7 +7,7 @@ use std::iter::FromIterator;
 fn array_and() {
     let a = BooleanArray::from_slice(vec![false, false, true, true]);
     let b = BooleanArray::from_slice(vec![false, true, false, true]);
-    let c = and(&a, &b).unwrap();
+    let c = and(&a, &b);
 
     let expected = BooleanArray::from_slice(vec![false, false, false, true]);
 
@@ -18,7 +18,7 @@ fn array_and() {
 fn array_or() {
     let a = BooleanArray::from_slice(vec![false, false, true, true]);
     let b = BooleanArray::from_slice(vec![false, true, false, true]);
-    let c = or(&a, &b).unwrap();
+    let c = or(&a, &b);
 
     let expected = BooleanArray::from_slice(vec![false, true, true, true]);
 
@@ -49,7 +49,7 @@ fn array_or_validity() {
         Some(false),
         Some(true),
     ]);
-    let c = or(&a, &b).unwrap();
+    let c = or(&a, &b);
 
     let expected = BooleanArray::from(vec![
         None,
@@ -100,7 +100,7 @@ fn array_and_validity() {
         Some(false),
         Some(true),
     ]);
-    let c = and(&a, &b).unwrap();
+    let c = and(&a, &b);
 
     let expected = BooleanArray::from(vec![
         None,
@@ -128,7 +128,7 @@ fn array_and_sliced_same_offset() {
 
     let a = a.slice(8, 4);
     let b = b.slice(8, 4);
-    let c = and(&a, &b).unwrap();
+    let c = and(&a, &b);
 
     let expected = BooleanArray::from_slice(vec![false, false, false, true]);
 
@@ -147,7 +147,7 @@ fn array_and_sliced_same_offset_mod8() {
     let a = a.slice(0, 4);
     let b = b.slice(8, 4);
 
-    let c = and(&a, &b).unwrap();
+    let c = and(&a, &b);
 
     let expected = BooleanArray::from_slice(vec![false, false, false, true]);
 
@@ -163,7 +163,7 @@ fn array_and_sliced_offset1() {
 
     let a = a.slice(8, 4);
 
-    let c = and(&a, &b).unwrap();
+    let c = and(&a, &b);
 
     let expected = BooleanArray::from_slice(vec![false, false, false, true]);
 
@@ -179,7 +179,7 @@ fn array_and_sliced_offset2() {
 
     let b = b.slice(8, 4);
 
-    let c = and(&a, &b).unwrap();
+    let c = and(&a, &b);
 
     let expected = BooleanArray::from_slice(vec![false, false, false, true]);
 
@@ -204,7 +204,7 @@ fn array_and_validity_offset() {
     let b = b.slice(2, 4);
     let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
 
-    let c = and(a, b).unwrap();
+    let c = and(a, b);
 
     let expected = BooleanArray::from(vec![Some(false), Some(false), None, Some(true)]);
 

--- a/tests/it/compute/boolean_kleene.rs
+++ b/tests/it/compute/boolean_kleene.rs
@@ -26,7 +26,7 @@ fn and_generic() {
         Some(false),
         Some(true),
     ]);
-    let c = and(&lhs, &rhs).unwrap();
+    let c = and(&lhs, &rhs);
 
     let expected = BooleanArray::from(&[
         None,
@@ -67,7 +67,7 @@ fn or_generic() {
         Some(false),
         Some(true),
     ]);
-    let c = or(&a, &b).unwrap();
+    let c = or(&a, &b);
 
     let expected = BooleanArray::from(&[
         None,
@@ -90,7 +90,7 @@ fn or_right_nulls() {
 
     let b = BooleanArray::from(&[Some(true), Some(false), None, Some(true), Some(false), None]);
 
-    let c = or(&a, &b).unwrap();
+    let c = or(&a, &b);
 
     let expected = BooleanArray::from(&[
         Some(true),
@@ -117,7 +117,7 @@ fn or_left_nulls() {
 
     let b = BooleanArray::from_slice(&[false, false, false, true, true, true]);
 
-    let c = or(&a, &b).unwrap();
+    let c = or(&a, &b);
 
     let expected = BooleanArray::from(vec![
         Some(true),

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -1394,3 +1394,38 @@ fn large_list_large_binary() -> Result<()> {
     array.try_extend(data).unwrap();
     list_array_generic(false, array.into())
 }
+
+#[test]
+fn list_utf8_nullable() -> Result<()> {
+    let data = vec![
+        Some(vec![Some("a".to_string())]),
+        None,
+        Some(vec![None, Some("b".to_string())]),
+        Some(vec![]),
+        Some(vec![Some("c".to_string())]),
+        None,
+    ];
+    let mut array =
+        MutableListArray::<i32, _>::new_with_field(MutableUtf8Array::<i32>::new(), "item", true);
+    array.try_extend(data).unwrap();
+    list_array_generic(true, array.into())
+}
+
+#[test]
+fn list_int_nullable() -> Result<()> {
+    let data = vec![
+        Some(vec![Some(1)]),
+        None,
+        Some(vec![None, Some(2)]),
+        Some(vec![]),
+        Some(vec![Some(3)]),
+        None,
+    ];
+    let mut array = MutableListArray::<i32, _>::new_with_field(
+        MutablePrimitiveArray::<i32>::new(),
+        "item",
+        true,
+    );
+    array.try_extend(data).unwrap();
+    list_array_generic(true, array.into())
+}


### PR DESCRIPTION
When two arrays do not have the same number of elements, it is a programmatic error to call a binary operator on them. This is better represented by a panic, since there is no way for a user to recover (it should have checked before). This is aligned with the rest of the binary operators we have.
