### PR TITLE
Added `TryExtendFromSelf`

### DIFF
--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -114,7 +114,7 @@ impl<O: Offset> BinaryArray<O> {
     /// Creates a new [`BinaryArray`] from a slice of optional `&[u8]`.
     // Note: this can't be `impl From` because Rust does not allow double `AsRef` on it.
     pub fn from<T: AsRef<[u8]>, P: AsRef<[Option<T>]>>(slice: P) -> Self {
-        Self::from_trusted_len_iter(slice.as_ref().iter().map(|x| x.as_ref()))
+        MutableBinaryArray::<O>::from(slice).into()
     }
 
     /// Returns an iterator of `Option<&[u8]>` over every element of this array.

--- a/src/array/binary/mutable_values.rs
+++ b/src/array/binary/mutable_values.rs
@@ -3,7 +3,8 @@ use std::{iter::FromIterator, sync::Arc};
 use crate::{
     array::{
         specification::{check_offsets_minimal, try_check_offsets},
-        Array, ArrayAccessor, ArrayValuesIter, MutableArray, Offset, TryExtend, TryPush,
+        Array, ArrayAccessor, ArrayValuesIter, MutableArray, Offset, TryExtend, TryExtendFromSelf,
+        TryPush,
     },
     bitmap::MutableBitmap,
     datatypes::DataType,
@@ -406,5 +407,12 @@ unsafe impl<'a, O: Offset> ArrayAccessor<'a> for MutableBinaryValuesArray<O> {
     #[inline]
     fn len(&self) -> usize {
         self.len()
+    }
+}
+
+impl<O: Offset> TryExtendFromSelf for MutableBinaryValuesArray<O> {
+    fn try_extend_from_self(&mut self, other: &Self) -> Result<()> {
+        self.values.extend_from_slice(&other.values);
+        try_extend_offsets(&mut self.offsets, &other.offsets)
     }
 }

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -1,9 +1,4 @@
-use crate::{
-    bitmap::{Bitmap, MutableBitmap},
-    buffer::Buffer,
-    datatypes::DataType,
-    error::Error,
-};
+use crate::{bitmap::Bitmap, buffer::Buffer, datatypes::DataType, error::Error};
 
 use super::Array;
 
@@ -321,18 +316,7 @@ impl FixedSizeBinaryArray {
     /// Creates a new [`FixedSizeBinaryArray`] from a slice of optional `[u8]`.
     // Note: this can't be `impl From` because Rust does not allow double `AsRef` on it.
     pub fn from<const N: usize, P: AsRef<[Option<[u8; N]>]>>(slice: P) -> Self {
-        let values = slice
-            .as_ref()
-            .iter()
-            .copied()
-            .flat_map(|x| x.unwrap_or([0; N]))
-            .collect::<Vec<_>>();
-        let validity = slice
-            .as_ref()
-            .iter()
-            .map(|x| x.is_some())
-            .collect::<MutableBitmap>();
-        Self::new(DataType::FixedSizeBinary(N), values.into(), validity.into())
+        MutableFixedSizeBinaryArray::from(slice).into()
     }
 }
 

--- a/src/array/list/iterator.rs
+++ b/src/array/list/iterator.rs
@@ -46,3 +46,27 @@ impl<'a, O: Offset> ListArray<O> {
         ListValuesIter::new(self)
     }
 }
+
+struct Iter<T, I: Iterator<Item = Option<T>>> {
+    current: i32,
+    offsets: std::vec::IntoIter<i32>,
+    values: I,
+}
+
+impl<T, I: Iterator<Item = Option<T>> + Clone> Iterator for Iter<T, I> {
+    type Item = Option<std::iter::Take<std::iter::Skip<I>>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.offsets.next();
+        next.map(|next| {
+            let length = next - self.current;
+            let iter = self
+                .values
+                .clone()
+                .skip(self.current as usize)
+                .take(length as usize);
+            self.current = next;
+            Some(iter)
+        })
+    }
+}

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -470,6 +470,13 @@ pub trait TryPush<A> {
     fn try_push(&mut self, item: A) -> Result<()>;
 }
 
+/// A trait describing the ability of a struct to extend from a reference of itself.
+/// Specialization of [`TryExtend`].
+pub trait TryExtendFromSelf {
+    /// Tries to extend itself with elements from `other`, failing only on overflow.
+    fn try_extend_from_self(&mut self, other: &Self) -> Result<()>;
+}
+
 /// Trait that [`BinaryArray`] and [`Utf8Array`] implement for the purposes of DRY.
 /// # Safety
 /// The implementer must ensure that

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -1,5 +1,7 @@
 use std::{iter::FromIterator, sync::Arc};
 
