### PR TITLE
Fix some doc links/typos

### DIFF
--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -157,13 +157,13 @@ impl<O: Offset> BinaryArray<O> {
         &self.data_type
     }
 
-    /// Returns the values of this [`Utf8Array`].
+    /// Returns the values of this [`BinaryArray`].
     #[inline]
     pub fn values(&self) -> &Buffer<u8> {
         &self.values
     }
 
-    /// Returns the offsets of this [`Utf8Array`].
+    /// Returns the offsets of this [`BinaryArray`].
     #[inline]
     pub fn offsets(&self) -> &Buffer<O> {
         &self.offsets

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -3,6 +3,7 @@ use crate::{
     datatypes::{DataType, Field},
     error::Error,
 };
+use std::sync::Arc;
 
 use super::{new_empty_array, new_null_array, Array};
 
@@ -118,8 +119,8 @@ impl FixedSizeListArray {
     }
 
     /// Boxes self into a [`Arc<dyn Array>`].
-    pub fn arced(self) -> std::sync::Arc<dyn Array> {
-        std::sync::Arc::new(self)
+    pub fn arced(self) -> Arc<dyn Array> {
+        Arc::new(self)
     }
 }
 

--- a/src/array/growable/mod.rs
+++ b/src/array/growable/mod.rs
@@ -3,6 +3,7 @@
 
 use crate::array::*;
 use crate::datatypes::*;
+use std::sync::Arc;
 
 mod binary;
 pub use binary::GrowableBinary;
@@ -44,7 +45,7 @@ pub trait Growable<'a> {
 
     /// Converts this [`Growable`] to an [`Arc<dyn Array>`], thereby finishing the mutation.
     /// Self will be empty after such operation.
-    fn as_arc(&mut self) -> std::sync::Arc<dyn Array> {
+    fn as_arc(&mut self) -> Arc<dyn Array> {
         self.as_box().into()
     }
 

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     datatypes::{DataType, Field},
     error::Error,
 };
+use std::sync::Arc;
 
 use super::{
     new_empty_array,
@@ -126,8 +127,8 @@ impl<O: Offset> ListArray<O> {
     }
 
     /// Boxes self into a [`Arc<dyn Array>`].
-    pub fn arced(self) -> std::sync::Arc<dyn Array> {
-        std::sync::Arc::new(self)
+    pub fn arced(self) -> Arc<dyn Array> {
+        Arc::new(self)
     }
 }
 

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -157,7 +157,7 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
         &mut self.values
     }
 
-    /// The offseta
+    /// The offsets
     pub fn offsets(&self) -> &Vec<O> {
         &self.offsets
     }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -132,7 +132,7 @@ pub trait MutableArray: std::fmt::Debug + Send + Sync {
     /// The optional validity of the array.
     fn validity(&self) -> Option<&MutableBitmap>;
 
-    /// Convert itself to an (immutable) ['Array'].
+    /// Convert itself to an (immutable) [`Array`].
     fn as_box(&mut self) -> Box<dyn Array>;
 
     /// Convert itself to an (immutable) atomically reference counted [`Array`].


### PR DESCRIPTION
Verified that `cargo doc --features full` runs without warnings, and that the links now work.