### PR TITLE
Fixed limit pushdown in parquet

### DIFF
--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -426,16 +426,18 @@ pub struct Iter<O: Offset, A: TraitBinaryArray<O>, I: DataPages> {
     data_type: DataType,
     items: VecDeque<(Binary<O>, MutableBitmap)>,
     chunk_size: Option<usize>,
+    remaining: usize,
     phantom_a: std::marker::PhantomData<A>,
 }
 
 impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> Iter<O, A, I> {
-    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>) -> Self {
+    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>, num_rows: usize) -> Self {
         Self {
             iter,
             data_type,
             items: VecDeque::new(),
             chunk_size,
+            remaining: num_rows,
             phantom_a: Default::default(),
         }
     }
@@ -448,6 +450,7 @@ impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> Iterator for Iter<O, A, I>
         let maybe_state = next(
             &mut self.iter,
             &mut self.items,
+            &mut self.remaining,
             self.chunk_size,
             &BinaryDecoder::<O>::default(),
         );

--- a/src/io/parquet/read/deserialize/binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/binary/dictionary.rs
@@ -26,6 +26,7 @@ where
     data_type: DataType,
     values: Dict,
     items: VecDeque<(Vec<K>, MutableBitmap)>,
+    remaining: usize,
     chunk_size: Option<usize>,
     phantom: std::marker::PhantomData<O>,
 }
@@ -36,12 +37,13 @@ where
     O: Offset,
     I: DataPages,
 {
-    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>) -> Self {
+    pub fn new(iter: I, data_type: DataType, num_rows: usize, chunk_size: Option<usize>) -> Self {
         Self {
             iter,
             data_type,
             values: Dict::Empty,
             items: VecDeque::new(),
+            remaining: num_rows,
             chunk_size,
             phantom: std::marker::PhantomData,
         }
@@ -93,6 +95,7 @@ where
             &mut self.items,
             &mut self.values,
             self.data_type.clone(),
+            &mut self.remaining,
             self.chunk_size,
             |dict| read_dict::<O>(self.data_type.clone(), dict),
         );
@@ -117,6 +120,7 @@ where
     data_type: DataType,
     values: Dict,
     items: VecDeque<(NestedState, (Vec<K>, MutableBitmap))>,
+    remaining: usize,
     chunk_size: Option<usize>,
     phantom: std::marker::PhantomData<O>,
 }
@@ -131,6 +135,7 @@ where
         iter: I,
         init: Vec<InitNested>,
         data_type: DataType,
