### PR TITLE
Fixed incorrect command in doc for generating ORC files

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -47,7 +47,7 @@ pip install pyarrow==6 pyorc
 # Generate the parquet files (this might take some time, depending on your computer setup)
 python parquet_integration/write_parquet.py
 # generate ORC files
-python parquet_integration/write_parquet.py
+python tests/it/io/orc/write.py
 
 # Get out of venv, back to normal terminal
 deactivate


### PR DESCRIPTION
While following `DEVELOPMENT.md` to setup a working environment for `arrow2`, I noticed that `cargo test --features full` failed because missing ORC files.

This PR replaced the incorrect command for "Generate ORC files" with the correct one.