### PR TITLE
Mutable struct push unchecked

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -9,7 +9,7 @@
 //! * [`Utf8Array`] and [`MutableUtf8Array`], an array of variable length utf8 values
 //! * [`BinaryArray`] and [`MutableBinaryArray`], an array of opaque variable length values
 //! * [`ListArray`] and [`MutableListArray`], an array of arrays (e.g. `[[1, 2], None, [], [None]]`)
-//! * [`StructArray`], an array of arrays identified by a string (e.g. `{"a": [1, 2], "b": [true, false]}`)
+//! * [`StructArray`] and [`MutableStructArray`], an array of arrays identified by a string (e.g. `{"a": [1, 2], "b": [true, false]}`)
 //! All immutable arrays implement the trait object [`Array`] and that can be downcasted
 //! to a concrete struct based on [`PhysicalType`](crate::datatypes::PhysicalType) available from [`Array::data_type`].
 //! All immutable arrays are backed by [`Buffer`](crate::buffer::Buffer) and thus cloning and slicing them is `O(1)`.

--- a/src/array/struct_/mutable.rs
+++ b/src/array/struct_/mutable.rs
@@ -110,20 +110,8 @@ impl MutableStructArray {
         }
     }
 
-    /// Call this after pushing into each child array.
-    /// # Panics
-    /// This function panics if any of the children does not have exactly one more
-    /// element than before the last call of `push`.
+    /// Call this once for each "row" of children you push.
     pub fn push(&mut self, valid: bool) {
-        self.push_unchecked(valid);
-        self.assert_lengths();
-    }
-
-    /// Call this after pushing into each child array.
-    /// # Safety
-    /// The caller must ensure that each of the children has exactly one more
-    /// element than before the last call of `push`.
-    pub fn push_unchecked(&mut self, valid: bool) {
         match &mut self.validity {
             Some(validity) => validity.push(valid),
             None => match valid {

--- a/src/array/struct_/mutable.rs
+++ b/src/array/struct_/mutable.rs
@@ -115,6 +115,15 @@ impl MutableStructArray {
     /// This function panics if any of the children does not have exactly one more
     /// element than before the last call of `push`.
     pub fn push(&mut self, valid: bool) {
+        self.push_unchecked(valid);
+        self.assert_lengths();
+    }
+
+    /// Call this after pushing into each child array.
+    /// # Safety
+    /// The caller must ensure that each of the children has exactly one more
+    /// element than before the last call of `push`.
+    pub fn push_unchecked(&mut self, valid: bool) {
         match &mut self.validity {
             Some(validity) => validity.push(valid),
             None => match valid {
@@ -122,7 +131,6 @@ impl MutableStructArray {
                 false => self.init_validity(),
             },
         };
-        self.assert_lengths();
     }
 
     fn push_null(&mut self) {


### PR DESCRIPTION
Adds `push_unchecked` to `MutableStructArray`.

In my tests, this reduced total time to generate a representative StructArray by more than 1/3.