### PR TITLE
Improved iterators

### DIFF
--- a/src/array/binary/iterator.rs
+++ b/src/array/binary/iterator.rs
@@ -1,6 +1,6 @@
 use crate::{
     array::{ArrayAccessor, ArrayValuesIter, Offset},
-    bitmap::utils::ZipValidity,
+    bitmap::utils::{BitmapIter, ZipValidity},
 };
 
 use super::BinaryArray;
@@ -24,7 +24,7 @@ pub type BinaryValueIter<'a, O> = ArrayValuesIter<'a, BinaryArray<O>>;
 
 impl<'a, O: Offset> IntoIterator for &'a BinaryArray<O> {
     type Item = Option<&'a [u8]>;
-    type IntoIter = ZipValidity<'a, &'a [u8], BinaryValueIter<'a, O>>;
+    type IntoIter = ZipValidity<&'a [u8], BinaryValueIter<'a, O>, BitmapIter<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     bitmap::{
-        utils::{zip_validity, BitmapIter, ZipValidity},
+        utils::{BitmapIter, ZipValidity},
         Bitmap,
     },
     buffer::Buffer,
@@ -117,7 +117,7 @@ impl<O: Offset> BinaryArray<O> {
 
     /// Returns an iterator of `Option<&[u8]>` over every element of this array.
     pub fn iter(&self) -> ZipValidity<&[u8], BinaryValueIter<O>, BitmapIter> {
-        zip_validity(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
+        ZipValidity::new(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
     }
 
     /// Returns an iterator of `&[u8]` over every element of this array, ignoring the validity

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     bitmap::{
-        utils::{zip_validity, ZipValidity},
+        utils::{zip_validity, BitmapIter, ZipValidity},
         Bitmap,
     },
     buffer::Buffer,
@@ -116,7 +116,7 @@ impl<O: Offset> BinaryArray<O> {
     }
 
     /// Returns an iterator of `Option<&[u8]>` over every element of this array.
-    pub fn iter(&self) -> ZipValidity<&[u8], BinaryValueIter<O>> {
+    pub fn iter(&self) -> ZipValidity<&[u8], BinaryValueIter<O>, BitmapIter> {
         zip_validity(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
     }
 

--- a/src/array/boolean/iterator.rs
+++ b/src/array/boolean/iterator.rs
@@ -1,4 +1,4 @@
-use crate::bitmap::utils::{zip_validity, BitmapIter, ZipValidity};
+use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::bitmap::IntoIter;
 
 use super::super::MutableArray;
@@ -41,7 +41,7 @@ impl<'a> MutableBooleanArray {
     /// Returns an iterator over the optional values of this [`MutableBooleanArray`].
     #[inline]
     pub fn iter(&'a self) -> ZipValidity<bool, BitmapIter<'a>, BitmapIter<'a>> {
-        zip_validity(
+        ZipValidity::new(
             self.values().iter(),
             self.validity().as_ref().map(|x| x.iter()),
         )

--- a/src/array/boolean/iterator.rs
+++ b/src/array/boolean/iterator.rs
@@ -1,11 +1,12 @@
 use crate::bitmap::utils::{zip_validity, BitmapIter, ZipValidity};
+use crate::bitmap::IntoIter;
 
 use super::super::MutableArray;
 use super::{BooleanArray, MutableBooleanArray};
 
 impl<'a> IntoIterator for &'a BooleanArray {
     type Item = Option<bool>;
-    type IntoIter = ZipValidity<'a, bool, BitmapIter<'a>>;
+    type IntoIter = ZipValidity<bool, BitmapIter<'a>, BitmapIter<'a>>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -13,9 +14,22 @@ impl<'a> IntoIterator for &'a BooleanArray {
     }
 }
 
+impl IntoIterator for BooleanArray {
+    type Item = Option<bool>;
+    type IntoIter = ZipValidity<bool, IntoIter, IntoIter>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        let (_, values, validity) = self.into_inner();
+        let values = values.into_iter();
+        let validity = validity.map(|x| x.into_iter());
+        ZipValidity::new(values, validity)
+    }
+}
+
 impl<'a> IntoIterator for &'a MutableBooleanArray {
     type Item = Option<bool>;
-    type IntoIter = ZipValidity<'a, bool, BitmapIter<'a>>;
+    type IntoIter = ZipValidity<bool, BitmapIter<'a>, BitmapIter<'a>>;
 
     #[inline]
     fn into_iter(self) -> Self::IntoIter {
@@ -26,7 +40,7 @@ impl<'a> IntoIterator for &'a MutableBooleanArray {
 impl<'a> MutableBooleanArray {
     /// Returns an iterator over the optional values of this [`MutableBooleanArray`].
     #[inline]
-    pub fn iter(&'a self) -> ZipValidity<'a, bool, BitmapIter<'a>> {
+    pub fn iter(&'a self) -> ZipValidity<bool, BitmapIter<'a>, BitmapIter<'a>> {
         zip_validity(
             self.values().iter(),
             self.validity().as_ref().map(|x| x.iter()),

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     bitmap::{
-        utils::{zip_validity, BitmapIter, ZipValidity},
+        utils::{BitmapIter, ZipValidity},
         Bitmap, MutableBitmap,
     },
     datatypes::{DataType, PhysicalType},
@@ -88,7 +88,7 @@ impl BooleanArray {
     /// Returns an iterator over the optional values of this [`BooleanArray`].
     #[inline]
     pub fn iter(&self) -> ZipValidity<bool, BitmapIter, BitmapIter> {
-        zip_validity(
+        ZipValidity::new(
             self.values().iter(),
             self.validity.as_ref().map(|x| x.iter()),
         )

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -87,7 +87,7 @@ impl BooleanArray {
 
     /// Returns an iterator over the optional values of this [`BooleanArray`].
     #[inline]
-    pub fn iter(&self) -> ZipValidity<bool, BitmapIter> {
+    pub fn iter(&self) -> ZipValidity<bool, BitmapIter, BitmapIter> {
         zip_validity(
             self.values().iter(),
             self.validity.as_ref().map(|x| x.iter()),
@@ -359,6 +359,17 @@ impl BooleanArray {
     /// Boxes self into a [`std::sync::Arc<dyn Array>`].
     pub fn arced(self) -> std::sync::Arc<dyn Array> {
         std::sync::Arc::new(self)
+    }
+
+    /// Returns its internal representation
+    #[must_use]
+    pub fn into_inner(self) -> (DataType, Bitmap, Option<Bitmap>) {
+        let Self {
+            data_type,
+            values,
+            validity,
+        } = self;
+        (data_type, values, validity)
     }
 
     /// The canonical method to create a [`BooleanArray`]

--- a/src/array/dictionary/iterator.rs
+++ b/src/array/dictionary/iterator.rs
@@ -1,4 +1,4 @@
-use crate::bitmap::utils::ZipValidity;
+use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::scalar::Scalar;
 use crate::trusted_len::TrustedLen;
 
@@ -56,7 +56,7 @@ impl<'a, K: DictionaryKey> DoubleEndedIterator for DictionaryValuesIter<'a, K> {
 }
 
 type ValuesIter<'a, K> = DictionaryValuesIter<'a, K>;
-type ZipIter<'a, K> = ZipValidity<'a, Box<dyn Scalar>, ValuesIter<'a, K>>;
+type ZipIter<'a, K> = ZipValidity<Box<dyn Scalar>, ValuesIter<'a, K>, BitmapIter<'a>>;
 
 impl<'a, K: DictionaryKey> IntoIterator for &'a DictionaryArray<K> {
     type Item = Option<Box<dyn Scalar>>;

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -2,7 +2,7 @@ use std::hint::unreachable_unchecked;
 
 use crate::{
     bitmap::{
-        utils::{zip_validity, ZipValidity},
+        utils::{zip_validity, BitmapIter, ZipValidity},
         Bitmap,
     },
     datatypes::{DataType, IntegerType},
@@ -190,7 +190,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// # Implementation
     /// This function will allocate a new [`Scalar`] per item and is usually not performant.
     /// Consider calling `keys_iter` and `values`, downcasting `values`, and iterating over that.
-    pub fn iter(&self) -> ZipValidity<Box<dyn Scalar>, DictionaryValuesIter<K>> {
+    pub fn iter(&self) -> ZipValidity<Box<dyn Scalar>, DictionaryValuesIter<K>, BitmapIter> {
         zip_validity(
             DictionaryValuesIter::new(self),
             self.keys.validity().as_ref().map(|x| x.iter()),

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -2,7 +2,7 @@ use std::hint::unreachable_unchecked;
 
 use crate::{
     bitmap::{
-        utils::{zip_validity, BitmapIter, ZipValidity},
+        utils::{BitmapIter, ZipValidity},
         Bitmap,
     },
     datatypes::{DataType, IntegerType},
@@ -191,7 +191,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// This function will allocate a new [`Scalar`] per item and is usually not performant.
     /// Consider calling `keys_iter` and `values`, downcasting `values`, and iterating over that.
     pub fn iter(&self) -> ZipValidity<Box<dyn Scalar>, DictionaryValuesIter<K>, BitmapIter> {
-        zip_validity(
+        ZipValidity::new(
             DictionaryValuesIter::new(self),
             self.keys.validity().as_ref().map(|x| x.iter()),
         )

--- a/src/array/fixed_size_binary/iterator.rs
+++ b/src/array/fixed_size_binary/iterator.rs
@@ -1,5 +1,5 @@
 use crate::array::{ArrayAccessor, ArrayValuesIter, MutableArray};
-use crate::bitmap::utils::{zip_validity, BitmapIter, ZipValidity};
+use crate::bitmap::utils::{BitmapIter, ZipValidity};
 
 use super::{FixedSizeBinaryArray, MutableFixedSizeBinaryArray};
 
@@ -47,7 +47,7 @@ impl<'a> IntoIterator for &'a FixedSizeBinaryArray {
 impl<'a> FixedSizeBinaryArray {
     /// constructs a new iterator
     pub fn iter(&'a self) -> ZipValidity<&'a [u8], FixedSizeBinaryValuesIter<'a>, BitmapIter<'a>> {
-        zip_validity(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
+        ZipValidity::new(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
     }
 
     /// Returns iterator over the values of [`FixedSizeBinaryArray`]
@@ -70,7 +70,7 @@ impl<'a> MutableFixedSizeBinaryArray {
     pub fn iter(
         &'a self,
     ) -> ZipValidity<&'a [u8], MutableFixedSizeBinaryValuesIter<'a>, BitmapIter<'a>> {
-        zip_validity(
+        ZipValidity::new(
             self.iter_values(),
             self.validity().as_ref().map(|x| x.iter()),
         )

--- a/src/array/fixed_size_binary/iterator.rs
+++ b/src/array/fixed_size_binary/iterator.rs
@@ -1,5 +1,5 @@
 use crate::array::{ArrayAccessor, ArrayValuesIter, MutableArray};
-use crate::bitmap::utils::{zip_validity, ZipValidity};
+use crate::bitmap::utils::{zip_validity, BitmapIter, ZipValidity};
 
 use super::{FixedSizeBinaryArray, MutableFixedSizeBinaryArray};
 
@@ -37,7 +37,7 @@ pub type MutableFixedSizeBinaryValuesIter<'a> = ArrayValuesIter<'a, MutableFixed
 
 impl<'a> IntoIterator for &'a FixedSizeBinaryArray {
     type Item = Option<&'a [u8]>;
-    type IntoIter = ZipValidity<'a, &'a [u8], FixedSizeBinaryValuesIter<'a>>;
+    type IntoIter = ZipValidity<&'a [u8], FixedSizeBinaryValuesIter<'a>, BitmapIter<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -46,7 +46,7 @@ impl<'a> IntoIterator for &'a FixedSizeBinaryArray {
 
 impl<'a> FixedSizeBinaryArray {
     /// constructs a new iterator
-    pub fn iter(&'a self) -> ZipValidity<'a, &'a [u8], FixedSizeBinaryValuesIter<'a>> {
+    pub fn iter(&'a self) -> ZipValidity<&'a [u8], FixedSizeBinaryValuesIter<'a>, BitmapIter<'a>> {
         zip_validity(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
     }
 
@@ -58,7 +58,7 @@ impl<'a> FixedSizeBinaryArray {
 
 impl<'a> IntoIterator for &'a MutableFixedSizeBinaryArray {
     type Item = Option<&'a [u8]>;
-    type IntoIter = ZipValidity<'a, &'a [u8], MutableFixedSizeBinaryValuesIter<'a>>;
+    type IntoIter = ZipValidity<&'a [u8], MutableFixedSizeBinaryValuesIter<'a>, BitmapIter<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -67,7 +67,9 @@ impl<'a> IntoIterator for &'a MutableFixedSizeBinaryArray {
 
 impl<'a> MutableFixedSizeBinaryArray {
     /// constructs a new iterator
-    pub fn iter(&'a self) -> ZipValidity<'a, &'a [u8], MutableFixedSizeBinaryValuesIter<'a>> {
+    pub fn iter(
+        &'a self,
+    ) -> ZipValidity<&'a [u8], MutableFixedSizeBinaryValuesIter<'a>, BitmapIter<'a>> {
         zip_validity(
             self.iter_values(),
             self.validity().as_ref().map(|x| x.iter()),

--- a/src/array/fixed_size_binary/iterator.rs
+++ b/src/array/fixed_size_binary/iterator.rs
@@ -1,53 +1,43 @@
+use crate::array::{ArrayAccessor, ArrayValuesIter, MutableArray};
 use crate::bitmap::utils::{zip_validity, ZipValidity};
 
-use super::super::MutableArray;
-use super::{FixedSizeBinaryArray, FixedSizeBinaryValues, MutableFixedSizeBinaryArray};
+use super::{FixedSizeBinaryArray, MutableFixedSizeBinaryArray};
 
-/// # Safety
-/// This iterator is `TrustedLen`
-pub struct FixedSizeBinaryValuesIter<'a, T: FixedSizeBinaryValues> {
-    array: &'a T,
-    len: usize,
-    index: usize,
-}
-
-impl<'a, T: FixedSizeBinaryValues> FixedSizeBinaryValuesIter<'a, T> {
-    #[inline]
-    pub fn new(array: &'a T) -> Self {
-        Self {
-            array,
-            len: array.values().len() / array.size(),
-            index: 0,
-        }
-    }
-}
-
-impl<'a, T: FixedSizeBinaryValues> Iterator for FixedSizeBinaryValuesIter<'a, T> {
+unsafe impl<'a> ArrayAccessor<'a> for FixedSizeBinaryArray {
     type Item = &'a [u8];
 
     #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.index >= self.len {
-            return None;
-        }
-        let index = self.index;
-        let r = Some(unsafe {
-            self.array
-                .values()
-                .get_unchecked(index * self.array.size()..(index + 1) * self.array.size())
-        });
-        self.index += 1;
-        r
+    unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
+        self.value_unchecked(index)
     }
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len - self.index, Some(self.len - self.index))
+    #[inline]
+    fn len(&self) -> usize {
+        self.len()
     }
 }
 
+unsafe impl<'a> ArrayAccessor<'a> for MutableFixedSizeBinaryArray {
+    type Item = &'a [u8];
+
+    #[inline]
+    unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
+        self.value_unchecked(index)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+/// Iterator of values of an [`FixedSizeBinaryArray`].
+pub type FixedSizeBinaryValuesIter<'a> = ArrayValuesIter<'a, FixedSizeBinaryArray>;
+pub type MutableFixedSizeBinaryValuesIter<'a> = ArrayValuesIter<'a, MutableFixedSizeBinaryArray>;
+
 impl<'a> IntoIterator for &'a FixedSizeBinaryArray {
     type Item = Option<&'a [u8]>;
-    type IntoIter = ZipValidity<'a, &'a [u8], FixedSizeBinaryValuesIter<'a, FixedSizeBinaryArray>>;
+    type IntoIter = ZipValidity<'a, &'a [u8], FixedSizeBinaryValuesIter<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -56,22 +46,19 @@ impl<'a> IntoIterator for &'a FixedSizeBinaryArray {
 
 impl<'a> FixedSizeBinaryArray {
     /// constructs a new iterator
-    pub fn iter(
-        &'a self,
-    ) -> ZipValidity<'a, &'a [u8], FixedSizeBinaryValuesIter<'a, FixedSizeBinaryArray>> {
+    pub fn iter(&'a self) -> ZipValidity<'a, &'a [u8], FixedSizeBinaryValuesIter<'a>> {
         zip_validity(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
     }
 
     /// Returns iterator over the values of [`FixedSizeBinaryArray`]
-    pub fn values_iter(&'a self) -> FixedSizeBinaryValuesIter<'a, FixedSizeBinaryArray> {
+    pub fn values_iter(&'a self) -> FixedSizeBinaryValuesIter<'a> {
         FixedSizeBinaryValuesIter::new(self)
     }
 }
 
 impl<'a> IntoIterator for &'a MutableFixedSizeBinaryArray {
     type Item = Option<&'a [u8]>;
-    type IntoIter =
-        ZipValidity<'a, &'a [u8], FixedSizeBinaryValuesIter<'a, MutableFixedSizeBinaryArray>>;
+    type IntoIter = ZipValidity<'a, &'a [u8], MutableFixedSizeBinaryValuesIter<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -80,9 +67,7 @@ impl<'a> IntoIterator for &'a MutableFixedSizeBinaryArray {
 
 impl<'a> MutableFixedSizeBinaryArray {
     /// constructs a new iterator
-    pub fn iter(
-        &'a self,
-    ) -> ZipValidity<'a, &'a [u8], FixedSizeBinaryValuesIter<'a, MutableFixedSizeBinaryArray>> {
+    pub fn iter(&'a self) -> ZipValidity<'a, &'a [u8], MutableFixedSizeBinaryValuesIter<'a>> {
         zip_validity(
             self.iter_values(),
             self.validity().as_ref().map(|x| x.iter()),
@@ -90,7 +75,7 @@ impl<'a> MutableFixedSizeBinaryArray {
     }
 
     /// Returns iterator over the values of [`MutableFixedSizeBinaryArray`]
-    pub fn iter_values(&'a self) -> FixedSizeBinaryValuesIter<'a, MutableFixedSizeBinaryArray> {
-        FixedSizeBinaryValuesIter::new(self)
+    pub fn iter_values(&'a self) -> MutableFixedSizeBinaryValuesIter<'a> {
+        MutableFixedSizeBinaryValuesIter::new(self)
     }
 }

--- a/src/array/fixed_size_binary/iterator.rs
+++ b/src/array/fixed_size_binary/iterator.rs
@@ -1,43 +1,13 @@
-use crate::array::{ArrayAccessor, ArrayValuesIter, MutableArray};
-use crate::bitmap::utils::{BitmapIter, ZipValidity};
+use crate::{
+    array::MutableArray,
+    bitmap::utils::{BitmapIter, ZipValidity},
+};
 
 use super::{FixedSizeBinaryArray, MutableFixedSizeBinaryArray};
 
-unsafe impl<'a> ArrayAccessor<'a> for FixedSizeBinaryArray {
-    type Item = &'a [u8];
-
-    #[inline]
-    unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        self.value_unchecked(index)
-    }
-
-    #[inline]
-    fn len(&self) -> usize {
-        self.len()
-    }
-}
-
-unsafe impl<'a> ArrayAccessor<'a> for MutableFixedSizeBinaryArray {
-    type Item = &'a [u8];
-
-    #[inline]
-    unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        self.value_unchecked(index)
-    }
-
-    #[inline]
-    fn len(&self) -> usize {
-        self.len()
-    }
-}
-
-/// Iterator of values of an [`FixedSizeBinaryArray`].
-pub type FixedSizeBinaryValuesIter<'a> = ArrayValuesIter<'a, FixedSizeBinaryArray>;
-pub type MutableFixedSizeBinaryValuesIter<'a> = ArrayValuesIter<'a, MutableFixedSizeBinaryArray>;
-
 impl<'a> IntoIterator for &'a FixedSizeBinaryArray {
     type Item = Option<&'a [u8]>;
-    type IntoIter = ZipValidity<&'a [u8], FixedSizeBinaryValuesIter<'a>, BitmapIter<'a>>;
+    type IntoIter = ZipValidity<&'a [u8], std::slice::ChunksExact<'a, u8>, BitmapIter<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -46,19 +16,21 @@ impl<'a> IntoIterator for &'a FixedSizeBinaryArray {
 
 impl<'a> FixedSizeBinaryArray {
     /// constructs a new iterator
-    pub fn iter(&'a self) -> ZipValidity<&'a [u8], FixedSizeBinaryValuesIter<'a>, BitmapIter<'a>> {
+    pub fn iter(
+        &'a self,
+    ) -> ZipValidity<&'a [u8], std::slice::ChunksExact<'a, u8>, BitmapIter<'a>> {
         ZipValidity::new(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
     }
 
     /// Returns iterator over the values of [`FixedSizeBinaryArray`]
-    pub fn values_iter(&'a self) -> FixedSizeBinaryValuesIter<'a> {
-        FixedSizeBinaryValuesIter::new(self)
+    pub fn values_iter(&'a self) -> std::slice::ChunksExact<'a, u8> {
+        self.values().chunks_exact(self.size)
     }
 }
 
 impl<'a> IntoIterator for &'a MutableFixedSizeBinaryArray {
     type Item = Option<&'a [u8]>;
-    type IntoIter = ZipValidity<&'a [u8], MutableFixedSizeBinaryValuesIter<'a>, BitmapIter<'a>>;
+    type IntoIter = ZipValidity<&'a [u8], std::slice::ChunksExact<'a, u8>, BitmapIter<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -69,7 +41,7 @@ impl<'a> MutableFixedSizeBinaryArray {
     /// constructs a new iterator
     pub fn iter(
         &'a self,
-    ) -> ZipValidity<&'a [u8], MutableFixedSizeBinaryValuesIter<'a>, BitmapIter<'a>> {
+    ) -> ZipValidity<&'a [u8], std::slice::ChunksExact<'a, u8>, BitmapIter<'a>> {
         ZipValidity::new(
             self.iter_values(),
             self.validity().as_ref().map(|x| x.iter()),
@@ -77,7 +49,7 @@ impl<'a> MutableFixedSizeBinaryArray {
     }
 
     /// Returns iterator over the values of [`MutableFixedSizeBinaryArray`]
-    pub fn iter_values(&'a self) -> MutableFixedSizeBinaryValuesIter<'a> {
-        MutableFixedSizeBinaryValuesIter::new(self)
+    pub fn iter_values(&'a self) -> std::slice::ChunksExact<'a, u8> {
+        self.values().chunks_exact(self.size())
     }
 }

--- a/src/array/fixed_size_binary/mutable.rs
+++ b/src/array/fixed_size_binary/mutable.rs
@@ -112,6 +112,12 @@ impl MutableFixedSizeBinaryArray {
         self.try_push(value).unwrap()
     }
 
+    /// Returns the length of this array
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.values.len() / self.size as usize
+    }
+
     /// Pop the last entry from [`MutableFixedSizeBinaryArray`].
     /// This function returns `None` iff this array is empty
     pub fn pop(&mut self) -> Option<Vec<u8>> {

--- a/src/array/fixed_size_list/iterator.rs
+++ b/src/array/fixed_size_list/iterator.rs
@@ -1,18 +1,28 @@
 use crate::{
-    array::{list::ListValuesIter, Array, IterableListArray},
+    array::{Array, ArrayAccessor, ArrayValuesIter},
     bitmap::utils::{zip_validity, ZipValidity},
 };
 
 use super::FixedSizeListArray;
 
-impl IterableListArray for FixedSizeListArray {
-    unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array> {
-        FixedSizeListArray::value_unchecked(self, i)
+unsafe impl<'a> ArrayAccessor<'a> for FixedSizeListArray {
+    type Item = Box<dyn Array>;
+
+    #[inline]
+    unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
+        self.value_unchecked(index)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.len()
     }
 }
 
-type ValuesIter<'a> = ListValuesIter<'a, FixedSizeListArray>;
-type ZipIter<'a> = ZipValidity<'a, Box<dyn Array>, ValuesIter<'a>>;
+/// Iterator of values of a [`FixedSizeListArray`].
+pub type FixedSizeListValuesIter<'a> = ArrayValuesIter<'a, FixedSizeListArray>;
+
+type ZipIter<'a> = ZipValidity<'a, Box<dyn Array>, FixedSizeListValuesIter<'a>>;
 
 impl<'a> IntoIterator for &'a FixedSizeListArray {
     type Item = Option<Box<dyn Array>>;
@@ -27,13 +37,13 @@ impl<'a> FixedSizeListArray {
     /// Returns an iterator of `Option<Box<dyn Array>>`
     pub fn iter(&'a self) -> ZipIter<'a> {
         zip_validity(
-            ListValuesIter::new(self),
+            FixedSizeListValuesIter::new(self),
             self.validity.as_ref().map(|x| x.iter()),
         )
     }
 
     /// Returns an iterator of `Box<dyn Array>`
-    pub fn values_iter(&'a self) -> ValuesIter<'a> {
-        ListValuesIter::new(self)
+    pub fn values_iter(&'a self) -> FixedSizeListValuesIter<'a> {
+        FixedSizeListValuesIter::new(self)
     }
 }

--- a/src/array/fixed_size_list/iterator.rs
+++ b/src/array/fixed_size_list/iterator.rs
@@ -1,6 +1,6 @@
 use crate::{
     array::{Array, ArrayAccessor, ArrayValuesIter},
-    bitmap::utils::{zip_validity, ZipValidity},
+    bitmap::utils::{zip_validity, BitmapIter, ZipValidity},
 };
 
 use super::FixedSizeListArray;
@@ -22,7 +22,7 @@ unsafe impl<'a> ArrayAccessor<'a> for FixedSizeListArray {
 /// Iterator of values of a [`FixedSizeListArray`].
 pub type FixedSizeListValuesIter<'a> = ArrayValuesIter<'a, FixedSizeListArray>;
 
-type ZipIter<'a> = ZipValidity<'a, Box<dyn Array>, FixedSizeListValuesIter<'a>>;
+type ZipIter<'a> = ZipValidity<Box<dyn Array>, FixedSizeListValuesIter<'a>, BitmapIter<'a>>;
 
 impl<'a> IntoIterator for &'a FixedSizeListArray {
     type Item = Option<Box<dyn Array>>;

--- a/src/array/fixed_size_list/iterator.rs
+++ b/src/array/fixed_size_list/iterator.rs
@@ -1,6 +1,6 @@
 use crate::{
     array::{Array, ArrayAccessor, ArrayValuesIter},
-    bitmap::utils::{zip_validity, BitmapIter, ZipValidity},
+    bitmap::utils::{BitmapIter, ZipValidity},
 };
 
 use super::FixedSizeListArray;
@@ -36,7 +36,7 @@ impl<'a> IntoIterator for &'a FixedSizeListArray {
 impl<'a> FixedSizeListArray {
     /// Returns an iterator of `Option<Box<dyn Array>>`
     pub fn iter(&'a self) -> ZipIter<'a> {
-        zip_validity(
+        ZipValidity::new(
             FixedSizeListValuesIter::new(self),
             self.validity.as_ref().map(|x| x.iter()),
         )

--- a/src/array/iterator.rs
+++ b/src/array/iterator.rs
@@ -17,7 +17,7 @@ pub unsafe trait ArrayAccessor<'a>: private::Sealed {
     fn len(&self) -> usize;
 }
 
-/// Iterator of values of an `ArrayAccessor`.
+/// Iterator of values of an [`ArrayAccessor`].
 #[derive(Debug, Clone)]
 pub struct ArrayValuesIter<'a, A: ArrayAccessor<'a>> {
     array: &'a A,

--- a/src/array/iterator.rs
+++ b/src/array/iterator.rs
@@ -6,11 +6,10 @@ mod private {
     impl<'a, T: super::ArrayAccessor<'a>> Sealed for T {}
 }
 
-///
+/// Sealed trait representing assess to a value of an array.
 /// # Safety
 /// Implementers of this trait guarantee that
 /// `value_unchecked` is safe when called up to `len`
-/// Implementations must guarantee that
 pub unsafe trait ArrayAccessor<'a>: private::Sealed {
     type Item: 'a;
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item;

--- a/src/array/list/iterator.rs
+++ b/src/array/list/iterator.rs
@@ -1,6 +1,6 @@
 use crate::array::Offset;
 use crate::array::{Array, ArrayAccessor, ArrayValuesIter};
-use crate::bitmap::utils::{zip_validity, ZipValidity};
+use crate::bitmap::utils::{zip_validity, BitmapIter, ZipValidity};
 
 use super::ListArray;
 
@@ -21,7 +21,7 @@ unsafe impl<'a, O: Offset> ArrayAccessor<'a> for ListArray<O> {
 /// Iterator of values of a [`ListArray`].
 pub type ListValuesIter<'a, O> = ArrayValuesIter<'a, ListArray<O>>;
 
-type ZipIter<'a, O> = ZipValidity<'a, Box<dyn Array>, ListValuesIter<'a, O>>;
+type ZipIter<'a, O> = ZipValidity<Box<dyn Array>, ListValuesIter<'a, O>, BitmapIter<'a>>;
 
 impl<'a, O: Offset> IntoIterator for &'a ListArray<O> {
     type Item = Option<Box<dyn Array>>;

--- a/src/array/list/iterator.rs
+++ b/src/array/list/iterator.rs
@@ -1,72 +1,27 @@
-use crate::array::{Array, IterableListArray};
+use crate::array::Offset;
+use crate::array::{Array, ArrayAccessor, ArrayValuesIter};
 use crate::bitmap::utils::{zip_validity, ZipValidity};
-use crate::{array::Offset, trusted_len::TrustedLen};
 
 use super::ListArray;
 
-/// Iterator of values of an [`ListArray`].
-pub struct ListValuesIter<'a, A: IterableListArray> {
-    array: &'a A,
-    index: usize,
-    end: usize,
-}
-
-impl<'a, A: IterableListArray> ListValuesIter<'a, A> {
-    #[inline]
-    pub(crate) fn new(array: &'a A) -> Self {
-        Self {
-            array,
-            index: 0,
-            end: array.len(),
-        }
-    }
-}
-
-impl<'a, A: IterableListArray> Iterator for ListValuesIter<'a, A> {
+unsafe impl<'a, O: Offset> ArrayAccessor<'a> for ListArray<O> {
     type Item = Box<dyn Array>;
 
     #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.index == self.end {
-            return None;
-        }
-        let old = self.index;
-        self.index += 1;
-        // Safety:
-        // self.end is maximized by the length of the array
-        Some(unsafe { self.array.value_unchecked(old) })
+    unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
+        self.value_unchecked(index)
     }
 
     #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.end - self.index, Some(self.end - self.index))
+    fn len(&self) -> usize {
+        self.len()
     }
 }
 
-unsafe impl<'a, A: IterableListArray> TrustedLen for ListValuesIter<'a, A> {}
+/// Iterator of values of a [`ListArray`].
+pub type ListValuesIter<'a, O> = ArrayValuesIter<'a, ListArray<O>>;
 
-impl<'a, A: IterableListArray> DoubleEndedIterator for ListValuesIter<'a, A> {
-    #[inline]
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.index == self.end {
-            None
-        } else {
-            self.end -= 1;
-            // Safety:
-            // self.end is maximized by the length of the array
-            Some(unsafe { self.array.value_unchecked(self.end) })
-        }
-    }
-}
-
-impl<O: Offset> IterableListArray for ListArray<O> {
-    unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array> {
-        ListArray::<O>::value_unchecked(self, i)
-    }
-}
-
-type ValuesIter<'a, O> = ListValuesIter<'a, ListArray<O>>;
-type ZipIter<'a, O> = ZipValidity<'a, Box<dyn Array>, ValuesIter<'a, O>>;
+type ZipIter<'a, O> = ZipValidity<'a, Box<dyn Array>, ListValuesIter<'a, O>>;
 
 impl<'a, O: Offset> IntoIterator for &'a ListArray<O> {
     type Item = Option<Box<dyn Array>>;
@@ -87,7 +42,7 @@ impl<'a, O: Offset> ListArray<O> {
     }
 
     /// Returns an iterator of `Box<dyn Array>`
-    pub fn values_iter(&'a self) -> ValuesIter<'a, O> {
+    pub fn values_iter(&'a self) -> ListValuesIter<'a, O> {
         ListValuesIter::new(self)
     }
 }

--- a/src/array/list/iterator.rs
+++ b/src/array/list/iterator.rs
@@ -1,6 +1,6 @@
 use crate::array::Offset;
 use crate::array::{Array, ArrayAccessor, ArrayValuesIter};
-use crate::bitmap::utils::{zip_validity, BitmapIter, ZipValidity};
+use crate::bitmap::utils::{BitmapIter, ZipValidity};
 
 use super::ListArray;
 
@@ -35,7 +35,7 @@ impl<'a, O: Offset> IntoIterator for &'a ListArray<O> {
 impl<'a, O: Offset> ListArray<O> {
     /// Returns an iterator of `Option<Box<dyn Array>>`
     pub fn iter(&'a self) -> ZipIter<'a, O> {
-        zip_validity(
+        ZipValidity::new(
             ListValuesIter::new(self),
             self.validity.as_ref().map(|x| x.iter()),
         )

--- a/src/array/map/iterator.rs
+++ b/src/array/map/iterator.rs
@@ -1,5 +1,5 @@
 use crate::array::Array;
-use crate::bitmap::utils::{zip_validity, BitmapIter, ZipValidity};
+use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::trusted_len::TrustedLen;
 
 use super::MapArray;
@@ -72,7 +72,7 @@ impl<'a> IntoIterator for &'a MapArray {
 impl<'a> MapArray {
     /// Returns an iterator of `Option<Box<dyn Array>>`
     pub fn iter(&'a self) -> ZipValidity<Box<dyn Array>, MapValuesIter<'a>, BitmapIter<'a>> {
-        zip_validity(
+        ZipValidity::new(
             MapValuesIter::new(self),
             self.validity.as_ref().map(|x| x.iter()),
         )

--- a/src/array/map/iterator.rs
+++ b/src/array/map/iterator.rs
@@ -1,5 +1,5 @@
 use crate::array::Array;
-use crate::bitmap::utils::{zip_validity, ZipValidity};
+use crate::bitmap::utils::{zip_validity, BitmapIter, ZipValidity};
 use crate::trusted_len::TrustedLen;
 
 use super::MapArray;
@@ -62,7 +62,7 @@ impl<'a> DoubleEndedIterator for MapValuesIter<'a> {
 
 impl<'a> IntoIterator for &'a MapArray {
     type Item = Option<Box<dyn Array>>;
-    type IntoIter = ZipValidity<'a, Box<dyn Array>, MapValuesIter<'a>>;
+    type IntoIter = ZipValidity<Box<dyn Array>, MapValuesIter<'a>, BitmapIter<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -71,7 +71,7 @@ impl<'a> IntoIterator for &'a MapArray {
 
 impl<'a> MapArray {
     /// Returns an iterator of `Option<Box<dyn Array>>`
-    pub fn iter(&'a self) -> ZipValidity<'a, Box<dyn Array>, MapValuesIter<'a>> {
+    pub fn iter(&'a self) -> ZipValidity<Box<dyn Array>, MapValuesIter<'a>, BitmapIter<'a>> {
         zip_validity(
             MapValuesIter::new(self),
             self.validity.as_ref().map(|x| x.iter()),

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -417,13 +417,6 @@ pub trait TryPush<A> {
     fn try_push(&mut self, item: A) -> Result<()>;
 }
 
-/// Trait that list arrays implement for the purposes of DRY.
-pub trait IterableListArray: Array {
-    /// # Safety
-    /// The caller must ensure that `i < self.len()`
-    unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array>;
-}
-
 /// Trait that [`BinaryArray`] and [`Utf8Array`] implement for the purposes of DRY.
 /// # Safety
 /// The implementer must ensure that

--- a/src/array/physical_binary.rs
+++ b/src/array/physical_binary.rs
@@ -159,7 +159,6 @@ pub(crate) unsafe fn extend_from_trusted_len_values_iter<I, P, O>(
 
 // Populates `offsets` and `values` [`Vec`]s with information extracted
 // from the incoming `iterator`.
-
 // the return value indicates how many items were added.
 #[inline]
 pub(crate) fn extend_from_values_iter<I, P, O>(

--- a/src/array/primitive/iterator.rs
+++ b/src/array/primitive/iterator.rs
@@ -1,6 +1,6 @@
 use crate::{
     array::MutableArray,
-    bitmap::utils::{zip_validity, BitmapIter, ZipValidity},
+    bitmap::utils::{BitmapIter, ZipValidity},
     bitmap::IntoIter as BitmapIntoIter,
     buffer::IntoIter,
     types::NativeType,
@@ -35,7 +35,7 @@ impl<'a, T: NativeType> MutablePrimitiveArray<T> {
     /// Returns an iterator over `Option<T>`
     #[inline]
     pub fn iter(&'a self) -> ZipValidity<&'a T, std::slice::Iter<'a, T>, BitmapIter<'a>> {
-        zip_validity(
+        ZipValidity::new(
             self.values().iter(),
             self.validity().as_ref().map(|x| x.iter()),
         )

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     bitmap::{
-        utils::{zip_validity, BitmapIter, ZipValidity},
+        utils::{BitmapIter, ZipValidity},
         Bitmap,
     },
     buffer::Buffer,
@@ -141,7 +141,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// Returns an iterator over the values and validity, `Option<&T>`.
     #[inline]
     pub fn iter(&self) -> ZipValidity<&T, std::slice::Iter<T>, BitmapIter> {
-        zip_validity(
+        ZipValidity::new(
             self.values().iter(),
             self.validity().as_ref().map(|x| x.iter()),
         )

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     bitmap::{
-        utils::{zip_validity, ZipValidity},
+        utils::{zip_validity, BitmapIter, ZipValidity},
         Bitmap,
     },
     buffer::Buffer,
@@ -140,7 +140,7 @@ impl<T: NativeType> PrimitiveArray<T> {
 
     /// Returns an iterator over the values and validity, `Option<&T>`.
     #[inline]
-    pub fn iter(&self) -> ZipValidity<&T, std::slice::Iter<T>> {
+    pub fn iter(&self) -> ZipValidity<&T, std::slice::Iter<T>, BitmapIter> {
         zip_validity(
             self.values().iter(),
             self.validity().as_ref().map(|x| x.iter()),
@@ -295,6 +295,17 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// Returns an option of a mutable reference to the values of this [`PrimitiveArray`].
     pub fn get_mut_values(&mut self) -> Option<&mut [T]> {
         self.values.get_mut().map(|x| x.as_mut())
+    }
+
+    /// Returns its internal representation
+    #[must_use]
+    pub fn into_inner(self) -> (DataType, Buffer<T>, Option<Bitmap>) {
+        let Self {
+            data_type,
+            values,
+            validity,
+        } = self;
+        (data_type, values, validity)
     }
 
     /// Try to convert this [`PrimitiveArray`] to a [`MutablePrimitiveArray`] via copy-on-write semantics.

--- a/src/array/struct_/iterator.rs
+++ b/src/array/struct_/iterator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bitmap::utils::{zip_validity, BitmapIter, ZipValidity},
+    bitmap::utils::{BitmapIter, ZipValidity},
     scalar::{new_scalar, Scalar},
     trusted_len::TrustedLen,
 };
@@ -89,7 +89,7 @@ impl<'a> IntoIterator for &'a StructArray {
 impl<'a> StructArray {
     /// Returns an iterator of `Option<Box<dyn Array>>`
     pub fn iter(&'a self) -> ZipIter<'a> {
-        zip_validity(
+        ZipValidity::new(
             StructValueIter::new(self),
             self.validity.as_ref().map(|x| x.iter()),
         )

--- a/src/array/struct_/iterator.rs
+++ b/src/array/struct_/iterator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bitmap::utils::{zip_validity, ZipValidity},
+    bitmap::utils::{zip_validity, BitmapIter, ZipValidity},
     scalar::{new_scalar, Scalar},
     trusted_len::TrustedLen,
 };
@@ -75,7 +75,7 @@ impl<'a> DoubleEndedIterator for StructValueIter<'a> {
 }
 
 type ValuesIter<'a> = StructValueIter<'a>;
-type ZipIter<'a> = ZipValidity<'a, Vec<Box<dyn Scalar>>, ValuesIter<'a>>;
+type ZipIter<'a> = ZipValidity<Vec<Box<dyn Scalar>>, ValuesIter<'a>, BitmapIter<'a>>;
 
 impl<'a> IntoIterator for &'a StructArray {
     type Item = Option<Vec<Box<dyn Scalar>>>;

--- a/src/array/utf8/iterator.rs
+++ b/src/array/utf8/iterator.rs
@@ -1,5 +1,5 @@
 use crate::array::{ArrayAccessor, ArrayValuesIter, Offset};
-use crate::bitmap::utils::ZipValidity;
+use crate::bitmap::utils::{BitmapIter, ZipValidity};
 
 use super::{MutableUtf8Array, MutableUtf8ValuesArray, Utf8Array};
 
@@ -22,7 +22,7 @@ pub type Utf8ValuesIter<'a, O> = ArrayValuesIter<'a, Utf8Array<O>>;
 
 impl<'a, O: Offset> IntoIterator for &'a Utf8Array<O> {
     type Item = Option<&'a str>;
-    type IntoIter = ZipValidity<'a, &'a str, Utf8ValuesIter<'a, O>>;
+    type IntoIter = ZipValidity<&'a str, Utf8ValuesIter<'a, O>, BitmapIter<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -48,7 +48,7 @@ pub type MutableUtf8ValuesIter<'a, O> = ArrayValuesIter<'a, MutableUtf8ValuesArr
 
 impl<'a, O: Offset> IntoIterator for &'a MutableUtf8Array<O> {
     type Item = Option<&'a str>;
-    type IntoIter = ZipValidity<'a, &'a str, MutableUtf8ValuesIter<'a, O>>;
+    type IntoIter = ZipValidity<&'a str, MutableUtf8ValuesIter<'a, O>, BitmapIter<'a>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     bitmap::{
-        utils::{zip_validity, BitmapIter, ZipValidity},
+        utils::{BitmapIter, ZipValidity},
         Bitmap,
     },
     buffer::Buffer,
@@ -133,7 +133,7 @@ impl<O: Offset> Utf8Array<O> {
 
     /// Returns an iterator of `Option<&str>`
     pub fn iter(&self) -> ZipValidity<&str, Utf8ValuesIter<O>, BitmapIter> {
-        zip_validity(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
+        ZipValidity::new(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
     }
 
     /// Returns an iterator of `&str`

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     bitmap::{
-        utils::{zip_validity, ZipValidity},
+        utils::{zip_validity, BitmapIter, ZipValidity},
         Bitmap,
     },
     buffer::Buffer,
@@ -132,7 +132,7 @@ impl<O: Offset> Utf8Array<O> {
     }
 
     /// Returns an iterator of `Option<&str>`
-    pub fn iter(&self) -> ZipValidity<&str, Utf8ValuesIter<O>> {
+    pub fn iter(&self) -> ZipValidity<&str, Utf8ValuesIter<O>, BitmapIter> {
         zip_validity(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
     }
 

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -4,7 +4,7 @@ use crate::array::physical_binary::*;
 use crate::{
     array::{Array, MutableArray, Offset, TryExtend, TryPush},
     bitmap::{
-        utils::{zip_validity, ZipValidity},
+        utils::{zip_validity, BitmapIter, ZipValidity},
         Bitmap, MutableBitmap,
     },
     datatypes::DataType,
@@ -205,7 +205,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// Returns an iterator of `Option<&str>`
-    pub fn iter(&self) -> ZipValidity<&str, MutableUtf8ValuesIter<O>> {
+    pub fn iter(&self) -> ZipValidity<&str, MutableUtf8ValuesIter<O>, BitmapIter> {
         zip_validity(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
     }
 

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -4,7 +4,7 @@ use crate::array::physical_binary::*;
 use crate::{
     array::{Array, MutableArray, Offset, TryExtend, TryPush},
     bitmap::{
-        utils::{zip_validity, BitmapIter, ZipValidity},
+        utils::{BitmapIter, ZipValidity},
         Bitmap, MutableBitmap,
     },
     datatypes::DataType,
@@ -206,7 +206,7 @@ impl<O: Offset> MutableUtf8Array<O> {
 
     /// Returns an iterator of `Option<&str>`
     pub fn iter(&self) -> ZipValidity<&str, MutableUtf8ValuesIter<O>, BitmapIter> {
-        zip_validity(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
+        ZipValidity::new(self.values_iter(), self.validity.as_ref().map(|x| x.iter()))
     }
 
     /// Converts itself into an [`Array`].

--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -7,7 +7,7 @@ use crate::{buffer::Bytes, error::Error, trusted_len::TrustedLen};
 use super::{
     chunk_iter_to_vec,
     utils::{count_zeros, fmt, get_bit, get_bit_unchecked, BitChunk, BitChunks, BitmapIter},
-    MutableBitmap,
+    IntoIter, MutableBitmap,
 };
 
 /// An immutable container semantically equivalent to `Arc<Vec<bool>>` but represented as `Arc<Vec<u8>>` where
@@ -363,5 +363,14 @@ impl<'a> IntoIterator for &'a Bitmap {
 
     fn into_iter(self) -> Self::IntoIter {
         BitmapIter::<'a>::new(&self.bytes, self.offset, self.length)
+    }
+}
+
+impl IntoIterator for Bitmap {
+    type Item = bool;
+    type IntoIter = IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter::new(self)
     }
 }

--- a/src/bitmap/iterator.rs
+++ b/src/bitmap/iterator.rs
@@ -1,0 +1,69 @@
+use crate::trusted_len::TrustedLen;
+
+use super::Bitmap;
+
+/// This crates' equivalent of [`std::vec::IntoIter`] for [`Bitmap`].
+#[derive(Debug, Clone)]
+pub struct IntoIter {
+    values: Bitmap,
+    index: usize,
+    end: usize,
+}
+
+impl IntoIter {
+    /// Creates a new [`IntoIter`] from a [`Bitmap`]
+    #[inline]
+    pub fn new(values: Bitmap) -> Self {
+        let end = values.len();
+        Self {
+            values,
+            index: 0,
+            end,
+        }
+    }
+}
+
+impl Iterator for IntoIter {
+    type Item = bool;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index == self.end {
+            return None;
+        }
+        let old = self.index;
+        self.index += 1;
+        Some(unsafe { self.values.get_bit_unchecked(old) })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.end - self.index, Some(self.end - self.index))
+    }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let new_index = self.index + n;
+        if new_index > self.end {
+            self.index = self.end;
+            None
+        } else {
+            self.index = new_index;
+            self.next()
+        }
+    }
+}
+
+impl DoubleEndedIterator for IntoIter {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index == self.end {
+            None
+        } else {
+            self.end -= 1;
+            Some(unsafe { self.values.get_bit_unchecked(self.end) })
+        }
+    }
+}
+
+unsafe impl TrustedLen for IntoIter {}

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -2,6 +2,9 @@
 mod immutable;
 pub use immutable::*;
 
+mod iterator;
+pub use iterator::IntoIter;
+
 mod mutable;
 pub use mutable::MutableBitmap;
 

--- a/src/bitmap/utils/mod.rs
+++ b/src/bitmap/utils/mod.rs
@@ -141,11 +141,3 @@ pub fn count_zeros(slice: &[u8], offset: usize, len: usize) -> usize {
 
     len - set_count
 }
-
-/// Returns an iterator adapter that returns Option<T> according to an optional validity.
-pub fn zip_validity<T, I: Iterator<Item = T>>(
-    values: I,
-    validity: Option<BitmapIter>,
-) -> ZipValidity<T, I, BitmapIter> {
-    ZipValidity::new(values, validity)
-}

--- a/src/bitmap/utils/mod.rs
+++ b/src/bitmap/utils/mod.rs
@@ -14,7 +14,7 @@ pub use chunks_exact_mut::BitChunksExactMut;
 pub use fmt::fmt;
 pub use iterator::BitmapIter;
 pub use slice_iterator::SlicesIterator;
-pub use zip_validity::{zip_validity, ZipValidity};
+pub use zip_validity::{ZipValidity, ZipValidityIter};
 
 const BIT_MASK: [u8; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
 const UNSET_BIT_MASK: [u8; 8] = [
@@ -140,4 +140,12 @@ pub fn count_zeros(slice: &[u8], offset: usize, len: usize) -> usize {
         .sum::<usize>();
 
     len - set_count
+}
+
+/// Returns an iterator adapter that returns Option<T> according to an optional validity.
+pub fn zip_validity<T, I: Iterator<Item = T>>(
+    values: I,
+    validity: Option<BitmapIter>,
+) -> ZipValidity<T, I, BitmapIter> {
+    ZipValidity::new(values, validity)
 }

--- a/src/buffer/iterator.rs
+++ b/src/buffer/iterator.rs
@@ -1,0 +1,69 @@
+use crate::trusted_len::TrustedLen;
+
+use super::Buffer;
+
+/// This crates' equivalent of [`std::vec::IntoIter`] for [`Buffer`].
+#[derive(Debug, Clone)]
+pub struct IntoIter<T: Copy> {
+    values: Buffer<T>,
+    index: usize,
+    end: usize,
+}
+
+impl<T: Copy> IntoIter<T> {
+    /// Creates a new [`Buffer`]
+    #[inline]
+    pub fn new(values: Buffer<T>) -> Self {
+        let end = values.len();
+        Self {
+            values,
+            index: 0,
+            end,
+        }
+    }
+}
+
+impl<T: Copy> Iterator for IntoIter<T> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index == self.end {
+            return None;
+        }
+        let old = self.index;
+        self.index += 1;
+        Some(*unsafe { self.values.get_unchecked(old) })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.end - self.index, Some(self.end - self.index))
+    }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        let new_index = self.index + n;
+        if new_index > self.end {
+            self.index = self.end;
+            None
+        } else {
+            self.index = new_index;
+            self.next()
+        }
+    }
+}
+
+impl<T: Copy> DoubleEndedIterator for IntoIter<T> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index == self.end {
+            None
+        } else {
+            self.end -= 1;
+            Some(*unsafe { self.values.get_unchecked(self.end) })
+        }
+    }
+}
+
+unsafe impl<T: Copy> TrustedLen for IntoIter<T> {}

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -1,9 +1,11 @@
 //! Contains [`Buffer`], an immutable container for all Arrow physical types (e.g. i32, f64).
 
 mod immutable;
+mod iterator;
 
 use crate::ffi::InternalArrowArray;
 
 pub(crate) type Bytes<T> = foreign_vec::ForeignVec<InternalArrowArray, T>;
+pub(super) use iterator::IntoIter;
 
 pub use immutable::Buffer;

--- a/src/io/avro/write/serialize.rs
+++ b/src/io/avro/write/serialize.rs
@@ -1,7 +1,7 @@
 use avro_schema::schema::{Record, Schema as AvroSchema};
 use avro_schema::write::encode;
 
-use crate::bitmap::utils::zip_validity;
+use crate::bitmap::utils::ZipValidity;
 use crate::datatypes::{IntervalUnit, PhysicalType, PrimitiveType};
 use crate::types::months_days_ns;
 use crate::{array::*, datatypes::DataType};
@@ -126,7 +126,7 @@ fn list_optional<'a, O: Offset>(array: &'a ListArray<O>, schema: &AvroSchema) ->
         .offsets()
         .windows(2)
         .map(|w| (w[1] - w[0]).to_usize() as i64);
-    let lengths = zip_validity(lengths, array.validity().as_ref().map(|x| x.iter()));
+    let lengths = ZipValidity::new(lengths, array.validity().as_ref().map(|x| x.iter()));
 
     Box::new(BufStreamingIterator::new(
         lengths,
@@ -180,7 +180,7 @@ fn struct_optional<'a>(array: &'a StructArray, schema: &Record) -> BoxSerializer
         .map(|(x, schema)| new_serializer(x.as_ref(), schema))
         .collect::<Vec<_>>();
 
-    let iterator = zip_validity(0..array.len(), array.validity().as_ref().map(|x| x.iter()));
+    let iterator = ZipValidity::new(0..array.len(), array.validity().as_ref().map(|x| x.iter()));
 
     Box::new(BufStreamingIterator::new(
         iterator,

--- a/src/io/json/write/serialize.rs
+++ b/src/io/json/write/serialize.rs
@@ -3,7 +3,7 @@ use lexical_core::ToLexical;
 use std::io::Write;
 use streaming_iterator::StreamingIterator;
 
-use crate::bitmap::utils::zip_validity;
+use crate::bitmap::utils::ZipValidity;
 use crate::datatypes::TimeUnit;
 use crate::io::iterator::BufStreamingIterator;
 use crate::temporal_conversions::{
@@ -103,7 +103,7 @@ fn struct_serializer<'a>(
     let names = array.fields().iter().map(|f| f.name.as_str());
 
     Box::new(BufStreamingIterator::new(
-        zip_validity(0..array.len(), array.validity().map(|x| x.iter())),
+        ZipValidity::new(0..array.len(), array.validity().map(|x| x.iter())),
         move |maybe, buf| {
             if maybe.is_some() {
                 let names = names.clone();
@@ -140,7 +140,7 @@ fn list_serializer<'a, O: Offset>(
     let mut serializer = new_serializer(array.values().as_ref());
 
     Box::new(BufStreamingIterator::new(
-        zip_validity(
+        ZipValidity::new(
             array.offsets().windows(2),
             array.validity().map(|x| x.iter()),
         ),

--- a/tests/it/array/boolean/mod.rs
+++ b/tests/it/array/boolean/mod.rs
@@ -131,3 +131,15 @@ fn from_iter() {
     let a: BooleanArray = iter.collect();
     assert_eq!(a.len(), 2);
 }
+
+#[test]
+fn into_iter() {
+    let data = vec![Some(true), None, Some(false)];
+    let rev = data.clone().into_iter().rev();
+
+    let array: BooleanArray = data.clone().into_iter().collect();
+
+    assert_eq!(array.clone().into_iter().collect::<Vec<_>>(), data);
+
+    assert!(array.into_iter().rev().eq(rev))
+}

--- a/tests/it/array/primitive/mod.rs
+++ b/tests/it/array/primitive/mod.rs
@@ -124,3 +124,15 @@ fn into_mut_3() {
     let array = PrimitiveArray::new(DataType::Int32, values, validity);
     assert!(array.into_mut().is_right());
 }
+
+#[test]
+fn into_iter() {
+    let data = vec![Some(1), None, Some(10)];
+    let rev = data.clone().into_iter().rev();
+
+    let array: Int32Array = data.clone().into_iter().collect();
+
+    assert_eq!(array.clone().into_iter().collect::<Vec<_>>(), data);
+
+    assert!(array.into_iter().rev().eq(rev))
+}

--- a/tests/it/bitmap/utils/zip_validity.rs
+++ b/tests/it/bitmap/utils/zip_validity.rs
@@ -1,11 +1,14 @@
-use arrow2::bitmap::{utils::zip_validity, Bitmap};
+use arrow2::bitmap::{
+    utils::{BitmapIter, ZipValidity},
+    Bitmap,
+};
 
 #[test]
 fn basic() {
     let a = Bitmap::from([true, false]);
     let a = Some(a.iter());
     let values = vec![0, 1];
-    let zip = zip_validity(values.into_iter(), a);
+    let zip = ZipValidity::new(values.into_iter(), a);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(a, vec![Some(0), None]);
@@ -16,7 +19,7 @@ fn complete() {
     let a = Bitmap::from([true, false, true, false, true, false, true, false]);
     let a = Some(a.iter());
     let values = vec![0, 1, 2, 3, 4, 5, 6, 7];
-    let zip = zip_validity(values.into_iter(), a);
+    let zip = ZipValidity::new(values.into_iter(), a);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(
@@ -36,7 +39,7 @@ fn slices() {
         let end = x[1];
         &values[start..end]
     });
-    let zip = zip_validity(iter, a);
+    let zip = ZipValidity::new(iter, a);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(a, vec![Some([1, 2].as_ref()), None]);
@@ -47,7 +50,7 @@ fn byte() {
     let a = Bitmap::from([true, false, true, false, false, true, true, false, true]);
     let a = Some(a.iter());
     let values = vec![0, 1, 2, 3, 4, 5, 6, 7, 8];
-    let zip = zip_validity(values.into_iter(), a);
+    let zip = ZipValidity::new(values.into_iter(), a);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(
@@ -71,7 +74,7 @@ fn offset() {
     let a = Bitmap::from([true, false, true, false, false, true, true, false, true]).slice(1, 8);
     let a = Some(a.iter());
     let values = vec![0, 1, 2, 3, 4, 5, 6, 7];
-    let zip = zip_validity(values.into_iter(), a);
+    let zip = ZipValidity::new(values.into_iter(), a);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(
@@ -83,7 +86,7 @@ fn offset() {
 #[test]
 fn none() {
     let values = vec![0, 1, 2];
-    let zip = zip_validity(values.into_iter(), None);
+    let zip = ZipValidity::new(values.into_iter(), None::<BitmapIter>);
 
     let a = zip.collect::<Vec<_>>();
     assert_eq!(a, vec![Some(0), Some(1), Some(2)]);
@@ -94,7 +97,7 @@ fn rev() {
     let a = Bitmap::from([true, false, true, false, false, true, true, false, true]).slice(1, 8);
     let a = Some(a.iter());
     let values = vec![0, 1, 2, 3, 4, 5, 6, 7];
-    let zip = zip_validity(values.into_iter(), a);
+    let zip = ZipValidity::new(values.into_iter(), a);
 
     let result = zip.rev().collect::<Vec<_>>();
     let expected = vec![None, Some(1), None, None, Some(4), Some(5), None, Some(7)]


### PR DESCRIPTION
This improves the zipped iterators to offer iterators to:
* the mutable counter-parts
* `into_iter` of the arrays

# Backwards incompatible

* `ZipValidity` generic signature changed:
    * Before: `ZipValidity<'a, T, I> where I: Iterator<Item = T>`
    * now: `ZipValidity<T, I, V> where I: Iterator<Item = T>, V: Iterator<Item = bool>`

* `FixedSizeBinaryValuesIter` was removed and replaced by `std::slice::ChunksExact<'a,u8>` since using std is always more idiomatic