### PR TITLE
Added support to read ORC

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,8 +19,9 @@ jobs:
           python3 -m venv venv
           source venv/bin/activate
           pip install pip --upgrade
-          pip install pyarrow==6
+          pip install pyarrow==6 pyorc
           python parquet_integration/write_parquet.py
+          python tests/it/io/orc/write.py
           deactivate
       - uses: Swatinem/rust-cache@v1
       - name: Generate code coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,16 +13,17 @@ jobs:
           submodules: true # needed to test IPC, which are located in a submodule
       - name: Install Rust
         run: rustup update stable
-      - uses: Swatinem/rust-cache@v1
       - name: Setup parquet files
         run: |
           apt update && apt install python3-pip python3-venv -y -q
           python3 -m venv venv
           source venv/bin/activate
           pip install pip --upgrade
-          pip install pyarrow==6
+          pip install pyarrow==6 pyorc
           python parquet_integration/write_parquet.py
+          python tests/it/io/orc/write.py
           deactivate
+      - uses: Swatinem/rust-cache@v1
       - name: Run
         run: cargo test --features full
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,9 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Run
         shell: bash
-        run: ARROW2_IGNORE_PARQUET= cargo test --features full
+        run: |
+          cargo check --features full
+          cargo test --tests
 
   clippy:
     name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ crc = { version = "2", optional = true }
 async-stream = { version = "0.3.2", optional = true }
 
 # ORC support
