### PR TITLE
Bump json_deserializer to 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ regex-syntax = { version = "^0.6", optional = true }
 streaming-iterator = { version = "0.1", optional = true }
 fallible-streaming-iterator = { version = "0.1", optional = true }
 
-json-deserializer = { version = "0.4.1", optional = true, features = ["preserve_order"] }
+json-deserializer = { version = "0.4.2", optional = true, features = ["preserve_order"] }
 indexmap = { version = "^1.6", optional = true }
 
 # used to print columns in a nice columnar format


### PR DESCRIPTION
This PR bumps `json_deserializer` to v0.4.2 to address the fix in jorgecarleitao/json-deserializer#14. I tested this locally against features in pola-rs/polars#3413 and confirmed the fixes are working correctly. Thanks for pushing out the release!