### PR TITLE
Added `MutableBinaryValuesArray`

### DIFF
--- a/src/array/binary/iterator.rs
+++ b/src/array/binary/iterator.rs
@@ -3,7 +3,7 @@ use crate::{
     bitmap::utils::ZipValidity,
 };
 
-use super::BinaryArray;
+use super::{BinaryArray, MutableBinaryValuesArray};
 
 unsafe impl<'a, O: Offset> ArrayAccessor<'a> for BinaryArray<O> {
     type Item = &'a [u8];
@@ -25,6 +25,18 @@ pub type BinaryValueIter<'a, O> = ArrayValuesIter<'a, BinaryArray<O>>;
 impl<'a, O: Offset> IntoIterator for &'a BinaryArray<O> {
     type Item = Option<&'a [u8]>;
     type IntoIter = ZipValidity<'a, &'a [u8], BinaryValueIter<'a, O>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator of values of an [`MutableBinaryValuesArray`].
+pub type MutableBinaryValuesIter<'a, O> = ArrayValuesIter<'a, MutableBinaryValuesArray<O>>;
+
+impl<'a, O: Offset> IntoIterator for &'a MutableBinaryValuesArray<O> {
+    type Item = &'a [u8];
+    type IntoIter = MutableBinaryValuesIter<'a, O>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -21,6 +21,8 @@ pub(super) mod fmt;
 mod iterator;
 pub use iterator::*;
 mod from;
+mod mutable_values;
+pub use mutable_values::*;
 mod mutable;
 pub use mutable::*;
 

--- a/src/array/binary/mutable_values.rs
+++ b/src/array/binary/mutable_values.rs
@@ -1,0 +1,410 @@
+use std::{iter::FromIterator, sync::Arc};
+
+use crate::{
+    array::{
+        specification::{check_offsets_minimal, try_check_offsets},
+        Array, ArrayAccessor, ArrayValuesIter, MutableArray, Offset, TryExtend, TryPush,
+    },
+    bitmap::MutableBitmap,
+    datatypes::DataType,
+    error::{Error, Result},
+    trusted_len::TrustedLen,
+};
+
+use super::{BinaryArray, MutableBinaryArray};
+use crate::array::physical_binary::*;
+
+/// A [`MutableArray`] that builds a [`BinaryArray`]. It differs
+/// from [`MutableBinaryArray`] in that it builds non-null [`BinaryArray`].
+#[derive(Debug, Clone)]
+pub struct MutableBinaryValuesArray<O: Offset> {
+    data_type: DataType,
+    offsets: Vec<O>,
+    values: Vec<u8>,
+}
+
+impl<O: Offset> From<MutableBinaryValuesArray<O>> for BinaryArray<O> {
+    fn from(other: MutableBinaryValuesArray<O>) -> Self {
+        // Safety:
+        // `MutableBinaryValuesArray` has the same invariants as `BinaryArray` and thus
+        // `BinaryArray` can be safely created from `MutableBinaryValuesArray` without checks.
+        unsafe {
+            BinaryArray::<O>::from_data_unchecked(
+                other.data_type,
+                other.offsets.into(),
+                other.values.into(),
+                None,
+            )
+        }
+    }
+}
+
+impl<O: Offset> From<MutableBinaryValuesArray<O>> for MutableBinaryArray<O> {
+    fn from(other: MutableBinaryValuesArray<O>) -> Self {
+        // Safety:
+        // `MutableBinaryValuesArray` has the same invariants as `MutableBinaryArray`
+        unsafe {
+            MutableBinaryArray::<O>::new_unchecked(
+                other.data_type,
+                other.offsets,
+                other.values,
+                None,
+            )
+        }
+    }
+}
+
+impl<O: Offset> Default for MutableBinaryValuesArray<O> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<O: Offset> MutableBinaryValuesArray<O> {
+    /// Returns an empty [`MutableBinaryValuesArray`].
+    pub fn new() -> Self {
+        Self {
+            data_type: Self::default_data_type(),
+            offsets: vec![O::default()],
+            values: Vec::<u8>::new(),
+        }
+    }
+
+    /// Returns a [`MutableBinaryValuesArray`] created from its internal representation.
+    ///
+    /// # Errors
+    /// This function returns an error iff:
+    /// * the offsets are not monotonically increasing
+    /// * The last offset is not equal to the values' length.
+    /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either `Binary` or `LargeBinary`.
+    /// # Implementation
+    /// This function is `O(N)` - checking monotinicity is `O(N)`
+    pub fn try_new(data_type: DataType, offsets: Vec<O>, values: Vec<u8>) -> Result<Self> {
+        try_check_offsets(&offsets, values.len())?;
+        if data_type.to_physical_type() != Self::default_data_type().to_physical_type() {
+            return Err(Error::oos(
+                "MutableBinaryValuesArray can only be initialized with DataType::Binary or DataType::LargeBinary",
+            ));
+        }
+
+        Ok(Self {
+            data_type,
+            offsets,
+            values,
+        })
+    }
+
+    /// Returns a [`MutableBinaryValuesArray`] created from its internal representation.
+    ///
+    /// # Panic
+    /// This function does not panic iff:
+    /// * The last offset is equal to the values' length.
+    /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is equal to either `Binary` or `LargeBinary`.
+    /// # Safety
+    /// This function is safe iff:
+    /// * the offsets are monotonically increasing
+    /// # Implementation
+    /// This function is `O(1)`
+    pub unsafe fn new_unchecked(data_type: DataType, offsets: Vec<O>, values: Vec<u8>) -> Self {
+        check_offsets_minimal(&offsets, values.len());
+
+        if data_type.to_physical_type() != Self::default_data_type().to_physical_type() {
+            panic!("MutableBinaryValuesArray can only be initialized with DataType::Binary or DataType::LargeBinary")
+        }
+
+        Self {
+            data_type,
+            offsets,
+            values,
+        }
+    }
+
+    /// Returns the default [`DataType`] of this container: [`DataType::Utf8`] or [`DataType::LargeUtf8`]
+    /// depending on the generic [`Offset`].
+    pub fn default_data_type() -> DataType {
+        BinaryArray::<O>::default_data_type()
+    }
+
+    /// Initializes a new [`MutableBinaryValuesArray`] with a pre-allocated capacity of items.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self::with_capacities(capacity, 0)
+    }
+
+    /// Initializes a new [`MutableBinaryValuesArray`] with a pre-allocated capacity of items and values.
+    pub fn with_capacities(capacity: usize, values: usize) -> Self {
+        let mut offsets = Vec::<O>::with_capacity(capacity + 1);
+        offsets.push(O::default());
+
+        Self {
+            data_type: Self::default_data_type(),
+            offsets,
+            values: Vec::<u8>::with_capacity(values),
+        }
+    }
+
+    /// returns its values.
+    #[inline]
+    pub fn values(&self) -> &Vec<u8> {
+        &self.values
+    }
+
+    /// returns its offsets.
+    #[inline]
+    pub fn offsets(&self) -> &Vec<O> {
+        &self.offsets
+    }
+
+    /// Reserves `additional` elements and `additional_values` on the values.
+    #[inline]
+    pub fn reserve(&mut self, additional: usize, additional_values: usize) {
+        self.offsets.reserve(additional + 1);
+        self.values.reserve(additional_values);
+    }
+
+    /// Returns the capacity in number of items
+    pub fn capacity(&self) -> usize {
+        self.offsets.capacity() - 1
+    }
+
+    /// Returns the length of this array
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.offsets.len() - 1
+    }
+
+    /// Pushes a new item to the array.
+    /// # Panic
+    /// This operation panics iff the length of all values (in bytes) exceeds `O` maximum value.
+    #[inline]
+    pub fn push<T: AsRef<[u8]>>(&mut self, value: T) {
+        self.try_push(value).unwrap()
+    }
+
+    /// Pop the last entry from [`MutableBinaryValuesArray`].
+    /// This function returns `None` iff this array is empty.
+    pub fn pop(&mut self) -> Option<Vec<u8>> {
+        if self.len() == 0 {
+            return None;
+        }
+        self.offsets.pop()?;
+        let start = self.offsets.last()?.to_usize();
+        let value = self.values.split_off(start);
+        Some(value.to_vec())
+    }
+
+    /// Returns the value of the element at index `i`.
+    /// # Panic
+    /// This function panics iff `i >= self.len`.
+    #[inline]
+    pub fn value(&self, i: usize) -> &[u8] {
+        assert!(i < self.len());
+        unsafe { self.value_unchecked(i) }
+    }
+
+    /// Returns the value of the element at index `i`.
+    /// # Safety
+    /// This function is safe iff `i < self.len`.
+    #[inline]
+    pub unsafe fn value_unchecked(&self, i: usize) -> &[u8] {
+        // soundness: the invariant of the function
+        let start = self.offsets.get_unchecked(i).to_usize();
+        let end = self.offsets.get_unchecked(i + 1).to_usize();
+
+        // soundness: the invariant of the struct
+        self.values.get_unchecked(start..end)
+    }
+
+    /// Returns an iterator of `&[u8]`
+    pub fn iter(&self) -> ArrayValuesIter<Self> {
+        ArrayValuesIter::new(self)
+    }
+
+    /// Shrinks the capacity of the [`MutableBinaryValuesArray`] to fit its current length.
+    pub fn shrink_to_fit(&mut self) {
+        self.values.shrink_to_fit();
+        self.offsets.shrink_to_fit();
+    }
+
+    /// Extract the low-end APIs from the [`MutableBinaryValuesArray`].
+    pub fn into_inner(self) -> (DataType, Vec<O>, Vec<u8>) {
+        (self.data_type, self.offsets, self.values)
+    }
+}
+
+impl<O: Offset> MutableArray for MutableBinaryValuesArray<O> {
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn validity(&self) -> Option<&MutableBitmap> {
+        None
+    }
+
+    fn as_box(&mut self) -> Box<dyn Array> {
+        // Safety:
+        // `MutableBinaryValuesArray` has the same invariants as `BinaryArray` and thus
+        // `BinaryArray` can be safely created from `MutableBinaryValuesArray` without checks.
+        let (data_type, offsets, values) = std::mem::take(self).into_inner();
+        unsafe { BinaryArray::from_data_unchecked(data_type, offsets.into(), values.into(), None) }
+            .boxed()
+    }
+
+    fn as_arc(&mut self) -> Arc<dyn Array> {
+        // Safety:
+        // `MutableBinaryValuesArray` has the same invariants as `BinaryArray` and thus
+        // `BinaryArray` can be safely created from `MutableBinaryValuesArray` without checks.
+        let (data_type, offsets, values) = std::mem::take(self).into_inner();
+        unsafe { BinaryArray::from_data_unchecked(data_type, offsets.into(), values.into(), None) }
+            .arced()
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn push_null(&mut self) {
+        self.push::<&[u8]>(b"")
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        self.reserve(additional, 0)
+    }
+
+    fn shrink_to_fit(&mut self) {
+        self.shrink_to_fit()
+    }
+}
+
+impl<O: Offset, P: AsRef<[u8]>> FromIterator<P> for MutableBinaryValuesArray<O> {
+    fn from_iter<I: IntoIterator<Item = P>>(iter: I) -> Self {
+        let (offsets, values) = values_iter(iter.into_iter());
+        // soundness: T: AsRef<[u8]> and offsets are monotonically increasing
+        unsafe { Self::new_unchecked(Self::default_data_type(), offsets, values) }
+    }
+}
+
+impl<O: Offset> MutableBinaryValuesArray<O> {
+    pub(crate) unsafe fn extend_from_trusted_len_iter<I, P>(
+        &mut self,
+        validity: &mut MutableBitmap,
+        iterator: I,
+    ) where
+        P: AsRef<[u8]>,
+        I: Iterator<Item = Option<P>>,
+    {
+        extend_from_trusted_len_iter(&mut self.offsets, &mut self.values, validity, iterator);
+    }
+
+    /// Extends the [`MutableBinaryValuesArray`] from a [`TrustedLen`]
+    #[inline]
+    pub fn extend_trusted_len<I, P>(&mut self, iterator: I)
+    where
+        P: AsRef<[u8]>,
+        I: TrustedLen<Item = P>,
+    {
+        unsafe { self.extend_trusted_len_unchecked(iterator) }
+    }
+
+    /// Extends [`MutableBinaryValuesArray`] from an iterator of trusted len.
+    /// # Safety
+    /// The iterator must be trusted len.
+    #[inline]
+    pub unsafe fn extend_trusted_len_unchecked<I, P>(&mut self, iterator: I)
+    where
+        P: AsRef<[u8]>,
+        I: Iterator<Item = P>,
+    {
+        extend_from_trusted_len_values_iter(&mut self.offsets, &mut self.values, iterator);
+    }
+
+    /// Creates a [`MutableBinaryValuesArray`] from a [`TrustedLen`]
+    #[inline]
+    pub fn from_trusted_len_iter<I, P>(iterator: I) -> Self
+    where
+        P: AsRef<[u8]>,
+        I: TrustedLen<Item = P>,
+    {
+        // soundness: I is `TrustedLen`
+        unsafe { Self::from_trusted_len_iter_unchecked(iterator) }
+    }
+
+    /// Returns a new [`MutableBinaryValuesArray`] from an iterator of trusted length.
+    /// # Safety
+    /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
+    /// I.e. that `size_hint().1` correctly reports its length.
+    #[inline]
+    pub unsafe fn from_trusted_len_iter_unchecked<I, P>(iterator: I) -> Self
+    where
+        P: AsRef<[u8]>,
+        I: Iterator<Item = P>,
+    {
+        let (offsets, values) = trusted_len_values_iter(iterator);
+
+        // soundness: offsets are monotonically increasing
+        Self::new_unchecked(Self::default_data_type(), offsets, values)
+    }
+
+    /// Returns a new [`MutableBinaryValuesArray`] from an iterator.
+    /// # Error
+    /// This operation errors iff the total length in bytes on the iterator exceeds `O`'s maximum value.
+    /// (`i32::MAX` or `i64::MAX` respectively).
+    pub fn try_from_iter<P: AsRef<[u8]>, I: IntoIterator<Item = P>>(iter: I) -> Result<Self> {
+        let iterator = iter.into_iter();
+        let (lower, _) = iterator.size_hint();
+        let mut array = Self::with_capacity(lower);
+        for item in iterator {
+            array.try_push(item)?;
+        }
+        Ok(array)
+    }
+}
+
+impl<O: Offset, T: AsRef<[u8]>> Extend<T> for MutableBinaryValuesArray<O> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        extend_from_values_iter(&mut self.offsets, &mut self.values, iter.into_iter());
+    }
+}
+
+impl<O: Offset, T: AsRef<[u8]>> TryExtend<T> for MutableBinaryValuesArray<O> {
+    fn try_extend<I: IntoIterator<Item = T>>(&mut self, iter: I) -> Result<()> {
+        let mut iter = iter.into_iter();
+        self.reserve(iter.size_hint().0, 0);
+        iter.try_for_each(|x| self.try_push(x))
+    }
+}
+
+impl<O: Offset, T: AsRef<[u8]>> TryPush<T> for MutableBinaryValuesArray<O> {
+    #[inline]
+    fn try_push(&mut self, value: T) -> Result<()> {
+        let bytes = value.as_ref();
+        self.values.extend_from_slice(bytes);
+
+        let size = O::from_usize(self.values.len()).ok_or(Error::Overflow)?;
+
+        self.offsets.push(size);
+        Ok(())
+    }
+}
+
+unsafe impl<'a, O: Offset> ArrayAccessor<'a> for MutableBinaryValuesArray<O> {
+    type Item = &'a [u8];
+
+    #[inline]
+    unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
+        self.value_unchecked(index)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.len()
+    }
+}

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -387,7 +387,7 @@ pub use equal::equal;
 pub use fmt::{get_display, get_value_display};
 
 pub use crate::types::Offset;
