### PR TITLE
Exposed parquet indexed page filtering to `FileReader`

### DIFF
--- a/benches/read_parquet.rs
+++ b/benches/read_parquet.rs
@@ -41,7 +41,7 @@ fn read_chunk(buffer: &[u8], size: usize, column: usize) -> Result<()> {
 
     let schema = schema.filter(|index, _| index == column);
 
-    let reader = read::FileReader::new(reader, metadata.row_groups, schema, None, None);
+    let reader = read::FileReader::new(reader, metadata.row_groups, schema, None, None, None);
 
     for maybe_chunk in reader {
         let columns = maybe_chunk?;

--- a/examples/parquet_read.rs
+++ b/examples/parquet_read.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Error> {
         .collect();
 
     // we can then read the row groups into chunks
-    let chunks = read::FileReader::new(reader, row_groups, schema, Some(1024 * 8 * 8), None);
+    let chunks = read::FileReader::new(reader, row_groups, schema, Some(1024 * 8 * 8), None, None);
 
     let start = SystemTime::now();
     for maybe_chunk in chunks {

--- a/examples/parquet_read_async.rs
+++ b/examples/parquet_read_async.rs
@@ -35,8 +35,15 @@ async fn main() -> Result<()> {
     for row_group in &metadata.row_groups {
         // A row group is consumed in two steps: the first step is to read the (compressed)
         // columns into memory, which is IO-bounded.
-        let column_chunks =
-            read::read_columns_many_async(factory, row_group, schema.fields.clone(), None).await?;
+        let column_chunks = read::read_columns_many_async(
+            factory,
+            row_group,
+            schema.fields.clone(),
+            None,
+            None,
+            None,
+        )
+        .await?;
 
         // the second step is to iterate over the columns in chunks.
         // this operation is CPU-bounded and should be sent to a separate thread pool (e.g. `tokio_rayon`) to not block

--- a/src/io/ipc/read/mod.rs
+++ b/src/io/ipc/read/mod.rs
@@ -29,6 +29,7 @@ pub mod stream_async;
 pub mod file_async;
 
 pub(crate) use common::first_dict_field;
+#[cfg(feature = "io_flight")]
 pub(crate) use common::{read_dictionary, read_record_batch};
 pub use file::{read_batch, read_file_dictionaries, read_file_metadata, FileMetadata};
 pub use reader::FileReader;

--- a/src/io/parquet/read/indexes/binary.rs
+++ b/src/io/parquet/read/indexes/binary.rs
@@ -20,7 +20,8 @@ pub fn deserialize(
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        ),
+        )
+        .boxed(),
     })
 }
 

--- a/src/io/parquet/read/indexes/binary.rs
+++ b/src/io/parquet/read/indexes/binary.rs
@@ -7,21 +7,20 @@ use crate::{
     trusted_len::TrustedLen,
 };
 
-use super::ColumnIndex;
+use super::ColumnPageStatistics;
 
 pub fn deserialize(
     indexes: &[PageIndex<Vec<u8>>],
     data_type: &DataType,
-) -> Result<ColumnIndex, Error> {
-    Ok(ColumnIndex {
+) -> Result<ColumnPageStatistics, Error> {
+    Ok(ColumnPageStatistics {
         min: deserialize_binary_iter(indexes.iter().map(|index| index.min.as_ref()), data_type)?,
         max: deserialize_binary_iter(indexes.iter().map(|index| index.max.as_ref()), data_type)?,
         null_count: PrimitiveArray::from_trusted_len_iter(
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        )
-        .boxed(),
+        ),
     })
 }
 

--- a/src/io/parquet/read/indexes/boolean.rs
+++ b/src/io/parquet/read/indexes/boolean.rs
@@ -2,10 +2,10 @@ use parquet2::indexes::PageIndex;
 
 use crate::array::{BooleanArray, PrimitiveArray};
 
-use super::ColumnIndex;
+use super::ColumnPageStatistics;
 
-pub fn deserialize(indexes: &[PageIndex<bool>]) -> ColumnIndex {
-    ColumnIndex {
+pub fn deserialize(indexes: &[PageIndex<bool>]) -> ColumnPageStatistics {
+    ColumnPageStatistics {
         min: Box::new(BooleanArray::from_trusted_len_iter(
             indexes.iter().map(|index| index.min),
         )),
@@ -16,7 +16,6 @@ pub fn deserialize(indexes: &[PageIndex<bool>]) -> ColumnIndex {
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        )
-        .boxed(),
+        ),
     }
 }

--- a/src/io/parquet/read/indexes/boolean.rs
+++ b/src/io/parquet/read/indexes/boolean.rs
@@ -16,6 +16,7 @@ pub fn deserialize(indexes: &[PageIndex<bool>]) -> ColumnIndex {
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        ),
+        )
+        .boxed(),
     }
 }

--- a/src/io/parquet/read/indexes/fixed_len_binary.rs
+++ b/src/io/parquet/read/indexes/fixed_len_binary.rs
@@ -6,10 +6,10 @@ use crate::{
     trusted_len::TrustedLen,
 };
 
-use super::ColumnIndex;
+use super::ColumnPageStatistics;
 
-pub fn deserialize(indexes: &[PageIndex<Vec<u8>>], data_type: DataType) -> ColumnIndex {
-    ColumnIndex {
+pub fn deserialize(indexes: &[PageIndex<Vec<u8>>], data_type: DataType) -> ColumnPageStatistics {
+    ColumnPageStatistics {
         min: deserialize_binary_iter(
             indexes.iter().map(|index| index.min.as_ref()),
             data_type.clone(),
@@ -19,8 +19,7 @@ pub fn deserialize(indexes: &[PageIndex<Vec<u8>>], data_type: DataType) -> Colum
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        )
-        .boxed(),
+        ),
     }
 }
 

--- a/src/io/parquet/read/indexes/fixed_len_binary.rs
+++ b/src/io/parquet/read/indexes/fixed_len_binary.rs
@@ -19,7 +19,8 @@ pub fn deserialize(indexes: &[PageIndex<Vec<u8>>], data_type: DataType) -> Colum
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        ),
+        )
+        .boxed(),
     }
 }
 

