### PR TITLE
Added support to read and write Parquet's delta-bitpacked (integer encoding)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ futures = { version = "0.3", optional = true }
 async-stream = { version = "0.3.2", optional = true }
 
 # parquet support
-parquet2 = { version = "0.15.0", optional = true, default_features = false, features = ["async"] }
+parquet2 = { version = "0.16", optional = true, default_features = false, features = ["async"] }
 
 # avro support
 avro-schema = { version = "0.3", optional = true }

--- a/arrow-parquet-integration-testing/main.py
+++ b/arrow-parquet-integration-testing/main.py
@@ -24,7 +24,7 @@ def _prepare(
         write,
         "--version",
         version,
-        "--encoding-utf8",
+        "--encoding-int",
         encoding_utf8,
         "--compression",
         compression,
@@ -75,8 +75,8 @@ def variations():
             # "generated_custom_metadata",
         ]:
             # pyarrow does not support decoding "delta"-encoded values.
-            # for encoding in ["plain", "delta"]:
-            for encoding in ["plain"]:
+            for encoding in ["plain", "delta"]:
+            #for encoding in ["plain"]:
                 for compression in ["uncompressed", "zstd", "snappy"]:
                     yield (version, file, compression, encoding)
 
@@ -95,4 +95,4 @@ if __name__ == "__main__":
             if str(c1.type) in ["month_interval", "day_time_interval"]:
                 # pyarrow does not support interval types from parquet
                 continue
-            assert c1 == c2
+            assert c1 == c2, (c1, c2)

--- a/arrow-parquet-integration-testing/main.py
+++ b/arrow-parquet-integration-testing/main.py
@@ -10,7 +10,12 @@ def get_file_path(file: str):
 
 
 def _prepare(
-    file: str, version: str, compression: str, encoding_utf8: str, projection=None
+    file: str,
+    version: str,
+    compression: str,
+    encoding_utf8: str,
+    encoding_int: str,
+    projection=None,
 ):
     write = f"{file}.parquet"
 
@@ -24,8 +29,10 @@ def _prepare(
         write,
         "--version",
         version,
-        "--encoding-int",
+        "--encoding-utf8",
         encoding_utf8,
+        "--encoding-int",
+        encoding_int,
         "--compression",
         compression,
     ]
@@ -38,7 +45,7 @@ def _prepare(
     return write
 
 
-def _expected(file: str):
+def _expected(file: str) -> pyarrow.Table:
     return pyarrow.ipc.RecordBatchFileReader(get_file_path(file)).read_all()
 
 
@@ -75,16 +82,19 @@ def variations():
             # "generated_custom_metadata",
         ]:
             # pyarrow does not support decoding "delta"-encoded values.
-            for encoding in ["plain", "delta"]:
-            #for encoding in ["plain"]:
+            for encoding_int in ["plain", "delta"]:
+                if encoding_int == "delta" and file in {"generated_primitive", "generated_null"}:
+                    # see https://issues.apache.org/jira/browse/ARROW-17465
+                    continue
+
                 for compression in ["uncompressed", "zstd", "snappy"]:
-                    yield (version, file, compression, encoding)
+                    yield (version, file, compression, "plain", encoding_int)
 
 
 if __name__ == "__main__":
-    for (version, file, compression, encoding_utf8) in variations():
+    for (version, file, compression, encoding_utf8, encoding_int) in variations():
         expected = _expected(file)
-        path = _prepare(file, version, compression, encoding_utf8)
+        path = _prepare(file, version, compression, encoding_utf8, encoding_int)
 
         table = pq.read_table(path)
         os.remove(path)

--- a/arrow-parquet-integration-testing/main_spark.py
+++ b/arrow-parquet-integration-testing/main_spark.py
@@ -7,7 +7,13 @@ import pyspark.sql
 from main import _prepare, _expected
 
 
-def test(file: str, version: str, column, compression: str, encoding: str):
+def test(
+    file: str,
+    version: str,
+    column: str,
+    compression: str,
+    encoding: str,
+):
     """
     Tests that pyspark can read a parquet file written by arrow2.
 
@@ -16,13 +22,13 @@ def test(file: str, version: str, column, compression: str, encoding: str):
     In pyspark: read (written) parquet to Python
     assert that they are equal
     """
-    # write parquet
-    path = _prepare(file, version, compression, encoding, [column[1]])
-
     # read IPC to Python
     expected = _expected(file)
-    expected = next(c for i, c in enumerate(expected) if i == column[1])
-    expected = expected.combine_chunks().tolist()
+    column_index = next(i for i, c in enumerate(expected.column_names) if c == column)
+    expected = expected[column].combine_chunks().tolist()
+
+    # write parquet
+    path = _prepare(file, version, compression, encoding, encoding, [column_index])
 
     # read parquet to Python
     spark = pyspark.sql.SparkSession.builder.config(
@@ -31,28 +37,34 @@ def test(file: str, version: str, column, compression: str, encoding: str):
         "false",
     ).getOrCreate()
 
