### PR TITLE
Delayed dict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,8 @@ futures = { version = "0.3", optional = true }
 async-stream = { version = "0.3.2", optional = true }
 
 # parquet support
-parquet2 = { version = "0.14.0", optional = true, default_features = false }
+#parquet2 = { version = "0.14.0", optional = true, default_features = false }
+parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "delay_dict", optional = true, default_features = false }
 
 # avro support
 avro-schema = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,8 +74,7 @@ futures = { version = "0.3", optional = true }
 async-stream = { version = "0.3.2", optional = true }
 
 # parquet support
-#parquet2 = { version = "0.14.0", optional = true, default_features = false }
-parquet2 = { git = "https://github.com/jorgecarleitao/parquet2", branch = "delay_dict", optional = true, default_features = false }
+parquet2 = { version = "0.15.0", optional = true, default_features = false, features = ["async"] }
 
 # avro support
 avro-schema = { version = "0.3", optional = true }

--- a/benches/read_parquet.rs
+++ b/benches/read_parquet.rs
@@ -59,7 +59,7 @@ fn add_benchmark(c: &mut Criterion) {
 
         let buffer = to_buffer(size, true, true, false, false);
         let a = format!("read ts dict 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 11).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 11).unwrap()));
 
         let a = format!("read utf8 2^{}", i);
         c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 2).unwrap()));

--- a/benches/read_parquet.rs
+++ b/benches/read_parquet.rs
@@ -57,6 +57,10 @@ fn add_benchmark(c: &mut Criterion) {
         let a = format!("read i64 2^{}", i);
         c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 0).unwrap()));
 
+        let buffer = to_buffer(size, true, true, false, false);
+        let a = format!("read ts dict 2^{}", i);
+        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 11).unwrap()));
+
         let a = format!("read utf8 2^{}", i);
         c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 2).unwrap()));
 

--- a/src/io/parquet/read/deserialize/README.md
+++ b/src/io/parquet/read/deserialize/README.md
@@ -7,7 +7,7 @@ module for non-nested arrays is `simple::page_iter_to_arrays`.
 
 This function expects
 
-* a (fallible) streaming iterator of decompressed and encoded pages, `DataPages`
+* a (fallible) streaming iterator of decompressed and encoded pages, `Pages`
 * the source (parquet) column type, including its logical information
 * the target (arrow) `DataType`
 * the chunk size
@@ -18,7 +18,7 @@ This design is shared among _all_ `(parquet, arrow)` implemented tuples. Their m
 difference is how they are deserialized, which depends on the source and target types.
 
 When the array iterator is pulled the first time, the following happens:
-* a page from `DataPages` is pulled
+* a page from `Pages` is pulled
 * a `PageState<'a>` is built from the page
 * the `PageState` is consumed into a mutable array:
     * if `chunk_size` is larger than the number of rows in the page, the mutable array state is preserved and a new page is pulled and the process repeated until we fill a chunk.

--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -221,7 +221,7 @@ impl<O: Offset> TraitBinaryArray<O> for Utf8Array<O> {
     }
 }
 