--- a/src/io/parquet/read/indexes/mod.rs
+++ b/src/io/parquet/read/indexes/mod.rs
@@ -45,7 +45,7 @@ impl ColumnIndex {
 ///
 /// This function maps timestamps, decimal types, etc. accordingly.
 /// # Implementation
-/// This function is CPU-bounded but `O(P)` where `P` is the total number of pages in all columns.
+/// This function is CPU-bounded `O(P)` where `P` is the total number of pages in all columns.
 /// # Error
 /// This function errors iff the value is not deserializable to arrow (e.g. invalid utf-8)
 fn deserialize(
@@ -115,6 +115,8 @@ fn populate_dt(data_type: &DataType, container: &mut Vec<DataType>) {
 
 /// Reads the column indexes from the reader assuming a valid set of derived Arrow fields
 /// for all parquet the columns in the file.
+///
+/// It returns one [`ColumnIndex`] per field in `fields`
 ///
 /// This function is expected to be used to filter out parquet pages.
 ///

--- a/src/io/parquet/read/indexes/mod.rs
+++ b/src/io/parquet/read/indexes/mod.rs
@@ -1,7 +1,7 @@
 use parquet2::indexes::{
     BooleanIndex, ByteIndex, FixedLenByteIndex, Index as ParquetIndex, NativeIndex,
 };
-use parquet2::metadata::ColumnChunkMetaData;
+use parquet2::metadata::{ColumnChunkMetaData, RowGroupMetaData};
 use parquet2::read::read_columns_indexes as _read_columns_indexes;
 use parquet2::schema::types::PhysicalType as ParquetPhysicalType;
 
@@ -13,9 +13,10 @@ mod primitive;
 use std::collections::VecDeque;
 use std::io::{Read, Seek};
 
+use crate::array::{DictionaryArray, ListArray, PrimitiveArray, StructArray};
 use crate::datatypes::{Field, PrimitiveType};
 use crate::{
-    array::{Array, UInt64Array},
+    array::Array,
     datatypes::{DataType, PhysicalType},
     error::Error,
 };
@@ -32,8 +33,8 @@ pub struct ColumnIndex {
     pub min: Box<dyn Array>,
     /// The maximum values in the pages
     pub max: Box<dyn Array>,
-    /// The number of null values in the pages
-    pub null_count: UInt64Array,
+    /// The number of null values in the pages. A [`UInt64Array`] for non-nested types
+    pub null_count: Box<dyn Array>,
 }
 
 impl ColumnIndex {
@@ -52,7 +53,7 @@ impl ColumnIndex {
 /// # Error
 /// This function errors iff the value is not deserializable to arrow (e.g. invalid utf-8)
 fn deserialize(
-    mut indexes: VecDeque<&Box<dyn ParquetIndex>>,
+    indexes: &mut VecDeque<&Box<dyn ParquetIndex>>,
     data_type: DataType,
 ) -> Result<ColumnIndex, Error> {
     match data_type.to_physical_type() {
@@ -65,7 +66,34 @@ fn deserialize(
                 .unwrap();
             Ok(boolean::deserialize(&index.indexes))
         }
-        PhysicalType::Primitive(PrimitiveType::Int32) => {
+        PhysicalType::Primitive(PrimitiveType::Int128) => {
+            let index = indexes.pop_front().unwrap();
+            match index.physical_type() {
+                ParquetPhysicalType::Int32 => {
+                    let index = index.as_any().downcast_ref::<NativeIndex<i32>>().unwrap();
+                    Ok(primitive::deserialize_i32(&index.indexes, data_type))
+                }
+                parquet2::schema::types::PhysicalType::Int64 => {
+                    let index = index.as_any().downcast_ref::<NativeIndex<i64>>().unwrap();
+                    Ok(primitive::deserialize_i64(
+                        &index.indexes,
+                        &index.primitive_type,
+                        data_type,
+                    ))
+                }
+                parquet2::schema::types::PhysicalType::FixedLenByteArray(_) => {
+                    let index = index.as_any().downcast_ref::<FixedLenByteIndex>().unwrap();
+                    Ok(fixed_len_binary::deserialize(&index.indexes, data_type))
+                }
+                other => Err(Error::nyi(format!(
+                    "Deserialize {other:?} to arrow's int64"
+                ))),
+            }
+        }
+        PhysicalType::Primitive(PrimitiveType::UInt8)
+        | PhysicalType::Primitive(PrimitiveType::UInt16)
+        | PhysicalType::Primitive(PrimitiveType::UInt32)
+        | PhysicalType::Primitive(PrimitiveType::Int32) => {
             let index = indexes
                 .pop_front()
                 .unwrap()
@@ -136,8 +164,151 @@ fn deserialize(
                 .unwrap();
             Ok(fixed_len_binary::deserialize(&index.indexes, data_type))
         }
-        _ => todo!(),
+        PhysicalType::Dictionary(_) => {
+            if let DataType::Dictionary(key, inner, is_sorted) = data_type.to_logical_type() {
+                let child = deserialize(indexes, (**inner).clone())?;
+                Ok(match_integer_type!(key, |$T| {
+                    let keys: Vec<$T> = (0..child.min.len() as $T).collect();
+                    let keys = PrimitiveArray::<$T>::from_vec(keys);
+                    ColumnIndex {
+                        min: DictionaryArray::<$T>::try_new(data_type.clone(), keys.clone(), child.min).map(|x|x.boxed())?,
+                        max: DictionaryArray::<$T>::try_new(data_type.clone(), keys.clone(), child.max).map(|x|x.boxed())?,
+                        null_count: DictionaryArray::<$T>::try_new(DataType::Dictionary(*key, Box::new(child.null_count.data_type().clone()), *is_sorted), keys, child.null_count).map(|x|x.boxed())?,
+                    }
+                }))
+            } else {
+                unreachable!()
+            }
+        }
+        PhysicalType::List => {
+            let inner = if let DataType::List(inner) = data_type.to_logical_type() {
+                inner
+            } else {
+                unreachable!()
+            };
+            let child = deserialize(indexes, inner.data_type.clone())?;
+            let offsets = vec![0, child.min.len() as i32];
+            Ok(ColumnIndex {
+                min: ListArray::<i32>::new(
+                    data_type.clone(),
+                    offsets.clone().into(),
+                    child.min,
+                    None,
+                )
+                .boxed(),
+                max: ListArray::<i32>::new(
+                    data_type.clone(),
+                    offsets.clone().into(),
+                    child.max,
+                    None,
+                )
+                .boxed(),
+                null_count: ListArray::<i32>::new(
+                    DataType::List({
+                        let mut inner = (**inner).clone();
+                        inner.data_type = child.null_count.data_type().clone();
+                        Box::new(inner)
+                    }),
+                    offsets.into(),
+                    child.null_count,
+                    None,
+                )
+                .boxed(),
+            })
+        }
+        PhysicalType::LargeList => {
+            let inner = if let DataType::LargeList(inner) = data_type.to_logical_type() {
+                inner
+            } else {
+                unreachable!()
+            };
+            let child = deserialize(indexes, inner.data_type.clone())?;
+            let offsets = vec![0, child.min.len() as i64];
+            Ok(ColumnIndex {
+                min: ListArray::<i64>::new(
+                    data_type.clone(),
+                    offsets.clone().into(),
+                    child.min,
+                    None,
+                )
+                .boxed(),
+                max: ListArray::<i64>::new(
+                    data_type.clone(),
+                    offsets.clone().into(),
+                    child.max,
+                    None,
+                )
+                .boxed(),
+                null_count: ListArray::<i64>::new(
+                    DataType::LargeList({
+                        let mut inner = (**inner).clone();
+                        inner.data_type = child.null_count.data_type().clone();
+                        Box::new(inner)
+                    }),
+                    offsets.into(),
+                    child.null_count,
+                    None,
+                )
+                .boxed(),
+            })
+        }
+        PhysicalType::Struct => {
+            let children_fields = if let DataType::Struct(children) = data_type.to_logical_type() {
+                children
+            } else {
+                unreachable!()
+            };
+            let children = children_fields
+                .iter()
+                .map(|child| deserialize(indexes, child.data_type.clone()))
+                .collect::<Result<Vec<_>, Error>>()?;
+            Ok(ColumnIndex {
+                min: StructArray::new(
+                    data_type.clone(),
+                    children.iter().map(|child| child.min.clone()).collect(),
+                    None,
+                )
+                .boxed(),
+                max: StructArray::new(
+                    data_type.clone(),
+                    children.iter().map(|child| child.max.clone()).collect(),
+                    None,
+                )
+                .boxed(),
+                null_count: StructArray::new(
+                    DataType::Struct({
+                        let mut children_fields = children_fields.clone();
+                        children_fields.iter_mut().zip(children.iter()).for_each(
+                            |(child_field, child)| {
+                                child_field.data_type = child.null_count.data_type().clone();
+                            },
+                        );
+                        children_fields
+                    }),
+                    children
+                        .iter()
+                        .map(|child| child.null_count.clone())
+                        .collect(),
+                    None,
+                )
+                .boxed(),
+            })
+        }
+
+        other => Err(Error::nyi(format!(
+            "Deserialize into arrow's {other:?} page index"
+        ))),
     }
+}
+
+/// Checks whether the row groups have page index information
+pub fn has_indexes(row_groups: &[RowGroupMetaData]) -> bool {
+    row_groups.iter().all(|group| {
+        group
+            .columns()
+            .iter()
+            .all(|chunk| chunk.column_chunk().column_index_offset.is_some())
+    })
 }
 
 /// Reads the column indexes from the reader assuming a valid set of derived Arrow fields
@@ -162,9 +333,9 @@ pub fn read_columns_indexes<R: Read + Seek>(
         .iter()
         .map(|field| {
             let indexes = get_field_pages(chunks, &indexes, &field.name);
-            let indexes = indexes.into_iter().collect();
+            let mut indexes = indexes.into_iter().collect();
 
-            deserialize(indexes, field.data_type.clone())
+            deserialize(&mut indexes, field.data_type.clone())
         })
         .collect()
 }

--- a/src/io/parquet/read/indexes/primitive.rs
+++ b/src/io/parquet/read/indexes/primitive.rs
@@ -151,7 +151,8 @@ pub fn deserialize_i32(indexes: &[PageIndex<i32>], data_type: DataType) -> Colum
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        ),
+        )
+        .boxed(),
     }
 }
 
@@ -175,7 +176,8 @@ pub fn deserialize_i64(
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        ),
+        )
+        .boxed(),
     }
 }
 
