### PR TITLE
Improved performance of reading Binary from parquet

### DIFF
--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -42,7 +42,7 @@ impl<O: Offset> Binary<O> {
         offsets.push(O::default());
         Self {
             offsets: Offsets(offsets),
-            values: vec![],
+            values: Vec::with_capacity(capacity * 24),
             last_offset: O::default(),
         }
     }


### PR DESCRIPTION
During a flamegraph of a parquet file I saw that `Binary<O>::push` spend a large amount reallocation. This PR  pre-allocates a the values buffer in parquet hinted by the capacity. This can prevent a few reallocations. The string/binary size is arbitrarily set to the size of a minimal string, e.g. 3 pointers. Could of course be something else that better fits real world data. I could do some runs to find a distribution?