-pub use binary::{BinaryArray, BinaryValueIter, MutableBinaryArray};
+pub use binary::{BinaryArray, BinaryValueIter, MutableBinaryArray, MutableBinaryValuesArray};
 pub use boolean::{BooleanArray, MutableBooleanArray};
 pub use dictionary::{DictionaryArray, DictionaryKey, MutableDictionaryArray};
 pub use fixed_size_binary::{FixedSizeBinaryArray, MutableFixedSizeBinaryArray};

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -73,13 +73,6 @@ pub fn try_check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) -> Re
     }
 }
 
-/// # Panics iff:
-/// * the `offsets` is not monotonically increasing, or
-/// * any offset is larger or equal to `values_len`.
-pub fn check_offsets<O: Offset>(offsets: &[O], values_len: usize) {
-    try_check_offsets(offsets, values_len).unwrap()
-}
-
 /// Checks that `offsets` is monotonically increasing, and all offsets are less than or equal to
 /// `values_len`.
 pub fn try_check_offsets<O: Offset>(offsets: &[O], values_len: usize) -> Result<()> {

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -92,7 +92,11 @@ impl<O: Offset> MutableUtf8Array<O> {
         values: Vec<u8>,
         validity: Option<MutableBitmap>,
     ) -> Self {
-        Self::from_data_unchecked(data_type, offsets, values, validity)
+        let values = MutableUtf8ValuesArray::new_unchecked(data_type, offsets, values);
+        if let Some(ref validity) = validity {
+            assert_eq!(values.len(), validity.len());
+        }
+        Self { values, validity }
     }
 
     /// Alias of `new_unchecked`
@@ -104,11 +108,7 @@ impl<O: Offset> MutableUtf8Array<O> {
         values: Vec<u8>,
         validity: Option<MutableBitmap>,
     ) -> Self {
-        let values = MutableUtf8ValuesArray::new_unchecked(data_type, offsets, values);
-        if let Some(ref validity) = validity {
-            assert_eq!(values.len(), validity.len());
-        }
-        Self { values, validity }
+        Self::new_unchecked(data_type, offsets, values, validity)
     }
 
     /// The canonical method to create a [`MutableUtf8Array`] out of low-end APIs.

--- a/tests/it/array/binary/mod.rs
+++ b/tests/it/array/binary/mod.rs
@@ -6,6 +6,7 @@ use arrow2::{
 };
 
 mod mutable;
+mod mutable_values;
 mod to_mutable;
 
 #[test]

--- a/tests/it/array/binary/mutable_values.rs
+++ b/tests/it/array/binary/mutable_values.rs
@@ -1,10 +1,10 @@
 use arrow2::array::MutableArray;
-use arrow2::array::MutableUtf8ValuesArray;
+use arrow2::array::MutableBinaryValuesArray;
 use arrow2::datatypes::DataType;
 
 #[test]
 fn capacity() {
-    let mut b = MutableUtf8ValuesArray::<i32>::with_capacity(100);
+    let mut b = MutableBinaryValuesArray::<i32>::with_capacity(100);
 
     assert_eq!(b.values().capacity(), 0);
     assert!(b.offsets().capacity() >= 101);
@@ -16,36 +16,29 @@ fn capacity() {
 fn offsets_must_be_monotonic_increasing() {
     let offsets = vec![0, 5, 4];
     let values = b"abbbbb".to_vec();
-    assert!(MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).is_err());
+    assert!(MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).is_err());
 }
 
 #[test]
 fn offsets_must_be_in_bounds() {
     let offsets = vec![0, 10];
     let values = b"abbbbb".to_vec();
-    assert!(MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).is_err());
+    assert!(MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).is_err());
 }
 
 #[test]
 fn data_type_must_be_consistent() {
     let offsets = vec![0, 4];
     let values = b"abbb".to_vec();
-    assert!(MutableUtf8ValuesArray::<i32>::try_new(DataType::Int32, offsets, values).is_err());
-}
-
-#[test]
-fn must_be_utf8() {
-    let offsets = vec![0, 4];
-    let values = vec![0, 159, 146, 150];
-    assert!(std::str::from_utf8(&values).is_err());
-    assert!(MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).is_err());
+    assert!(MutableBinaryValuesArray::<i32>::try_new(DataType::Int32, offsets, values).is_err());
 }
 
 #[test]
 fn as_box() {
     let offsets = vec![0, 2];
     let values = b"ab".to_vec();
-    let mut b = MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).unwrap();
+    let mut b =
+        MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).unwrap();
     let _ = b.as_box();
 }
 