-impl<'a, O: Offset> DecodedState<'a> for (Binary<O>, MutableBitmap) {
+impl<O: Offset> DecodedState for (Binary<O>, MutableBitmap) {
     fn len(&self) -> usize {
         self.0.len()
     }

--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -4,7 +4,7 @@ use std::default::Default;
 use parquet2::{
     deserialize::SliceFilteredIter,
     encoding::{hybrid_rle, Encoding},
-    page::{split_buffer, BinaryPageDict, DataPage},
+    page::{split_buffer, DataPage, DictPage},
     schema::Repetition,
 };
 
@@ -20,7 +20,7 @@ use super::super::utils::{
     extend_from_decoder, get_selected_rows, next, DecodedState, FilteredOptionalPageValidity,
     MaybeNext, OptionalPageValidity,
 };
-use super::super::DataPages;
+use super::super::Pages;
 use super::{super::utils, utils::*};
 
 /*
@@ -99,14 +99,16 @@ impl<'a> FilteredRequired<'a> {
     }
 }
 
+pub(super) type Dict = Vec<Vec<u8>>;
+
 #[derive(Debug)]
 pub(super) struct RequiredDictionary<'a> {
     pub values: hybrid_rle::HybridRleDecoder<'a>,
-    pub dict: &'a BinaryPageDict,
+    pub dict: &'a Dict,
 }
 
 impl<'a> RequiredDictionary<'a> {
-    pub fn try_new(page: &'a DataPage, dict: &'a BinaryPageDict) -> Result<Self> {
+    pub fn try_new(page: &'a DataPage, dict: &'a Dict) -> Result<Self> {
         let values = utils::dict_indices_decoder(page)?;
 
         Ok(Self { dict, values })
@@ -121,11 +123,11 @@ impl<'a> RequiredDictionary<'a> {
 #[derive(Debug)]
 pub(super) struct FilteredRequiredDictionary<'a> {
     pub values: SliceFilteredIter<hybrid_rle::HybridRleDecoder<'a>>,
-    pub dict: &'a BinaryPageDict,
+    pub dict: &'a Dict,
 }
 
 impl<'a> FilteredRequiredDictionary<'a> {
-    pub fn try_new(page: &'a DataPage, dict: &'a BinaryPageDict) -> Result<Self> {
+    pub fn try_new(page: &'a DataPage, dict: &'a Dict) -> Result<Self> {
         let values = utils::dict_indices_decoder(page)?;
 
         let rows = get_selected_rows(page);
@@ -143,11 +145,11 @@ impl<'a> FilteredRequiredDictionary<'a> {
 #[derive(Debug)]
 pub(super) struct ValuesDictionary<'a> {
     pub values: hybrid_rle::HybridRleDecoder<'a>,
-    pub dict: &'a BinaryPageDict,
+    pub dict: &'a Dict,
 }
 
 impl<'a> ValuesDictionary<'a> {
-    pub fn try_new(page: &'a DataPage, dict: &'a BinaryPageDict) -> Result<Self> {
+    pub fn try_new(page: &'a DataPage, dict: &'a Dict) -> Result<Self> {
         let values = utils::dict_indices_decoder(page)?;
 
         Ok(Self { dict, values })
@@ -232,42 +234,29 @@ struct BinaryDecoder<O: Offset> {
 
 impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
     type State = State<'a>;
+    type Dict = Dict;
     type DecodedState = (Binary<O>, MutableBitmap);
 
-    fn build_state(&self, page: &'a DataPage) -> Result<Self::State> {
+    fn build_state(&self, page: &'a DataPage, dict: Option<&'a Self::Dict>) -> Result<Self::State> {
         let is_optional =
             page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
         let is_filtered = page.selected_rows().is_some();
 
-        match (
-            page.encoding(),
-            page.dictionary_page(),
-            is_optional,
-            is_filtered,
-        ) {
-            (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, false) => {
-                Ok(State::RequiredDictionary(RequiredDictionary::try_new(
-                    page,
-                    dict.as_any().downcast_ref().unwrap(),
-                )?))
-            }
+        match (page.encoding(), dict, is_optional, is_filtered) {
+            (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, false) => Ok(
+                State::RequiredDictionary(RequiredDictionary::try_new(page, dict)?),
+            ),
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, false) => {
-                let dict = dict.as_any().downcast_ref().unwrap();
-
                 Ok(State::OptionalDictionary(
                     OptionalPageValidity::try_new(page)?,
                     ValuesDictionary::try_new(page, dict)?,
                 ))
             }
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, true) => {
-                let dict = dict.as_any().downcast_ref().unwrap();
-
                 FilteredRequiredDictionary::try_new(page, dict)
                     .map(State::FilteredRequiredDictionary)
             }
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, true) => {
-                let dict = dict.as_any().downcast_ref().unwrap();
-
                 Ok(State::FilteredOptionalDictionary(
                     FilteredOptionalPageValidity::try_new(page)?,
                     ValuesDictionary::try_new(page, dict)?,
@@ -332,15 +321,8 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 }
             }
             State::OptionalDictionary(page_validity, page_values) => {
-                let dict_values = page_values.dict.values();
-                let dict_offsets = page_values.dict.offsets();
-
-                let op = move |index: u32| {
-                    let index = index as usize;
-                    let dict_offset_i = dict_offsets[index] as usize;
-                    let dict_offset_ip1 = dict_offsets[index + 1] as usize;
-                    &dict_values[dict_offset_i..dict_offset_ip1]
-                };
+                let page_dict = &page_values.dict;
+                let op = move |index: u32| page_dict[index as usize].as_ref();
                 utils::extend_from_decoder(
                     validity,
                     page_validity,
@@ -350,14 +332,8 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 )
             }
             State::RequiredDictionary(page) => {
-                let dict_values = page.dict.values();
-                let dict_offsets = page.dict.offsets();
-                let op = move |index: u32| {
-                    let index = index as usize;
-                    let dict_offset_i = dict_offsets[index] as usize;
-                    let dict_offset_ip1 = dict_offsets[index + 1] as usize;
-                    &dict_values[dict_offset_i..dict_offset_ip1]
-                };
+                let page_dict = &page.dict;
+                let op = move |index: u32| page_dict[index as usize].as_ref();
 
                 for x in page.values.by_ref().map(op).take(additional) {
                     values.push(x)
@@ -373,29 +349,16 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 );
             }
             State::FilteredRequiredDictionary(page) => {
-                let dict_values = page.dict.values();
-                let dict_offsets = page.dict.offsets();
-                let op = move |index: u32| {
-                    let index = index as usize;
-                    let dict_offset_i = dict_offsets[index] as usize;
-                    let dict_offset_ip1 = dict_offsets[index + 1] as usize;
-                    &dict_values[dict_offset_i..dict_offset_ip1]
-                };
+                let page_dict = &page.dict;
+                let op = move |index: u32| page_dict[index as usize].as_ref();
 
                 for x in page.values.by_ref().map(op).take(additional) {
                     values.push(x)
                 }
             }
             State::FilteredOptionalDictionary(page_validity, page_values) => {
-                let dict_values = page_values.dict.values();
-                let dict_offsets = page_values.dict.offsets();
-
-                let op = move |index: u32| {
-                    let index = index as usize;
-                    let dict_offset_i = dict_offsets[index] as usize;
-                    let dict_offset_ip1 = dict_offsets[index + 1] as usize;
-                    &dict_values[dict_offset_i..dict_offset_ip1]
-                };
+                let page_dict = &page_values.dict;
+                let op = move |index: u32| page_dict[index as usize].as_ref();
                 utils::extend_from_decoder(
                     validity,
                     page_validity,
@@ -405,6 +368,10 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 )
             }
         }
+    }
+
+    fn deserialize_dict(&self, page: &DictPage) -> Self::Dict {
+        deserialize_plain(&page.buffer, page.num_values)
     }
 }
 
@@ -421,21 +388,23 @@ pub(super) fn finish<O: Offset, A: TraitBinaryArray<O>>(
     )
 }
 
-pub struct Iter<O: Offset, A: TraitBinaryArray<O>, I: DataPages> {
+pub struct Iter<O: Offset, A: TraitBinaryArray<O>, I: Pages> {
     iter: I,
     data_type: DataType,
     items: VecDeque<(Binary<O>, MutableBitmap)>,
+    dict: Option<Dict>,
     chunk_size: Option<usize>,
     remaining: usize,
     phantom_a: std::marker::PhantomData<A>,
 }
 
-impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> Iter<O, A, I> {
+impl<O: Offset, A: TraitBinaryArray<O>, I: Pages> Iter<O, A, I> {
     pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>, num_rows: usize) -> Self {
         Self {
             iter,
             data_type,
             items: VecDeque::new(),
+            dict: None,
             chunk_size,
             remaining: num_rows,
             phantom_a: Default::default(),
@@ -443,13 +412,14 @@ impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> Iter<O, A, I> {
     }
 }
 
-impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> Iterator for Iter<O, A, I> {
+impl<O: Offset, A: TraitBinaryArray<O>, I: Pages> Iterator for Iter<O, A, I> {
     type Item = Result<A>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let maybe_state = next(
             &mut self.iter,
             &mut self.items,
+            &mut self.dict,
             &mut self.remaining,
             self.chunk_size,
             &BinaryDecoder::<O>::default(),
@@ -463,4 +433,10 @@ impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> Iterator for Iter<O, A, I>
             MaybeNext::More => self.next(),
         }
     }
+}
+
+pub(super) fn deserialize_plain(values: &[u8], num_values: usize) -> Dict {
+    SizedBinaryIter::new(values, num_values)
+        .map(|x| x.to_vec())
+        .collect()
 }

--- a/src/io/parquet/read/deserialize/binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/binary/dictionary.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use parquet2::page::{BinaryPageDict, DictPage};
+use parquet2::page::DictPage;
 
 use crate::{
     array::{Array, BinaryArray, DictionaryArray, DictionaryKey, Offset, Utf8Array},
@@ -10,21 +10,21 @@ use crate::{
     io::parquet::read::deserialize::nested_utils::{InitNested, NestedState},
 };
 
-use super::super::dictionary::*;
-use super::super::utils::MaybeNext;
-use super::super::DataPages;
+use super::super::Pages;
+use super::{super::dictionary::*, utils::SizedBinaryIter};
+use super::{super::utils::MaybeNext, utils::Binary};
 
-/// An iterator adapter over [`DataPages`] assumed to be encoded as parquet's dictionary-encoded binary representation
+/// An iterator adapter over [`Pages`] assumed to be encoded as parquet's dictionary-encoded binary representation
 #[derive(Debug)]
 pub struct DictIter<K, O, I>
 where
-    I: DataPages,
+    I: Pages,
     O: Offset,
     K: DictionaryKey,
 {
     iter: I,
     data_type: DataType,
-    values: Dict,
+    values: Option<Box<dyn Array>>,
     items: VecDeque<(Vec<K>, MutableBitmap)>,
     remaining: usize,
     chunk_size: Option<usize>,
@@ -35,13 +35,13 @@ impl<K, O, I> DictIter<K, O, I>
 where
     K: DictionaryKey,
     O: Offset,
-    I: DataPages,
+    I: Pages,
 {
     pub fn new(iter: I, data_type: DataType, num_rows: usize, chunk_size: Option<usize>) -> Self {
         Self {
             iter,
             data_type,
-            values: Dict::Empty,
+            values: None,
             items: VecDeque::new(),
             remaining: num_rows,
             chunk_size,
@@ -50,40 +50,35 @@ where
     }
 }
 
-fn read_dict<O: Offset>(data_type: DataType, dict: &dyn DictPage) -> Box<dyn Array> {
+fn read_dict<O: Offset>(data_type: DataType, dict: &DictPage) -> Box<dyn Array> {
     let data_type = match data_type {
         DataType::Dictionary(_, values, _) => *values,
         _ => data_type,
     };
 
-    let dict = dict.as_any().downcast_ref::<BinaryPageDict>().unwrap();
-    let offsets = dict
-        .offsets()
-        .iter()
-        .map(|x| O::from_usize(*x as usize).unwrap())
-        .collect::<Vec<_>>();
-    let values = dict.values().to_vec();
+    let values = SizedBinaryIter::new(&dict.buffer, dict.num_values);
+
+    let mut data = Binary::<O>::with_capacity(dict.num_values);
+    data.values = Vec::with_capacity(dict.buffer.len() - 4 * dict.num_values);
+    for item in values {
+        data.push(item)
+    }
 
     match data_type.to_physical_type() {
-        PhysicalType::Utf8 | PhysicalType::LargeUtf8 => Box::new(Utf8Array::<O>::from_data(
-            data_type,
-            offsets.into(),
-            values.into(),
-            None,
-        )) as _,
-        PhysicalType::Binary | PhysicalType::LargeBinary => Box::new(BinaryArray::<O>::from_data(
-            data_type,
-            offsets.into(),
-            values.into(),
-            None,
-        )) as _,
+        PhysicalType::Utf8 | PhysicalType::LargeUtf8 => {
+            Utf8Array::<O>::new(data_type, data.offsets.0.into(), data.values.into(), None).boxed()
+        }
+        PhysicalType::Binary | PhysicalType::LargeBinary => {
+            BinaryArray::<O>::new(data_type, data.offsets.0.into(), data.values.into(), None)
+                .boxed()
+        }
         _ => unreachable!(),
     }
 }
 
 impl<K, O, I> Iterator for DictIter<K, O, I>
 where
-    I: DataPages,
+    I: Pages,
     O: Offset,
     K: DictionaryKey,
 {
@@ -112,14 +107,14 @@ where
 #[derive(Debug)]
 pub struct NestedDictIter<K, O, I>
 where
-    I: DataPages,
+    I: Pages,
     O: Offset,
     K: DictionaryKey,
 {
     iter: I,
     init: Vec<InitNested>,
     data_type: DataType,
-    values: Dict,
+    values: Option<Box<dyn Array>>,
     items: VecDeque<(NestedState, (Vec<K>, MutableBitmap))>,
     remaining: usize,
     chunk_size: Option<usize>,
@@ -128,7 +123,7 @@ where
 
 impl<K, O, I> NestedDictIter<K, O, I>
 where
-    I: DataPages,
+    I: Pages,
     O: Offset,
     K: DictionaryKey,
 {
@@ -143,7 +138,7 @@ where
             iter,
             init,
             data_type,
-            values: Dict::Empty,
+            values: None,
             items: VecDeque::new(),
             remaining: num_rows,
             chunk_size,
@@ -154,7 +149,7 @@ where
 
 impl<K, O, I> Iterator for NestedDictIter<K, O, I>
 where
-    I: DataPages,
+    I: Pages,
     O: Offset,
     K: DictionaryKey,
 {

--- a/src/io/parquet/read/deserialize/binary/nested.rs
+++ b/src/io/parquet/read/deserialize/binary/nested.rs
@@ -2,22 +2,22 @@ use std::collections::VecDeque;
 
 use parquet2::{
     encoding::Encoding,
-    page::{split_buffer, DataPage},
+    page::{split_buffer, DataPage, DictPage},
     schema::Repetition,
 };
 
 use crate::{
     array::Offset, bitmap::MutableBitmap, datatypes::DataType, error::Result,
-    io::parquet::read::DataPages,
+    io::parquet::read::Pages,
 };
 
-use super::super::nested_utils::*;
 use super::super::utils::MaybeNext;
 use super::basic::ValuesDictionary;
 use super::utils::*;
+use super::{super::nested_utils::*, basic::deserialize_plain};
 use super::{
     super::utils,
-    basic::{finish, TraitBinaryArray},
+    basic::{finish, Dict, TraitBinaryArray},
 };
 
 #[derive(Debug)]
@@ -46,25 +46,23 @@ struct BinaryDecoder<O: Offset> {
 
 impl<'a, O: Offset> NestedDecoder<'a> for BinaryDecoder<O> {
     type State = State<'a>;
+    type Dictionary = Dict;
     type DecodedState = (Binary<O>, MutableBitmap);
 
-    fn build_state(&self, page: &'a DataPage) -> Result<Self::State> {
+    fn build_state(
+        &self,
+        page: &'a DataPage,
+        dict: Option<&'a Self::Dictionary>,
+    ) -> Result<Self::State> {
         let is_optional =
             page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
         let is_filtered = page.selected_rows().is_some();
 
-        match (
-            page.encoding(),
-            page.dictionary_page(),
-            is_optional,
-            is_filtered,
-        ) {
+        match (page.encoding(), dict, is_optional, is_filtered) {
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, false) => {
-                let dict = dict.as_any().downcast_ref().unwrap();
                 ValuesDictionary::try_new(page, dict).map(State::RequiredDictionary)
             }
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, false) => {
-                let dict = dict.as_any().downcast_ref().unwrap();
                 ValuesDictionary::try_new(page, dict).map(State::OptionalDictionary)
             }
             (Encoding::Plain, _, true, false) => {
@@ -105,28 +103,14 @@ impl<'a, O: Offset> NestedDecoder<'a> for BinaryDecoder<O> {
                 values.push(value);
             }
             State::RequiredDictionary(page) => {
-                let dict_values = page.dict.values();
-                let dict_offsets = page.dict.offsets();
-
-                let op = move |index: u32| {
-                    let index = index as usize;
-                    let dict_offset_i = dict_offsets[index] as usize;
-                    let dict_offset_ip1 = dict_offsets[index + 1] as usize;
-                    &dict_values[dict_offset_i..dict_offset_ip1]
-                };
+                let dict_values = &page.dict;
+                let op = move |index: u32| dict_values[index as usize].as_ref();
                 let item = page.values.next().map(op).unwrap_or_default();
                 values.push(item);
             }
             State::OptionalDictionary(page) => {
-                let dict_values = page.dict.values();
-                let dict_offsets = page.dict.offsets();
-
-                let op = move |index: u32| {
-                    let index = index as usize;
-                    let dict_offset_i = dict_offsets[index] as usize;
-                    let dict_offset_ip1 = dict_offsets[index + 1] as usize;
-                    &dict_values[dict_offset_i..dict_offset_ip1]
-                };
+                let dict_values = &page.dict;
+                let op = move |index: u32| dict_values[index as usize].as_ref();
                 let item = page.values.next().map(op).unwrap_or_default();
                 values.push(item);
                 validity.push(true);
@@ -139,19 +123,24 @@ impl<'a, O: Offset> NestedDecoder<'a> for BinaryDecoder<O> {
         values.push(&[]);
         validity.push(false);
     }
+
+    fn deserialize_dict(&self, page: &DictPage) -> Self::Dictionary {
+        deserialize_plain(&page.buffer, page.num_values)
+    }
 }
 
-pub struct NestedIter<O: Offset, A: TraitBinaryArray<O>, I: DataPages> {
+pub struct NestedIter<O: Offset, A: TraitBinaryArray<O>, I: Pages> {
     iter: I,
     data_type: DataType,
     init: Vec<InitNested>,
     items: VecDeque<(NestedState, (Binary<O>, MutableBitmap))>,
+    dict: Option<Dict>,
     chunk_size: Option<usize>,
     remaining: usize,
     phantom_a: std::marker::PhantomData<A>,
 }
 
-impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> NestedIter<O, A, I> {
+impl<O: Offset, A: TraitBinaryArray<O>, I: Pages> NestedIter<O, A, I> {
     pub fn new(
         iter: I,
         init: Vec<InitNested>,
@@ -164,6 +153,7 @@ impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> NestedIter<O, A, I> {
             data_type,
             init,
             items: VecDeque::new(),
+            dict: None,
             chunk_size,
             remaining: num_rows,
             phantom_a: Default::default(),
@@ -171,13 +161,14 @@ impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> NestedIter<O, A, I> {
     }
 }
 
-impl<O: Offset, A: TraitBinaryArray<O>, I: DataPages> Iterator for NestedIter<O, A, I> {
+impl<O: Offset, A: TraitBinaryArray<O>, I: Pages> Iterator for NestedIter<O, A, I> {
     type Item = Result<(NestedState, A)>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let maybe_state = next(
             &mut self.iter,
             &mut self.items,
+            &mut self.dict,
             &mut self.remaining,
             &self.init,
             self.chunk_size,

--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -107,10 +107,10 @@ impl<'a> Iterator for BinaryIter<'a> {
         if self.values.is_empty() {
             return None;
         }
-        let length = u32::from_le_bytes(self.values[0..4].try_into().unwrap()) as usize;
-        self.values = &self.values[4..];
-        let result = &self.values[..length];
-        self.values = &self.values[length..];
+        let (length, remaining) = self.values.split_at(4);
+        let length = u32::from_le_bytes(length.try_into().unwrap()) as usize;
+        let (result, remaining) = remaining.split_at(length);
+        self.values = remaining;
         Some(result)
     }
 }

--- a/src/io/parquet/read/deserialize/boolean/basic.rs
+++ b/src/io/parquet/read/deserialize/boolean/basic.rs
@@ -100,7 +100,7 @@ impl<'a> utils::PageState<'a> for State<'a> {
     }
 }
 
-impl<'a> DecodedState<'a> for (MutableBitmap, MutableBitmap) {
+impl DecodedState for (MutableBitmap, MutableBitmap) {
     fn len(&self) -> usize {
         self.0.len()
     }

--- a/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
@@ -150,7 +150,7 @@ struct BinaryDecoder {
     size: usize,
 }
 
-impl<'a> DecodedState<'a> for (FixedSizeBinary, MutableBitmap) {
+impl DecodedState for (FixedSizeBinary, MutableBitmap) {
     fn len(&self) -> usize {
         self.0.len()
     }

--- a/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use parquet2::{
     deserialize::SliceFilteredIter,
     encoding::{hybrid_rle, Encoding},
-    page::{split_buffer, DataPage, FixedLenByteArrayPageDict},
+    page::{split_buffer, DataPage, DictPage},
     schema::Repetition,
 };
 
@@ -16,8 +16,10 @@ use super::super::utils::{
     DecodedState, Decoder, FilteredOptionalPageValidity, MaybeNext, OptionalPageValidity,
     PageState, Pushable,
 };
-use super::super::DataPages;
+use super::super::Pages;
 use super::utils::FixedSizeBinary;
+
+type Dict = Vec<u8>;
 
 #[derive(Debug)]
 struct Optional<'a> {
@@ -83,11 +85,11 @@ impl<'a> FilteredRequired<'a> {
 #[derive(Debug)]
 struct RequiredDictionary<'a> {
     pub values: hybrid_rle::HybridRleDecoder<'a>,
-    dict: &'a FixedLenByteArrayPageDict,
+    dict: &'a Dict,
 }
 
 impl<'a> RequiredDictionary<'a> {
-    fn try_new(page: &'a DataPage, dict: &'a FixedLenByteArrayPageDict) -> Result<Self> {
+    fn try_new(page: &'a DataPage, dict: &'a Dict) -> Result<Self> {
         let values = dict_indices_decoder(page)?;
 
         Ok(Self { dict, values })
@@ -103,11 +105,11 @@ impl<'a> RequiredDictionary<'a> {
 struct OptionalDictionary<'a> {
     values: hybrid_rle::HybridRleDecoder<'a>,
     validity: OptionalPageValidity<'a>,
-    dict: &'a FixedLenByteArrayPageDict,
+    dict: &'a Dict,
 }
 
 impl<'a> OptionalDictionary<'a> {
-    fn try_new(page: &'a DataPage, dict: &'a FixedLenByteArrayPageDict) -> Result<Self> {
+    fn try_new(page: &'a DataPage, dict: &'a Dict) -> Result<Self> {
         let values = dict_indices_decoder(page)?;
 
         Ok(Self {
@@ -156,19 +158,15 @@ impl<'a> DecodedState<'a> for (FixedSizeBinary, MutableBitmap) {
 
 impl<'a> Decoder<'a> for BinaryDecoder {
     type State = State<'a>;
+    type Dict = Dict;
     type DecodedState = (FixedSizeBinary, MutableBitmap);
 
-    fn build_state(&self, page: &'a DataPage) -> Result<Self::State> {
+    fn build_state(&self, page: &'a DataPage, dict: Option<&'a Self::Dict>) -> Result<Self::State> {
         let is_optional =
             page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
         let is_filtered = page.selected_rows().is_some();
 
-        match (
-            page.encoding(),
-            page.dictionary_page(),
-            is_optional,
-            is_filtered,
-        ) {
+        match (page.encoding(), dict, is_optional, is_filtered) {
             (Encoding::Plain, _, true, false) => {
                 Ok(State::Optional(Optional::try_new(page, self.size)?))
             }
@@ -176,12 +174,10 @@ impl<'a> Decoder<'a> for BinaryDecoder {
                 Ok(State::Required(Required::new(page, self.size)))
             }
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, false) => {
-                RequiredDictionary::try_new(page, dict.as_any().downcast_ref().unwrap())
-                    .map(State::RequiredDictionary)
+                RequiredDictionary::try_new(page, dict).map(State::RequiredDictionary)
             }
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, false) => {
-                OptionalDictionary::try_new(page, dict.as_any().downcast_ref().unwrap())
-                    .map(State::OptionalDictionary)
+                OptionalDictionary::try_new(page, dict).map(State::OptionalDictionary)
             }
             (Encoding::Plain, None, false, true) => Ok(State::FilteredRequired(
                 FilteredRequired::new(page, self.size),
@@ -232,11 +228,9 @@ impl<'a> Decoder<'a> for BinaryDecoder {
                 }
             }
             State::OptionalDictionary(page) => {
-                let dict_values = page.dict.values();
-                let size = page.dict.size();
                 let op = |index: u32| {
                     let index = index as usize;
-                    &dict_values[index * size..(index + 1) * size]
+                    &page.dict[index * self.size..(index + 1) * self.size]
                 };
 
                 extend_from_decoder(
@@ -248,11 +242,9 @@ impl<'a> Decoder<'a> for BinaryDecoder {
                 )
             }
             State::RequiredDictionary(page) => {
-                let dict_values = page.dict.values();
-                let size = page.dict.size();
                 let op = |index: u32| {
                     let index = index as usize;
-                    &dict_values[index * size..(index + 1) * size]
+                    &page.dict[index * self.size..(index + 1) * self.size]
                 };
 
                 for x in page.values.by_ref().map(op).take(remaining) {
@@ -270,6 +262,10 @@ impl<'a> Decoder<'a> for BinaryDecoder {
             }
         }
     }
+
+    fn deserialize_dict(&self, page: &DictPage) -> Self::Dict {
+        page.buffer.clone()
+    }
 }
 
 fn finish(
@@ -280,16 +276,17 @@ fn finish(
     FixedSizeBinaryArray::new(data_type.clone(), values.values.into(), validity.into())
 }
 
-pub struct Iter<I: DataPages> {
+pub struct Iter<I: Pages> {
     iter: I,
     data_type: DataType,
     size: usize,
     items: VecDeque<(FixedSizeBinary, MutableBitmap)>,
+    dict: Option<Dict>,
     chunk_size: Option<usize>,
     remaining: usize,
 }
 
-impl<I: DataPages> Iter<I> {
+impl<I: Pages> Iter<I> {
     pub fn new(iter: I, data_type: DataType, num_rows: usize, chunk_size: Option<usize>) -> Self {
         let size = FixedSizeBinaryArray::get_size(&data_type);
         Self {
@@ -297,19 +294,21 @@ impl<I: DataPages> Iter<I> {
             data_type,
             size,
             items: VecDeque::new(),
+            dict: None,
             chunk_size,
             remaining: num_rows,
         }
     }
 }
 
-impl<I: DataPages> Iterator for Iter<I> {
+impl<I: Pages> Iterator for Iter<I> {
     type Item = Result<FixedSizeBinaryArray>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let maybe_state = next(
             &mut self.iter,
             &mut self.items,
+            &mut self.dict,
             &mut self.remaining,
             self.chunk_size,
             &BinaryDecoder { size: self.size },

--- a/src/io/parquet/read/deserialize/mod.rs
+++ b/src/io/parquet/read/deserialize/mod.rs
@@ -101,7 +101,7 @@ fn columns_to_iter_recursive<'a, I: 'a>(
     chunk_size: Option<usize>,
 ) -> Result<NestedArrayIter<'a>>
 where
-    I: DataPages,
+    I: Pages,
 {
     if init.is_empty() && is_primitive(&field.data_type) {
         return Ok(Box::new(
@@ -148,7 +148,7 @@ fn n_columns(data_type: &DataType) -> usize {
     }
 }
 
-/// An iterator adapter that maps multiple iterators of [`DataPages`] into an iterator of [`Array`]s.
+/// An iterator adapter that maps multiple iterators of [`Pages`] into an iterator of [`Array`]s.
 ///
 /// For a non-nested datatypes such as [`DataType::Int32`], this function requires a single element in `columns` and `types`.
 /// For nested types, `columns` must be composed by all parquet columns with associated types `types`.
@@ -162,7 +162,7 @@ pub fn column_iter_to_arrays<'a, I: 'a>(
     num_rows: usize,
 ) -> Result<ArrayIter<'a>>
 where
-    I: DataPages,
+    I: Pages,
 {
     Ok(Box::new(
         columns_to_iter_recursive(columns, types, field, vec![], num_rows, chunk_size)?

--- a/src/io/parquet/read/deserialize/mod.rs
+++ b/src/io/parquet/read/deserialize/mod.rs
@@ -31,12 +31,14 @@ pub fn get_page_iterator<R: Read + Seek>(
     reader: R,
     pages_filter: Option<PageFilter>,
     buffer: Vec<u8>,
+    max_header_size: usize,
 ) -> Result<PageReader<R>> {
     Ok(_get_page_iterator(
         column_metadata,
         reader,
         pages_filter,
         buffer,
+        max_header_size,
     )?)
 }
 

--- a/src/io/parquet/read/deserialize/nested.rs
+++ b/src/io/parquet/read/deserialize/nested.rs
@@ -33,7 +33,7 @@ pub fn columns_to_iter_recursive<'a, I: 'a>(
     chunk_size: Option<usize>,
 ) -> Result<NestedArrayIter<'a>>
 where
-    I: DataPages,
+    I: Pages,
 {
     use crate::datatypes::PhysicalType::*;
     use crate::datatypes::PrimitiveType::*;
@@ -311,7 +311,7 @@ where
     })
 }
 
-fn dict_read<'a, K: DictionaryKey, I: 'a + DataPages>(
+fn dict_read<'a, K: DictionaryKey, I: 'a + Pages>(
     iter: I,
     init: Vec<InitNested>,
     _type_: &PrimitiveType,

--- a/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/src/io/parquet/read/deserialize/nested_utils.rs
@@ -247,7 +247,7 @@ impl Nested for NestedStruct {
 pub(super) trait NestedDecoder<'a> {
     type State: PageState<'a>;
     type Dictionary;
-    type DecodedState: DecodedState<'a>;
+    type DecodedState: DecodedState;
 
     fn build_state(
         &self,

--- a/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/src/io/parquet/read/deserialize/nested_utils.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use parquet2::{
     encoding::hybrid_rle::HybridRleDecoder,
-    page::{split_buffer, DataPage},
+    page::{split_buffer, DataPage, DictPage, Page},
     read::levels::get_bit_width,
 };
 
@@ -10,7 +10,7 @@ use crate::{array::Array, bitmap::MutableBitmap, error::Result};
 
 pub use super::utils::Zip;
 use super::utils::{DecodedState, MaybeNext};
-use super::{super::DataPages, utils::PageState};
+use super::{super::Pages, utils::PageState};
 
 /// trait describing deserialized repetition and definition levels
 pub trait Nested: std::fmt::Debug + Send + Sync {
@@ -246,15 +246,22 @@ impl Nested for NestedStruct {
 /// A decoder that knows how to map `State` -> Array
 pub(super) trait NestedDecoder<'a> {
     type State: PageState<'a>;
+    type Dictionary;
     type DecodedState: DecodedState<'a>;
 
-    fn build_state(&self, page: &'a DataPage) -> Result<Self::State>;
+    fn build_state(
+        &self,
+        page: &'a DataPage,
+        dict: Option<&'a Self::Dictionary>,
+    ) -> Result<Self::State>;
 
     /// Initializes a new state
     fn with_capacity(&self, capacity: usize) -> Self::DecodedState;
 
     fn push_valid(&self, state: &mut Self::State, decoded: &mut Self::DecodedState);
     fn push_null(&self, decoded: &mut Self::DecodedState);
+
+    fn deserialize_dict(&self, page: &DictPage) -> Self::Dictionary;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -340,11 +347,12 @@ pub(super) fn extend<'a, D: NestedDecoder<'a>>(
     page: &'a DataPage,
     init: &[InitNested],
     items: &mut VecDeque<(NestedState, D::DecodedState)>,
+    dict: Option<&'a D::Dictionary>,
     remaining: &mut usize,
     decoder: &D,
     chunk_size: Option<usize>,
 ) -> Result<()> {
-    let mut values_page = decoder.build_state(page)?;
+    let mut values_page = decoder.build_state(page, dict)?;
     let mut page = NestedPage::try_new(page)?;
 
     let capacity = chunk_size.unwrap_or(0);
@@ -467,13 +475,14 @@ fn extend_offsets2<'a, D: NestedDecoder<'a>>(
 pub(super) fn next<'a, I, D>(
     iter: &'a mut I,
     items: &mut VecDeque<(NestedState, D::DecodedState)>,
+    dict: &'a mut Option<D::Dictionary>,
     remaining: &mut usize,
     init: &[InitNested],
     chunk_size: Option<usize>,
     decoder: &D,
 ) -> MaybeNext<Result<(NestedState, D::DecodedState)>>
 where
-    I: DataPages,
+    I: Pages,
     D: NestedDecoder<'a>,
 {
     // front[a1, a2, a3, ...]back
@@ -499,8 +508,24 @@ where
             }
         }
         Ok(Some(page)) => {
+            let page = match page {
+                Page::Data(page) => page,
+                Page::Dict(dict_page) => {
+                    *dict = Some(decoder.deserialize_dict(dict_page));
+                    return MaybeNext::More;
+                }
+            };
+
             // there is a new page => consume the page from the start
-            let error = extend(page, init, items, remaining, decoder, chunk_size);
+            let error = extend(
+                page,
+                init,
+                items,
+                dict.as_ref(),
+                remaining,
+                decoder,
+                chunk_size,
+            );
             match error {
                 Ok(_) => {}
                 Err(e) => return MaybeNext::Some(Err(e)),

--- a/src/io/parquet/read/deserialize/primitive/basic.rs
+++ b/src/io/parquet/read/deserialize/primitive/basic.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use parquet2::{
     deserialize::SliceFilteredIter,
     encoding::{hybrid_rle, Encoding},
-    page::{split_buffer, DataPage, PrimitivePageDict},
+    page::{split_buffer, DataPage, DictPage},
     schema::Repetition,
     types::decode,
     types::NativeType as ParquetNativeType,
@@ -16,7 +16,7 @@ use crate::{
 
 use super::super::utils;
 use super::super::utils::{get_selected_rows, FilteredOptionalPageValidity, OptionalPageValidity};
-use super::super::DataPages;
+use super::super::Pages;
 
 #[derive(Debug)]
 struct FilteredRequiredValues<'a> {
@@ -63,25 +63,22 @@ impl<'a> Values<'a> {
 }
 
 #[derive(Debug)]
-pub(super) struct ValuesDictionary<'a, P>
+pub(super) struct ValuesDictionary<'a, T>
 where
-    P: ParquetNativeType,
+    T: NativeType,
 {
     pub values: hybrid_rle::HybridRleDecoder<'a>,
-    pub dict: &'a [P],
+    pub dict: &'a Vec<T>,
 }
 
-impl<'a, P> ValuesDictionary<'a, P>
+impl<'a, T> ValuesDictionary<'a, T>
 where
-    P: ParquetNativeType,
+    T: NativeType,
 {
-    pub fn try_new(page: &'a DataPage, dict: &'a PrimitivePageDict<P>) -> Result<Self> {
+    pub fn try_new(page: &'a DataPage, dict: &'a Vec<T>) -> Result<Self> {
         let values = utils::dict_indices_decoder(page)?;
 
-        Ok(Self {
-            dict: dict.values(),
-            values,
-        })
+        Ok(Self { dict, values })
     }
 
     #[inline]
@@ -92,21 +89,21 @@ where
 
 // The state of a `DataPage` of `Primitive` parquet primitive type
 #[derive(Debug)]
-enum State<'a, P>
+enum State<'a, T>
 where
-    P: ParquetNativeType,
+    T: NativeType,
 {
     Optional(OptionalPageValidity<'a>, Values<'a>),
     Required(Values<'a>),
-    RequiredDictionary(ValuesDictionary<'a, P>),
-    OptionalDictionary(OptionalPageValidity<'a>, ValuesDictionary<'a, P>),
+    RequiredDictionary(ValuesDictionary<'a, T>),
+    OptionalDictionary(OptionalPageValidity<'a>, ValuesDictionary<'a, T>),
     FilteredRequired(FilteredRequiredValues<'a>),
     FilteredOptional(FilteredOptionalPageValidity<'a>, Values<'a>),
 }
 
-impl<'a, P> utils::PageState<'a> for State<'a, P>
+impl<'a, T> utils::PageState<'a> for State<'a, T>
 where
-    P: ParquetNativeType,
+    T: NativeType,
 {
     fn len(&self) -> usize {
         match self {
@@ -160,27 +157,20 @@ where
     P: ParquetNativeType,
     F: Copy + Fn(P) -> T,
 {
-    type State = State<'a, P>;
+    type State = State<'a, T>;
+    type Dict = Vec<T>;
     type DecodedState = (Vec<T>, MutableBitmap);
 
-    fn build_state(&self, page: &'a DataPage) -> Result<Self::State> {
+    fn build_state(&self, page: &'a DataPage, dict: Option<&'a Self::Dict>) -> Result<Self::State> {
         let is_optional =
             page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
         let is_filtered = page.selected_rows().is_some();
 
-        match (
-            page.encoding(),
-            page.dictionary_page(),
-            is_optional,
-            is_filtered,
-        ) {
+        match (page.encoding(), dict, is_optional, is_filtered) {
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, false) => {
-                let dict = dict.as_any().downcast_ref().unwrap();
                 ValuesDictionary::try_new(page, dict).map(State::RequiredDictionary)
             }
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, false) => {
-                let dict = dict.as_any().downcast_ref().unwrap();
-
                 Ok(State::OptionalDictionary(
                     OptionalPageValidity::try_new(page)?,
                     ValuesDictionary::try_new(page, dict)?,
@@ -242,12 +232,12 @@ where
                     page_validity,
                     Some(remaining),
                     values,
-                    &mut page_values.values.by_ref().map(op1).map(self.op),
+                    &mut page_values.values.by_ref().map(op1),
                 )
             }
             State::RequiredDictionary(page) => {
                 let op1 = |index: u32| page.dict[index as usize];
-                values.extend(page.values.by_ref().map(op1).map(self.op).take(remaining));
+                values.extend(page.values.by_ref().map(op1).take(remaining));
             }
             State::FilteredRequired(page) => {
                 values.extend(
@@ -269,6 +259,10 @@ where
             }
         }
     }
+
+    fn deserialize_dict(&self, page: &DictPage) -> Self::Dict {
+        deserialize_plain(&page.buffer, self.op)
+    }
 }
 
 pub(super) fn finish<T: NativeType>(
@@ -284,11 +278,11 @@ pub(super) fn finish<T: NativeType>(
     MutablePrimitiveArray::from_data(data_type.clone(), values, validity)
 }
 
-/// An [`Iterator`] adapter over [`DataPages`] assumed to be encoded as primitive arrays
+/// An [`Iterator`] adapter over [`Pages`] assumed to be encoded as primitive arrays
 #[derive(Debug)]
 pub struct Iter<T, I, P, F>
 where
-    I: DataPages,
+    I: Pages,
     T: NativeType,
     P: ParquetNativeType,
     F: Fn(P) -> T,
@@ -298,13 +292,14 @@ where
     items: VecDeque<(Vec<T>, MutableBitmap)>,
     remaining: usize,
     chunk_size: Option<usize>,
+    dict: Option<Vec<T>>,
     op: F,
     phantom: std::marker::PhantomData<P>,
 }
 
 impl<T, I, P, F> Iter<T, I, P, F>
 where
-    I: DataPages,
+    I: Pages,
     T: NativeType,
 
     P: ParquetNativeType,
@@ -321,6 +316,7 @@ where
             iter,
             data_type,
             items: VecDeque::new(),
+            dict: None,
             remaining: num_rows,
             chunk_size,
             op,
@@ -331,7 +327,7 @@ where
 
 impl<T, I, P, F> Iterator for Iter<T, I, P, F>
 where
-    I: DataPages,
+    I: Pages,
     T: NativeType,
     P: ParquetNativeType,
     F: Copy + Fn(P) -> T,
@@ -342,6 +338,7 @@ where
         let maybe_state = utils::next(
             &mut self.iter,
             &mut self.items,
+            &mut self.dict,
             &mut self.remaining,
             self.chunk_size,
             &PrimitiveDecoder::new(self.op),
@@ -355,4 +352,17 @@ where
             utils::MaybeNext::More => self.next(),
         }
     }
+}
+
+pub(super) fn deserialize_plain<T, P, F>(values: &[u8], op: F) -> Vec<T>
+where
+    T: NativeType,
+    P: ParquetNativeType,
+    F: Copy + Fn(P) -> T,
+{
+    values
+        .chunks_exact(std::mem::size_of::<P>())
+        .map(decode)
+        .map(op)
+        .collect::<Vec<_>>()
 }

--- a/src/io/parquet/read/deserialize/primitive/basic.rs
+++ b/src/io/parquet/read/deserialize/primitive/basic.rs
@@ -145,7 +145,7 @@ where
     }
 }
 
-impl<'a, T: std::fmt::Debug> utils::DecodedState<'a> for (Vec<T>, MutableBitmap) {
+impl<T: std::fmt::Debug> utils::DecodedState for (Vec<T>, MutableBitmap) {
     fn len(&self) -> usize {
         self.0.len()
     }

--- a/src/io/parquet/read/deserialize/simple.rs
+++ b/src/io/parquet/read/deserialize/simple.rs
@@ -12,7 +12,7 @@ use crate::{
     types::{days_ms, NativeType},
 };
 
-use super::super::{ArrayIter, DataPages};
+use super::super::{ArrayIter, Pages};
 use super::binary;
 use super::boolean;
 use super::fixed_size_binary;
@@ -54,9 +54,9 @@ where
     })
 }
 
-/// An iterator adapter that maps an iterator of DataPages into an iterator of Arrays
+/// An iterator adapter that maps an iterator of Pages into an iterator of Arrays
 /// of [`DataType`] `data_type` and length `chunk_size`.
-pub fn page_iter_to_arrays<'a, I: 'a + DataPages>(
+pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
     pages: I,
     type_: &PrimitiveType,
     data_type: DataType,
@@ -339,7 +339,7 @@ fn unifiy_timestmap_unit(
     }
 }
 
-fn timestamp<'a, I: 'a + DataPages>(
+fn timestamp<'a, I: Pages + 'a>(
     pages: I,
     physical_type: &PhysicalType,
     logical_type: &Option<PrimitiveLogicalType>,
@@ -377,7 +377,7 @@ fn timestamp<'a, I: 'a + DataPages>(
     }
 }
 
-fn timestamp_dict<'a, K: DictionaryKey, I: 'a + DataPages>(
+fn timestamp_dict<'a, K: DictionaryKey, I: Pages + 'a>(
     pages: I,
     physical_type: &PhysicalType,
     logical_type: &Option<PrimitiveLogicalType>,
@@ -429,7 +429,7 @@ fn timestamp_dict<'a, K: DictionaryKey, I: 'a + DataPages>(
     }
 }
 
-fn dict_read<'a, K: DictionaryKey, I: 'a + DataPages>(
+fn dict_read<'a, K: DictionaryKey, I: Pages + 'a>(
     iter: I,
     physical_type: &PhysicalType,
     logical_type: &Option<PrimitiveLogicalType>,

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -17,7 +17,7 @@ pub use parquet2::{
     error::Error as ParquetError,
     fallible_streaming_iterator,
     metadata::{ColumnChunkMetaData, ColumnDescriptor, RowGroupMetaData},
-    page::{CompressedDataPage, DataPage, DataPageHeader},
+    page::{CompressedDataPage, DataPageHeader, Page},
     read::{
         decompress, get_column_iterator, get_page_stream,
         read_columns_indexes as _read_columns_indexes, read_metadata as _read_metadata,
@@ -41,16 +41,13 @@ pub use indexes::{read_columns_indexes, ColumnIndex};
 pub use row_group::*;
 pub use schema::{infer_schema, FileMetaData};
 
-/// Trait describing a [`FallibleStreamingIterator`] of [`DataPage`]
-pub trait DataPages:
-    FallibleStreamingIterator<Item = DataPage, Error = ParquetError> + Send + Sync
+/// Trait describing a [`FallibleStreamingIterator`] of [`Page`]
+pub trait Pages:
+    FallibleStreamingIterator<Item = Page, Error = ParquetError> + Send + Sync
 {
 }
 
-impl<I: FallibleStreamingIterator<Item = DataPage, Error = ParquetError> + Send + Sync> DataPages
-    for I
-{
-}
+impl<I: FallibleStreamingIterator<Item = Page, Error = ParquetError> + Send + Sync> Pages for I {}
 
 /// Type def for a sharable, boxed dyn [`Iterator`] of arrays
 pub type ArrayIter<'a> = Box<dyn Iterator<Item = Result<Box<dyn Array>>> + Send + Sync + 'a>;

--- a/src/io/parquet/read/row_group.rs
+++ b/src/io/parquet/read/row_group.rs
@@ -180,11 +180,13 @@ pub fn to_deserializer<'a>(
     let (columns, types): (Vec<_>, Vec<_>) = columns
         .into_iter()
         .map(|(column_meta, chunk)| {
+            let len = chunk.len();
             let pages = PageReader::new(
                 std::io::Cursor::new(chunk),
                 column_meta,
                 std::sync::Arc::new(|_, _| true),
                 vec![],
+                len * 2 + 1024,
             );
             (
                 BasicDecompressor::new(pages, vec![]),

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -1,6 +1,6 @@
 use parquet2::{
     encoding::{hybrid_rle::encode_u32, Encoding},
-    page::{EncodedDictPage, EncodedPage},
+    page::{DictPage, EncodedPage},
     schema::types::PrimitiveType,
     statistics::{serialize_statistics, ParquetStatistics},
     write::DynIter,
@@ -153,7 +153,7 @@ macro_rules! dyn_prim {
         primitive_encode_plain::<$from, $to>(values, false, &mut buffer);
         let stats = primitive_build_statistics::<$from, $to>(values, $type_.clone());
         let stats = serialize_statistics(&stats);
-        (EncodedDictPage::new(buffer, values.len()), stats)
+        (DictPage::new(buffer, values.len(), false), stats)
     }};
 }
 
@@ -190,7 +190,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                     let mut buffer = vec![];
                     utf8_encode_plain::<i32>(array, false, &mut buffer);
                     let stats = utf8_build_statistics(array, type_.clone());
-                    (EncodedDictPage::new(buffer, array.len()), stats)
+                    (DictPage::new(buffer, array.len(), false), stats)
                 }
                 DataType::LargeUtf8 => {
                     let array = array.values().as_any().downcast_ref().unwrap();
@@ -198,7 +198,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                     let mut buffer = vec![];
                     utf8_encode_plain::<i64>(array, false, &mut buffer);
                     let stats = utf8_build_statistics(array, type_.clone());
-                    (EncodedDictPage::new(buffer, array.len()), stats)
+                    (DictPage::new(buffer, array.len(), false), stats)
                 }
                 DataType::Binary => {
                     let array = array.values().as_any().downcast_ref().unwrap();
@@ -206,7 +206,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                     let mut buffer = vec![];
                     binary_encode_plain::<i32>(array, false, &mut buffer);
                     let stats = binary_build_statistics(array, type_.clone());
-                    (EncodedDictPage::new(buffer, array.len()), stats)
+                    (DictPage::new(buffer, array.len(), false), stats)
                 }
                 DataType::LargeBinary => {
                     let array = array.values().as_any().downcast_ref().unwrap();
@@ -214,7 +214,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                     let mut buffer = vec![];
                     binary_encode_plain::<i64>(array, false, &mut buffer);
                     let stats = binary_build_statistics(array, type_.clone());
-                    (EncodedDictPage::new(buffer, array.len()), stats)
+                    (DictPage::new(buffer, array.len(), false), stats)
                 }
                 DataType::FixedSizeBinary(_) => {
                     let mut buffer = vec![];
@@ -222,7 +222,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                     fixed_binary_encode_plain(array, false, &mut buffer);
                     let stats = fixed_binary_build_statistics(array, type_.clone());
                     let stats = serialize_statistics(&stats);
-                    (EncodedDictPage::new(buffer, array.len()), stats)
+                    (DictPage::new(buffer, array.len(), false), stats)
                 }
                 other => {
                     return Err(Error::NotYetImplemented(format!(

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -21,7 +21,7 @@ use crate::types::NativeType;
 
 use parquet2::schema::types::PrimitiveType as ParquetPrimitiveType;
 pub use parquet2::{
-    compression::{BrotliLevel, CompressionLevel, CompressionOptions, GzipLevel, ZstdLevel},
+    compression::{BrotliLevel, CompressionOptions, GzipLevel, ZstdLevel},
     encoding::Encoding,
     fallible_streaming_iterator,
     metadata::{Descriptor, FileMetaData, KeyValue, SchemaDescriptor, ThriftFileMetaData},

--- a/src/io/parquet/write/utils.rs
+++ b/src/io/parquet/write/utils.rs
@@ -93,7 +93,6 @@ pub fn build_plain_page(
     Ok(DataPage::new(
         header,
         buffer,
-        None,
         Descriptor {
             primitive_type: type_,
             max_def_level: 0,


### PR DESCRIPTION
This PR is a follow-up on https://github.com/jorgecarleitao/parquet2/pull/160, bringing its design changes here.

The main idea of this PR is that we no longer use the in-memory format for dictionary pages from `parquet2`. Instead, the dictionary pages are deserialized by us and, depending on the target `arrow2::datatypes::DataType`, we specialize to what it is deserialised to (e.g. for `DataType::Dictionary` we use one, for `DataType::Utf8` we use another).

This is probably the (globally) optimal way to deserialize dictionary-encoded data to arrow.
