### PR TITLE
`FileSink` now closes the underlying writer.

### DIFF
--- a/src/io/parquet/write/sink.rs
+++ b/src/io/parquet/write/sink.rs
@@ -1,7 +1,7 @@
 use ahash::AHashMap;
 use std::{pin::Pin, task::Poll};
 
-use futures::{future::BoxFuture, AsyncWrite, FutureExt, Sink, TryFutureExt};
+use futures::{future::BoxFuture, AsyncWrite, AsyncWriteExt, FutureExt, Sink, TryFutureExt};
 use parquet2::metadata::KeyValue;
 use parquet2::write::FileStreamer;
 use parquet2::write::WriteOptions as ParquetWriteOptions;
@@ -218,6 +218,7 @@ where
 
                     this.task = Some(Box::pin(async move {
                         writer.end(kv_meta).map_err(Error::from).await?;
+                        writer.into_inner().close().map_err(Error::from).await?;
                         Ok(None)
                     }));
                     this.poll_complete(cx)


### PR DESCRIPTION
This PR modifies `FileSink` to, on close, close its inner `FileStreamer`'s owned writer. At the moment, the inner `AsyncWrite`'s `close` method is not called when the `FileSink` is closed.

This is a minor backwards-incompatible change. While it won't affect cases where the FileSink wraps an actual file, which is generally closed when dropped, it may affect behavior when wrapping an `AsyncWrite` which expects close to be called. (In my case, that was a handle to an S3 object.)