### PR TITLE
Reduced binary size

### DIFF
--- a/src/io/flight/mod.rs
+++ b/src/io/flight/mod.rs
@@ -241,11 +241,9 @@ pub fn deserialize_message(
             )?;
             Ok(None)
         }
-        t => {
-            return Err(Error::nyi(format!(
-                "Reading types other than record batches not yet supported, unable to read {:?}",
-                t
-            )));
-        }
+        t => Err(Error::nyi(format!(
+            "Reading types other than record batches not yet supported, unable to read {:?}",
+            t
+        ))),
     }
 }

--- a/src/io/ipc/read/deserialize.rs
+++ b/src/io/ipc/read/deserialize.rs
@@ -58,76 +58,66 @@ pub fn read<R: Read + Seek>(
             )
             .map(|x| x.boxed())
         }),
-        Binary => {
-            let array = read_binary::<i32, _>(
-                field_nodes,
-                data_type,
-                buffers,
-                reader,
-                block_offset,
-                is_little_endian,
-                compression,
-                limit,
-                scratch,
-            )?;
-            Ok(Box::new(array))
-        }
-        LargeBinary => {
-            let array = read_binary::<i64, _>(
-                field_nodes,
-                data_type,
-                buffers,
-                reader,
-                block_offset,
-                is_little_endian,
-                compression,
-                limit,
-                scratch,
-            )?;
-            Ok(Box::new(array))
-        }
-        FixedSizeBinary => {
-            let array = read_fixed_size_binary(
-                field_nodes,
-                data_type,
-                buffers,
-                reader,
-                block_offset,
-                is_little_endian,
-                compression,
-                limit,
-                scratch,
-            )?;
-            Ok(Box::new(array))
-        }
-        Utf8 => {
-            let array = read_utf8::<i32, _>(
-                field_nodes,
-                data_type,
-                buffers,
-                reader,
-                block_offset,
-                is_little_endian,
-                compression,
-                limit,
-                scratch,
-            )?;
-            Ok(Box::new(array))
-        }
-        LargeUtf8 => {
-            let array = read_utf8::<i64, _>(
-                field_nodes,
-                data_type,
-                buffers,
-                reader,
-                block_offset,
-                is_little_endian,
-                compression,
-                limit,
-                scratch,
-            )?;
-            Ok(Box::new(array))
-        }
+        Binary => read_binary::<i32, _>(
+            field_nodes,
+            data_type,
+            buffers,
+            reader,
+            block_offset,
+            is_little_endian,
+            compression,
+            limit,
+            scratch,
+        )
+        .map(|x| x.boxed()),
+        LargeBinary => read_binary::<i64, _>(
+            field_nodes,
+            data_type,
+            buffers,
+            reader,
+            block_offset,
+            is_little_endian,
+            compression,
+            limit,
+            scratch,
+        )
+        .map(|x| x.boxed()),
+        FixedSizeBinary => read_fixed_size_binary(
+            field_nodes,
+            data_type,
+            buffers,
+            reader,
+            block_offset,
+            is_little_endian,
+            compression,
+            limit,
+            scratch,
+        )
+        .map(|x| x.boxed()),
+        Utf8 => read_utf8::<i32, _>(
+            field_nodes,
+            data_type,
+            buffers,
+            reader,
+            block_offset,
+            is_little_endian,
+            compression,
+            limit,
+            scratch,
+        )
+        .map(|x| x.boxed()),
+        LargeUtf8 => read_utf8::<i64, _>(
+            field_nodes,
+            data_type,
+            buffers,
+            reader,
+            block_offset,
+            is_little_endian,
+            compression,
+            limit,
+            scratch,
+        )
+        .map(|x| x.boxed()),
         List => read_list::<i32, _>(
             field_nodes,
             data_type,

--- a/src/io/orc/read/mod.rs
+++ b/src/io/orc/read/mod.rs
@@ -354,6 +354,6 @@ pub fn deserialize(data_type: DataType, column: &Column) -> Result<Box<dyn Array
         DataType::LargeUtf8 => deserialize_utf8::<i64>(data_type, column).map(|x| x.boxed()),
         DataType::Binary => deserialize_binary::<i32>(data_type, column).map(|x| x.boxed()),
         DataType::LargeBinary => deserialize_binary::<i64>(data_type, column).map(|x| x.boxed()),
-        dt => return Err(Error::nyi(format!("Deserializing {dt:?} from ORC"))),
+        dt => Err(Error::nyi(format!("Deserializing {dt:?} from ORC"))),
     }
 }


### PR DESCRIPTION
A function with many matches seems to be better handled if split in multiple smaller functions (per variant).