### PR TITLE
Fixed error in memory usage of sliced binary/list/utf8arrays

### DIFF
--- a/src/compute/aggregate/memory.rs
+++ b/src/compute/aggregate/memory.rs
@@ -9,9 +9,15 @@ fn validity_size(validity: Option<&Bitmap>) -> usize {
 macro_rules! dyn_binary {
     ($array:expr, $ty:ty, $o:ty) => {{
         let array = $array.as_any().downcast_ref::<$ty>().unwrap();
+        let offsets = array.offsets();
 
-        array.values().len()
-            + array.offsets().len() * std::mem::size_of::<$o>()
+        // in case of Binary/Utf8/List the offsets are sliced,
+        // not the values buffer
+        let values_start = offsets[0] as usize;
+        let values_end = offsets[offsets.len() - 1] as usize;
+
+        values_end - values_start
+            + offsets.len() * std::mem::size_of::<$o>()
             + validity_size(array.validity())
     }};
 }


### PR DESCRIPTION
fixes #1292 

The `estimated_bytes_size` function did not shrink if an Utf8 array was sliced, leading to a slice recursion until there were only 3 elements left in the array. This lead to writing 175e7 / 3 pages to the parquet file, which was insanely slow. 

This PR adapts `estimated_bytes_size` so that it reports the sliced array size. It already does this for other data types and I think this is most consistent and least error prone.

If you think we should make it a dedicated function or a branch flagged by an extra argument, that's also fine. 