+        num_rows: usize,
         chunk_size: Option<usize>,
     ) -> Self {
         Self {
@@ -139,6 +144,7 @@ where
             data_type,
             values: Dict::Empty,
             items: VecDeque::new(),
+            remaining: num_rows,
             chunk_size,
             phantom: Default::default(),
         }
@@ -157,6 +163,7 @@ where
         let maybe_state = nested_next_dict(
             &mut self.iter,
             &mut self.items,
+            &mut self.remaining,
             &self.init,
             &mut self.values,
             self.data_type.clone(),
@@ -177,6 +184,7 @@ pub fn iter_to_arrays_nested<'a, K, O, I>(
     iter: I,
     init: Vec<InitNested>,
     data_type: DataType,
+    num_rows: usize,
     chunk_size: Option<usize>,
 ) -> NestedArrayIter<'a>
 where
@@ -185,7 +193,7 @@ where
     K: DictionaryKey,
 {
     Box::new(
-        NestedDictIter::<K, O, I>::new(iter, init, data_type, chunk_size).map(|result| {
+        NestedDictIter::<K, O, I>::new(iter, init, data_type, num_rows, chunk_size).map(|result| {
             let (mut nested, array) = result?;
             let _ = nested.nested.pop().unwrap(); // the primitive
             Ok((nested, array.boxed()))

--- a/src/io/parquet/read/deserialize/boolean/basic.rs
+++ b/src/io/parquet/read/deserialize/boolean/basic.rs
@@ -192,15 +192,17 @@ pub struct Iter<I: DataPages> {
     data_type: DataType,
     items: VecDeque<(MutableBitmap, MutableBitmap)>,
     chunk_size: Option<usize>,
+    remaining: usize,
 }
 
 impl<I: DataPages> Iter<I> {
-    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>) -> Self {
+    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>, num_rows: usize) -> Self {
         Self {
             iter,
             data_type,
             items: VecDeque::new(),
             chunk_size,
+            remaining: num_rows,
         }
     }
 }
@@ -212,6 +214,7 @@ impl<I: DataPages> Iterator for Iter<I> {
         let maybe_state = next(
             &mut self.iter,
             &mut self.items,
+            &mut self.remaining,
             self.chunk_size,
             &BooleanDecoder::default(),
         );

--- a/src/io/parquet/read/deserialize/dictionary/mod.rs
+++ b/src/io/parquet/read/deserialize/dictionary/mod.rs
@@ -257,6 +257,7 @@ pub(super) fn next_dict<
     items: &mut VecDeque<(Vec<K>, MutableBitmap)>,
     dict: &mut Dict,
     data_type: DataType,
+    remaining: &mut usize,
     chunk_size: Option<usize>,
     read_dict: F,
 ) -> MaybeNext<Result<DictionaryArray<K>>> {
@@ -288,7 +289,13 @@ pub(super) fn next_dict<
                 Err(e) => return MaybeNext::Some(Err(e)),
             };
 
-            utils::extend_from_new_page(page, chunk_size, items, &PrimitiveDecoder::<K>::default());
+            utils::extend_from_new_page(
+                page,
+                chunk_size,
+                items,
+                remaining,
+                &PrimitiveDecoder::<K>::default(),
+            );
 
             if items.front().unwrap().len() < chunk_size.unwrap_or(usize::MAX) {
                 MaybeNext::More

--- a/src/io/parquet/read/deserialize/dictionary/nested.rs
+++ b/src/io/parquet/read/deserialize/dictionary/nested.rs
@@ -136,9 +136,11 @@ impl<'a, K: DictionaryKey> NestedDecoder<'a> for DictionaryDecoder<K> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn next_dict<'a, K: DictionaryKey, I: DataPages, F: Fn(&dyn DictPage) -> Box<dyn Array>>(
     iter: &'a mut I,
     items: &mut VecDeque<(NestedState, (Vec<K>, MutableBitmap))>,
+    remaining: &mut usize,
     init: &[InitNested],
     dict: &mut Dict,
     data_type: DataType,
@@ -171,6 +173,7 @@ pub fn next_dict<'a, K: DictionaryKey, I: DataPages, F: Fn(&dyn DictPage) -> Box
                 page,
                 init,
                 items,
+                remaining,
                 &DictionaryDecoder::<K>::default(),
                 chunk_size,
             );

--- a/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
@@ -286,10 +286,11 @@ pub struct Iter<I: DataPages> {
     size: usize,
     items: VecDeque<(FixedSizeBinary, MutableBitmap)>,
     chunk_size: Option<usize>,
+    remaining: usize,
 }
 
 impl<I: DataPages> Iter<I> {
-    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>) -> Self {
+    pub fn new(iter: I, data_type: DataType, num_rows: usize, chunk_size: Option<usize>) -> Self {
         let size = FixedSizeBinaryArray::get_size(&data_type);
         Self {
             iter,
@@ -297,6 +298,7 @@ impl<I: DataPages> Iter<I> {
             size,
             items: VecDeque::new(),
             chunk_size,
+            remaining: num_rows,
         }
     }
 }
@@ -308,6 +310,7 @@ impl<I: DataPages> Iterator for Iter<I> {
         let maybe_state = next(
             &mut self.iter,
             &mut self.items,
+            &mut self.remaining,
             self.chunk_size,
             &BinaryDecoder { size: self.size },
         );

--- a/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/src/io/parquet/read/deserialize/nested_utils.rs
@@ -455,7 +455,7 @@ fn extend_offsets2<'a, D: NestedDecoder<'a>>(
 
         let next_rep = page.iter.peek().map(|x| x.0).unwrap_or(0);
 
-        if next_rep == 0 && rows == additional.saturating_add(1) {
+        if next_rep == 0 && rows == additional {
             break;
         }
     }

--- a/src/io/parquet/read/deserialize/null.rs
+++ b/src/io/parquet/read/deserialize/null.rs
@@ -2,11 +2,12 @@ use crate::{array::NullArray, datatypes::DataType};
 
 use super::super::{ArrayIter, DataPages};
 
-/// Converts [`DataPages`] to an [`Iterator`] of [`Array`]
+/// Converts [`DataPages`] to an [`ArrayIter`]
 pub fn iter_to_arrays<'a, I>(
     mut iter: I,
     data_type: DataType,
     chunk_size: Option<usize>,
+    num_rows: usize,
 ) -> ArrayIter<'a>
 where
     I: 'a + DataPages,
@@ -14,16 +15,22 @@ where
     let mut len = 0usize;
 
     while let Ok(Some(x)) = iter.next() {
-        len += x.num_values()
+        let rows = x.num_values();
+        len = (len + rows).min(num_rows);
+        if len == num_rows {
+            break;
+        }
     }
+
     if len == 0 {
         return Box::new(std::iter::empty());
     }
 
     let chunk_size = chunk_size.unwrap_or(len);
 
-    let complete_chunks = chunk_size / len;
-    let remainder = chunk_size % len;
+    let complete_chunks = len / chunk_size;
+
+    let remainder = len - (complete_chunks * chunk_size);
     let i_data_type = data_type.clone();
     let complete = (0..complete_chunks)
         .map(move |_| Ok(NullArray::new(i_data_type.clone(), chunk_size).boxed()));
@@ -32,5 +39,58 @@ where
     } else {
         let array = NullArray::new(data_type, remainder);
         Box::new(complete.chain(std::iter::once(Ok(array.boxed()))))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use parquet2::{
+        encoding::Encoding,
+        error::Error as ParquetError,
+        metadata::Descriptor,
+        page::{DataPage, DataPageHeader, DataPageHeaderV1},
+        schema::types::{PhysicalType, PrimitiveType},
+    };
+
+    use crate::{array::NullArray, datatypes::DataType, error::Error};
+
+    use super::iter_to_arrays;
+
+    #[test]
+    fn limit() {
+        let new_page = |values: i32| {
+            DataPage::new(
+                DataPageHeader::V1(DataPageHeaderV1 {
+                    num_values: values,
+                    encoding: Encoding::Plain.into(),
+                    definition_level_encoding: Encoding::Plain.into(),
+                    repetition_level_encoding: Encoding::Plain.into(),
+                    statistics: None,
+                }),
+                vec![],
+                None,
+                Descriptor {
+                    primitive_type: PrimitiveType::from_physical(
+                        "a".to_string(),
+                        PhysicalType::Int32,
+                    ),
+                    max_def_level: 0,
+                    max_rep_level: 0,
+                },
+                None,
+            )
+        };
+
+        let p1 = new_page(100);
+        let p2 = new_page(100);
+        let pages = vec![Result::<_, ParquetError>::Ok(&p1), Ok(&p2)];
+        let pages = fallible_streaming_iterator::convert(pages.into_iter());
+        let arrays = iter_to_arrays(pages, DataType::Null, Some(10), 101);
+
+        let arrays = arrays.collect::<Result<Vec<_>, Error>>().unwrap();
+        let expected = std::iter::repeat(NullArray::new(DataType::Null, 10).boxed())
+            .take(10)
+            .chain(std::iter::once(NullArray::new(DataType::Null, 1).boxed()));
+        assert_eq!(arrays, expected.collect::<Vec<_>>())
     }
 }

--- a/src/io/parquet/read/file.rs
+++ b/src/io/parquet/read/file.rs
@@ -240,6 +240,7 @@ impl<R: Read + Seek> RowGroupReader<R> {
             row_group,
             self.schema.fields.clone(),
             self.chunk_size,
+            Some(self.remaining_rows),
         )?;
 
         let result = RowGroupDeserializer::new(

--- a/src/io/parquet/read/row_group.rs
+++ b/src/io/parquet/read/row_group.rs
@@ -175,7 +175,7 @@ pub fn to_deserializer<'a>(
     num_rows: usize,
     chunk_size: Option<usize>,
 ) -> Result<ArrayIter<'a>> {
-    let chunk_size = chunk_size.unwrap_or(usize::MAX).min(num_rows);
+    let chunk_size = chunk_size.map(|c| c.min(num_rows));
 
     let (columns, types): (Vec<_>, Vec<_>) = columns
         .into_iter()
@@ -193,7 +193,7 @@ pub fn to_deserializer<'a>(
         })
         .unzip();
 
-    column_iter_to_arrays(columns, types, field, Some(chunk_size))
+    column_iter_to_arrays(columns, types, field, chunk_size, num_rows)
 }
 
 /// Returns a vector of iterators of [`Array`] ([`ArrayIter`]) corresponding to the top

--- a/src/io/parquet/read/row_group.rs
+++ b/src/io/parquet/read/row_group.rs
@@ -65,14 +65,7 @@ impl Iterator for RowGroupDeserializer {
         let chunk = self
             .column_chunks
             .iter_mut()
-            .map(|iter| {
-                let array = iter.next().unwrap()?;
-                Ok(if array.len() > self.remaining_rows {
-                    array.slice(0, array.len() - self.remaining_rows)
-                } else {
-                    array
-                })
-            })
+            .map(|iter| iter.next().unwrap())
             .collect::<Result<Vec<_>>>()
             .and_then(Chunk::try_new);
         self.remaining_rows = self.remaining_rows.saturating_sub(
@@ -218,7 +211,11 @@ pub fn read_columns_many<'a, R: Read + Seek>(
     row_group: &RowGroupMetaData,
     fields: Vec<Field>,
     chunk_size: Option<usize>,
+    limit: Option<usize>,
 ) -> Result<Vec<ArrayIter<'a>>> {
+    let num_rows = row_group.num_rows();
+    let num_rows = limit.map(|limit| limit.min(num_rows)).unwrap_or(num_rows);
+
     // reads all the necessary columns for all fields from the row group
     // This operation is IO-bounded `O(C)` where C is the number of columns in the row group
     let field_columns = fields
@@ -229,9 +226,7 @@ pub fn read_columns_many<'a, R: Read + Seek>(
     field_columns
         .into_iter()
         .zip(fields.into_iter())
-        .map(|(columns, field)| {
-            to_deserializer(columns, field, row_group.num_rows() as usize, chunk_size)
-        })
+        .map(|(columns, field)| to_deserializer(columns, field, num_rows, chunk_size))
         .collect()
 }
 

--- a/src/io/print.rs
+++ b/src/io/print.rs
@@ -8,27 +8,27 @@ use crate::{
 use comfy_table::{Cell, Table};
 
 /// Returns a visual representation of [`Chunk`]
-pub fn write<A: AsRef<dyn Array>, N: AsRef<str>>(batches: &[Chunk<A>], names: &[N]) -> String {
+pub fn write<A: AsRef<dyn Array>, N: AsRef<str>>(chunks: &[Chunk<A>], names: &[N]) -> String {
     let mut table = Table::new();
     table.load_preset("||--+-++|    ++++++");
 
-    if batches.is_empty() {
+    if chunks.is_empty() {
         return table.to_string();
     }
 
     let header = names.iter().map(|name| Cell::new(name.as_ref()));
     table.set_header(header);
 
-    for batch in batches {
-        let displayes = batch
+    for chunk in chunks {
+        let displayes = chunk
             .arrays()
             .iter()
             .map(|array| get_display(array.as_ref(), ""))
             .collect::<Vec<_>>();
 
-        for row in 0..batch.len() {
+        for row in 0..chunk.len() {
             let mut cells = Vec::new();
-            (0..batch.arrays().len()).for_each(|col| {
+            (0..chunk.arrays().len()).for_each(|col| {
                 let mut string = String::new();
                 displayes[col](&mut string, row).unwrap();
                 cells.push(Cell::new(string));

--- a/tests/it/io/parquet/integration.rs
+++ b/tests/it/io/parquet/integration.rs
@@ -14,7 +14,7 @@ fn test_file(version: &str, file_name: &str) -> Result<()> {
 
     let data = integration_write(&schema, &batches)?;
 
-    let (read_schema, read_batches) = integration_read(&data)?;
+    let (read_schema, read_batches) = integration_read(&data, None)?;
 
     assert_eq!(schema, read_schema);
     assert_eq!(batches, read_batches);

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -124,7 +124,8 @@ fn read_with_indexes(
         vec![pages],
         vec![&c1.descriptor().descriptor.primitive_type],
         schema.fields[1].clone(),
-        Some(row_group.num_rows() as usize),
+        None,
+        row_group.num_rows() as usize,
     )?;
 
     let arrays = arrays.collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
The limit was not correctly applied within a row group, only across row groups, resulting in un-necessary CPU work and memory usage.