@@ -53,7 +46,8 @@ fn as_box() {
 fn as_arc() {
     let offsets = vec![0, 2];
     let values = b"ab".to_vec();
-    let mut b = MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).unwrap();
+    let mut b =
+        MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).unwrap();
     let _ = b.as_arc();
 }
 
@@ -61,14 +55,15 @@ fn as_arc() {
 fn extend_trusted_len() {
     let offsets = vec![0, 2];
     let values = b"ab".to_vec();
-    let mut b = MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).unwrap();
+    let mut b =
+        MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).unwrap();
     b.extend_trusted_len(vec!["a", "b"].into_iter());
 
     let offsets = vec![0, 2, 3, 4];
     let values = b"abab".to_vec();
     assert_eq!(
         b.as_box(),
-        MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values)
+        MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values)
             .unwrap()
             .as_box()
     )
@@ -76,13 +71,13 @@ fn extend_trusted_len() {
 
 #[test]
 fn from_trusted_len() {
-    let mut b = MutableUtf8ValuesArray::<i32>::from_trusted_len_iter(vec!["a", "b"].into_iter());
+    let mut b = MutableBinaryValuesArray::<i32>::from_trusted_len_iter(vec!["a", "b"].into_iter());
 
     let offsets = vec![0, 1, 2];
     let values = b"ab".to_vec();
     assert_eq!(
         b.as_box(),
-        MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values)
+        MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values)
             .unwrap()
             .as_box()
     )
@@ -92,7 +87,8 @@ fn from_trusted_len() {
 fn extend_from_iter() {
     let offsets = vec![0, 2];
     let values = b"ab".to_vec();
-    let mut b = MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).unwrap();
+    let mut b =
+        MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).unwrap();
     b.extend_trusted_len(vec!["a", "b"].into_iter());
 
     let a = b.clone();
@@ -102,7 +98,7 @@ fn extend_from_iter() {
     let values = b"abababab".to_vec();
     assert_eq!(
         b.as_box(),
-        MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values)
+        MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values)
             .unwrap()
             .as_box()
     )


### PR DESCRIPTION
This PR adds `MutableBinaryValuesArray`, an auxiliary struct to build non-optional binary values. This is similar to `MutableUtf8ValuesArray`, but without the utf8 requirement.

# Backward-incompatible

* `MutableBinaryArray::reserve` now requires two parameters. Use `reserve(..., 0)` to recover the original behavior (Closes #1277)