### PR TITLE
Added `reserve` to pushable containers in parquet extend_from_decoder

### DIFF
--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -25,6 +25,9 @@ impl<O: Offset> Offsets<O> {
 }
 
 impl<O: Offset> Pushable<O> for Offsets<O> {
+    fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional)
+    }
     #[inline]
     fn len(&self) -> usize {
         self.0.len() - 1
@@ -88,6 +91,11 @@ impl<O: Offset> Binary<O> {
 }
 
 impl<'a, O: Offset> Pushable<&'a [u8]> for Binary<O> {
+    fn reserve(&mut self, additional: usize) {
+        let avg_len = self.values.len() / std::cmp::max(self.last_offset.to_usize(), 1);
+        self.values.reserve(additional * avg_len);
+        self.offsets.reserve(additional);
+    }
     #[inline]
     fn len(&self) -> usize {
         self.len()

--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -91,6 +91,7 @@ impl<O: Offset> Binary<O> {
 }
 
 impl<'a, O: Offset> Pushable<&'a [u8]> for Binary<O> {
+    #[inline]
     fn reserve(&mut self, additional: usize) {
         let avg_len = self.values.len() / std::cmp::max(self.last_offset.to_usize(), 1);
         self.values.reserve(additional * avg_len);

--- a/src/io/parquet/read/deserialize/fixed_size_binary/utils.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/utils.rs
@@ -30,6 +30,7 @@ impl FixedSizeBinary {
 }
 
 impl<'a> Pushable<&'a [u8]> for FixedSizeBinary {
+    #[inline]
     fn reserve(&mut self, additional: usize) {
         self.values.reserve(additional * self.size);
     }

--- a/src/io/parquet/read/deserialize/fixed_size_binary/utils.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/utils.rs
@@ -30,6 +30,9 @@ impl FixedSizeBinary {
 }
 
 impl<'a> Pushable<&'a [u8]> for FixedSizeBinary {
+    fn reserve(&mut self, additional: usize) {
+        self.values.reserve(additional * self.size);
+    }
     #[inline]
     fn push(&mut self, value: &[u8]) {
         debug_assert_eq!(value.len(), self.size);


### PR DESCRIPTION
This ensure we reserve the amount of slots we are going to push into the container up front.