### PR TITLE
Fixed link from the API to the guide

### DIFF
--- a/src/doc/lib.md
+++ b/src/doc/lib.md
@@ -5,7 +5,7 @@ This is a library for efficient in-memory data operations with
 It is a re-write from the bottom up of the official `arrow` crate with soundness
 and type safety in mind.
 
-Check out [the guide](https://jorgecarleitao.github.io/arrow2/) for an introduction.
+Check out [the guide](https://jorgecarleitao.github.io/arrow2/main/guide/) for an introduction.
 Below is an example of some of the things you can do with it:
 
 ```rust


### PR DESCRIPTION
Not sure exactly how things are set up, but https://jorgecarleitao.github.io/arrow2/ seems to be an old version of the guide, with the link to the IO docs broken. I see that in the README that https://jorgecarleitao.github.io/arrow2/main/guide/ seems to be the latest version of the guide, so using it in the API docs.