### PR TITLE
perf: elide unneeded offset checks in reading parquet binary/utf8 columns

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -431,6 +431,7 @@ mod ffi;
 mod fmt;
 pub mod growable;
 mod iterator;
+pub mod offsets;
 pub mod ord;
 
 pub(crate) use iterator::ArrayAccessor;

--- a/src/array/offsets.rs
+++ b/src/array/offsets.rs
@@ -1,0 +1,47 @@
+//! Contains the [`ValidityOffsets'] struct and implementations.
+use crate::array::specification::try_check_offsets;
+use crate::array::Offset;
+use crate::buffer::Buffer;
+use crate::error::{Error, Result};
+
+/// Offsets that have the invariant that they
+/// are monotonically increasing.
+pub struct ValidOffsets<O: Offset>(Buffer<O>);
+
+impl<O: Offset> ValidOffsets<O> {
+    /// Try to create a new [`ValidOffsets`] buffer by checking the offsets.
+    pub fn try_new(offsets: Buffer<O>) -> Result<Self> {
+        match offsets.last() {
+            None => Err(Error::oos("offsets must have at least one element")),
+            Some(last) => {
+                try_check_offsets(offsets.as_slice(), last.to_usize())?;
+                Ok(ValidOffsets(offsets))
+            }
+        }
+    }
+
+    /// Create a new [`ValidOffsets`] buffer.
+    ///
+    /// # Safety
+    ///
+    /// The offsets must be monotonically increasing.
+    pub unsafe fn new_unchecked(offsets: Buffer<O>) -> Result<Self> {
+        if offsets.first().is_none() {
+            Err(Error::oos("offsets must have at least one element"))
+        } else {
+            Ok(ValidOffsets(offsets))
+        }
+    }
+}
+
+impl<O: Offset> From<ValidOffsets<O>> for Buffer<O> {
+    fn from(vo: ValidOffsets<O>) -> Self {
+        vo.0
+    }
+}
+
+impl<O: Offset> AsRef<[O]> for ValidOffsets<O> {
+    fn as_ref(&self) -> &[O] {
+        self.0.as_slice()
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,4 +1,3 @@
-#![forbid(unsafe_code)]
 //! Contains modules to interface with other formats such as [`csv`],
 //! [`parquet`], [`json`], [`ipc`], [`mod@print`] and [`avro`].
 

--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -1,3 +1,4 @@
+use crate::array::offsets::ValidOffsets;
 use crate::array::Offset;
 
 use super::super::utils::Pushable;
@@ -50,6 +51,13 @@ impl<O: Offset> Pushable<O> for Offsets<O> {
 }
 
 impl<O: Offset> Binary<O> {
+    pub fn into_inner(self) -> (ValidOffsets<O>, Vec<u8>) {
+        // Safety:
+        // the invariant that all offsets are monotonically increasing is upheld.
+        let offsets = unsafe { ValidOffsets::new_unchecked(self.offsets.0.into()) }.unwrap();
+        (offsets, self.values)
+    }
+
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
         let mut offsets = Vec::with_capacity(1 + capacity);


### PR DESCRIPTION
This would close #1306 and uses a `unsafe` conversion which is actually sound because we have carefully constructed the `Offsets` and uphold its invariant. This saves 5% runtime in my local benchmark of reading utf8 columns. I expect the maximum performance increase is ~10% when we deal with one character strings.