### PR TITLE
Bumped arrow-format to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ hash_hasher = "^2.0.3"
 simdutf8 = "0.1.3"
 # faster hashing
 ahash = { version = "0.7" }
-# A Rust port of SwissTable 
+# A Rust port of SwissTable
 hashbrown = { version = "0.12", default-features = false, optional = true }
 
 # for timezone support
@@ -58,7 +58,7 @@ indexmap = { version = "^1.6", optional = true }
 # used to print columns in a nice columnar format
 comfy-table = { version = "5.0", optional = true, default-features = false }
 
-arrow-format = { version = "0.7", optional = true, features = ["ipc"] }
+arrow-format = { version = "0.8", optional = true, features = ["ipc"] }
 
 hex = { version = "^0.4", optional = true }
 

--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -29,7 +29,7 @@ logging = ["tracing-subscriber"]
 
 [dependencies]
 arrow2 = { path = "../", features = ["io_ipc", "io_ipc_compression", "io_flight", "io_json_integration"] }
-arrow-format = { version = "0.7", features = ["flight-data", "flight-service"] }
+arrow-format = { version = "0.8", features = ["flight-data", "flight-service"] }
 async-trait = "0.1.41"
 clap = { version = "^3", features = ["derive"] }
 futures = "0.3"

--- a/integration-testing/Cargo.toml
+++ b/integration-testing/Cargo.toml
@@ -34,11 +34,11 @@ async-trait = "0.1.41"
 clap = { version = "^3", features = ["derive"] }
 futures = "0.3"
 hex = "0.4"
-prost = "0.10"
+prost = "0.11"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread"] }
-tonic = "0.7.0"
+tonic = "0.8.0"
 tracing-subscriber = { version = "0.3.1", optional = true }
 async-stream = { version = "0.3.2" }


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

It's required to use the same version of `arrow-format` for downstream.

This PR will help address issues like:

```rust
error[E0308]: mismatched types
   --> src/query/service/src/api/rpc/exchange/exchange_transform.rs:243:53
    |
243 |                     let data = FragmentData::create(values);
    |                                -------------------- ^^^^^^ expected struct `common_arrow::arrow_format::flight::data::FlightData`, found struct `arrow_format::flight::data::FlightData`
    |                                |
    |                                arguments to this function are incorrect
    |
    = note: struct `arrow_format::flight::data::FlightData` and struct `common_arrow::arrow_format::flight::data::FlightData` have similar names, but are actually distinct types
note: struct `arrow_format::flight::data::FlightData` is defined in crate `arrow_format`
   --> /home/xuanwo/.cargo/registry/src/github.com-1ecc6299db9ec823/arrow-format-0.7.0/src/flight/data.rs:202:1
    |
202 | pub struct FlightData {
    | ^^^^^^^^^^^^^^^^^^^^^
note: struct `common_arrow::arrow_format::flight::data::FlightData` is defined in crate `arrow_format`
   --> /home/xuanwo/.cargo/registry/src/github.com-1ecc6299db9ec823/arrow-format-0.8.0/src/flight/data.rs:215:1
    |
215 | pub struct FlightData {
    | ^^^^^^^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `arrow_format` are being used?
note: associated function defined here
   --> src/query/service/src/api/rpc/packets/packet_data.rs:34:12
    |
34  |     pub fn create(data: FlightData) -> FragmentData {
    |            ^^^^^^ ----------------
```

Fix https://github.com/jorgecarleitao/arrow2/issues/1294