@@ -187,7 +189,8 @@ pub fn deserialize_i96(indexes: &[PageIndex<[u32; 3]>], data_type: DataType) -> 
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        ),
+        )
+        .boxed(),
     }
 }
 
@@ -199,6 +202,7 @@ pub fn deserialize_id<T: NativeType>(indexes: &[PageIndex<T>], data_type: DataTy
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        ),
+        )
+        .boxed(),
     }
 }

--- a/src/io/parquet/read/indexes/primitive.rs
+++ b/src/io/parquet/read/indexes/primitive.rs
@@ -7,7 +7,7 @@ use crate::datatypes::{DataType, TimeUnit};
 use crate::trusted_len::TrustedLen;
 use crate::types::NativeType;
 
-use super::ColumnIndex;
+use super::ColumnPageStatistics;
 
 #[inline]
 fn deserialize_int32<I: TrustedLen<Item = Option<i32>>>(
@@ -143,16 +143,15 @@ fn deserialize_id_s<T: NativeType, I: TrustedLen<Item = Option<T>>>(
     Box::new(PrimitiveArray::<T>::from_trusted_len_iter(iter).to(data_type))
 }
 
-pub fn deserialize_i32(indexes: &[PageIndex<i32>], data_type: DataType) -> ColumnIndex {
-    ColumnIndex {
+pub fn deserialize_i32(indexes: &[PageIndex<i32>], data_type: DataType) -> ColumnPageStatistics {
+    ColumnPageStatistics {
         min: deserialize_int32(indexes.iter().map(|index| index.min), data_type.clone()),
         max: deserialize_int32(indexes.iter().map(|index| index.max), data_type),
         null_count: PrimitiveArray::from_trusted_len_iter(
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        )
-        .boxed(),
+        ),
     }
 }
 
@@ -160,8 +159,8 @@ pub fn deserialize_i64(
     indexes: &[PageIndex<i64>],
     primitive_type: &PrimitiveType,
     data_type: DataType,
-) -> ColumnIndex {
-    ColumnIndex {
+) -> ColumnPageStatistics {
+    ColumnPageStatistics {
         min: deserialize_int64(
             indexes.iter().map(|index| index.min),
             primitive_type,
@@ -176,33 +175,36 @@ pub fn deserialize_i64(
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        )
-        .boxed(),
+        ),
     }
 }
 
-pub fn deserialize_i96(indexes: &[PageIndex<[u32; 3]>], data_type: DataType) -> ColumnIndex {
-    ColumnIndex {
+pub fn deserialize_i96(
+    indexes: &[PageIndex<[u32; 3]>],
+    data_type: DataType,
+) -> ColumnPageStatistics {
+    ColumnPageStatistics {
         min: deserialize_int96(indexes.iter().map(|index| index.min), data_type.clone()),
         max: deserialize_int96(indexes.iter().map(|index| index.max), data_type),
         null_count: PrimitiveArray::from_trusted_len_iter(
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        )
-        .boxed(),
+        ),
     }
 }
 
-pub fn deserialize_id<T: NativeType>(indexes: &[PageIndex<T>], data_type: DataType) -> ColumnIndex {
-    ColumnIndex {
+pub fn deserialize_id<T: NativeType>(
+    indexes: &[PageIndex<T>],
+    data_type: DataType,
+) -> ColumnPageStatistics {
+    ColumnPageStatistics {
         min: deserialize_id_s(indexes.iter().map(|index| index.min), data_type.clone()),
         max: deserialize_id_s(indexes.iter().map(|index| index.max), data_type),
         null_count: PrimitiveArray::from_trusted_len_iter(
             indexes
                 .iter()
                 .map(|index| index.null_count.map(|x| x as u64)),
-        )
-        .boxed(),
+        ),
     }
 }

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -37,7 +37,7 @@ use crate::{array::Array, error::Result};
 
 pub use deserialize::{column_iter_to_arrays, get_page_iterator};
 pub use file::{FileReader, RowGroupReader};
-pub use indexes::{read_columns_indexes, ColumnIndex};
+pub use indexes::{has_indexes, read_columns_indexes, ColumnIndex};
 pub use row_group::*;
 pub use schema::{infer_schema, FileMetaData};
 

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -3,7 +3,7 @@
 
 mod deserialize;
 mod file;
-mod indexes;
+pub mod indexes;
 mod row_group;
 pub mod schema;
 pub mod statistics;
@@ -37,7 +37,6 @@ use crate::{array::Array, error::Result};
 
 pub use deserialize::{column_iter_to_arrays, get_page_iterator};
 pub use file::{FileReader, RowGroupReader};
-pub use indexes::{has_indexes, read_columns_indexes, ColumnIndex};
 pub use row_group::*;
 pub use schema::{infer_schema, FileMetaData};
 

--- a/src/io/parquet/read/row_group.rs
+++ b/src/io/parquet/read/row_group.rs
@@ -302,9 +302,6 @@ pub fn read_columns_many<'a, R: Read + Seek>(
 /// Returns a vector of iterators of [`Array`] corresponding to the top level parquet fields whose
 /// name matches `fields`'s names.
 ///
-/// This operation is IO-bounded `O(C)` where C is the number of columns in the row group -
-/// it reads all the columns to memory from the row group associated to the requested fields.
-///
 /// # Implementation
 /// This operation is IO-bounded `O(C)` where C is the number of columns in the row group -
 /// it reads all the columns to memory from the row group associated to the requested fields.

--- a/src/io/parquet/read/row_group.rs
+++ b/src/io/parquet/read/row_group.rs
@@ -5,8 +5,9 @@ use futures::{
     AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt,
 };
 use parquet2::{
+    indexes::FilteredPage,
     metadata::ColumnChunkMetaData,
-    read::{BasicDecompressor, PageReader},
+    read::{BasicDecompressor, IndexedPageReader, PageMetaData, PageReader},
 };
 
 use crate::{
@@ -91,6 +92,21 @@ pub fn get_field_columns<'a>(
         .collect()
 }
 
+/// Returns all [`ColumnChunkMetaData`] associated to `field_name`.
+/// For non-nested parquet types, this returns a single column
+pub fn get_field_pages<'a, T>(
+    columns: &'a [ColumnChunkMetaData],
+    items: &'a [T],
+    field_name: &str,
+) -> Vec<&'a T> {
+    columns
+        .iter()
+        .zip(items)
+        .filter(|(metadata, _)| metadata.descriptor().path_in_schema[0] == field_name)
+        .map(|(_, item)| item)
+        .collect()
+}
+
 /// Reads all columns that are part of the parquet field `field_name`
 /// # Implementation
 /// This operation is IO-bounded `O(C)` where C is the number of columns associated to
@@ -167,6 +183,12 @@ pub async fn read_columns_async<
     try_join_all(futures).await
 }
 
+type Pages = Box<
+    dyn Iterator<Item = std::result::Result<parquet2::page::CompressedPage, parquet2::error::Error>>
+        + Sync
+        + Send,
+>;
+
 /// Converts a vector of columns associated with the parquet field whose name is [`Field`]
 /// to an iterator of [`Array`], [`ArrayIter`] of chunk size `chunk_size`.
 pub fn to_deserializer<'a>(
@@ -174,26 +196,59 @@ pub fn to_deserializer<'a>(
     field: Field,
     num_rows: usize,
     chunk_size: Option<usize>,
+    pages: Option<Vec<Vec<FilteredPage>>>,
 ) -> Result<ArrayIter<'a>> {
     let chunk_size = chunk_size.map(|c| c.min(num_rows));
 
-    let (columns, types): (Vec<_>, Vec<_>) = columns
-        .into_iter()
-        .map(|(column_meta, chunk)| {
-            let len = chunk.len();
-            let pages = PageReader::new(
-                std::io::Cursor::new(chunk),
-                column_meta,
-                std::sync::Arc::new(|_, _| true),
-                vec![],
-                len * 2 + 1024,
-            );
-            (
-                BasicDecompressor::new(pages, vec![]),
-                &column_meta.descriptor().descriptor.primitive_type,
-            )
-        })
-        .unzip();
+    let (columns, types) = if let Some(pages) = pages {
+        let (columns, types): (Vec<_>, Vec<_>) = columns
+            .into_iter()
+            .zip(pages.into_iter())
+            .map(|((column_meta, chunk), mut pages)| {
+                // de-offset the start, since we read in chunks (and offset is from start of file)
+                let mut meta: PageMetaData = column_meta.into();
+                pages
+                    .iter_mut()
+                    .for_each(|page| page.start -= meta.column_start);
+                meta.column_start = 0;
+                let pages = IndexedPageReader::new_with_page_meta(
+                    std::io::Cursor::new(chunk),
+                    meta,
+                    pages,
+                    vec![],
+                    vec![],
+                );
+                let pages = Box::new(pages) as Pages;
+                (
+                    BasicDecompressor::new(pages, vec![]),
+                    &column_meta.descriptor().descriptor.primitive_type,
+                )
+            })
+            .unzip();
+
+        (columns, types)
+    } else {
+        let (columns, types): (Vec<_>, Vec<_>) = columns
+            .into_iter()
+            .map(|(column_meta, chunk)| {
+                let len = chunk.len();
+                let pages = PageReader::new(
+                    std::io::Cursor::new(chunk),
+                    column_meta,
+                    std::sync::Arc::new(|_, _| true),
+                    vec![],
+                    len * 2 + 1024,
+                );
+                let pages = Box::new(pages) as Pages;
+                (
+                    BasicDecompressor::new(pages, vec![]),
+                    &column_meta.descriptor().descriptor.primitive_type,
+                )
+            })
+            .unzip();
+
+        (columns, types)
+    };
 
     column_iter_to_arrays(columns, types, field, chunk_size, num_rows)
 }
