### PR TITLE
perf: auto-vectorize check_offsets `~-64-73%`

### DIFF
--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -76,17 +76,35 @@ pub fn try_check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) -> Re
 /// Checks that `offsets` is monotonically increasing, and all offsets are less than or equal to
 /// `values_len`.
 pub fn try_check_offsets<O: Offset>(offsets: &[O], values_len: usize) -> Result<()> {
-    if offsets.windows(2).any(|window| window[0] > window[1]) {
-        Err(Error::oos("offsets must be monotonically increasing"))
-    } else if offsets
-        .last()
-        .map_or(true, |last| last.to_usize() > values_len)
-    {
-        Err(Error::oos(
-            "offsets must have at least one element and must not exceed values length",
-        ))
-    } else {
-        Ok(())
+    // this code is carefully constructed to auto-vectorize, don't change naively!
+    match offsets.first() {
+        None => Ok(()),
+        Some(first) => {
+            let mut previous = *first;
+            let mut any_invalid = false;
+
+            // This loop will auto-vectorize because there is not any break,
+            // an invalid value will be returned once the whole offsets buffer is processed.
+            for offset in offsets {
+                if previous > *offset {
+                    any_invalid = true
+                }
+                previous = *offset;
+            }
+
+            if any_invalid {
+                Err(Error::oos("offsets must be monotonically increasing"))
+            } else if offsets
+                .last()
+                .map_or(true, |last| last.to_usize() > values_len)
+            {
+                Err(Error::oos(
+                    "offsets must have at least one element and must not exceed values length",
+                ))
+            } else {
+                Ok(())
+            }
+        }
     }
 }
 

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -78,7 +78,7 @@ pub fn try_check_offsets_and_utf8<O: Offset>(offsets: &[O], values: &[u8]) -> Re
 pub fn try_check_offsets<O: Offset>(offsets: &[O], values_len: usize) -> Result<()> {
     // this code is carefully constructed to auto-vectorize, don't change naively!
     match offsets.first() {
-        None => Ok(()),
+        None => Err(Error::oos("offsets must have at least one element")),
         Some(first) => {
             let mut previous = *first;
             let mut any_invalid = false;


### PR DESCRIPTION
This PR ensures that `check_offsets` is auto-vectorized. A break in a tight loop often prevents this auto-vectorization, so we keep a variable around in the hot loop and we decide if we must return an error once we have processed the data.

```
Gnuplot not found, using plotters backend
check_offsets^10        time:   [212.92 ns 213.20 ns 213.53 ns]                             
                        change: [-73.878% -73.296% -72.720%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

check_offsets^12        time:   [857.28 ns 858.50 ns 859.97 ns]                              
                        change: [-66.556% -66.487% -66.419%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

check_offsets^14        time:   [3.2819 µs 3.2895 µs 3.2976 µs]                              
                        change: [-69.058% -68.997% -68.927%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  5 (5.00%) high mild
  1 (1.00%) high severe

check_offsets^16        time:   [13.689 µs 13.701 µs 13.715 µs]                              
                        change: [-64.854% -64.650% -64.446%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  4 (4.00%) high severe

check_offsets^18        time:   [59.150 µs 59.216 µs 59.300 µs]                             
                        change: [-61.642% -61.554% -61.465%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high severe

check_offsets^20        time:   [238.54 µs 239.10 µs 239.75 µs]                             
                        change: [-64.237% -64.127% -64.026%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe


```