### PR TITLE
doc(): fix small typo in error message for impl StructArray

### DIFF
--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -56,7 +56,7 @@ impl StructArray {
         }
         if fields.len() != values.len() {
             return Err(Error::oos(
-                "A StructArray must a number of fields in its DataType equal to the number of child values",
+                "A StructArray must have a number of fields in its DataType equal to the number of child values",
             ));
         }
 


### PR DESCRIPTION
Run into this error message using arrow2, here a quick rewrite.