### PR TITLE
add bytes_estimate for binary push in parquet deserialize

### DIFF
--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -480,12 +480,12 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
 
 pub(super) fn finish<O: Offset, A: TraitBinaryArray<O>>(
     data_type: &DataType,
-    mut values:  Binary<O>,
+    mut values: Binary<O>,
     validity: MutableBitmap,
 ) -> Result<A> {
     values.offsets.shrink_to_fit();
     values.values.shrink_to_fit();
-    
+
     A::try_new(
         data_type.clone(),
         values.offsets.0.into(),

--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -480,7 +480,7 @@ pub(super) fn finish<O: Offset, A: TraitBinaryArray<O>>(
     mut values: Binary<O>,
     mut validity: MutableBitmap,
 ) -> Result<A> {
-    values.offsets.0.shrink_to_fit();
+    values.offsets.shrink_to_fit();
     values.values.shrink_to_fit();
     validity.shrink_to_fit();
 

--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -480,13 +480,16 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
 
 pub(super) fn finish<O: Offset, A: TraitBinaryArray<O>>(
     data_type: &DataType,
-    values: Binary<O>,
+    mut values:  Binary<O>,
     validity: MutableBitmap,
 ) -> Result<A> {
+    values.offsets.shrink_to_fit();
+    values.values.shrink_to_fit();
+    
     A::try_new(
         data_type.clone(),
         values.offsets.0.into(),
-        values.values.into(),
+        values.into(),
         validity.into(),
     )
 }

--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -481,15 +481,16 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
 pub(super) fn finish<O: Offset, A: TraitBinaryArray<O>>(
     data_type: &DataType,
     mut values: Binary<O>,
-    validity: MutableBitmap,
+    mut validity: MutableBitmap,
 ) -> Result<A> {
-    values.offsets.shrink_to_fit();
+    values.offsets.0.shrink_to_fit();
     values.values.shrink_to_fit();
+    validity.shrink_to_fit();
 
     A::try_new(
         data_type.clone(),
         values.offsets.0.into(),
-        values.into(),
+        values.values.into(),
         validity.into(),
     )
 }

--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -63,6 +63,14 @@ impl<O: Offset> Binary<O> {
 
     #[inline]
     pub fn push(&mut self, v: &[u8]) {
+        if self.offsets.0.len() == 101 && self.offsets.0.capacity() > 101 {
+            let bytes_per_row = self.values.len() / 100 + 1;
+            let bytes_estimate = bytes_per_row * self.offsets.0.capacity();
+            if bytes_estimate > self.values.capacity() {
+                self.values.reserve(bytes_estimate - self.values.capacity());
+            }
+        }
+
         self.values.extend(v);
         self.last_offset += O::from_usize(v.len()).unwrap();
         self.offsets.push(self.last_offset)

--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -45,9 +45,9 @@ impl<O: Offset> Binary<O> {
 
     #[inline]
     pub fn push(&mut self, v: &[u8]) {
-        if self.offsets.0.len() == 101 && self.offsets.0.capacity() > 101 {
+        if self.offsets.len() == 100 && self.offsets.capacity() > 100 {
             let bytes_per_row = self.values.len() / 100 + 1;
-            let bytes_estimate = bytes_per_row * self.offsets.0.capacity();
+            let bytes_estimate = bytes_per_row * self.offsets.capacity();
             if bytes_estimate > self.values.capacity() {
                 self.values.reserve(bytes_estimate - self.values.capacity());
             }

--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -56,7 +56,7 @@ impl<O: Offset> Binary<O> {
         offsets.push(O::default());
         Self {
             offsets: Offsets(offsets),
-            values: Vec::with_capacity(capacity * 24),
+            values: Vec::with_capacity(capacity.min(100) * 24),
             last_offset: O::default(),
         }
     }

--- a/src/io/parquet/read/deserialize/utils.rs
+++ b/src/io/parquet/read/deserialize/utils.rs
@@ -409,7 +409,7 @@ pub(super) fn extend_from_new_page<'a, T: Decoder<'a>>(
     remaining: &mut usize,
     decoder: &T,
 ) {
-    let capacity = chunk_size.unwrap_or(0);
+    let capacity = chunk_size.unwrap_or(1048576);
     let chunk_size = chunk_size.unwrap_or(usize::MAX);
 
     let mut decoded = if let Some(decoded) = items.pop_back() {

--- a/src/io/parquet/read/deserialize/utils.rs
+++ b/src/io/parquet/read/deserialize/utils.rs
@@ -409,7 +409,7 @@ pub(super) fn extend_from_new_page<'a, T: Decoder<'a>>(
     remaining: &mut usize,
     decoder: &T,
 ) {
-    let capacity = chunk_size.unwrap_or(1048576);
+    let capacity = chunk_size.unwrap_or(0);
     let chunk_size = chunk_size.unwrap_or(usize::MAX);
 
     let mut decoded = if let Some(decoded) = items.pop_back() {


### PR DESCRIPTION
<img width="1768" alt="image" src="https://user-images.githubusercontent.com/3325189/204799872-76ba2f14-b098-47eb-9656-ad42d6902c0d.png">


 ```
values: Vec::with_capacity(capacity * 24),
```
Now `Binary<O>`  will allocate too much memory even if the binary has a small size per item.

1. Here we will reverse the capacity when pushing the 101st item by calculating the byte size per row.
2. Add `shrink_to_fit()` during finish method.


