### PR TITLE
Upgraded ahash to v0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,7 @@ ethnum = "1"
 hash_hasher = "^2.0.3"
 # For SIMD utf8 validation
 simdutf8 = "0.1.3"
-# faster hashing
-ahash = { version = "0.7" }
+
 # A Rust port of SwissTable
 hashbrown = { version = "0.12", default-features = false, optional = true }
 
@@ -100,6 +99,14 @@ multiversion = { version = "0.6.1", optional = true }
 
 # For support for odbc
 odbc-api = { version = "0.36", optional = true }
+
+# faster hashing
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ahash = { version = "0.8", features=["compile-time-rng"] }
+getrandom = { version = "0.2", features = ["js"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+ahash = { version = "0.8", features=["runtime-rng"] }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -1,7 +1,7 @@
 //! Contains the [`hash`] and typed (e.g. [`hash_primitive`]) operators.
 // multiversion does not copy documentation, causing a false positive
 #![allow(missing_docs)]
-use ahash::{CallHasher, RandomState};
+use ahash::RandomState;
 use multiversion::multiversion;
 use std::hash::Hash;
 
@@ -26,7 +26,7 @@ use super::arity::unary;
 pub fn hash_primitive<T: NativeType + Hash>(array: &PrimitiveArray<T>) -> PrimitiveArray<u64> {
     let state = new_state!();
 
-    unary(array, |x| T::get_hash(&x, &state), DataType::UInt64)
+    unary(array, |x| state.hash_one(x), DataType::UInt64)
 }
 
 #[multiversion]
@@ -37,7 +37,7 @@ pub fn hash_boolean(array: &BooleanArray) -> PrimitiveArray<u64> {
 
     let values = array
         .values_iter()
-        .map(|x| u8::get_hash(&x, &state))
+        .map(|x| state.hash_one(x))
         .collect::<Vec<_>>()
         .into();
 
@@ -52,7 +52,7 @@ pub fn hash_utf8<O: Offset>(array: &Utf8Array<O>) -> PrimitiveArray<u64> {
 
     let values = array
         .values_iter()
-        .map(|x| <[u8]>::get_hash(&x.as_bytes(), &state))
+        .map(|x| state.hash_one(x.as_bytes()))
         .collect::<Vec<_>>()
         .into();
 
@@ -64,7 +64,7 @@ pub fn hash_binary<O: Offset>(array: &BinaryArray<O>) -> PrimitiveArray<u64> {
     let state = new_state!();
     let values = array
         .values_iter()
-        .map(|x| <[u8]>::get_hash(&x, &state))
+        .map(|x| state.hash_one(x))
         .collect::<Vec<_>>()
         .into();
 


### PR DESCRIPTION
This is a resubmission of #1271, which was reverted in 6e46651, due to compilation errors with the wasm32 target. It builds on #1274 to fix those compilation errors.

Closes #1274.