@@ -214,6 +269,7 @@ pub fn read_columns_many<'a, R: Read + Seek>(
     fields: Vec<Field>,
     chunk_size: Option<usize>,
     limit: Option<usize>,
+    pages: Option<Vec<Vec<Vec<FilteredPage>>>>,
 ) -> Result<Vec<ArrayIter<'a>>> {
     let num_rows = row_group.num_rows();
     let num_rows = limit.map(|limit| limit.min(num_rows)).unwrap_or(num_rows);
@@ -225,11 +281,22 @@ pub fn read_columns_many<'a, R: Read + Seek>(
         .map(|field| read_columns(reader, row_group.columns(), &field.name))
         .collect::<Result<Vec<_>>>()?;
 
-    field_columns
-        .into_iter()
-        .zip(fields.into_iter())
-        .map(|(columns, field)| to_deserializer(columns, field, num_rows, chunk_size))
-        .collect()
+    if let Some(pages) = pages {
+        field_columns
+            .into_iter()
+            .zip(fields)
+            .zip(pages)
+            .map(|((columns, field), pages)| {
+                to_deserializer(columns, field, num_rows, chunk_size, Some(pages))
+            })
+            .collect()
+    } else {
+        field_columns
+            .into_iter()
+            .zip(fields.into_iter())
+            .map(|(columns, field)| to_deserializer(columns, field, num_rows, chunk_size, None))
+            .collect()
+    }
 }
 
 /// Returns a vector of iterators of [`Array`] corresponding to the top level parquet fields whose