-    result = spark.read.parquet(path).select(column[0]).collect()
-    result = [r[column[0]] for r in result]
+    result = spark.read.parquet(path).select(column).collect()
+    result = [r[column] for r in result]
     os.remove(path)
 
     # assert equality
     assert expected == result
 
 
-test("generated_primitive", "2", ("utf8_nullable", 24), "uncompressed", "delta")
-test("generated_primitive", "2", ("utf8_nullable", 24), "snappy", "delta")
+test("generated_null", "2", "f1", "uncompressed", "delta")
 
-test("generated_dictionary", "1", ("dict0", 0), "uncompressed", "plain")
-test("generated_dictionary", "1", ("dict0", 0), "snappy", "plain")
-test("generated_dictionary", "2", ("dict0", 0), "uncompressed", "plain")
-test("generated_dictionary", "2", ("dict0", 0), "snappy", "plain")
+test("generated_primitive", "2", "utf8_nullable", "uncompressed", "delta")
+test("generated_primitive", "2", "utf8_nullable", "snappy", "delta")
+test("generated_primitive", "2", "int32_nullable", "uncompressed", "delta")
+test("generated_primitive", "2", "int32_nullable", "snappy", "delta")
+test("generated_primitive", "2", "int16_nullable", "uncompressed", "delta")
+test("generated_primitive", "2", "int16_nullable", "snappy", "delta")
 
-test("generated_dictionary", "1", ("dict1", 1), "uncompressed", "plain")
-test("generated_dictionary", "1", ("dict1", 1), "snappy", "plain")
-test("generated_dictionary", "2", ("dict1", 1), "uncompressed", "plain")
-test("generated_dictionary", "2", ("dict1", 1), "snappy", "plain")
+test("generated_dictionary", "1", "dict0", "uncompressed", "plain")
+test("generated_dictionary", "1", "dict0", "snappy", "plain")
+test("generated_dictionary", "2", "dict0", "uncompressed", "plain")
+test("generated_dictionary", "2", "dict0", "snappy", "plain")
 
-test("generated_dictionary", "1", ("dict2", 2), "uncompressed", "plain")
-test("generated_dictionary", "1", ("dict2", 2), "snappy", "plain")
-test("generated_dictionary", "2", ("dict2", 2), "uncompressed", "plain")
-test("generated_dictionary", "2", ("dict2", 2), "snappy", "plain")
+test("generated_dictionary", "1", "dict1", "uncompressed", "plain")
+test("generated_dictionary", "1", "dict1", "snappy", "plain")
+test("generated_dictionary", "2", "dict1", "uncompressed", "plain")
+test("generated_dictionary", "2", "dict1", "snappy", "plain")
+
+test("generated_dictionary", "1", "dict2", "uncompressed", "plain")
+test("generated_dictionary", "1", "dict2", "snappy", "plain")
+test("generated_dictionary", "2", "dict2", "uncompressed", "plain")
+test("generated_dictionary", "2", "dict2", "snappy", "plain")

--- a/src/io/parquet/mod.rs
+++ b/src/io/parquet/mod.rs
@@ -22,6 +22,6 @@ impl From<parquet2::error::Error> for Error {
 
 impl From<Error> for parquet2::error::Error {
     fn from(error: Error) -> Self {
-        parquet2::error::Error::General(error.to_string())
+        parquet2::error::Error::OutOfSpec(error.to_string())
     }
 }

--- a/src/io/parquet/read/deserialize/boolean/nested.rs
+++ b/src/io/parquet/read/deserialize/boolean/nested.rs
@@ -82,7 +82,7 @@ impl<'a> NestedDecoder<'a> for BooleanDecoder {
         )
     }
 
