### PR TITLE
Upgrade to ahash v0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ hash_hasher = "^2.0.3"
 # For SIMD utf8 validation
 simdutf8 = "0.1.3"
 # faster hashing
-ahash = { version = "0.7" }
+ahash = { version = "0.8" }
 
 # for timezone support
 chrono-tz = { version = "0.6", optional = true }


### PR DESCRIPTION
Hey @jorgecarleitao! Just looking to avoid a duplicate dependency downstream, and this looked to drop in easily.