@@ -252,16 +319,32 @@ pub async fn read_columns_many_async<
     row_group: &RowGroupMetaData,
     fields: Vec<Field>,
     chunk_size: Option<usize>,
+    limit: Option<usize>,
+    pages: Option<Vec<Vec<Vec<FilteredPage>>>>,
 ) -> Result<Vec<ArrayIter<'a>>> {
+    let num_rows = row_group.num_rows();
+    let num_rows = limit.map(|limit| limit.min(num_rows)).unwrap_or(num_rows);
+
     let futures = fields
         .iter()
         .map(|field| read_columns_async(factory.clone(), row_group.columns(), &field.name));
 
     let field_columns = try_join_all(futures).await?;
 
-    field_columns
-        .into_iter()
-        .zip(fields.into_iter())
-        .map(|(columns, field)| to_deserializer(columns, field, row_group.num_rows(), chunk_size))
-        .collect()
+    if let Some(pages) = pages {
+        field_columns
+            .into_iter()
+            .zip(fields)
+            .zip(pages)
+            .map(|((columns, field), pages)| {
+                to_deserializer(columns, field, num_rows, chunk_size, Some(pages))
+            })
+            .collect()
+    } else {
+        field_columns
+            .into_iter()
+            .zip(fields.into_iter())
+            .map(|(columns, field)| to_deserializer(columns, field, num_rows, chunk_size, None))
+            .collect()
+    }
 }