-    fn push_valid(&self, state: &mut State, decoded: &mut Self::DecodedState) {
+    fn push_valid(&self, state: &mut State, decoded: &mut Self::DecodedState) -> Result<()> {
         let (values, validity) = decoded;
         match state {
             State::Optional(page_values) => {
@@ -95,6 +95,7 @@ impl<'a> NestedDecoder<'a> for BooleanDecoder {
                 values.push(value);
             }
         }
+        Ok(())
     }
 
     fn push_null(&self, decoded: &mut Self::DecodedState) {

--- a/src/io/parquet/read/deserialize/dictionary/mod.rs
+++ b/src/io/parquet/read/deserialize/dictionary/mod.rs
@@ -163,7 +163,8 @@ where
                 Some(remaining),
                 values,
                 &mut page.values.by_ref().map(|x| {
-                    let x: usize = x.try_into().unwrap();
+                    // todo: rm unwrap
+                    let x: usize = x.unwrap().try_into().unwrap();
                     match x.try_into() {
                         Ok(key) => key,
                         // todo: convert this to an error.
@@ -176,7 +177,8 @@ where
                     page.values
                         .by_ref()
                         .map(|x| {
-                            let x: usize = x.try_into().unwrap();
+                            // todo: rm unwrap
+                            let x: usize = x.unwrap().try_into().unwrap();
                             let x: K = match x.try_into() {
                                 Ok(key) => key,
                                 // todo: convert this to an error.
@@ -195,7 +197,8 @@ where
                 Some(remaining),
                 values,
                 &mut page_values.by_ref().map(|x| {
-                    let x: usize = x.try_into().unwrap();
+                    // todo: rm unwrap
+                    let x: usize = x.unwrap().try_into().unwrap();
                     let x: K = match x.try_into() {
                         Ok(key) => key,
                         // todo: convert this to an error.
@@ -211,7 +214,8 @@ where
                     page.values
                         .by_ref()
                         .map(|x| {
-                            let x: usize = x.try_into().unwrap();
+                            // todo: rm unwrap
+                            let x: usize = x.unwrap().try_into().unwrap();
                             let x: K = match x.try_into() {
                                 Ok(key) => key,
                                 // todo: convert this to an error.

--- a/src/io/parquet/read/deserialize/dictionary/nested.rs
+++ b/src/io/parquet/read/deserialize/dictionary/nested.rs
@@ -110,11 +110,11 @@ impl<'a, K: DictionaryKey> NestedDecoder<'a> for DictionaryDecoder<K> {
         )
     }
 
-    fn push_valid(&self, state: &mut Self::State, decoded: &mut Self::DecodedState) {
+    fn push_valid(&self, state: &mut Self::State, decoded: &mut Self::DecodedState) -> Result<()> {
         let (values, validity) = decoded;
         match state {
             State::Optional(page_values) => {
-                let key = page_values.next();
+                let key = page_values.next().transpose()?;
                 // todo: convert unwrap to error
                 let key = match K::try_from(key.unwrap_or_default() as usize) {
                     Ok(key) => key,
@@ -124,7 +124,7 @@ impl<'a, K: DictionaryKey> NestedDecoder<'a> for DictionaryDecoder<K> {
                 validity.push(true);
             }
             State::Required(page_values) => {
-                let key = page_values.values.next();
+                let key = page_values.values.next().transpose()?;
                 let key = match K::try_from(key.unwrap_or_default() as usize) {
                     Ok(key) => key,
                     Err(_) => todo!(),
@@ -132,6 +132,7 @@ impl<'a, K: DictionaryKey> NestedDecoder<'a> for DictionaryDecoder<K> {
                 values.push(key);
             }
         }
+        Ok(())
     }
 
     fn push_null(&self, decoded: &mut Self::DecodedState) {

--- a/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/basic.rs
@@ -227,27 +227,26 @@ impl<'a> Decoder<'a> for BinaryDecoder {
                     values.push(x)
                 }
             }
-            State::OptionalDictionary(page) => {
-                let op = |index: u32| {
-                    let index = index as usize;
+            State::OptionalDictionary(page) => extend_from_decoder(
+                validity,
+                &mut page.validity,
+                Some(remaining),
+                values,
+                page.values.by_ref().map(|index| {
+                    let index = index.unwrap() as usize;
                     &page.dict[index * self.size..(index + 1) * self.size]
-                };
-
-                extend_from_decoder(
-                    validity,
-                    &mut page.validity,
-                    Some(remaining),
-                    values,
-                    page.values.by_ref().map(op),
-                )
-            }
+                }),
+            ),
             State::RequiredDictionary(page) => {
-                let op = |index: u32| {
-                    let index = index as usize;
-                    &page.dict[index * self.size..(index + 1) * self.size]
-                };
-
-                for x in page.values.by_ref().map(op).take(remaining) {
+                for x in page
+                    .values
+                    .by_ref()
+                    .map(|index| {
+                        let index = index.unwrap() as usize;
+                        &page.dict[index * self.size..(index + 1) * self.size]
+                    })
+                    .take(remaining)
+                {
                     values.push(x)
                 }
             }

--- a/src/io/parquet/read/deserialize/primitive/basic.rs
+++ b/src/io/parquet/read/deserialize/primitive/basic.rs
@@ -19,7 +19,7 @@ use super::super::utils::{get_selected_rows, FilteredOptionalPageValidity, Optio
 use super::super::Pages;
 
 #[derive(Debug)]
-struct FilteredRequiredValues<'a> {
+pub(super) struct FilteredRequiredValues<'a> {
     values: SliceFilteredIter<std::slice::ChunksExact<'a, u8>>,
 }
 
@@ -89,7 +89,7 @@ where
 
 // The state of a `DataPage` of `Primitive` parquet primitive type
 #[derive(Debug)]
-enum State<'a, T>
+pub(super) enum State<'a, T>
 where
     T: NativeType,
 {
@@ -118,7 +118,7 @@ where
 }
 
 #[derive(Debug)]
-struct PrimitiveDecoder<T, P, F>
+pub(super) struct PrimitiveDecoder<T, P, F>
 where
     T: NativeType,
     P: ParquetNativeType,
@@ -126,7 +126,7 @@ where
 {
     phantom: std::marker::PhantomData<T>,
     phantom_p: std::marker::PhantomData<P>,
-    op: F,
+    pub op: F,
 }
 
 impl<T, P, F> PrimitiveDecoder<T, P, F>
@@ -136,7 +136,7 @@ where
     F: Fn(P) -> T,
 {
     #[inline]
-    fn new(op: F) -> Self {
+    pub(super) fn new(op: F) -> Self {
         Self {
             phantom: std::marker::PhantomData,
             phantom_p: std::marker::PhantomData,
@@ -183,9 +183,9 @@ where
                 Ok(State::Optional(validity, values))
             }
             (Encoding::Plain, _, false, false) => Ok(State::Required(Values::try_new::<P>(page)?)),
-            (Encoding::Plain, _, false, true) => Ok(State::FilteredRequired(
-                FilteredRequiredValues::try_new::<P>(page)?,
-            )),
+            (Encoding::Plain, _, false, true) => {
+                FilteredRequiredValues::try_new::<P>(page).map(State::FilteredRequired)
+            }
             (Encoding::Plain, _, true, true) => Ok(State::FilteredOptional(
                 FilteredOptionalPageValidity::try_new(page)?,
                 Values::try_new::<P>(page)?,

--- a/src/io/parquet/read/deserialize/primitive/basic.rs
+++ b/src/io/parquet/read/deserialize/primitive/basic.rs
@@ -232,12 +232,18 @@ where
                     page_validity,
                     Some(remaining),
                     values,
-                    &mut page_values.values.by_ref().map(op1),
+                    &mut page_values.values.by_ref().map(|x| x.unwrap()).map(op1),
                 )
             }
             State::RequiredDictionary(page) => {
                 let op1 = |index: u32| page.dict[index as usize];
-                values.extend(page.values.by_ref().map(op1).take(remaining));
+                values.extend(
+                    page.values
+                        .by_ref()
+                        .map(|x| x.unwrap())
+                        .map(op1)
+                        .take(remaining),
+                );
             }
             State::FilteredRequired(page) => {
                 values.extend(

--- a/src/io/parquet/read/deserialize/primitive/integer.rs
+++ b/src/io/parquet/read/deserialize/primitive/integer.rs
@@ -1,0 +1,260 @@
+use std::collections::VecDeque;
+
+use num_traits::AsPrimitive;
+use parquet2::{
+    deserialize::SliceFilteredIter,
+    encoding::{delta_bitpacked::Decoder, Encoding},
+    page::{split_buffer, DataPage, DictPage},
+    schema::Repetition,
+    types::NativeType as ParquetNativeType,
+};
+
+use crate::{
+    array::MutablePrimitiveArray,
+    bitmap::MutableBitmap,
+    datatypes::DataType,
+    error::Result,
+    io::parquet::read::deserialize::utils::{
+        get_selected_rows, FilteredOptionalPageValidity, OptionalPageValidity,
+    },
+    types::NativeType,
+};
+
+use super::super::utils;
+use super::super::Pages;
+
+use super::basic::{finish, PrimitiveDecoder, State as PrimitiveState};
+
+/// The state of a [`DataPage`] of an integer parquet type (i32 or i64)
+#[derive(Debug)]
+enum State<'a, T>
+where
+    T: NativeType,
+{
+    Common(PrimitiveState<'a, T>),
+    DeltaBinaryPackedRequired(Decoder<'a>),
+    DeltaBinaryPackedOptional(OptionalPageValidity<'a>, Decoder<'a>),
+    FilteredDeltaBinaryPackedRequired(SliceFilteredIter<Decoder<'a>>),
+    FilteredDeltaBinaryPackedOptional(FilteredOptionalPageValidity<'a>, Decoder<'a>),
+}
+
+impl<'a, T> utils::PageState<'a> for State<'a, T>
+where
+    T: NativeType,
+{
+    fn len(&self) -> usize {
+        match self {
+            State::Common(state) => state.len(),
+            State::DeltaBinaryPackedRequired(state) => state.size_hint().0,
+            State::DeltaBinaryPackedOptional(state, _) => state.len(),
+            State::FilteredDeltaBinaryPackedRequired(state) => state.size_hint().0,
+            State::FilteredDeltaBinaryPackedOptional(state, _) => state.len(),
+        }
+    }
+}
+
+/// Decoder of integer parquet type
+#[derive(Debug)]
+struct IntDecoder<T, P, F>(PrimitiveDecoder<T, P, F>)
+where
+    T: NativeType,
+    P: ParquetNativeType,
+    i64: num_traits::AsPrimitive<P>,
+    F: Fn(P) -> T;
+
+impl<T, P, F> IntDecoder<T, P, F>
+where
+    T: NativeType,
+    P: ParquetNativeType,
+    i64: num_traits::AsPrimitive<P>,
+    F: Fn(P) -> T,
+{
+    #[inline]
+    fn new(op: F) -> Self {
+        Self(PrimitiveDecoder::new(op))
+    }
+}
+
+impl<'a, T, P, F> utils::Decoder<'a> for IntDecoder<T, P, F>
+where
+    T: NativeType,
+    P: ParquetNativeType,
+    i64: num_traits::AsPrimitive<P>,
+    F: Copy + Fn(P) -> T,
+{
+    type State = State<'a, T>;
+    type Dict = Vec<T>;
+    type DecodedState = (Vec<T>, MutableBitmap);
+
+    fn build_state(&self, page: &'a DataPage, dict: Option<&'a Self::Dict>) -> Result<Self::State> {
+        let is_optional =
+            page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
+        let is_filtered = page.selected_rows().is_some();
+
+        match (page.encoding(), dict, is_optional, is_filtered) {
+            (Encoding::DeltaBinaryPacked, _, false, false) => {
+                let (_, _, values) = split_buffer(page)?;
+                Ok(State::DeltaBinaryPackedRequired(Decoder::new(values)))
+            }
+            (Encoding::DeltaBinaryPacked, _, true, false) => {
+                let (_, _, values) = split_buffer(page)?;
+                Ok(State::DeltaBinaryPackedOptional(
+                    OptionalPageValidity::try_new(page)?,
+                    Decoder::new(values),
+                ))
+            }
+            (Encoding::DeltaBinaryPacked, _, false, true) => {
+                let (_, _, values) = split_buffer(page)?;
+                let values = Decoder::new(values);
+
+                let rows = get_selected_rows(page);
+                let values = SliceFilteredIter::new(values, rows);
+
+                Ok(State::FilteredDeltaBinaryPackedRequired(values))
+            }
+            (Encoding::DeltaBinaryPacked, _, true, true) => {
+                let (_, _, values) = split_buffer(page)?;
+                let values = Decoder::new(values);
+
+                Ok(State::FilteredDeltaBinaryPackedOptional(
+                    FilteredOptionalPageValidity::try_new(page)?,
+                    values,
+                ))
+            }
+            _ => self.0.build_state(page, dict).map(State::Common),
+        }
+    }
+
+    fn with_capacity(&self, capacity: usize) -> Self::DecodedState {
+        self.0.with_capacity(capacity)
+    }
+
+    fn extend_from_state(
+        &self,
+        state: &mut Self::State,
+        decoded: &mut Self::DecodedState,
+        remaining: usize,
+    ) {
+        let (values, validity) = decoded;
+        match state {
+            State::Common(state) => self.0.extend_from_state(state, decoded, remaining),
+            State::DeltaBinaryPackedRequired(state) => {
+                values.extend(
+                    state
+                        .by_ref()
+                        .map(|x| x.as_())
+                        .map(self.0.op)
+                        .take(remaining),
+                );
+            }
+            State::DeltaBinaryPackedOptional(page_validity, page_values) => {
+                utils::extend_from_decoder(
+                    validity,
+                    page_validity,
+                    Some(remaining),
+                    values,
+                    page_values.by_ref().map(|x| x.as_()).map(self.0.op),
+                )
+            }
+            State::FilteredDeltaBinaryPackedRequired(page) => {
+                values.extend(
+                    page.by_ref()
+                        .map(|x| x.as_())
+                        .map(self.0.op)
+                        .take(remaining),
+                );
+            }
+            State::FilteredDeltaBinaryPackedOptional(page_validity, page_values) => {
+                utils::extend_from_decoder(
+                    validity,
+                    page_validity,
+                    Some(remaining),
+                    values,
+                    page_values.by_ref().map(|x| x.as_()).map(self.0.op),
+                );
+            }
+        }
+    }
+
+    fn deserialize_dict(&self, page: &DictPage) -> Self::Dict {
+        self.0.deserialize_dict(page)
+    }
+}
+
+/// An [`Iterator`] adapter over [`Pages`] assumed to be encoded as primitive arrays
+/// encoded as parquet integer types
+#[derive(Debug)]
+pub struct IntegerIter<T, I, P, F>
+where
+    I: Pages,
+    T: NativeType,
+    P: ParquetNativeType,
+    F: Fn(P) -> T,
+{
+    iter: I,
+    data_type: DataType,
+    items: VecDeque<(Vec<T>, MutableBitmap)>,
+    remaining: usize,
+    chunk_size: Option<usize>,
+    dict: Option<Vec<T>>,
+    op: F,
+    phantom: std::marker::PhantomData<P>,
+}
+
+impl<T, I, P, F> IntegerIter<T, I, P, F>
+where
+    I: Pages,
+    T: NativeType,
+
+    P: ParquetNativeType,
+    F: Copy + Fn(P) -> T,
+{
+    pub fn new(
+        iter: I,
+        data_type: DataType,
+        num_rows: usize,
+        chunk_size: Option<usize>,
+        op: F,
+    ) -> Self {
+        Self {
+            iter,
+            data_type,
+            items: VecDeque::new(),
+            dict: None,
+            remaining: num_rows,
+            chunk_size,
+            op,
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl<T, I, P, F> Iterator for IntegerIter<T, I, P, F>
+where
+    I: Pages,
+    T: NativeType,
+    P: ParquetNativeType,
+    i64: num_traits::AsPrimitive<P>,
+    F: Copy + Fn(P) -> T,
+{
+    type Item = Result<MutablePrimitiveArray<T>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let maybe_state = utils::next(
+            &mut self.iter,
+            &mut self.items,
+            &mut self.dict,
+            &mut self.remaining,
+            self.chunk_size,
+            &IntDecoder::new(self.op),
+        );
+        match maybe_state {
+            utils::MaybeNext::Some(Ok((values, validity))) => {
+                Some(Ok(finish(&self.data_type, values, validity)))
+            }
+            utils::MaybeNext::Some(Err(e)) => Some(Err(e)),
+            utils::MaybeNext::None => None,
+            utils::MaybeNext::More => self.next(),
+        }
+    }
+}

--- a/src/io/parquet/read/deserialize/primitive/mod.rs
+++ b/src/io/parquet/read/deserialize/primitive/mod.rs
@@ -1,7 +1,9 @@
 mod basic;
 mod dictionary;
+mod integer;
 mod nested;
 
 pub use basic::Iter;
 pub use dictionary::{DictIter, NestedDictIter};
+pub use integer::IntegerIter;
 pub use nested::NestedIter;

--- a/src/io/parquet/read/deserialize/primitive/nested.rs
+++ b/src/io/parquet/read/deserialize/primitive/nested.rs
@@ -113,7 +113,7 @@ where
         )
     }
 
-    fn push_valid(&self, state: &mut Self::State, decoded: &mut Self::DecodedState) {
+    fn push_valid(&self, state: &mut Self::State, decoded: &mut Self::DecodedState) -> Result<()> {
         let (values, validity) = decoded;
         match state {
             State::Optional(page_values) => {
@@ -128,19 +128,24 @@ where
                 values.push(value.unwrap_or_default());
             }
             State::RequiredDictionary(page) => {
-                let op1 = |index: u32| page.dict[index as usize];
-                let value = page.values.next().map(op1);
+                let value = page
+                    .values
+                    .next()
+                    .map(|index| page.dict[index.unwrap() as usize]);
 
                 values.push(value.unwrap_or_default());
             }
             State::OptionalDictionary(page) => {
-                let op1 = |index: u32| page.dict[index as usize];
-                let value = page.values.next().map(op1);
+                let value = page
+                    .values
+                    .next()
+                    .map(|index| page.dict[index.unwrap() as usize]);
 
                 values.push(value.unwrap_or_default());
                 validity.push(true);
             }
         }
+        Ok(())
     }
 
     fn push_null(&self, decoded: &mut Self::DecodedState) {

--- a/src/io/parquet/read/deserialize/simple.rs
+++ b/src/io/parquet/read/deserialize/simple.rs
@@ -71,14 +71,14 @@ pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
     Ok(match data_type.to_logical_type() {
         Null => null::iter_to_arrays(pages, data_type, chunk_size, num_rows),
         Boolean => dyn_iter(boolean::Iter::new(pages, data_type, chunk_size, num_rows)),
-        UInt8 => dyn_iter(iden(primitive::Iter::new(
+        UInt8 => dyn_iter(iden(primitive::IntegerIter::new(
             pages,
             data_type,
             num_rows,
             chunk_size,
             |x: i32| x as u8,
         ))),
-        UInt16 => dyn_iter(iden(primitive::Iter::new(
+        UInt16 => dyn_iter(iden(primitive::IntegerIter::new(
             pages,
             data_type,
             num_rows,
@@ -86,7 +86,7 @@ pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
             |x: i32| x as u16,
         ))),
         UInt32 => match physical_type {
-            PhysicalType::Int32 => dyn_iter(iden(primitive::Iter::new(
+            PhysicalType::Int32 => dyn_iter(iden(primitive::IntegerIter::new(
                 pages,
                 data_type,
                 num_rows,
@@ -94,7 +94,7 @@ pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
                 |x: i32| x as u32,
             ))),
             // some implementations of parquet write arrow's u32 into i64.
-            PhysicalType::Int64 => dyn_iter(iden(primitive::Iter::new(
+            PhysicalType::Int64 => dyn_iter(iden(primitive::IntegerIter::new(
                 pages,
                 data_type,
                 num_rows,
@@ -108,21 +108,21 @@ pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
                 )))
             }
         },
-        Int8 => dyn_iter(iden(primitive::Iter::new(
+        Int8 => dyn_iter(iden(primitive::IntegerIter::new(
             pages,
             data_type,
             num_rows,
             chunk_size,
             |x: i32| x as i8,
         ))),
-        Int16 => dyn_iter(iden(primitive::Iter::new(
+        Int16 => dyn_iter(iden(primitive::IntegerIter::new(
             pages,
             data_type,
             num_rows,
             chunk_size,
             |x: i32| x as i16,
         ))),
-        Int32 | Date32 | Time32(_) => dyn_iter(iden(primitive::Iter::new(
+        Int32 | Date32 | Time32(_) => dyn_iter(iden(primitive::IntegerIter::new(
             pages,
             data_type,
             num_rows,
@@ -200,14 +200,14 @@ pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
         }
 
         Decimal(_, _) => match physical_type {
-            PhysicalType::Int32 => dyn_iter(iden(primitive::Iter::new(
+            PhysicalType::Int32 => dyn_iter(iden(primitive::IntegerIter::new(
                 pages,
                 data_type,
                 num_rows,
                 chunk_size,
                 |x: i32| x as i128,
             ))),
-            PhysicalType::Int64 => dyn_iter(iden(primitive::Iter::new(
+            PhysicalType::Int64 => dyn_iter(iden(primitive::IntegerIter::new(
                 pages,
                 data_type,
                 num_rows,
@@ -250,14 +250,14 @@ pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
         },
 
         // INT64
-        Int64 | Date64 | Time64(_) | Duration(_) => dyn_iter(iden(primitive::Iter::new(
+        Int64 | Date64 | Time64(_) | Duration(_) => dyn_iter(iden(primitive::IntegerIter::new(
             pages,
             data_type,
             num_rows,
             chunk_size,
             |x: i64| x as i64,
         ))),
-        UInt64 => dyn_iter(iden(primitive::Iter::new(
+        UInt64 => dyn_iter(iden(primitive::IntegerIter::new(
             pages,
             data_type,
             num_rows,
@@ -368,7 +368,7 @@ fn timestamp<'a, I: Pages + 'a>(
         ));
     }
 
-    let iter = primitive::Iter::new(pages, data_type, num_rows, chunk_size, |x: i64| x);
+    let iter = primitive::IntegerIter::new(pages, data_type, num_rows, chunk_size, |x: i64| x);
     let (factor, is_multiplier) = unifiy_timestmap_unit(logical_type, time_unit);
     match (factor, is_multiplier) {
         (1, _) => Ok(dyn_iter(iden(iter))),

--- a/src/io/parquet/read/deserialize/utils.rs
+++ b/src/io/parquet/read/deserialize/utils.rs
@@ -126,7 +126,7 @@ impl<'a> PageValidity<'a> for FilteredOptionalPageValidity<'a> {
             (run, offset)
         } else {
             // a new run
-            let run = self.iter.next()?; // no run -> None
+            let run = self.iter.next()?.unwrap(); // no run -> None
             self.current = Some((run, 0));
             return self.next_limited(limit);
         };
@@ -234,7 +234,7 @@ impl<'a> OptionalPageValidity<'a> {
             (run, offset)
         } else {
             // a new run
-            let run = self.iter.next()?; // no run -> None
+            let run = self.iter.next()?.unwrap(); // no run -> None
             self.current = Some((run, 0));
             return self.next_limited(limit);
         };
@@ -492,9 +492,6 @@ pub(super) fn dict_indices_decoder(page: &DataPage) -> Result<hybrid_rle::Hybrid
     let bit_width = indices_buffer[0];
     let indices_buffer = &indices_buffer[1..];
 
-    Ok(hybrid_rle::HybridRleDecoder::new(
-        indices_buffer,
-        bit_width as u32,
-        page.num_values(),
-    ))
+    hybrid_rle::HybridRleDecoder::try_new(indices_buffer, bit_width as u32, page.num_values())
+        .map_err(Error::from)
 }

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -149,8 +149,7 @@ macro_rules! dyn_prim {
     ($from:ty, $to:ty, $array:expr, $options:expr, $type_:expr) => {{
         let values = $array.values().as_any().downcast_ref().unwrap();
 
-        let mut buffer = vec![];
-        primitive_encode_plain::<$from, $to>(values, false, &mut buffer);
+        let buffer = primitive_encode_plain::<$from, $to>(values, false, vec![]);
         let stats = primitive_build_statistics::<$from, $to>(values, $type_.clone());
         let stats = serialize_statistics(&stats);
         (DictPage::new(buffer, values.len(), false), stats)

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -48,20 +48,20 @@ fn serialize_keys_values<K: DictionaryKey>(
         let keys = keys
             .zip(validity.iter())
             .filter_map(|(key, is_valid)| is_valid.then(|| key));
-        let num_bits = utils::get_bit_width(keys.clone().max().unwrap_or(0) as u64) as u8;
+        let num_bits = utils::get_bit_width(keys.clone().max().unwrap_or(0) as u64);
 
         let keys = utils::ExactSizedIter::new(keys, array.len() - validity.unset_bits());
 
         // num_bits as a single byte
-        buffer.push(num_bits);
+        buffer.push(num_bits as u8);
 
         // followed by the encoded indices.
         Ok(encode_u32(buffer, keys, num_bits)?)
     } else {
-        let num_bits = utils::get_bit_width(keys.clone().max().unwrap_or(0) as u64) as u8;
+        let num_bits = utils::get_bit_width(keys.clone().max().unwrap_or(0) as u64);
 
         // num_bits as a single byte
-        buffer.push(num_bits);
+        buffer.push(num_bits as u8);
 
         // followed by the encoded indices.
         Ok(encode_u32(buffer, keys, num_bits)?)

--- a/src/io/parquet/write/nested/mod.rs
+++ b/src/io/parquet/write/nested/mod.rs
@@ -33,7 +33,7 @@ fn write_rep_levels(buffer: &mut Vec<u8>, nested: &[Nested], version: Version) -
     if max_level == 0 {
         return Ok(());
     }
-    let num_bits = get_bit_width(max_level) as u8;
+    let num_bits = get_bit_width(max_level);
 
     let levels = rep::RepLevelsIter::new(nested);
 
@@ -61,7 +61,7 @@ fn write_def_levels(buffer: &mut Vec<u8>, nested: &[Nested], version: Version) -
     if max_level == 0 {
         return Ok(());
     }
-    let num_bits = get_bit_width(max_level) as u8;
+    let num_bits = get_bit_width(max_level);
 
     let levels = def::DefLevelsIter::new(nested);
 

--- a/src/io/parquet/write/primitive/mod.rs
+++ b/src/io/parquet/write/primitive/mod.rs
@@ -1,7 +1,8 @@
 mod basic;
 mod nested;
 
-pub use basic::array_to_page;
+pub use basic::array_to_page_integer;
+pub use basic::array_to_page_plain;
 pub(crate) use basic::build_statistics;
 pub(crate) use basic::encode_plain;
 pub use nested::array_to_page as nested_array_to_page;

--- a/src/io/parquet/write/primitive/nested.rs
+++ b/src/io/parquet/write/primitive/nested.rs
@@ -31,7 +31,7 @@ where
     let (repetition_levels_byte_length, definition_levels_byte_length) =
         nested::write_rep_and_def(options.version, nested, &mut buffer)?;
 
-    encode_plain(array, is_optional, &mut buffer);
+    let buffer = encode_plain(array, is_optional, buffer);
 
     let statistics = if options.write_statistics {
         Some(serialize_statistics(&build_statistics(

--- a/src/io/parquet/write/row_group.rs
+++ b/src/io/parquet/write/row_group.rs
@@ -45,7 +45,7 @@ pub fn row_group_iter<A: AsRef<dyn Array> + 'static + Send + Sync>(
                         let pages = DynIter::new(
                             pages
                                 .into_iter()
-                                .map(|x| x.map_err(|e| ParquetError::General(e.to_string()))),
+                                .map(|x| x.map_err(|e| ParquetError::OutOfSpec(e.to_string()))),
                         );
 
                         let compressed_pages = Compressor::new(pages, options.compression, vec![])

--- a/tests/it/io/parquet/read_indexes.rs
+++ b/tests/it/io/parquet/read_indexes.rs
@@ -198,6 +198,30 @@ fn indexed_optional_i32() -> Result<()> {
 }
 
 #[test]
+fn indexed_optional_i32_delta() -> Result<()> {
+    let array21 = Int32Array::from([Some(1), Some(2), None]);
+    let array22 = Int32Array::from([None, Some(5), Some(6)]);
+    let expected = Int32Array::from_slice([5]).boxed();
+
+    read_with_indexes(
+        pages(&[&array21, &array22], Encoding::DeltaBinaryPacked)?,
+        expected,
+    )
+}
+
+#[test]
+fn indexed_required_i32_delta() -> Result<()> {
+    let array21 = Int32Array::from_slice([1, 2, 3]);
+    let array22 = Int32Array::from_slice([4, 5, 6]);
+    let expected = Int32Array::from_slice([5]).boxed();
+
+    read_with_indexes(
+        pages(&[&array21, &array22], Encoding::DeltaBinaryPacked)?,
+        expected,
+    )
+}
+
+#[test]
 fn indexed_optional_utf8() -> Result<()> {
     let array21 = Utf8Array::<i32>::from([Some("a"), Some("b"), None]);
     let array22 = Utf8Array::<i32>::from([None, Some("e"), Some("f")]);

--- a/tests/it/io/parquet/write.rs
+++ b/tests/it/io/parquet/write.rs
@@ -92,6 +92,28 @@ fn int64_optional_v2() -> Result<()> {
     )
 }
 
+#[test]
+fn int64_optional_delta() -> Result<()> {
+    round_trip(
+        "int64",
+        "nullable",
+        Version::V2,
+        CompressionOptions::Uncompressed,
+        vec![Encoding::DeltaBinaryPacked],
+    )
+}
+
+#[test]
+fn int64_required_delta() -> Result<()> {
+    round_trip(
+        "int64",
+        "required",
+        Version::V2,
+        CompressionOptions::Uncompressed,
+        vec![Encoding::DeltaBinaryPacked],
+    )
+}
+
 #[cfg(feature = "io_parquet_compression")]
 #[test]
 fn int64_optional_v2_compressed() -> Result<()> {


### PR DESCRIPTION
This PR adds support to read `Encoding::DeltaLengthByteArray`, an important encoding for integer types. For now this is only supported on non-nested types.