### PR TITLE
Improved API of `mmap`

### DIFF
--- a/examples/ipc_file_mmap.rs
+++ b/examples/ipc_file_mmap.rs
@@ -8,7 +8,7 @@ use arrow2::mmap::{mmap_dictionaries_unchecked, mmap_unchecked};
 // Arrow2 requires a struct that implements `Clone + AsRef<[u8]>`, which
 // usually `Arc<Mmap>` supports. Here we mock it
 #[derive(Clone)]
-struct Mmap(Arc<Vec<u8>>);
+struct Mmap(Vec<u8>);
 
 impl AsRef<[u8]> for Mmap {
     #[inline]
@@ -19,7 +19,7 @@ impl AsRef<[u8]> for Mmap {
 
 fn main() -> Result<()> {
     // given a mmap
-    let mmap = Mmap(Arc::new(vec![]));
+    let mmap = Arc::new(Mmap(vec![]));
 
     // read the metadata
     let metadata = read::read_file_metadata(&mut std::io::Cursor::new(mmap.as_ref()))?;

--- a/src/io/ipc/read/reader.rs
+++ b/src/io/ipc/read/reader.rs
@@ -27,13 +27,13 @@ pub struct FileMetadata {
     /// The blocks in the file
     ///
     /// A block indicates the regions in the file to read to get data
-    pub(crate) blocks: Vec<arrow_format::ipc::Block>,
+    pub blocks: Vec<arrow_format::ipc::Block>,
 
     /// Dictionaries associated to each dict_id
     pub(crate) dictionaries: Option<Vec<arrow_format::ipc::Block>>,
 
     /// The total size of the file in bytes
-    pub(crate) size: u64,
+    pub size: u64,
 }
 
 fn read_dictionary_message<R: Read + Seek>(

--- a/tests/it/io/ipc/mmap.rs
+++ b/tests/it/io/ipc/mmap.rs
@@ -3,6 +3,7 @@ use arrow2::chunk::Chunk;
 use arrow2::datatypes::{DataType, Field, Schema};
 use arrow2::error::Result;
 use arrow2::io::ipc::read::read_file_metadata;
+use std::sync::Arc;
 
 use super::write::file::write;
 
@@ -10,9 +11,9 @@ fn round_trip(array: Box<dyn Array>) -> Result<()> {
     let schema = Schema::from(vec![Field::new("a", array.data_type().clone(), true)]);
     let columns = Chunk::try_new(vec![array.clone()])?;
 
-    let data = write(&[columns], &schema, None, None)?;
+    let data = Arc::new(write(&[columns], &schema, None, None)?);
 
-    let metadata = read_file_metadata(&mut std::io::Cursor::new(&data))?;
+    let metadata = read_file_metadata(&mut std::io::Cursor::new(data.as_ref()))?;
 
     let dictionaries =
         unsafe { arrow2::mmap::mmap_dictionaries_unchecked(&metadata, data.clone())? };


### PR DESCRIPTION
Two changes.

### 1. expose more information on the `FileMetaData`.
I wanted to know how many `Chunks` there are in the IPC file. This also exposes the `size` attribute as that can also be valuable information.

If they are an invariant for unsafe code, I can expose them via functions?


### 2. use Arc<T>

There was an assumption that `Arc<Mmap` implements `Clone + AsRef<[u8]`. It does not. Calling `as_ref` on an `Arc<T> ` gives us `T`, which was opaque to us.

Changed the function signature so that we can pass an `Arc<Mmap>`. 