### PR TITLE
Temporary skip decimal256 integration tests

### DIFF
--- a/integration-testing/unskip.patch
+++ b/integration-testing/unskip.patch
@@ -1,14 +1,24 @@
 diff --git a/dev/archery/archery/integration/datagen.py b/dev/archery/archery/integration/datagen.py
-index 422130738..22e7e1834 100644
+index 591aa6d0b..febe79bb2 100644
 --- a/dev/archery/archery/integration/datagen.py
 +++ b/dev/archery/archery/integration/datagen.py
-@@ -1626,7 +1626,8 @@ def get_generated_json_files(tempdir=None):
+@@ -1602,7 +1602,8 @@ def get_generated_json_files(tempdir=None):
+ 
+         generate_decimal256_case()
+         .skip_category('Go')  # TODO(ARROW-7948): Decimal + Go
+-        .skip_category('JS'),
++        .skip_category('JS')
++        .skip_category('Rust'),
+ 
+         generate_datetime_case(),
+ 
+@@ -1624,7 +1625,8 @@ def get_generated_json_files(tempdir=None):
          generate_non_canonical_map_case()
          .skip_category('C#')
          .skip_category('Java')   # TODO(ARROW-8715)
 -        .skip_category('JS'),     # TODO(ARROW-8716)
 +        .skip_category('JS')     # TODO(ARROW-8716)
-+        .skip_category('Rust'),   # TODO(ARROW-8715)
++        .skip_category('Rust'),
  
          generate_nested_case()
          .skip_category('C#'),


### PR DESCRIPTION
We do not support it but they are being run on the arrow's test suite.

See #1194, that adds support.