### PR TITLE
Optimized slicing

### DIFF
--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -203,7 +203,8 @@ impl<O: Offset> BinaryArray<O> {
         let validity = self
             .validity
             .clone()
-            .map(|x| x.slice_unchecked(offset, length));
+            .map(|bitmap| bitmap.slice_unchecked(offset, length))
+            .and_then(|bitmap| (bitmap.unset_bits() > 0).then(|| bitmap));
         let offsets = self.offsets.clone().slice_unchecked(offset, length + 1);
         Self {
             data_type: self.data_type.clone(),

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -167,7 +167,8 @@ impl BooleanArray {
         let validity = self
             .validity
             .clone()
-            .map(|x| x.slice_unchecked(offset, length));
+            .map(|bitmap| bitmap.slice_unchecked(offset, length))
+            .and_then(|bitmap| (bitmap.unset_bits() > 0).then(|| bitmap));
         Self {
             data_type: self.data_type.clone(),
             values: self.values.clone().slice_unchecked(offset, length),

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -131,7 +131,8 @@ impl FixedSizeBinaryArray {
         let validity = self
             .validity
             .clone()
-            .map(|x| x.slice_unchecked(offset, length));
+            .map(|bitmap| bitmap.slice_unchecked(offset, length))
+            .and_then(|bitmap| (bitmap.unset_bits() > 0).then(|| bitmap));
         let values = self
             .values
             .clone()

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -150,7 +150,8 @@ impl FixedSizeListArray {
         let validity = self
             .validity
             .clone()
-            .map(|x| x.slice_unchecked(offset, length));
+            .map(|bitmap| bitmap.slice_unchecked(offset, length))
+            .and_then(|bitmap| (bitmap.unset_bits() > 0).then(|| bitmap));
         let values = self
             .values
             .clone()

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -222,7 +222,8 @@ impl<O: Offset> ListArray<O> {
         let validity = self
             .validity
             .clone()
-            .map(|x| x.slice_unchecked(offset, length));
+            .map(|bitmap| bitmap.slice_unchecked(offset, length))
+            .and_then(|bitmap| (bitmap.unset_bits() > 0).then(|| bitmap));
         let offsets = self.offsets.clone().slice_unchecked(offset, length + 1);
         Self {
             data_type: self.data_type.clone(),

--- a/src/array/map/mod.rs
+++ b/src/array/map/mod.rs
@@ -167,7 +167,8 @@ impl MapArray {
         let validity = self
             .validity
             .clone()
-            .map(|x| x.slice_unchecked(offset, length));
+            .map(|bitmap| bitmap.slice_unchecked(offset, length))
+            .and_then(|bitmap| (bitmap.unset_bits() > 0).then(|| bitmap));
         Self {
             data_type: self.data_type.clone(),
             offsets,

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -233,7 +233,8 @@ impl<T: NativeType> PrimitiveArray<T> {
         let validity = self
             .validity
             .clone()
-            .map(|x| x.slice_unchecked(offset, length));
+            .map(|bitmap| bitmap.slice_unchecked(offset, length))
+            .and_then(|bitmap| (bitmap.unset_bits() > 0).then(|| bitmap));
         Self {
             data_type: self.data_type.clone(),
             values: self.values.clone().slice_unchecked(offset, length),

--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -198,7 +198,8 @@ impl StructArray {
         let validity = self
             .validity
             .clone()
-            .map(|x| x.slice_unchecked(offset, length));
+            .map(|bitmap| bitmap.slice_unchecked(offset, length))
+            .and_then(|bitmap| (bitmap.unset_bits() > 0).then(|| bitmap));
         Self {
             data_type: self.data_type.clone(),
             values: self

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -220,7 +220,8 @@ impl<O: Offset> Utf8Array<O> {
         let validity = self
             .validity
             .clone()
-            .map(|x| x.slice_unchecked(offset, length));
+            .map(|bitmap| bitmap.slice_unchecked(offset, length))
+            .and_then(|bitmap| (bitmap.unset_bits() > 0).then(|| bitmap));
         // + 1: `length == 0` implies that we take the first offset.
         let offsets = self.offsets.clone().slice_unchecked(offset, length + 1);
         Self {


### PR DESCRIPTION
This PR drops the validity on `slice` and `slice_unchecked` when the resulting array has no null values. This:

* drops strong ref count, therefore allowing the validity to be freed earlier.
* allows users of the arrays to not have to check the validity's unset bits to branch an the faster case where there are no null values

Follow up of #1284