### PR TITLE
Added constructor `new_from`

### DIFF
--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -48,7 +48,7 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
     pub fn new_from(values: M, data_type: DataType, size: usize) -> Self {
         assert_eq!(values.len(), 0);
         match data_type {
-            DataType::FixedSizeList(..) => {},
+            DataType::FixedSizeList(..) => (),
             _ => panic!("data type must be FixedSizeList (got {:?})", data_type),
         };
         Self {

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -32,13 +32,7 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
     /// Creates a new [`MutableFixedSizeListArray`] from a [`MutableArray`] and size.
     pub fn new(values: M, size: usize) -> Self {
         let data_type = FixedSizeListArray::default_datatype(values.data_type().clone(), size);
-        assert_eq!(values.len(), 0);
-        Self {
-            size,
-            data_type,
-            values,
-            validity: None,
-        }
+        Self::new_from(values, data_type, size)
     }
 
     /// Creates a new [`MutableFixedSizeListArray`] from a [`MutableArray`] and size.
@@ -47,6 +41,11 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
             Box::new(Field::new(name, values.data_type().clone(), nullable)),
             size,
         );
+        Self::new_from(values, data_type, size)
+    }
+
+    /// Creates a new [`MutableFixedSizeListArray`] from a [`MutableArray`], [`DataType`] and size.
+    pub fn new_from(values: M, data_type: DataType, size: usize) -> Self {
         assert_eq!(values.len(), 0);
         Self {
             size,

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -47,6 +47,10 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
     /// Creates a new [`MutableFixedSizeListArray`] from a [`MutableArray`], [`DataType`] and size.
     pub fn new_from(values: M, data_type: DataType, size: usize) -> Self {
         assert_eq!(values.len(), 0);
+        match data_type {
+            DataType::FixedSizeList(..) => {},
+            _ => panic!("data type must be FixedSizeList (got {:?})", data_type),
+        };
         Self {
             size,
             data_type,


### PR DESCRIPTION
Implements a more general `MutableFixedSizeListArray` constructor, `new_from`, to allow creating one with a non-nullable datatype (since `default_datatype` creates one that's nullable).