### PR TITLE
Added support for parquet sidecar to `FileReader`

### DIFF
--- a/benches/read_parquet.rs
+++ b/benches/read_parquet.rs
@@ -32,10 +32,16 @@ fn to_buffer(
     buffer
 }
 
-fn read_batch(buffer: &[u8], size: usize, column: usize) -> Result<()> {
-    let file = Cursor::new(buffer);
+fn read_chunk(buffer: &[u8], size: usize, column: usize) -> Result<()> {
+    let mut reader = Cursor::new(buffer);
 
-    let reader = read::FileReader::try_new(file, Some(&[column]), None, None, None)?;
+    let metadata = read::read_metadata(&mut reader)?;
+
+    let schema = read::infer_schema(&metadata)?;
+
+    let schema = schema.filter(|index, _| index == column);
+
+    let reader = read::FileReader::new(reader, metadata, schema, None, None, None);
 
     for maybe_chunk in reader {
         let columns = maybe_chunk?;
@@ -49,43 +55,43 @@ fn add_benchmark(c: &mut Criterion) {
         let size = 2usize.pow(i);
         let buffer = to_buffer(size, true, false, false, false);
         let a = format!("read i64 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 0).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 0).unwrap()));
 
         let a = format!("read utf8 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 2).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 2).unwrap()));
 
         let a = format!("read utf8 large 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 6).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 6).unwrap()));
 
         let a = format!("read utf8 emoji 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 12).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 12).unwrap()));
 
         let a = format!("read bool 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 3).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 3).unwrap()));
 
         let buffer = to_buffer(size, true, true, false, false);
         let a = format!("read utf8 dict 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 2).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 2).unwrap()));
 
         let buffer = to_buffer(size, true, false, false, true);
         let a = format!("read i64 snappy 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 0).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 0).unwrap()));
 
         let buffer = to_buffer(size, true, false, true, false);
         let a = format!("read utf8 multi 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 2).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 2).unwrap()));
 
         let buffer = to_buffer(size, true, false, true, true);
         let a = format!("read utf8 multi snappy 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 2).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 2).unwrap()));
 
         let buffer = to_buffer(size, true, false, true, true);
         let a = format!("read i64 multi snappy 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 0).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 0).unwrap()));
 
         let buffer = to_buffer(size, false, false, false, false);
         let a = format!("read required utf8 2^{}", i);
-        c.bench_function(&a, |b| b.iter(|| read_batch(&buffer, size, 2).unwrap()));
+        c.bench_function(&a, |b| b.iter(|| read_chunk(&buffer, size, 2).unwrap()));
     });
 }
 

--- a/benches/read_parquet.rs
+++ b/benches/read_parquet.rs
@@ -41,7 +41,7 @@ fn read_chunk(buffer: &[u8], size: usize, column: usize) -> Result<()> {
 
     let schema = schema.filter(|index, _| index == column);
 
-    let reader = read::FileReader::new(reader, metadata, schema, None, None, None);
+    let reader = read::FileReader::new(reader, metadata.row_groups, schema, None, None);
 
     for maybe_chunk in reader {
         let columns = maybe_chunk?;

--- a/examples/parquet_read.rs
+++ b/examples/parquet_read.rs
@@ -25,11 +25,20 @@ fn main() -> Result<(), Error> {
 
     println!("{:#?}", statistics);
 
-    // and create an iterator of
-    let reader = read::FileReader::new(reader, metadata, schema, Some(1024 * 8 * 8), None, None);
+    // say we found that we only need to read the first two row groups, "0" and "1"
+    let row_groups = metadata
+        .row_groups
+        .into_iter()
+        .enumerate()
+        .filter(|(index, _)| *index == 0 || *index == 1)
+        .map(|(_, row_group)| row_group)
+        .collect();
+
+    // we can then read the row groups into chunks
+    let chunks = read::FileReader::new(reader, row_groups, schema, Some(1024 * 8 * 8), None);
 
     let start = SystemTime::now();
-    for maybe_chunk in reader {
+    for maybe_chunk in chunks {
         let chunk = maybe_chunk?;
         assert!(!chunk.is_empty());
     }

--- a/examples/parquet_read.rs
+++ b/examples/parquet_read.rs
@@ -10,8 +10,10 @@ fn main() -> Result<()> {
 
     let file_path = &args[1];
 
-    let reader = File::open(file_path)?;
-    let reader = read::FileReader::try_new(reader, None, Some(1024 * 8 * 8), None, None)?;
+    let mut reader = File::open(file_path)?;
+
+    let metadata = read::read_metadata(&mut reader)?;
+    let reader = read::FileReader::try_new(reader, metadata, None, Some(1024 * 8 * 8), None, None)?;
 
     println!("{:#?}", reader.schema());
 

--- a/examples/parquet_read_async.rs
+++ b/examples/parquet_read_async.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
         // the runtime.
         // Furthermore, this operation is trivially paralellizable e.g. via rayon, as each iterator
         // can be advanced in parallel (parallel decompression and deserialization).
-        let chunks = RowGroupDeserializer::new(column_chunks, row_group.num_rows() as usize, None);
+        let chunks = RowGroupDeserializer::new(column_chunks, row_group.num_rows(), None);
         for maybe_chunk in chunks {
             let chunk = maybe_chunk?;
             println!("{}", chunk.len());

--- a/examples/s3/src/main.rs
+++ b/examples/s3/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> Result<()> {
 
     // this is CPU-bounded and should be sent to a separate thread-pool.
     // We do it here for simplicity
-    let chunks = read::RowGroupDeserializer::new(column_chunks, group.num_rows() as usize, None);
+    let chunks = read::RowGroupDeserializer::new(column_chunks, group.num_rows(), None);
     let chunks = chunks.collect::<Result<Vec<_>>>()?;
 
     // this is a single chunk because chunk_size is `None`

--- a/src/datatypes/schema.rs
+++ b/src/datatypes/schema.rs
@@ -26,6 +26,28 @@ impl Schema {
             metadata,
         }
     }
+
+    /// Returns a new [`Schema`] with a subset of all fields whose `predicate`
+    /// evaluates to true.
+    pub fn filter<F: Fn(usize, &Field) -> bool>(self, predicate: F) -> Self {
+        let fields = self
+            .fields
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, f)| {
+                if (predicate)(index, &f) {
+                    Some(f)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        Schema {
+            fields,
+            metadata: self.metadata,
+        }
+    }
 }
 
 impl From<Vec<Field>> for Schema {

--- a/src/io/parquet/read/file.rs
+++ b/src/io/parquet/read/file.rs
@@ -10,7 +10,7 @@ use crate::{
     error::{Error, Result},
 };
 
-use super::{infer_schema, read_metadata, FileMetaData, RowGroupDeserializer, RowGroupMetaData};
+use super::{infer_schema, FileMetaData, RowGroupDeserializer, RowGroupMetaData};
 
 type GroupFilter = Arc<dyn Fn(usize, &RowGroupMetaData) -> bool + Send + Sync>;
 
@@ -29,23 +29,20 @@ pub struct FileReader<R: Read + Seek> {
 }
 
 impl<R: Read + Seek> FileReader<R> {
-    /// Creates a new [`FileReader`] by reading the metadata from `reader` and constructing
-    /// Arrow's schema from it.
+    /// Returns a new [`FileReader`].
     ///
     /// # Error
     /// This function errors iff:
-    /// * reading the metadata from the reader fails
     /// * it is not possible to derive an arrow schema from the parquet file
     /// * the projection contains columns that do not exist
     pub fn try_new(
-        mut reader: R,
+        reader: R,
+        metadata: FileMetaData,
         projection: Option<&[usize]>,
         chunk_size: Option<usize>,
         limit: Option<usize>,
         groups_filter: Option<GroupFilter>,
     ) -> Result<Self> {
-        let metadata = read_metadata(&mut reader)?;
-
         let schema = infer_schema(&metadata)?;
 
         let schema_metadata = schema.metadata;

--- a/src/io/parquet/read/row_group.rs
+++ b/src/io/parquet/read/row_group.rs
@@ -260,8 +260,6 @@ pub async fn read_columns_many_async<
     field_columns
         .into_iter()
         .zip(fields.into_iter())
-        .map(|(columns, field)| {
-            to_deserializer(columns, field, row_group.num_rows() as usize, chunk_size)
-        })
+        .map(|(columns, field)| to_deserializer(columns, field, row_group.num_rows(), chunk_size))
         .collect()
 }

--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -500,7 +500,7 @@ fn all_types() -> Result<()> {
 
     let metadata = read_metadata(&mut reader)?;
     let schema = infer_schema(&metadata)?;
-    let reader = FileReader::new(reader, metadata, schema, None, None, None);
+    let reader = FileReader::new(reader, metadata.row_groups, schema, None, None);
 
     let batches = reader.collect::<Result<Vec<_>>>()?;
     assert_eq!(batches.len(), 1);
@@ -542,7 +542,7 @@ fn all_types_chunked() -> Result<()> {
     let metadata = read_metadata(&mut reader)?;
     let schema = infer_schema(&metadata)?;
     // chunk it in 5 (so, (5,3))
-    let reader = FileReader::new(reader, metadata, schema, Some(5), None, None);
+    let reader = FileReader::new(reader, metadata.row_groups, schema, Some(5), None);
 
     let batches = reader.collect::<Result<Vec<_>>>()?;
     assert_eq!(batches.len(), 2);
@@ -605,7 +605,7 @@ fn invalid_utf8() -> Result<()> {
 
     let metadata = read_metadata(&mut reader)?;
     let schema = infer_schema(&metadata)?;
-    let reader = FileReader::new(reader, metadata, schema, Some(5), None, None);
+    let reader = FileReader::new(reader, metadata.row_groups, schema, Some(5), None);
 
     let error = reader.collect::<Result<Vec<_>>>().unwrap_err();
     assert!(

--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -499,7 +499,8 @@ fn all_types() -> Result<()> {
     let mut reader = std::fs::File::open(path)?;
 
     let metadata = read_metadata(&mut reader)?;
-    let reader = FileReader::try_new(reader, metadata, None, None, None, None)?;
+    let schema = infer_schema(&metadata)?;
+    let reader = FileReader::new(reader, metadata, schema, None, None, None);
 
     let batches = reader.collect::<Result<Vec<_>>>()?;
     assert_eq!(batches.len(), 1);
@@ -539,8 +540,9 @@ fn all_types_chunked() -> Result<()> {
     let mut reader = std::fs::File::open(path)?;
 
     let metadata = read_metadata(&mut reader)?;
+    let schema = infer_schema(&metadata)?;
     // chunk it in 5 (so, (5,3))
-    let reader = FileReader::try_new(reader, metadata, None, Some(5), None, None)?;
+    let reader = FileReader::new(reader, metadata, schema, Some(5), None, None);
 
     let batches = reader.collect::<Result<Vec<_>>>()?;
     assert_eq!(batches.len(), 2);
@@ -602,7 +604,8 @@ fn invalid_utf8() -> Result<()> {
     let mut reader = Cursor::new(invalid_data);
 
     let metadata = read_metadata(&mut reader)?;
-    let reader = FileReader::try_new(reader, metadata, None, Some(5), None, None)?;
+    let schema = infer_schema(&metadata)?;
+    let reader = FileReader::new(reader, metadata, schema, Some(5), None, None);
 
     let error = reader.collect::<Result<Vec<_>>>().unwrap_err();
     assert!(

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -125,7 +125,7 @@ fn read_with_indexes(
         vec![&c1.descriptor().descriptor.primitive_type],
         schema.fields[1].clone(),
         None,
-        row_group.num_rows() as usize,
+        row_group.num_rows(),
     )?;
 
     let arrays = arrays.collect::<Result<Vec<_>>>()?;

--- a/tests/it/io/parquet/write_async.rs
+++ b/tests/it/io/parquet/write_async.rs
@@ -63,7 +63,7 @@ async fn test_parquet_async_roundtrip() {
         let column_chunks = read_columns_many_async(factory, group, schema.fields.clone(), None)
             .await
             .unwrap();
-        let chunks = RowGroupDeserializer::new(column_chunks, group.num_rows() as usize, None);
+        let chunks = RowGroupDeserializer::new(column_chunks, group.num_rows(), None);
         let mut chunks = chunks.collect::<Result<Vec<_>>>().unwrap();
         out.append(&mut chunks);
     }


### PR DESCRIPTION
Initializing a `FileReader` currently:
* is IO bounded, by reading the metadata
* infers an Arrow schema (and fails if it can't infer one)
* clones the `FileMetadata` to have it available for users
* has an `Arc<Fn>` on it to filter row groups that most use-cases I saw so far is not useful

This PR refactors `FileReader::try_new` into `FileReader::new` by allowing its users more flexibility into how the file is read.

The main idea is that `FileReader` is now initialized as follows:

```rust
    // we can read its metadata:
    let metadata = read::read_metadata(&mut reader)?;

    // and infer a [`Schema`] from the `metadata`.
    let schema = read::infer_schema(&metadata)?;

    // we can filter the columns we need (here we select all)
    // (projection pushdown)
    let schema = schema.filter(|_index, _field| true);

    // we can read the statistics of all parquet's row groups (here for the first field)
    let statistics = read::statistics::deserialize(&schema.fields[0], &metadata.row_groups)?;

    // say we found that we only need to read the first two row groups, "0" and "1"
    // (row-group filter pushdown)
    let row_groups = metadata
        .row_groups
        .into_iter()
        .enumerate()
        .filter(|(index, _)| *index == 0 || *index == 1)
        .map(|(_, row_group)| row_group)
        .collect();

    // we can then read the row groups into chunks
    let chunks = read::FileReader::new(reader, row_groups, schema, Some(1024 * 8 * 8), None);
```

this gives the user the flexibility to perform the necessary preparation to the metadata (`Schema` and `row_groups`) to read the file. `let row_groups = metadata.row_groups` if no predictive pushdown is being used.

This also allows row groups defined somewhere else (e.g. a parquet sidecar) to be used.