### PR TITLE
Improved github page generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ jobs:
   guide:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
@@ -14,6 +14,20 @@ jobs:
           mdbook-version: "latest"
 
       - run: mdbook build guide
+
+      - name: Deploy
+        if: github.ref == 'refs/heads/docs_test' || startsWith(github.ref, 'refs/tags/v')
+        uses: peaceiris/actions-gh-pages@v3.7.3
+        with:
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./guide/book
+          destination_dir: ./${{github.ref_name}}/guide
+          keep_files: false
+
+  docs:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -23,24 +37,18 @@ jobs:
           override: true
           components: rustfmt, rust-src
 
+      - uses: Swatinem/rust-cache@v1
+
       - name: Build Documentation
         run: cargo doc --lib --features full --no-deps
         env:
           RUSTDOCFLAGS: --cfg docsrs
 
       - name: Deploy
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/docs_test' || startsWith(github.ref, 'refs/tags/v')
         uses: peaceiris/actions-gh-pages@v3.7.3
         with:
           personal_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./guide/book
+          publish_dir: ./target/doc/arrow2
+          destination_dir: ./${{github.ref_name}}/docs
           keep_files: false
-
-      - name: Deploy
-        if: github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3.7.3
-        with:
-          personal_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc
-          destination_dir: ./docs
-          keep_files: true

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ A Rust crate to work with [Apache Arrow](https://arrow.apache.org/).
 The most feature-complete implementation of the Arrow format after the C++
 implementation.
 
-Check out [the guide](https://jorgecarleitao.github.io/arrow2/) for a general introduction
-on how to use this crate, and
-[API docs](https://jorgecarleitao.github.io/arrow2/docs/arrow2/index.html) for a detailed
-documentation of each of its APIs.
+Check out [the guide](https://jorgecarleitao.github.io/arrow2/main/guide)
+for a general introduction on how to use this crate, and
+[API docs](https://jorgecarleitao.github.io/arrow2/main/docs)
+for a detailed documentation of each of its APIs.
 
 ## Features
 


### PR DESCRIPTION
This PR makes the github pages contain the guide and API docs for specific versions, thereby allowing users to see the published guide for a given version.

Essentially, after the PR, we will start having available:
* https://jorgecarleitao.github.io/arrow2/main/guide
* https://jorgecarleitao.github.io/arrow2/main/docs
* https://jorgecarleitao.github.io/arrow2/{tag}/guide
* https://jorgecarleitao.github.io/arrow2/{tag}/docs