+use crate::array::physical_binary::extend_validity;
+use crate::array::TryExtendFromSelf;
 use crate::bitmap::Bitmap;
 use crate::{
     array::{Array, MutableArray, TryExtend, TryPush},
@@ -653,5 +655,15 @@ where
 impl<T: NativeType> PartialEq for MutablePrimitiveArray<T> {
     fn eq(&self, other: &Self) -> bool {
         self.iter().eq(other.iter())
+    }
+}
+
+impl<T: NativeType> TryExtendFromSelf for MutablePrimitiveArray<T> {
+    fn try_extend_from_self(&mut self, other: &Self) -> Result<()> {
+        extend_validity(self.len(), &mut self.validity, &other.validity);
+
+        let slice = other.values.as_slice();
+        self.values.extend_from_slice(slice);
+        Ok(())
     }
 }

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -128,7 +128,7 @@ impl<O: Offset> Utf8Array<O> {
     /// A convenience method that uses [`Self::from_trusted_len_iter`].
     // Note: this can't be `impl From` because Rust does not allow double `AsRef` on it.
     pub fn from<T: AsRef<str>, P: AsRef<[Option<T>]>>(slice: P) -> Self {
-        Self::from_trusted_len_iter(slice.as_ref().iter().map(|x| x.as_ref()))
+        MutableUtf8Array::<O>::from(slice).into()
     }
 
     /// Returns an iterator of `Option<&str>`

--- a/src/array/utf8/mutable_values.rs
+++ b/src/array/utf8/mutable_values.rs
@@ -3,7 +3,7 @@ use std::{iter::FromIterator, sync::Arc};
 use crate::{
     array::{
         specification::{check_offsets_minimal, try_check_offsets_and_utf8},
-        Array, ArrayValuesIter, MutableArray, Offset, TryExtend, TryPush,
+        Array, ArrayValuesIter, MutableArray, Offset, TryExtend, TryExtendFromSelf, TryPush,
     },
     bitmap::MutableBitmap,
     datatypes::DataType,
@@ -405,5 +405,12 @@ impl<O: Offset, T: AsRef<str>> TryPush<T> for MutableUtf8ValuesArray<O> {
 
         self.offsets.push(size);
         Ok(())
+    }
+}
+
+impl<O: Offset> TryExtendFromSelf for MutableUtf8ValuesArray<O> {
+    fn try_extend_from_self(&mut self, other: &Self) -> Result<()> {
+        self.values.extend_from_slice(&other.values);
+        try_extend_offsets(&mut self.offsets, &other.offsets)
     }
 }

--- a/tests/it/array/binary/mutable.rs
+++ b/tests/it/array/binary/mutable.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use arrow2::array::{BinaryArray, MutableArray, MutableBinaryArray};
+use arrow2::array::{BinaryArray, MutableArray, MutableBinaryArray, TryExtendFromSelf};
 use arrow2::bitmap::Bitmap;
 use arrow2::error::Error;
 
@@ -149,5 +149,17 @@ fn extend_trusted_len() {
     assert_eq!(
         array.validity(),
         Some(&Bitmap::from_u8_slice(&[0b00001011], 4))
+    );
+}
+
+#[test]
+fn extend_from_self() {
+    let mut a = MutableBinaryArray::<i32>::from(&[Some(b"aa"), None]);
+
+    a.try_extend_from_self(&a.clone()).unwrap();
+
+    assert_eq!(
+        a,
+        MutableBinaryArray::<i32>::from([Some(b"aa"), None, Some(b"aa"), None])
     );
 }

--- a/tests/it/array/boolean/mutable.rs
+++ b/tests/it/array/boolean/mutable.rs
@@ -1,4 +1,4 @@
-use arrow2::array::{MutableArray, MutableBooleanArray};
+use arrow2::array::{MutableArray, MutableBooleanArray, TryExtendFromSelf};
 use arrow2::bitmap::MutableBitmap;
 use arrow2::datatypes::DataType;
 use arrow2::error::Result;
@@ -161,4 +161,16 @@ fn shrink_to_fit() {
     a.push(true);
     a.shrink_to_fit();
     assert_eq!(a.capacity(), 8);
+}
+
+#[test]
+fn extend_from_self() {
+    let mut a = MutableBooleanArray::from([Some(true), None]);
+
+    a.try_extend_from_self(&a.clone()).unwrap();
+
+    assert_eq!(
+        a,
+        MutableBooleanArray::from([Some(true), None, Some(true), None])
+    );
 }

--- a/tests/it/array/fixed_size_binary/mutable.rs
+++ b/tests/it/array/fixed_size_binary/mutable.rs
@@ -154,3 +154,15 @@ fn shrink_to_fit_and_capacity() {
     array.shrink_to_fit();
     assert_eq!(array.capacity(), 1);
 }
+
+#[test]
+fn extend_from_self() {
+    let mut a = MutableFixedSizeBinaryArray::from([Some([1u8, 2u8]), None]);
+
+    a.try_extend_from_self(&a.clone()).unwrap();
+
+    assert_eq!(
+        a,
+        MutableFixedSizeBinaryArray::from([Some([1u8, 2u8]), None, Some([1u8, 2u8]), None])
+    );
+}

--- a/tests/it/array/fixed_size_list/mutable.rs
+++ b/tests/it/array/fixed_size_list/mutable.rs
@@ -63,3 +63,26 @@ fn new_with_field() {
     let expected = Int32Array::from(vec![None, None, None]);
     assert_eq!(a, &expected)
 }
+
+#[test]
+fn extend_from_self() {
+    let data = vec![
+        Some(vec![Some(1i32), Some(2), Some(3)]),
+        None,
+        Some(vec![Some(4), None, Some(6)]),
+    ];
+    let mut a = MutableFixedSizeListArray::new(MutablePrimitiveArray::<i32>::new(), 3);
+    a.try_extend(data.clone()).unwrap();
+
+    a.try_extend_from_self(&a.clone()).unwrap();
+    let a: FixedSizeListArray = a.into();
+
+    let mut expected = data.clone();
+    expected.extend(data);
+
+    let mut b = MutableFixedSizeListArray::new(MutablePrimitiveArray::<i32>::new(), 3);
+    b.try_extend(expected).unwrap();
+    let b: FixedSizeListArray = b.into();
+
+    assert_eq!(a, b);
+}

--- a/tests/it/array/list/mutable.rs
+++ b/tests/it/array/list/mutable.rs
@@ -48,3 +48,26 @@ fn push() {
     assert_eq!(array.offsets().as_ref(), [0, 3]);
     assert_eq!(array.validity(), None);
 }
+
+#[test]
+fn extend_from_self() {
+    let data = vec![
+        Some(vec![Some(1i32), Some(2), Some(3)]),
+        None,
+        Some(vec![Some(4), None, Some(6)]),
+    ];
+    let mut a = MutableListArray::<i32, MutablePrimitiveArray<i32>>::new();
+    a.try_extend(data.clone()).unwrap();
+
+    a.try_extend_from_self(&a.clone()).unwrap();
+    let a: ListArray<i32> = a.into();
+
+    let mut expected = data.clone();
+    expected.extend(data);
+
+    let mut b = MutableListArray::<i32, MutablePrimitiveArray<i32>>::new();
+    b.try_extend(expected).unwrap();
+    let b: ListArray<i32> = b.into();
+
+    assert_eq!(a, b);
+}

--- a/tests/it/array/primitive/mutable.rs
+++ b/tests/it/array/primitive/mutable.rs
@@ -10,7 +10,7 @@ use std::iter::FromIterator;
 fn from_and_into_data() {
     let a = MutablePrimitiveArray::from_data(
         DataType::Int32,
-        Vec::from([1i32, 0]),
+        vec![1i32, 0],
         Some(MutableBitmap::from([true, false])),
     );
     assert_eq!(a.len(), 2);
@@ -30,7 +30,7 @@ fn from_vec() {
 fn to() {
     let a = MutablePrimitiveArray::from_data(
         DataType::Int32,
-        Vec::from([1i32, 0]),
+        vec![1i32, 0],
         Some(MutableBitmap::from([true, false])),
     );
     let a = a.to(DataType::Date32);
@@ -41,7 +41,7 @@ fn to() {
 fn values_mut_slice() {
     let mut a = MutablePrimitiveArray::from_data(
         DataType::Int32,
-        Vec::from([1i32, 0]),
+        vec![1i32, 0],
         Some(MutableBitmap::from([true, false])),
     );
     let values = a.values_mut_slice();
@@ -315,4 +315,16 @@ fn try_from_trusted_len_iter() {
 fn wrong_data_type() {
     let values = vec![1u8];
     MutablePrimitiveArray::from_data(DataType::Utf8, values, None);
+}
+
+#[test]
+fn extend_from_self() {
+    let mut a = MutablePrimitiveArray::from([Some(1), None]);
+
+    a.try_extend_from_self(&a.clone()).unwrap();
+
+    assert_eq!(
+        a,
+        MutablePrimitiveArray::from([Some(1), None, Some(1), None])
+    );
 }

--- a/tests/it/array/utf8/mutable.rs
+++ b/tests/it/array/utf8/mutable.rs
@@ -1,4 +1,4 @@
-use arrow2::array::{MutableArray, MutableUtf8Array, Utf8Array};
+use arrow2::array::{MutableArray, MutableUtf8Array, TryExtendFromSelf, Utf8Array};
 use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::DataType;
 
@@ -197,4 +197,16 @@ fn as_box_twice() {
     let mut a = MutableUtf8Array::<i32>::new();
     let _ = a.as_arc();
     let _ = a.as_arc();
+}
+
+#[test]
+fn extend_from_self() {
+    let mut a = MutableUtf8Array::<i32>::from(&[Some("aa"), None]);
+
+    a.try_extend_from_self(&a.clone()).unwrap();
+
+    assert_eq!(
+        a,
+        MutableUtf8Array::<i32>::from([Some("aa"), None, Some("aa"), None])
+    );
 }


### PR DESCRIPTION
This PR adds a trait implemented for most mutable arrays that tells how a mutable array extends from itself, `fn try_extend_from_self(&mut self, other: &Self) -> Result<()>`

This also adds some functions that were missing in mutable counterparts to make it more idiomatic to write them (such as `Clone` and `from`).

Closes #1268