--- a/src/io/parquet/read/statistics/dictionary.rs
+++ b/src/io/parquet/read/statistics/dictionary.rs
@@ -40,7 +40,8 @@ impl MutableArray for DynMutableDictionary {
         let inner = self.inner.as_box();
         match self.data_type.to_physical_type() {
             PhysicalType::Dictionary(key) => match_integer_type!(key, |$T| {
-                let keys = PrimitiveArray::<$T>::from_iter((0..inner.len() as $T).map(Some));
+                let keys: Vec<$T> = (0..inner.len() as $T).collect();
+                let keys = PrimitiveArray::<$T>::from_vec(keys);
                 Box::new(DictionaryArray::<$T>::try_new(self.data_type.clone(), keys, inner).unwrap())
             }),
             _ => todo!(),

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -27,11 +27,13 @@ pub fn read_column<R: Read + Seek>(mut reader: R, column: &str) -> Result<ArrayS
     let schema = p_read::infer_schema(&metadata)?;
 
     // verify that we can read indexes
-    let _indexes = p_read::read_columns_indexes(
-        &mut reader,
-        metadata.row_groups[0].columns(),
-        &schema.fields,
-    )?;
+    if p_read::has_indexes(&metadata.row_groups) {
+        let _indexes = p_read::read_columns_indexes(
+            &mut reader,
+            metadata.row_groups[0].columns(),
+            &schema.fields,
+        )?;
+    }
 
     let schema = schema.filter(|_, f| f.name == column);
 

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -26,11 +26,13 @@ pub fn read_column<R: Read + Seek>(mut reader: R, column: &str) -> Result<ArrayS
     let metadata = p_read::read_metadata(&mut reader)?;
     let schema = p_read::infer_schema(&metadata)?;
 
+    let row_group = &metadata.row_groups[0];
+
     // verify that we can read indexes
-    if p_read::indexes::has_indexes(&metadata.row_groups) {
+    if p_read::indexes::has_indexes(row_group) {
         let _indexes = p_read::indexes::read_filtered_pages(
             &mut reader,
-            &metadata.row_groups[0],
+            row_group,
             &schema.fields,
             |_, _| vec![],
         )?;

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -39,7 +39,7 @@ pub fn read_column<R: Read + Seek>(mut reader: R, column: &str) -> Result<ArrayS
 
     let statistics = deserialize(field, &metadata.row_groups)?;
 
-    let mut reader = p_read::FileReader::new(reader, metadata.row_groups, schema, None, None);
+    let mut reader = p_read::FileReader::new(reader, metadata.row_groups, schema, None, None, None);
 
     Ok((
         reader.next().unwrap()?.into_arrays().pop().unwrap(),
@@ -1171,6 +1171,7 @@ fn integration_read(data: &[u8], limit: Option<usize>) -> Result<IntegrationRead
         schema.clone(),
         None,
         limit,
+        None,
     );
 
     let batches = reader.collect::<Result<Vec<_>>>()?;
@@ -1559,7 +1560,7 @@ fn filter_chunk() -> Result<()> {
         .map(|(_, row_group)| row_group)
         .collect();
 
-    let reader = p_read::FileReader::new(reader, row_groups, schema, None, None);
+    let reader = p_read::FileReader::new(reader, row_groups, schema, None, None, None);
 
     let new_chunks = reader.collect::<Result<Vec<_>>>()?;
 

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -27,11 +27,12 @@ pub fn read_column<R: Read + Seek>(mut reader: R, column: &str) -> Result<ArrayS
     let schema = p_read::infer_schema(&metadata)?;
 
     // verify that we can read indexes
-    if p_read::has_indexes(&metadata.row_groups) {
-        let _indexes = p_read::read_columns_indexes(
+    if p_read::indexes::has_indexes(&metadata.row_groups) {
+        let _indexes = p_read::indexes::read_filtered_pages(
             &mut reader,
-            metadata.row_groups[0].columns(),
+            &metadata.row_groups[0],
             &schema.fields,
+            |_, _| vec![],
         )?;
     }
 

--- a/tests/it/io/parquet/read.rs
+++ b/tests/it/io/parquet/read.rs
@@ -500,7 +500,7 @@ fn all_types() -> Result<()> {
 
     let metadata = read_metadata(&mut reader)?;
     let schema = infer_schema(&metadata)?;
-    let reader = FileReader::new(reader, metadata.row_groups, schema, None, None);
+    let reader = FileReader::new(reader, metadata.row_groups, schema, None, None, None);
 
     let batches = reader.collect::<Result<Vec<_>>>()?;
     assert_eq!(batches.len(), 1);
@@ -542,7 +542,7 @@ fn all_types_chunked() -> Result<()> {
     let metadata = read_metadata(&mut reader)?;
     let schema = infer_schema(&metadata)?;
     // chunk it in 5 (so, (5,3))
-    let reader = FileReader::new(reader, metadata.row_groups, schema, Some(5), None);
+    let reader = FileReader::new(reader, metadata.row_groups, schema, Some(5), None, None);
 
     let batches = reader.collect::<Result<Vec<_>>>()?;
     assert_eq!(batches.len(), 2);
@@ -605,7 +605,7 @@ fn invalid_utf8() -> Result<()> {
 
     let metadata = read_metadata(&mut reader)?;
     let schema = infer_schema(&metadata)?;
-    let reader = FileReader::new(reader, metadata.row_groups, schema, Some(5), None);
+    let reader = FileReader::new(reader, metadata.row_groups, schema, Some(5), None, None);
 
     let error = reader.collect::<Result<Vec<_>>>().unwrap_err();
     assert!(

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -75,11 +75,6 @@ fn read_with_indexes(
     (pages1, pages2, schema): (Vec<EncodedPage>, Vec<EncodedPage>, Schema),
     expected: Box<dyn Array>,
 ) -> Result<()> {
-    let expected = Chunk::new(vec![
-        PrimitiveArray::<i64>::from_slice([5]).boxed(),
-        expected,
-    ]);
-
     let options = WriteOptions {
         write_statistics: true,
         compression: CompressionOptions::Uncompressed,
@@ -108,8 +103,9 @@ fn read_with_indexes(
 
     let schema = infer_schema(&metadata)?;
 
-    // todo: enable filter and projection pushdown...
-    //let schema = schema.filter(|index, _| index == 1);
+    // apply projection pushdown
+    let schema = schema.filter(|index, _| index == 1);
+    let expected = Chunk::new(vec![expected]);
 
     // per row group,
     // per field,

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -110,6 +110,8 @@ fn read_with_indexes(
     let pages = row_groups
         .iter()
         .map(|row_group| {
+            assert!(indexes::has_indexes(row_group));
+
             indexes::read_filtered_pages(&mut reader, row_group, &schema.fields, |_, intervals| {
                 let first_field = &intervals[0];
                 let first_field_column = &first_field[0];

--- a/tests/it/io/parquet/write_async.rs
+++ b/tests/it/io/parquet/write_async.rs
@@ -60,9 +60,10 @@ async fn test_parquet_async_roundtrip() {
 
     let mut out = vec![];
     for group in &metadata.row_groups {
-        let column_chunks = read_columns_many_async(factory, group, schema.fields.clone(), None)
-            .await
-            .unwrap();
+        let column_chunks =
+            read_columns_many_async(factory, group, schema.fields.clone(), None, None, None)
+                .await
+                .unwrap();
         let chunks = RowGroupDeserializer::new(column_chunks, group.num_rows(), None);
         let mut chunks = chunks.collect::<Result<Vec<_>>>().unwrap();
         out.append(&mut chunks);


### PR DESCRIPTION
This PR adds a new parameter to `FileReader::new` containing an option to perform page-level filter pushdown.

These filters reduce CPU-bounded work when deserializing.

Note that page-level filtering is not yet supported for nested types.