-orc-format = { git = "https://github.com/DataEngineeringLabs/orc-format.git", optional = true }
+orc-format = { git = "https://github.com/DataEngineeringLabs/orc-format.git", branch = "iters", optional = true }
 
 # Arrow integration tests support
 serde = { version = "^1.0", features = ["rc"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ crc = { version = "2", optional = true }
 async-stream = { version = "0.3.2", optional = true }
 
 # ORC support
-orc-format = { git = "https://github.com/DataEngineeringLabs/orc-format.git", branch = "iters", optional = true }
+orc-format = { version = "0.3.0", optional = true }
 
 # Arrow integration tests support
 serde = { version = "^1.0", features = ["rc"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,15 +72,20 @@ parquet2 = { version = "0.14.0", optional = true, default_features = false }
 
 # avro support
 avro-schema = { version = "0.2", optional = true }
-serde = { version = "^1.0", features = ["rc"], optional = true }
-serde_derive = { version = "^1.0", optional = true }
-serde_json = { version = "^1.0", features = ["preserve_order"], optional = true }
 # compression of avro
 libflate = { version = "1.1.1", optional = true }
 snap = { version = "1", optional = true }
 crc = { version = "2", optional = true }
 # async avro
 async-stream = { version = "0.3.2", optional = true }
+
+# ORC support
+orc-format = { git = "https://github.com/DataEngineeringLabs/orc-format.git", optional = true }
+
+# Arrow integration tests support
+serde = { version = "^1.0", features = ["rc"], optional = true }
+serde_derive = { version = "^1.0", optional = true }
+serde_json = { version = "^1.0", features = ["preserve_order"], optional = true }
 
 # for division/remainder optimization at runtime
 strength_reduce = { version = "0.2", optional = true }
@@ -126,6 +131,7 @@ full = [
     "io_parquet",
     "io_parquet_compression",
     "io_avro",
+    "io_orc",
     "io_avro_compression",
     "io_avro_async",
     "regex",
@@ -145,6 +151,7 @@ io_ipc_write_async = ["io_ipc", "futures"]
 io_ipc_read_async = ["io_ipc", "futures", "async-stream"]
 io_ipc_compression = ["lz4", "zstd"]
 io_flight = ["io_ipc", "arrow-format/flight-data"]
+
 # base64 + io_ipc because arrow schemas are stored as base64-encoded ipc format.
 io_parquet = ["parquet2", "io_ipc", "base64", "futures", "streaming-iterator", "fallible-streaming-iterator"]
 io_parquet_compression = [
@@ -154,6 +161,7 @@ io_parquet_compression = [
     "parquet2/lz4",
     "parquet2/brotli",
 ]
+
 io_avro = ["avro-schema", "streaming-iterator", "fallible-streaming-iterator", "serde_json"]
 io_avro_compression = [
     "libflate",
@@ -161,6 +169,9 @@ io_avro_compression = [
     "crc",
 ]
 io_avro_async = ["io_avro", "futures", "async-stream"]
+
+io_orc = [ "orc-format" ]
+
 # serde+serde_json: its dependencies + error handling
 # serde_derive: there is some derive around
 io_json_integration = ["hex", "serde", "serde_derive", "serde_json", "io_ipc"]

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,9 +42,11 @@ source venv/bin/activate
 pip install pip --upgrade
 
 # Install pyarrow, version 6
-pip install pyarrow==6
+pip install pyarrow==6 pyorc
 
 # Generate the parquet files (this might take some time, depending on your computer setup)
+python parquet_integration/write_parquet.py
+# generate ORC files
 python parquet_integration/write_parquet.py
 
 # Get out of venv, back to normal terminal

--- a/examples/orc_read.rs
+++ b/examples/orc_read.rs
@@ -1,0 +1,55 @@
+use arrow2::array::*;
+use arrow2::error::Error;
+use arrow2::io::orc::{format, read};
+
+fn deserialize_column(path: &str, column_name: &str) -> Result<Box<dyn Array>, Error> {
+    // open the file
+    let mut reader = std::fs::File::open(path).unwrap();
+
+    // read its metadata (IO-bounded)
+    let metadata = format::read::read_metadata(&mut reader)?;
+
+    // infer its (Arrow) [`Schema`]
+    let schema = read::infer_schema(&metadata.footer)?;
+
+    // find the position of the column in the schema
+    let (pos, field) = schema
+        .fields
+        .iter()
+        .enumerate()
+        .find(|f| f.1.name == column_name)
+        .unwrap();
+
+    // pick a stripe (basically a set of rows)
+    let stripe = 0;
+
+    // read the stripe's footer (IO-bounded)
+    let footer = format::read::read_stripe_footer(&mut reader, &metadata, stripe, &mut vec![])?;
+
+    // read the column's data from the stripe (IO-bounded)
+    let data_type = field.data_type.clone();
+    let column = format::read::read_stripe_column(
+        &mut reader,
+        &metadata,
+        0,
+        footer,
+        // 1 because ORC schemas always start with a struct, which we ignore
+        1 + pos as u32,
+        vec![],
+    )?;
+
+    // finally, deserialize to Arrow (CPU-bounded)
+    read::deserialize(data_type, &column)
+}
+
+fn main() -> Result<(), Error> {
+    use std::env;
+    let args: Vec<String> = env::args().collect();
+
+    let file_path = &args[1];
+    let column = &args[2];
+
+    let array = deserialize_column(file_path, column)?;
+    println!("{array:?}");
+    Ok(())
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -5,6 +5,9 @@
 #[cfg(feature = "io_odbc")]
 pub mod odbc;
 
+#[cfg(feature = "io_orc")]
+pub mod orc;
+
 #[cfg(any(
     feature = "io_csv_read",
     feature = "io_csv_read_async",

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -6,6 +6,7 @@
 pub mod odbc;
 
 #[cfg(feature = "io_orc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io_orc")))]
 pub mod orc;
 
 #[cfg(any(

--- a/src/io/orc/mod.rs
+++ b/src/io/orc/mod.rs
@@ -5,8 +5,8 @@ pub use orc_format as format;
 
 use crate::error::Error;
 
-impl From<format::Error> for Error {
-    fn from(error: format::Error) -> Self {
+impl From<format::error::Error> for Error {
+    fn from(error: format::error::Error) -> Self {
         Error::ExternalFormat(format!("{:?}", error))
     }
 }

--- a/src/io/orc/mod.rs
+++ b/src/io/orc/mod.rs
@@ -1,0 +1,12 @@
+//! APIs to read from [ORC format](https://orc.apache.org).
+pub mod read;
+
+pub use orc_format as format;
+
+use crate::error::Error;
+
+impl From<format::Error> for Error {
+    fn from(error: format::Error) -> Self {
+        Error::ExternalFormat(format!("{:?}", error))
+    }
+}

--- a/src/io/orc/read/mod.rs
+++ b/src/io/orc/read/mod.rs
@@ -1,0 +1,178 @@
+//! APIs to read from [ORC format](https://orc.apache.org).
+use std::io::{Read, Seek, SeekFrom};
+
+use crate::array::{BooleanArray, Float32Array};
+use crate::bitmap::{Bitmap, MutableBitmap};
+use crate::datatypes::{DataType, Field, Schema};
+use crate::error::Error;
+
+use orc_format::fallible_streaming_iterator::FallibleStreamingIterator;
+use orc_format::proto::stream::Kind;
+use orc_format::proto::{CompressionKind, Footer, StripeInformation, Type};
+use orc_format::read::decode;
+use orc_format::read::Stripe;
+
+/// Infers a [`Schema`] from the files' [`Footer`].
+/// # Errors
+/// This function errors if the type is not yet supported.
+pub fn infer_schema(footer: &Footer) -> Result<Schema, Error> {
+    let types = &footer.types;
+
+    let dt = infer_dt(&footer.types[0], types)?;
+    if let DataType::Struct(fields) = dt {
+        Ok(fields.into())
+    } else {
+        Err(Error::ExternalFormat(
+            "ORC root type must be a struct".to_string(),
+        ))
+    }
+}
+
+fn infer_dt(type_: &Type, types: &[Type]) -> Result<DataType, Error> {
+    use orc_format::proto::r#type::Kind::*;
+    let dt = match type_.kind() {
+        Boolean => DataType::Boolean,
+        Byte => DataType::Int8,
+        Short => DataType::Int16,
+        Int => DataType::Int32,
+        Long => DataType::Int64,
+        Float => DataType::Float32,
+        Double => DataType::Float64,
+        String => DataType::Utf8,
+        Binary => DataType::Binary,
+        Struct => {
+            let sub_types = type_
+                .subtypes
+                .iter()
+                .cloned()
+                .zip(type_.field_names.iter())
+                .map(|(i, name)| {
+                    infer_dt(
+                        types.get(i as usize).ok_or_else(|| {
+                            Error::ExternalFormat(format!("ORC field {i} not found"))
+                        })?,
+                        types,
+                    )
+                    .map(|dt| Field::new(name, dt, true))
+                })
+                .collect::<Result<Vec<_>, Error>>()?;
+            DataType::Struct(sub_types)
+        }
+        kind => return Err(Error::nyi(format!("Reading {kind:?} from ORC"))),
+    };
+    Ok(dt)
+}
+
+/// Reads the stripe [`StripeInformation`] into memory.
+pub fn read_stripe<R: Read + Seek>(
+    reader: &mut R,
+    stripe_info: StripeInformation,
+    compression: CompressionKind,
+) -> Result<Stripe, Error> {
+    let offset = stripe_info.offset();
+    reader.seek(SeekFrom::Start(offset)).unwrap();
+
+    let len = stripe_info.index_length() + stripe_info.data_length() + stripe_info.footer_length();
+    let mut stripe = vec![0; len as usize];
+    reader.read_exact(&mut stripe).unwrap();
+
+    Ok(Stripe::try_new(stripe, stripe_info, compression)?)
+}
+
+fn deserialize_validity(
+    stripe: &Stripe,
+    column: usize,
+    scratch: &mut Vec<u8>,
+) -> Result<Option<Bitmap>, Error> {
+    let mut chunks = stripe.get_bytes(column, Kind::Present, std::mem::take(scratch))?;
+
+    let mut validity = MutableBitmap::with_capacity(stripe.number_of_rows());
+    let mut remaining = stripe.number_of_rows();
+    while let Some(chunk) = chunks.next()? {
+        // todo: this can be faster by iterating in bytes instead of single bits via `BooleanRun`
+        let iter = decode::BooleanIter::new(chunk, remaining);
+        for item in iter {
+            remaining -= 1;
+            validity.push(item?)
+        }
+    }
+    *scratch = std::mem::take(&mut chunks.into_inner());
+
+    Ok(validity.into())
+}
+
+/// Deserializes column `column` from `stripe`, assumed to represent a f32
+pub fn deserialize_f32(
+    data_type: DataType,
+    stripe: &Stripe,
+    column: usize,
+) -> Result<Float32Array, Error> {
+    let mut scratch = vec![];
+    let num_rows = stripe.number_of_rows();
+
+    let validity = deserialize_validity(stripe, column, &mut scratch)?;
+
+    let mut chunks = stripe.get_bytes(column, Kind::Data, scratch)?;
+
+    let mut values = Vec::with_capacity(num_rows);
+    if let Some(validity) = &validity {
+        let mut validity_iter = validity.iter();
+        while let Some(chunk) = chunks.next()? {
+            let mut valid_iter = decode::deserialize_f32(chunk);
+            let iter = validity_iter.by_ref().map(|is_valid| {
+                if is_valid {
+                    valid_iter.next().unwrap()
+                } else {
+                    0.0f32
+                }
+            });
+            values.extend(iter);
+        }
+    } else {
+        while let Some(chunk) = chunks.next()? {
+            values.extend(decode::deserialize_f32(chunk));
+        }
+    }
+
+    Float32Array::try_new(data_type, values.into(), validity)
+}
+
+/// Deserializes column `column` from `stripe`, assumed to represent a boolean array
+pub fn deserialize_bool(
+    data_type: DataType,
+    stripe: &Stripe,
+    column: usize,
+) -> Result<BooleanArray, Error> {
+    let num_rows = stripe.number_of_rows();
+    let mut scratch = vec![];
+
+    let validity = deserialize_validity(stripe, column, &mut scratch)?;
+
+    let mut chunks = stripe.get_bytes(column, Kind::Data, std::mem::take(&mut scratch))?;
+
+    let mut values = MutableBitmap::with_capacity(num_rows);
+    if let Some(validity) = &validity {
+        let mut validity_iter = validity.iter();
+
+        while let Some(chunk) = chunks.next()? {
+            let mut valid_iter = decode::BooleanIter::new(chunk, chunk.len() * 8);
+            validity_iter.by_ref().try_for_each(|is_valid| {
+                values.push(if is_valid {
+                    valid_iter.next().unwrap()?
+                } else {
+                    false
+                });
+                Result::<(), Error>::Ok(())
+            })?;
+        }
+    } else {
+        while let Some(chunk) = chunks.next()? {
+            let valid_iter = decode::BooleanIter::new(chunk, chunk.len() * 8);
+            for v in valid_iter {
+                values.push(v?)
+            }
+        }
+    }
+
+    BooleanArray::try_new(data_type, values.into(), validity)
+}

--- a/src/io/orc/read/mod.rs
+++ b/src/io/orc/read/mod.rs
@@ -1,17 +1,14 @@
 //! APIs to read from [ORC format](https://orc.apache.org).
-use std::io::{Read, Seek, SeekFrom};
-
 use crate::array::{Array, BooleanArray, Int64Array, PrimitiveArray};
 use crate::bitmap::{Bitmap, MutableBitmap};
 use crate::datatypes::{DataType, Field, Schema};
 use crate::error::Error;
 use crate::types::NativeType;
 
-use orc_format::fallible_streaming_iterator::FallibleStreamingIterator;
 use orc_format::proto::stream::Kind;
-use orc_format::proto::{CompressionKind, Footer, StripeInformation, Type};
+use orc_format::proto::{Footer, Type};
 use orc_format::read::decode;
-use orc_format::read::Stripe;
+use orc_format::read::Column;
 
 /// Infers a [`Schema`] from the files' [`Footer`].
 /// # Errors
@@ -64,80 +61,50 @@ fn infer_dt(type_: &Type, types: &[Type]) -> Result<DataType, Error> {
     Ok(dt)
 }
 
-/// Reads the stripe [`StripeInformation`] into memory.
-pub fn read_stripe<R: Read + Seek>(
-    reader: &mut R,
-    stripe_info: StripeInformation,
-    compression: CompressionKind,
-) -> Result<Stripe, Error> {
-    let offset = stripe_info.offset();
-    reader.seek(SeekFrom::Start(offset)).unwrap();
+fn deserialize_validity(column: &Column, scratch: &mut Vec<u8>) -> Result<Option<Bitmap>, Error> {
+    let mut stream = column.get_stream(Kind::Present, std::mem::take(scratch))?;
 
-    let len = stripe_info.index_length() + stripe_info.data_length() + stripe_info.footer_length();
-    let mut stripe = vec![0; len as usize];
-    reader.read_exact(&mut stripe).unwrap();
+    let stream = decode::BooleanIter::new(&mut stream, column.number_of_rows());
 
-    Ok(Stripe::try_new(stripe, stripe_info, compression)?)
-}
-
-fn deserialize_validity(
-    stripe: &Stripe,
-    column: usize,
-    scratch: &mut Vec<u8>,
-) -> Result<Option<Bitmap>, Error> {
-    let mut chunks = stripe.get_bytes(column, Kind::Present, std::mem::take(scratch))?;
-
-    let mut validity = MutableBitmap::with_capacity(stripe.number_of_rows());
-    let mut remaining = stripe.number_of_rows();
-    while let Some(chunk) = chunks.next()? {
-        // todo: this can be faster by iterating in bytes instead of single bits via `BooleanRun`
-        let iter = decode::BooleanIter::new(chunk, remaining);
-        for item in iter {
-            remaining -= 1;
-            validity.push(item?)
-        }
+    let mut validity = MutableBitmap::with_capacity(column.number_of_rows());
+    for item in stream {
+        validity.push(item?)
     }
-    *scratch = std::mem::take(&mut chunks.into_inner());
+
+    //*scratch = std::mem::take(&mut stream.into_inner());
 
     Ok(validity.into())
 }
 
 /// Deserializes column `column` from `stripe`, assumed to represent a f32
-fn deserialize_float<T: NativeType>(
+fn deserialize_float<T: NativeType + decode::Float>(
     data_type: DataType,
-    stripe: &Stripe,
-    column: usize,
+    column: &Column,
 ) -> Result<PrimitiveArray<T>, Error> {
     let mut scratch = vec![];
-    let num_rows = stripe.number_of_rows();
+    let num_rows = column.number_of_rows();
 
-    let validity = deserialize_validity(stripe, column, &mut scratch)?;
+    let validity = deserialize_validity(column, &mut scratch)?;
 
-    let mut chunks = stripe.get_bytes(column, Kind::Data, scratch)?;
+    let mut chunks = column.get_stream(Kind::Data, scratch)?;
 
     let mut values = Vec::with_capacity(num_rows);
     if let Some(validity) = &validity {
-        let mut validity_iter = validity.iter();
-        while let Some(chunk) = chunks.next()? {
-            let mut valid_iter = chunk
-                .chunks_exact(std::mem::size_of::<T>())
-                .map(|chunk| T::from_le_bytes(chunk.try_into().unwrap_or_default()));
-            let iter = validity_iter.by_ref().map(|is_valid| {
-                if is_valid {
-                    valid_iter.next().unwrap()
-                } else {
-                    T::default()
-                }
-            });
-            values.extend(iter);
+        let validity_iter = validity.iter();
+        let mut items =
+            decode::FloatIter::<T, _>::new(&mut chunks, validity.len() - validity.unset_bits());
+
+        for is_valid in validity_iter {
+            if is_valid {
+                values.push(items.next().transpose()?.unwrap_or_default())
+            } else {
+                values.push(T::default())
+            }
         }
     } else {
-        while let Some(chunk) = chunks.next()? {
-            values.extend(
-                chunk
-                    .chunks_exact(std::mem::size_of::<T>())
-                    .map(|chunk| T::from_le_bytes(chunk.try_into().unwrap_or_default())),
-            );
+        let items = decode::FloatIter::<T, _>::new(&mut chunks, num_rows);
+        for item in items {
+            values.push(item?);
         }
     }
 
@@ -145,163 +112,96 @@ fn deserialize_float<T: NativeType>(
 }
 
 /// Deserializes column `column` from `stripe`, assumed to represent a boolean array
-fn deserialize_bool(
-    data_type: DataType,
-    stripe: &Stripe,
-    column: usize,
-) -> Result<BooleanArray, Error> {
-    let num_rows = stripe.number_of_rows();
+fn deserialize_bool(data_type: DataType, column: &Column) -> Result<BooleanArray, Error> {
+    let num_rows = column.number_of_rows();
     let mut scratch = vec![];
 
-    let validity = deserialize_validity(stripe, column, &mut scratch)?;
+    let validity = deserialize_validity(column, &mut scratch)?;
 
-    let mut chunks = stripe.get_bytes(column, Kind::Data, std::mem::take(&mut scratch))?;
+    let mut chunks = column.get_stream(Kind::Data, std::mem::take(&mut scratch))?;
 
     let mut values = MutableBitmap::with_capacity(num_rows);
     if let Some(validity) = &validity {
-        let mut validity_iter = validity.iter();
+        let validity_iter = validity.iter();
 
-        while let Some(chunk) = chunks.next()? {
-            let mut valid_iter = decode::BooleanIter::new(chunk, chunk.len() * 8);
-            validity_iter.by_ref().try_for_each(|is_valid| {
-                values.push(if is_valid {
-                    valid_iter.next().unwrap()?
-                } else {
-                    false
-                });
-                Result::<(), Error>::Ok(())
-            })?;
+        let mut items =
+            decode::BooleanIter::new(&mut chunks, validity.len() - validity.unset_bits());
+
+        for is_valid in validity_iter {
+            values.push(if is_valid {
+                items.next().transpose()?.unwrap_or_default()
+            } else {
+                false
+            });
         }
     } else {
-        while let Some(chunk) = chunks.next()? {
-            let valid_iter = decode::BooleanIter::new(chunk, num_rows);
-            for v in valid_iter {
-                values.push(v?)
-            }
+        let valid_iter = decode::BooleanIter::new(&mut chunks, num_rows);
+        for v in valid_iter {
+            values.push(v?)
         }
     }
 
     BooleanArray::try_new(data_type, values.into(), validity)
 }
 
-struct IntIter<'a> {
-    current: Option<decode::SignedRleV2Run<'a>>,
-    runs: decode::SignedRleV2Iter<'a>,
-}
-
-impl<'a> IntIter<'a> {
-    fn new(data: &'a [u8]) -> Self {
-        Self {
-            runs: decode::SignedRleV2Iter::new(data),
-            current: None,
-        }
-    }
-}
-
-impl<'a> Iterator for IntIter<'a> {
-    type Item = Result<i64, Error>;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        let next = if let Some(run) = &mut self.current {
-            match run {
-                decode::SignedRleV2Run::Direct(values_iter) => values_iter.next(),
-                decode::SignedRleV2Run::Delta(values_iter) => values_iter.next(),
-                decode::SignedRleV2Run::ShortRepeat(values_iter) => values_iter.next(),
-            }
-        } else {
-            None
-        };
-
-        if next.is_none() {
-            match self.runs.next()? {
-                Ok(run) => self.current = Some(run),
-                Err(e) => return Some(Err(Error::ExternalFormat(format!("{:?}", e)))),
-            }
-            self.next()
-        } else {
-            next.map(Ok)
-        }
-    }
-}
-
 /// Deserializes column `column` from `stripe`, assumed to represent a boolean array
-fn deserialize_i64(
-    data_type: DataType,
-    stripe: &Stripe,
-    column: usize,
-) -> Result<Int64Array, Error> {
-    let num_rows = stripe.number_of_rows();
+fn deserialize_i64(data_type: DataType, column: &Column) -> Result<Int64Array, Error> {
+    let num_rows = column.number_of_rows();
     let mut scratch = vec![];
 
-    let validity = deserialize_validity(stripe, column, &mut scratch)?;
+    let validity = deserialize_validity(column, &mut scratch)?;
 
-    let mut chunks = stripe.get_bytes(column, Kind::Data, std::mem::take(&mut scratch))?;
+    let chunks = column.get_stream(Kind::Data, std::mem::take(&mut scratch))?;
 
     let mut values = Vec::with_capacity(num_rows);
     if let Some(validity) = &validity {
         let validity_iter = validity.iter();
+        let mut iter =
+            decode::SignedRleV2Iter::new(chunks, validity.len() - validity.unset_bits(), vec![]);
 
-        let mut iter = IntIter::new(chunks.next()?.unwrap());
         for is_valid in validity_iter {
             if is_valid {
-                let item = iter.next().transpose()?;
-                let item = if let Some(item) = item {
-                    item
-                } else {
-                    iter = IntIter::new(chunks.next()?.unwrap());
-                    iter.next().transpose()?.unwrap()
-                };
+                let item = iter.next().transpose()?.unwrap_or_default();
                 values.push(item);
             } else {
                 values.push(0);
             }
         }
     } else {
-        while let Some(chunk) = chunks.next()? {
-            decode::SignedRleV2Iter::new(chunk).try_for_each(|run| {
-                run.map(|run| match run {
-                    decode::SignedRleV2Run::Direct(values_iter) => values.extend(values_iter),
-                    decode::SignedRleV2Run::Delta(values_iter) => values.extend(values_iter),
-                    decode::SignedRleV2Run::ShortRepeat(values_iter) => values.extend(values_iter),
-                })
-            })?;
-        }
+        let mut iter = decode::SignedRleV2RunIter::new(chunks, num_rows, vec![]);
+        iter.try_for_each(|run| {
+            run.map(|run| match run {
+                decode::SignedRleV2Run::Direct(values_iter) => values.extend(values_iter),
+                decode::SignedRleV2Run::Delta(values_iter) => values.extend(values_iter),
+                decode::SignedRleV2Run::ShortRepeat(values_iter) => values.extend(values_iter),
+            })
+        })?;
     }
 
     Int64Array::try_new(data_type, values.into(), validity)
 }
 
 /// Deserializes column `column` from `stripe`, assumed to represent a boolean array
-fn deserialize_int<T>(
-    data_type: DataType,
-    stripe: &Stripe,
-    column: usize,
-) -> Result<PrimitiveArray<T>, Error>
+fn deserialize_int<T>(data_type: DataType, column: &Column) -> Result<PrimitiveArray<T>, Error>
 where
     T: NativeType + TryFrom<i64>,
 {
-    let num_rows = stripe.number_of_rows();
+    let num_rows = column.number_of_rows();
     let mut scratch = vec![];
 
-    let validity = deserialize_validity(stripe, column, &mut scratch)?;
+    let validity = deserialize_validity(column, &mut scratch)?;
 
-    let mut chunks = stripe.get_bytes(column, Kind::Data, std::mem::take(&mut scratch))?;
+    let chunks = column.get_stream(Kind::Data, std::mem::take(&mut scratch))?;
 
     let mut values = Vec::<T>::with_capacity(num_rows);
     if let Some(validity) = &validity {
         let validity_iter = validity.iter();
 
-        let mut iter = IntIter::new(chunks.next()?.unwrap());
+        let mut iter =
+            decode::SignedRleV2Iter::new(chunks, validity.len() - validity.unset_bits(), vec![]);
         for is_valid in validity_iter {
             if is_valid {
-                let item = iter.next().transpose()?;
-                let item = if let Some(item) = item {
-                    item
-                } else {
-                    iter = IntIter::new(chunks.next()?.unwrap());
-                    iter.next().transpose()?.unwrap()
-                };
+                let item = iter.next().transpose()?.unwrap_or_default();
                 let item = item
                     .try_into()
                     .map_err(|_| Error::ExternalFormat("value uncastable".to_string()))?;
@@ -311,39 +211,39 @@ where
             }
         }
     } else {
-        while let Some(chunk) = chunks.next()? {
-            decode::SignedRleV2Iter::new(chunk).try_for_each(|run| {
-                run.map_err(Error::from).and_then(|run| match run {
-                    decode::SignedRleV2Run::Direct(values_iter) => {
-                        for item in values_iter {
-                            let item = item.try_into().map_err(|_| {
-                                Error::ExternalFormat("value uncastable".to_string())
-                            })?;
-                            values.push(item);
-                        }
-                        Ok(())
+        let mut iter = decode::SignedRleV2RunIter::new(chunks, num_rows, vec![]);
+
+        iter.try_for_each(|run| {
+            run.map_err(Error::from).and_then(|run| match run {
+                decode::SignedRleV2Run::Direct(values_iter) => {
+                    for item in values_iter {
+                        let item = item
+                            .try_into()
+                            .map_err(|_| Error::ExternalFormat("value uncastable".to_string()))?;
+                        values.push(item);
                     }
-                    decode::SignedRleV2Run::Delta(values_iter) => {
-                        for item in values_iter {
-                            let item = item.try_into().map_err(|_| {
-                                Error::ExternalFormat("value uncastable".to_string())
-                            })?;
-                            values.push(item);
-                        }
-                        Ok(())
+                    Ok(())
+                }
+                decode::SignedRleV2Run::Delta(values_iter) => {
+                    for item in values_iter {
+                        let item = item
+                            .try_into()
+                            .map_err(|_| Error::ExternalFormat("value uncastable".to_string()))?;
+                        values.push(item);
                     }
-                    decode::SignedRleV2Run::ShortRepeat(values_iter) => {
-                        for item in values_iter {
-                            let item = item.try_into().map_err(|_| {
-                                Error::ExternalFormat("value uncastable".to_string())
-                            })?;
-                            values.push(item);
-                        }
-                        Ok(())
+                    Ok(())
+                }
+                decode::SignedRleV2Run::ShortRepeat(values_iter) => {
+                    for item in values_iter {
+                        let item = item
+                            .try_into()
+                            .map_err(|_| Error::ExternalFormat("value uncastable".to_string()))?;
+                        values.push(item);
                     }
-                })
-            })?;
-        }
+                    Ok(())
+                }
+            })
+        })?;
     }
 
     PrimitiveArray::try_new(data_type, values.into(), validity)
@@ -351,19 +251,15 @@ where
 
 /// Deserializes column `column` from `stripe`, assumed
 /// to represent an array of `data_type`.
-pub fn deserialize(
-    data_type: DataType,
-    stripe: &Stripe,
-    column: usize,
-) -> Result<Box<dyn Array>, Error> {
+pub fn deserialize(data_type: DataType, column: &Column) -> Result<Box<dyn Array>, Error> {
     match data_type {
-        DataType::Boolean => deserialize_bool(data_type, stripe, column).map(|x| x.boxed()),
-        DataType::Int8 => deserialize_int::<i8>(data_type, stripe, column).map(|x| x.boxed()),
-        DataType::Int16 => deserialize_int::<i16>(data_type, stripe, column).map(|x| x.boxed()),
-        DataType::Int32 => deserialize_int::<i32>(data_type, stripe, column).map(|x| x.boxed()),
-        DataType::Int64 => deserialize_i64(data_type, stripe, column).map(|x| x.boxed()),
-        DataType::Float32 => deserialize_float::<f32>(data_type, stripe, column).map(|x| x.boxed()),
-        DataType::Float64 => deserialize_float::<f64>(data_type, stripe, column).map(|x| x.boxed()),
+        DataType::Boolean => deserialize_bool(data_type, column).map(|x| x.boxed()),
+        DataType::Int8 => deserialize_int::<i8>(data_type, column).map(|x| x.boxed()),
+        DataType::Int16 => deserialize_int::<i16>(data_type, column).map(|x| x.boxed()),
+        DataType::Int32 => deserialize_int::<i32>(data_type, column).map(|x| x.boxed()),
+        DataType::Int64 => deserialize_i64(data_type, column).map(|x| x.boxed()),
+        DataType::Float32 => deserialize_float::<f32>(data_type, column).map(|x| x.boxed()),
+        DataType::Float64 => deserialize_float::<f64>(data_type, column).map(|x| x.boxed()),
         dt => return Err(Error::nyi(format!("Reading {dt:?} from ORC"))),
     }
 }

--- a/tests/it/io/mod.rs
+++ b/tests/it/io/mod.rs
@@ -16,6 +16,9 @@ mod parquet;
 #[cfg(feature = "io_avro")]
 mod avro;
 
+#[cfg(feature = "io_orc")]
+mod orc;
+
 #[cfg(any(
     feature = "io_csv_read",
     feature = "io_csv_write",

--- a/tests/it/io/orc/mod.rs
+++ b/tests/it/io/orc/mod.rs
@@ -1,0 +1,1 @@
+mod read;

--- a/tests/it/io/orc/read.rs
+++ b/tests/it/io/orc/read.rs
@@ -13,25 +13,42 @@ fn infer() -> Result<(), Error> {
     Ok(())
 }
 
-#[test]
-fn float32() -> Result<(), Error> {
+fn deserialize_column(column_name: &str) -> Result<Box<dyn Array>, Error> {
     let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
     let metadata = format::read::read_metadata(&mut reader)?;
+    let schema = read::infer_schema(&metadata.footer)?;
+
     let footer = format::read::read_stripe_footer(&mut reader, &metadata, 0, &mut vec![])?;
 
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 1, vec![])?;
+    let (pos, field) = schema
+        .fields
+        .iter()
+        .enumerate()
+        .find(|f| f.1.name == column_name)
+        .unwrap();
 
+    let data_type = field.data_type.clone();
+    let column = format::read::read_stripe_column(
+        &mut reader,
+        &metadata,
+        0,
+        footer,
+        1 + pos as u32,
+        vec![],
+    )?;
+
+    read::deserialize(data_type, &column)
+}
+
+#[test]
+fn float32() -> Result<(), Error> {
     assert_eq!(
-        read::deserialize(DataType::Float32, &column)?,
+        deserialize_column("float_nullable")?,
         Float32Array::from([Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)]).boxed()
     );
 
-    let (footer, scratch) = column.into_inner();
-
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 2, scratch)?;
-
     assert_eq!(
-        read::deserialize(DataType::Float32, &column)?,
+        deserialize_column("float_required")?,
         Float32Array::from([Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)]).boxed()
     );
     Ok(())
@@ -39,23 +56,13 @@ fn float32() -> Result<(), Error> {
 
 #[test]
 fn float64() -> Result<(), Error> {
-    let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
-    let metadata = format::read::read_metadata(&mut reader)?;
-    let footer = format::read::read_stripe_footer(&mut reader, &metadata, 0, &mut vec![])?;
-
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 7, vec![])?;
-
     assert_eq!(
-        read::deserialize(DataType::Float64, &column)?,
+        deserialize_column("double_nullable")?,
         Float64Array::from([Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)]).boxed()
     );
 
-    let (footer, scratch) = column.into_inner();
-
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 8, scratch)?;
-
     assert_eq!(
-        read::deserialize(DataType::Float64, &column)?,
+        deserialize_column("double_required")?,
         Float64Array::from([Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)]).boxed()
     );
     Ok(())
@@ -63,23 +70,13 @@ fn float64() -> Result<(), Error> {
 
 #[test]
 fn boolean() -> Result<(), Error> {
-    let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
-    let metadata = format::read::read_metadata(&mut reader)?;
-    let footer = format::read::read_stripe_footer(&mut reader, &metadata, 0, &mut vec![])?;
-
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 3, vec![])?;
-
     assert_eq!(
-        read::deserialize(DataType::Boolean, &column)?,
+        deserialize_column("bool_nullable")?,
         BooleanArray::from([Some(true), Some(false), None, Some(true), Some(false)]).boxed()
     );
 
-    let (footer, scratch) = column.into_inner();
-
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 4, scratch)?;
-
     assert_eq!(
-        read::deserialize(DataType::Boolean, &column)?,
+        deserialize_column("bool_required")?,
         BooleanArray::from([Some(true), Some(false), Some(true), Some(true), Some(false)]).boxed()
     );
     Ok(())
@@ -87,23 +84,13 @@ fn boolean() -> Result<(), Error> {
 
 #[test]
 fn int() -> Result<(), Error> {
-    let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
-    let metadata = format::read::read_metadata(&mut reader)?;
-    let footer = format::read::read_stripe_footer(&mut reader, &metadata, 0, &mut vec![])?;
-
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 6, vec![])?;
-
     assert_eq!(
-        read::deserialize(DataType::Int32, &column)?,
+        deserialize_column("int_required")?,
         Int32Array::from([Some(5), Some(-5), Some(1), Some(5), Some(5)]).boxed()
     );
 
-    let (footer, _scratch) = column.into_inner();
-
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 5, vec![])?;
-
     assert_eq!(
-        read::deserialize(DataType::Int32, &column)?,
+        deserialize_column("int_nullable")?,
         Int32Array::from([Some(5), Some(-5), None, Some(5), Some(5)]).boxed()
     );
     Ok(())
@@ -111,23 +98,13 @@ fn int() -> Result<(), Error> {
 
 #[test]
 fn bigint() -> Result<(), Error> {
-    let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
-    let metadata = format::read::read_metadata(&mut reader)?;
-    let footer = format::read::read_stripe_footer(&mut reader, &metadata, 0, &mut vec![])?;
-
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 10, vec![])?;
-
     assert_eq!(
-        read::deserialize(DataType::Int64, &column)?,
+        deserialize_column("bigint_required")?,
         Int64Array::from([Some(5), Some(-5), Some(1), Some(5), Some(5)]).boxed()
     );
 
-    let (footer, scratch) = column.into_inner();
-
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 9, scratch)?;
-
     assert_eq!(
-        read::deserialize(DataType::Int64, &column)?,
+        deserialize_column("bigint_nullable")?,
         Int64Array::from([Some(5), Some(-5), None, Some(5), Some(5)]).boxed()
     );
     Ok(())
@@ -135,23 +112,13 @@ fn bigint() -> Result<(), Error> {
 
 #[test]
 fn utf8() -> Result<(), Error> {
-    let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
-    let metadata = format::read::read_metadata(&mut reader)?;
-    let footer = format::read::read_stripe_footer(&mut reader, &metadata, 0, &mut vec![])?;
-
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 11, vec![])?;
-
     assert_eq!(
-        read::deserialize(DataType::Utf8, &column)?,
+        deserialize_column("utf8_required")?,
         Utf8Array::<i32>::from_slice(["a", "bb", "ccc", "dddd", "eeeee"]).boxed()
     );
 
-    let (footer, _scratch) = column.into_inner();
-
-    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 12, vec![])?;
-
     assert_eq!(
-        read::deserialize(DataType::Utf8, &column)?,
+        deserialize_column("utf8_nullable")?,
         Utf8Array::<i32>::from([Some("a"), Some("bb"), None, Some("dddd"), Some("eeeee")]).boxed()
     );
     Ok(())

--- a/tests/it/io/orc/read.rs
+++ b/tests/it/io/orc/read.rs
@@ -6,11 +6,17 @@ use arrow2::io::orc::{format, read};
 #[test]
 fn infer() -> Result<(), Error> {
     let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
-    let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
+    let (_, footer, _) = format::read::read_metadata(&mut reader)?;
     let schema = read::infer_schema(&footer)?;
 
-    assert_eq!(schema.fields.len(), 12);
+    assert_eq!(schema.fields.len(), 6);
+    Ok(())
+}
 
+#[test]
+fn float32() -> Result<(), Error> {
+    let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
+    let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
     let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
 
     let array = read::deserialize_f32(DataType::Float32, &stripe, 1)?;
@@ -19,10 +25,50 @@ fn infer() -> Result<(), Error> {
         Float32Array::from([Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)])
     );
 
-    let array = read::deserialize_bool(DataType::Boolean, &stripe, 2)?;
+    let array = read::deserialize_f32(DataType::Float32, &stripe, 2)?;
+    assert_eq!(
+        array,
+        Float32Array::from([Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)])
+    );
+    Ok(())
+}
+
+#[test]
+fn boolean() -> Result<(), Error> {
+    let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
+    let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
+    let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
+
+    let array = read::deserialize_bool(DataType::Boolean, &stripe, 3)?;
     assert_eq!(
         array,
         BooleanArray::from([Some(true), Some(false), None, Some(true), Some(false)])
+    );
+
+    let array = read::deserialize_bool(DataType::Boolean, &stripe, 4)?;
+    assert_eq!(
+        array,
+        BooleanArray::from([Some(true), Some(false), Some(true), Some(true), Some(false)])
+    );
+    Ok(())
+}
+
+#[test]
+fn int() -> Result<(), Error> {
+    let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
+    let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
+    let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
+
+    let array = read::deserialize_i32(DataType::Int32, &stripe, 5)?;
+    assert_eq!(
+        array,
+        Int32Array::from([Some(5), Some(-5), None, Some(5), Some(5)])
+    );
+
+    let array = read::deserialize_i32(DataType::Int32, &stripe, 6)?;
+    assert_eq!(
+        array,
+        Int32Array::from([Some(5), Some(-5), Some(1), Some(5), Some(5)])
     );
     Ok(())
 }

--- a/tests/it/io/orc/read.rs
+++ b/tests/it/io/orc/read.rs
@@ -6,26 +6,33 @@ use arrow2::io::orc::{format, read};
 #[test]
 fn infer() -> Result<(), Error> {
     let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
-    let (_, footer, _) = format::read::read_metadata(&mut reader)?;
-    let schema = read::infer_schema(&footer)?;
+    let metadata = format::read::read_metadata(&mut reader)?;
+    let schema = read::infer_schema(&metadata.footer)?;
 
-    assert_eq!(schema.fields.len(), 8);
+    assert_eq!(schema.fields.len(), 10);
     Ok(())
 }
 
 #[test]
 fn float32() -> Result<(), Error> {
     let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
-    let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
-    let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
+    let metadata = format::read::read_metadata(&mut reader)?;
+    let footer = format::read::read_stripe_footer(&mut reader, &metadata, 0, &mut vec![])?;
+
+    let column =
+        format::read::read_stripe_column(&mut reader, &metadata, 0, footer.clone(), 1, vec![])?;
 
     assert_eq!(
-        read::deserialize(DataType::Float32, &stripe, 1)?,
+        read::deserialize(DataType::Float32, &column)?,
         Float32Array::from([Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)]).boxed()
     );
 
+    let (footer, scratch) = column.into_inner();
+
+    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 2, scratch)?;
+
     assert_eq!(
-        read::deserialize(DataType::Float32, &stripe, 2)?,
+        read::deserialize(DataType::Float32, &column)?,
         Float32Array::from([Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)]).boxed()
     );
     Ok(())
@@ -34,16 +41,22 @@ fn float32() -> Result<(), Error> {
 #[test]
 fn float64() -> Result<(), Error> {
     let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
-    let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
-    let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
+    let metadata = format::read::read_metadata(&mut reader)?;
+    let footer = format::read::read_stripe_footer(&mut reader, &metadata, 0, &mut vec![])?;
+
+    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 7, vec![])?;
 
     assert_eq!(
-        read::deserialize(DataType::Float64, &stripe, 7)?,
+        read::deserialize(DataType::Float64, &column)?,
         Float64Array::from([Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)]).boxed()
     );
 
+    let (footer, scratch) = column.into_inner();
+
+    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 8, vec![])?;
+
     assert_eq!(
-        read::deserialize(DataType::Float64, &stripe, 8)?,
+        read::deserialize(DataType::Float64, &column)?,
         Float64Array::from([Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)]).boxed()
     );
     Ok(())
@@ -52,16 +65,22 @@ fn float64() -> Result<(), Error> {
 #[test]
 fn boolean() -> Result<(), Error> {
     let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
-    let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
-    let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
+    let metadata = format::read::read_metadata(&mut reader)?;
+    let footer = format::read::read_stripe_footer(&mut reader, &metadata, 0, &mut vec![])?;
+
+    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 3, vec![])?;
 
     assert_eq!(
-        read::deserialize(DataType::Boolean, &stripe, 3)?,
+        read::deserialize(DataType::Boolean, &column)?,
         BooleanArray::from([Some(true), Some(false), None, Some(true), Some(false)]).boxed()
     );
 
+    let (footer, scratch) = column.into_inner();
+
+    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 4, vec![])?;
+
     assert_eq!(
-        read::deserialize(DataType::Boolean, &stripe, 4)?,
+        read::deserialize(DataType::Boolean, &column)?,
         BooleanArray::from([Some(true), Some(false), Some(true), Some(true), Some(false)]).boxed()
     );
     Ok(())
@@ -70,17 +89,47 @@ fn boolean() -> Result<(), Error> {
 #[test]
 fn int() -> Result<(), Error> {
     let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
-    let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
-    let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
+    let metadata = format::read::read_metadata(&mut reader)?;
+    let footer = format::read::read_stripe_footer(&mut reader, &metadata, 0, &mut vec![])?;
+
+    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 6, vec![])?;
 
     assert_eq!(
-        read::deserialize(DataType::Int32, &stripe, 5)?,
-        Int32Array::from([Some(5), Some(-5), None, Some(5), Some(5)]).boxed()
+        read::deserialize(DataType::Int32, &column)?,
+        Int32Array::from([Some(5), Some(-5), Some(1), Some(5), Some(5)]).boxed()
     );
 
+    let (footer, _scratch) = column.into_inner();
+
+    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 5, vec![])?;
+
     assert_eq!(
-        read::deserialize(DataType::Int32, &stripe, 6)?,
-        Int32Array::from([Some(5), Some(-5), Some(1), Some(5), Some(5)]).boxed()
+        read::deserialize(DataType::Int32, &column)?,
+        Int32Array::from([Some(5), Some(-5), None, Some(5), Some(5)]).boxed()
+    );
+    Ok(())
+}
+
+#[test]
+fn bigint() -> Result<(), Error> {
+    let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
+    let metadata = format::read::read_metadata(&mut reader)?;
+    let footer = format::read::read_stripe_footer(&mut reader, &metadata, 0, &mut vec![])?;
+
+    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 10, vec![])?;
+
+    assert_eq!(
+        read::deserialize(DataType::Int64, &column)?,
+        Int64Array::from([Some(5), Some(-5), Some(1), Some(5), Some(5)]).boxed()
+    );
+
+    let (footer, scratch) = column.into_inner();
+
+    let column = format::read::read_stripe_column(&mut reader, &metadata, 0, footer, 9, vec![])?;
+
+    assert_eq!(
+        read::deserialize(DataType::Int64, &column)?,
+        Int64Array::from([Some(5), Some(-5), None, Some(5), Some(5)]).boxed()
     );
     Ok(())
 }

--- a/tests/it/io/orc/read.rs
+++ b/tests/it/io/orc/read.rs
@@ -9,7 +9,7 @@ fn infer() -> Result<(), Error> {
     let (_, footer, _) = format::read::read_metadata(&mut reader)?;
     let schema = read::infer_schema(&footer)?;
 
-    assert_eq!(schema.fields.len(), 6);
+    assert_eq!(schema.fields.len(), 8);
     Ok(())
 }
 
@@ -27,6 +27,24 @@ fn float32() -> Result<(), Error> {
     assert_eq!(
         read::deserialize(DataType::Float32, &stripe, 2)?,
         Float32Array::from([Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)]).boxed()
+    );
+    Ok(())
+}
+
+#[test]
+fn float64() -> Result<(), Error> {
+    let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
+    let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
+    let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
+
+    assert_eq!(
+        read::deserialize(DataType::Float64, &stripe, 7)?,
+        Float64Array::from([Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)]).boxed()
+    );
+
+    assert_eq!(
+        read::deserialize(DataType::Float64, &stripe, 8)?,
+        Float64Array::from([Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)]).boxed()
     );
     Ok(())
 }

--- a/tests/it/io/orc/read.rs
+++ b/tests/it/io/orc/read.rs
@@ -1,0 +1,28 @@
+use arrow2::array::*;
+use arrow2::datatypes::DataType;
+use arrow2::error::Error;
+use arrow2::io::orc::{format, read};
+
+#[test]
+fn infer() -> Result<(), Error> {
+    let mut reader = std::fs::File::open("fixtures/pyorc/test.orc").unwrap();
+    let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
+    let schema = read::infer_schema(&footer)?;
+
+    assert_eq!(schema.fields.len(), 12);
+
+    let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
+
+    let array = read::deserialize_f32(DataType::Float32, &stripe, 1)?;
+    assert_eq!(
+        array,
+        Float32Array::from([Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)])
+    );
+
+    let array = read::deserialize_bool(DataType::Boolean, &stripe, 2)?;
+    assert_eq!(
+        array,
+        BooleanArray::from([Some(true), Some(false), None, Some(true), Some(false)])
+    );
+    Ok(())
+}

--- a/tests/it/io/orc/read.rs
+++ b/tests/it/io/orc/read.rs
@@ -19,16 +19,14 @@ fn float32() -> Result<(), Error> {
     let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
     let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
 
-    let array = read::deserialize_f32(DataType::Float32, &stripe, 1)?;
     assert_eq!(
-        array,
-        Float32Array::from([Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)])
+        read::deserialize(DataType::Float32, &stripe, 1)?,
+        Float32Array::from([Some(1.0), Some(2.0), None, Some(4.0), Some(5.0)]).boxed()
     );
 
-    let array = read::deserialize_f32(DataType::Float32, &stripe, 2)?;
     assert_eq!(
-        array,
-        Float32Array::from([Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)])
+        read::deserialize(DataType::Float32, &stripe, 2)?,
+        Float32Array::from([Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)]).boxed()
     );
     Ok(())
 }
@@ -39,16 +37,14 @@ fn boolean() -> Result<(), Error> {
     let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
     let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
 
-    let array = read::deserialize_bool(DataType::Boolean, &stripe, 3)?;
     assert_eq!(
-        array,
-        BooleanArray::from([Some(true), Some(false), None, Some(true), Some(false)])
+        read::deserialize(DataType::Boolean, &stripe, 3)?,
+        BooleanArray::from([Some(true), Some(false), None, Some(true), Some(false)]).boxed()
     );
 
-    let array = read::deserialize_bool(DataType::Boolean, &stripe, 4)?;
     assert_eq!(
-        array,
-        BooleanArray::from([Some(true), Some(false), Some(true), Some(true), Some(false)])
+        read::deserialize(DataType::Boolean, &stripe, 4)?,
+        BooleanArray::from([Some(true), Some(false), Some(true), Some(true), Some(false)]).boxed()
     );
     Ok(())
 }
@@ -59,16 +55,14 @@ fn int() -> Result<(), Error> {
     let (ps, footer, _) = format::read::read_metadata(&mut reader)?;
     let stripe = read::read_stripe(&mut reader, footer.stripes[0].clone(), ps.compression())?;
 
-    let array = read::deserialize_i32(DataType::Int32, &stripe, 5)?;
     assert_eq!(
-        array,
-        Int32Array::from([Some(5), Some(-5), None, Some(5), Some(5)])
+        read::deserialize(DataType::Int32, &stripe, 5)?,
+        Int32Array::from([Some(5), Some(-5), None, Some(5), Some(5)]).boxed()
     );
 
-    let array = read::deserialize_i32(DataType::Int32, &stripe, 6)?;
     assert_eq!(
-        array,
-        Int32Array::from([Some(5), Some(-5), Some(1), Some(5), Some(5)])
+        read::deserialize(DataType::Int32, &stripe, 6)?,
+        Int32Array::from([Some(5), Some(-5), Some(1), Some(5), Some(5)]).boxed()
     );
     Ok(())
 }

--- a/tests/it/io/orc/read.rs
+++ b/tests/it/io/orc/read.rs
@@ -1,5 +1,4 @@
 use arrow2::array::*;
-use arrow2::datatypes::DataType;
 use arrow2::error::Error;
 use arrow2::io::orc::{format, read};
 

--- a/tests/it/io/orc/write.py
+++ b/tests/it/io/orc/write.py
@@ -10,6 +10,8 @@ data = {
     "bool_required": [True, False, True, True, False],
     "int_nulable": [5, -5, None, 5, 5],
     "int_required": [5, -5, 1, 5, 5],
+    "double_nulable": [1.0, 2.0, None, 4.0, 5.0],
+    "double_required": [1.0, 2.0, 3.0, 4.0, 5.0],
 }
 
 def infer_schema(data):
@@ -26,6 +28,8 @@ def infer_schema(data):
             dt = "string"
         else:
             raise NotImplementedError
+        if key.startswith("double"):
+            dt = "double"
         schema += key + ":" + dt + ","
 
     schema = schema[:-1] + ">"

--- a/tests/it/io/orc/write.py
+++ b/tests/it/io/orc/write.py
@@ -8,14 +8,14 @@ data = {
     "float_required": [1.0, 2.0, 3.0, 4.0, 5.0],
     "bool_nullable": [True, False, None, True, False],
     "bool_required": [True, False, True, True, False],
-    "int_nulable": [5, -5, None, 5, 5],
+    "int_nullable": [5, -5, None, 5, 5],
     "int_required": [5, -5, 1, 5, 5],
-    "double_nulable": [1.0, 2.0, None, 4.0, 5.0],
+    "double_nullable": [1.0, 2.0, None, 4.0, 5.0],
     "double_required": [1.0, 2.0, 3.0, 4.0, 5.0],
-    "bigint_nulable": [5, -5, None, 5, 5],
+    "bigint_nullable": [5, -5, None, 5, 5],
     "bigint_required": [5, -5, 1, 5, 5],
-    "utf8_nulable": ["a", "bb", "ccc", "dddd", "eeeee"],
-    "utf8_required": ["a", "bb", None, "dddd", "eeeee"],
+    "utf8_required": ["a", "bb", "ccc", "dddd", "eeeee"],
+    "utf8_nullable": ["a", "bb", None, "dddd", "eeeee"],
 }
 
 def infer_schema(data):

--- a/tests/it/io/orc/write.py
+++ b/tests/it/io/orc/write.py
@@ -14,6 +14,8 @@ data = {
     "double_required": [1.0, 2.0, 3.0, 4.0, 5.0],
     "bigint_nulable": [5, -5, None, 5, 5],
     "bigint_required": [5, -5, 1, 5, 5],
+    "utf8_nulable": ["a", "bb", "ccc", "dddd", "eeeee"],
+    "utf8_required": ["a", "bb", None, "dddd", "eeeee"],
 }
 
 def infer_schema(data):

--- a/tests/it/io/orc/write.py
+++ b/tests/it/io/orc/write.py
@@ -12,6 +12,8 @@ data = {
     "int_required": [5, -5, 1, 5, 5],
     "double_nulable": [1.0, 2.0, None, 4.0, 5.0],
     "double_required": [1.0, 2.0, 3.0, 4.0, 5.0],
+    "bigint_nulable": [5, -5, None, 5, 5],
+    "bigint_required": [5, -5, 1, 5, 5],
 }
 
 def infer_schema(data):
@@ -30,6 +32,8 @@ def infer_schema(data):
             raise NotImplementedError
         if key.startswith("double"):
             dt = "double"
+        if key.startswith("bigint"):
+            dt = "bigint"
         schema += key + ":" + dt + ","
 
     schema = schema[:-1] + ">"

--- a/tests/it/io/orc/write.py
+++ b/tests/it/io/orc/write.py
@@ -4,28 +4,42 @@ import pyorc
 
 
 data = {
-    "a": [1.0, 2.0, None, 4.0, 5.0],
-    "b": [True, False, None, True, False],
-    "str_direct": ["a", "cccccc", None, "ddd", "ee"],
-    "d": ["a", "bb", None, "ccc", "ddd"],
-    "e": ["ddd", "cc", None, "bb", "a"],
-    "f": ["aaaaa", "bbbbb", None, "ccccc", "ddddd"],
-    "int_short_repeated": [5, 5, None, 5, 5],
-    "int_neg_short_repeated": [-5, -5, None, -5, -5],
-    "int_delta": [1, 2, None, 4, 5],
-    "int_neg_delta": [5, 4, None, 2, 1],
-    "int_direct": [1, 6, None, 3, 2],
-    "int_neg_direct": [-1, -6, None, -3, -2],
+    "float_nullable": [1.0, 2.0, None, 4.0, 5.0],
+    "float_required": [1.0, 2.0, 3.0, 4.0, 5.0],
+    "bool_nullable": [True, False, None, True, False],
+    "bool_required": [True, False, True, True, False],
+    "int_nulable": [5, -5, None, 5, 5],
+    "int_required": [5, -5, 1, 5, 5],
 }
+
+def infer_schema(data):
+    schema = "struct<"
+    for key, value in data.items():
+        dt = type(value[0])
+        if dt == float:
+            dt = "float"
+        elif dt == int:
+            dt = "int"
+        elif dt == bool:
+            dt = "boolean"
+        elif dt == str:
+            dt = "string"
+        else:
+            raise NotImplementedError
+        schema += key + ":" + dt + ","
+
+    schema = schema[:-1] + ">"
+    return schema
 
 
 def _write(
-    schema: str,
     data,
     file_name: str,
     compression=pyorc.CompressionKind.NONE,
     dict_key_size_threshold=0.0,
 ):
+    schema = infer_schema(data)
+
     output = open(file_name, "wb")
     writer = pyorc.Writer(
         output,
@@ -40,8 +54,4 @@ def _write(
     writer.close()
 
 os.makedirs("fixtures/pyorc", exist_ok=True)
-_write(
-    "struct<a:float,b:boolean,str_direct:string,d:string,e:string,f:string,int_short_repeated:int,int_neg_short_repeated:int,int_delta:int,int_neg_delta:int,int_direct:int,int_neg_direct:int>",
-    data,
-    "fixtures/pyorc/test.orc",
-)
+_write(data, "fixtures/pyorc/test.orc")

--- a/tests/it/io/orc/write.py
+++ b/tests/it/io/orc/write.py
@@ -1,0 +1,47 @@
+import os
+
+import pyorc
+
+
+data = {
+    "a": [1.0, 2.0, None, 4.0, 5.0],
+    "b": [True, False, None, True, False],
+    "str_direct": ["a", "cccccc", None, "ddd", "ee"],
+    "d": ["a", "bb", None, "ccc", "ddd"],
+    "e": ["ddd", "cc", None, "bb", "a"],
+    "f": ["aaaaa", "bbbbb", None, "ccccc", "ddddd"],
+    "int_short_repeated": [5, 5, None, 5, 5],
+    "int_neg_short_repeated": [-5, -5, None, -5, -5],
+    "int_delta": [1, 2, None, 4, 5],
+    "int_neg_delta": [5, 4, None, 2, 1],
+    "int_direct": [1, 6, None, 3, 2],
+    "int_neg_direct": [-1, -6, None, -3, -2],
+}
+
+
+def _write(
+    schema: str,
+    data,
+    file_name: str,
+    compression=pyorc.CompressionKind.NONE,
+    dict_key_size_threshold=0.0,
+):
+    output = open(file_name, "wb")
+    writer = pyorc.Writer(
+        output,
+        schema,
+        dict_key_size_threshold=dict_key_size_threshold,
+        compression=compression,
+    )
+    num_rows = len(list(data.values())[0])
+    for x in range(num_rows):
+        row = tuple(values[x] for values in data.values())
+        writer.write(row)
+    writer.close()
+
+os.makedirs("fixtures/pyorc", exist_ok=True)
+_write(
+    "struct<a:float,b:boolean,str_direct:string,d:string,e:string,f:string,int_short_repeated:int,int_neg_short_repeated:int,int_delta:int,int_neg_delta:int,int_direct:int,int_neg_direct:int>",
+    data,
+    "fixtures/pyorc/test.orc",
+)


### PR DESCRIPTION
Added support to read ORC files:

* schema and schema conversion to arrow
* `i16`, `i32`, `i64`, `f32`, `f64`, `utf8` and `binary`
* example and tests
* under feature flag `io_orc`
