### PR TITLE
Added `Offsets` and `OffsetsBuffer`

### DIFF
--- a/benches/iter_list.rs
+++ b/benches/iter_list.rs
@@ -16,8 +16,7 @@ fn add_benchmark(c: &mut Criterion) {
         let values = Buffer::from_iter(0..size as i32);
         let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
 
-        let mut offsets = (0..size as i32).step_by(2).collect::<Vec<_>>();
-        offsets.push(size as i32);
+        let offsets = (0..=size as i32).step_by(2).collect::<Vec<_>>();
 
         let validity = (0..(offsets.len() - 1))
             .map(|i| i % 4 == 0)
@@ -26,7 +25,7 @@ fn add_benchmark(c: &mut Criterion) {
         let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
         let array = ListArray::<i32>::from_data(
             data_type,
-            offsets.into(),
+            offsets.try_into().unwrap(),
             Box::new(values),
             Some(validity),
         );

--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -1,7 +1,8 @@
 use crate::{
-    array::{FromFfi, Offset, ToFfi},
+    array::{FromFfi, ToFfi},
     bitmap::align,
     ffi,
+    offset::Offset,
 };
 
 use crate::error::Result;

--- a/src/array/binary/fmt.rs
+++ b/src/array/binary/fmt.rs
@@ -1,7 +1,8 @@
 use std::fmt::{Debug, Formatter, Result, Write};
 
+use crate::offset::Offset;
+
 use super::super::fmt::write_vec;
-use super::super::Offset;
 use super::BinaryArray;
 
 pub fn write_value<O: Offset, W: Write>(array: &BinaryArray<O>, index: usize, f: &mut W) -> Result {

--- a/src/array/binary/from.rs
+++ b/src/array/binary/from.rs
@@ -1,6 +1,6 @@
 use std::iter::FromIterator;
 
-use crate::array::Offset;
+use crate::offset::Offset;
 
 use super::{BinaryArray, MutableBinaryArray};
 

--- a/src/array/binary/iterator.rs
+++ b/src/array/binary/iterator.rs
@@ -1,6 +1,7 @@
 use crate::{
-    array::{ArrayAccessor, ArrayValuesIter, Offset},
+    array::{ArrayAccessor, ArrayValuesIter},
     bitmap::utils::{BitmapIter, ZipValidity},
+    offset::Offset,
 };
 
 use super::{BinaryArray, MutableBinaryValuesArray};

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -40,7 +40,7 @@ pub use mutable::*;
 /// assert_eq!(array.values_iter().collect::<Vec<_>>(), vec![[1, 2].as_ref(), &[], &[3]]);
 /// // the underlying representation:
 /// assert_eq!(array.values(), &Buffer::from(vec![1, 2, 3]));
-/// assert_eq!(array.offsets(), &Buffer::from(vec![0, 2, 2, 3]));
+/// assert_eq!(array.offsets().buffer(), &Buffer::from(vec![0, 2, 2, 3]));
 /// assert_eq!(array.validity(), Some(&Bitmap::from([true, false, true])));
 /// ```
 ///

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     buffer::Buffer,
     datatypes::DataType,
     error::Error,
+    offset::Offset,
     trusted_len::TrustedLen,
 };
 
@@ -13,7 +14,7 @@ use either::Either;
 
 use super::{
     specification::{try_check_offsets, try_check_offsets_bounds},
-    Array, GenericBinaryArray, Offset,
+    Array, GenericBinaryArray,
 };
 
 mod ffi;

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -78,7 +78,7 @@ impl<O: Offset> BinaryArray<O> {
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> Result<Self, Error> {
-        try_check_offsets_bounds(offsets.buffer(), values.len())?;
+        try_check_offsets_bounds(&offsets, values.len())?;
 
         if validity
             .as_ref()
@@ -145,8 +145,7 @@ impl<O: Offset> BinaryArray<O> {
     #[inline]
     pub unsafe fn value_unchecked(&self, i: usize) -> &[u8] {
         // soundness: the invariant of the function
-        let start = self.offsets.buffer().get_unchecked(i).to_usize();
-        let end = self.offsets.buffer().get_unchecked(i + 1).to_usize();
+        let (start, end) = self.offsets.start_end_unchecked(i);
 
         // soundness: the invariant of the struct
         self.values.get_unchecked(start..end)

--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -1,13 +1,14 @@
 use std::{iter::FromIterator, sync::Arc};
 
 use crate::{
-    array::{Array, MutableArray, Offset, TryExtend, TryExtendFromSelf, TryPush},
+    array::{Array, MutableArray, TryExtend, TryExtendFromSelf, TryPush},
     bitmap::{
         utils::{BitmapIter, ZipValidity},
         Bitmap, MutableBitmap,
     },
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
     trusted_len::TrustedLen,
 };
 

--- a/src/array/binary/mutable_values.rs
+++ b/src/array/binary/mutable_values.rs
@@ -66,7 +66,7 @@ impl<O: Offset> MutableBinaryValuesArray<O> {
     /// # Implementation
     /// This function is `O(1)`
     pub fn try_new(data_type: DataType, offsets: Offsets<O>, values: Vec<u8>) -> Result<Self> {
-        try_check_offsets_bounds(offsets.as_slice(), values.len())?;
+        try_check_offsets_bounds(&offsets, values.len())?;
 
         if data_type.to_physical_type() != Self::default_data_type().to_physical_type() {
             return Err(Error::oos(
@@ -166,8 +166,7 @@ impl<O: Offset> MutableBinaryValuesArray<O> {
     #[inline]
     pub unsafe fn value_unchecked(&self, i: usize) -> &[u8] {
         // soundness: the invariant of the function
-        let start = self.offsets.as_slice().get_unchecked(i).to_usize();
-        let end = self.offsets.as_slice().get_unchecked(i + 1).to_usize();
+        let (start, end) = self.offsets.start_end(i);
 
         // soundness: the invariant of the struct
         self.values.get_unchecked(start..end)

--- a/src/array/binary/mutable_values.rs
+++ b/src/array/binary/mutable_values.rs
@@ -3,12 +3,12 @@ use std::{iter::FromIterator, sync::Arc};
 use crate::{
     array::{
         specification::{check_offsets_minimal, try_check_offsets},
-        Array, ArrayAccessor, ArrayValuesIter, MutableArray, Offset, TryExtend, TryExtendFromSelf,
-        TryPush,
+        Array, ArrayAccessor, ArrayValuesIter, MutableArray, TryExtend, TryExtendFromSelf, TryPush,
     },
     bitmap::MutableBitmap,
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
     trusted_len::TrustedLen,
 };
 

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -157,15 +157,12 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
     }
 
     fn take_into(&mut self) -> DictionaryArray<K> {
-        // Safety - the invariant of this struct ensures that this is up-held
-        unsafe {
-            DictionaryArray::<K>::try_new(
-                self.data_type.clone(),
-                std::mem::take(&mut self.keys).into(),
-                self.values.as_box(),
-            )
-            .unwrap()
-        }
+        DictionaryArray::<K>::try_new(
+            self.data_type.clone(),
+            std::mem::take(&mut self.keys).into(),
+            self.values.as_box(),
+        )
+        .unwrap()
     }
 }
 

--- a/src/array/equal/binary.rs
+++ b/src/array/equal/binary.rs
@@ -1,4 +1,5 @@
-use crate::array::{BinaryArray, Offset};
+use crate::array::BinaryArray;
+use crate::offset::Offset;
 
 pub(super) fn equal<O: Offset>(lhs: &BinaryArray<O>, rhs: &BinaryArray<O>) -> bool {
     lhs.data_type() == rhs.data_type() && lhs.len() == rhs.len() && lhs.iter().eq(rhs.iter())

--- a/src/array/equal/list.rs
+++ b/src/array/equal/list.rs
@@ -1,4 +1,5 @@
-use crate::array::{Array, ListArray, Offset};
+use crate::array::{Array, ListArray};
+use crate::offset::Offset;
 
 pub(super) fn equal<O: Offset>(lhs: &ListArray<O>, rhs: &ListArray<O>) -> bool {
     lhs.data_type() == rhs.data_type() && lhs.len() == rhs.len() && lhs.iter().eq(rhs.iter())

--- a/src/array/equal/mod.rs
+++ b/src/array/equal/mod.rs
@@ -1,3 +1,4 @@
+use crate::offset::Offset;
 use crate::types::NativeType;
 
 use super::*;

--- a/src/array/equal/utf8.rs
+++ b/src/array/equal/utf8.rs
@@ -1,4 +1,5 @@
-use crate::array::{Offset, Utf8Array};
+use crate::array::Utf8Array;
+use crate::offset::Offset;
 
 pub(super) fn equal<O: Offset>(lhs: &Utf8Array<O>, rhs: &Utf8Array<O>) -> bool {
     lhs.data_type() == rhs.data_type() && lhs.len() == rhs.len() && lhs.iter().eq(rhs.iter())

--- a/src/array/growable/binary.rs
+++ b/src/array/growable/binary.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
 use crate::{
-    array::{Array, BinaryArray, Offset},
+    array::{Array, BinaryArray},
     bitmap::MutableBitmap,
     datatypes::DataType,
+    offset::Offset,
 };
 
 use super::{

--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -3,12 +3,12 @@ use std::sync::Arc;
 use crate::{
     array::{Array, ListArray},
     bitmap::MutableBitmap,
-    offset::Offset,
+    offset::{Offset, Offsets},
 };
 
 use super::{
     make_growable,
-    utils::{build_extend_null_bits, extend_offsets, ExtendNullBits},
+    utils::{build_extend_null_bits, ExtendNullBits},
     Growable,
 };
 
@@ -21,37 +21,15 @@ fn extend_offset_values<O: Offset>(
     let array = growable.arrays[index];
     let offsets = array.offsets();
 
-    if array.null_count() == 0 {
-        // offsets
-        extend_offsets::<O>(
-            &mut growable.offsets,
-            &mut growable.last_offset,
-            &offsets[start..start + len + 1],
-        );
+    growable
+        .offsets
+        .try_extend_from_slice(offsets, start, len)
+        .unwrap();
 
-        let end = offsets[start + len].to_usize();
-        let start = offsets[start].to_usize();
-        let len = end - start;
-        growable.values.extend(index, start, len)
-    } else {
-        growable.offsets.reserve(len);
-
-        let new_offsets = &mut growable.offsets;
-        let inner_values = &mut growable.values;
-        let last_offset = &mut growable.last_offset;
-        (start..start + len).for_each(|i| {
-            if array.is_valid(i) {
-                let len = offsets[i + 1] - offsets[i];
-                // compute the new offset
-                *last_offset += len;
-
-                // append value
-                inner_values.extend(index, offsets[i].to_usize(), len.to_usize());
-            }
-            // append offset
-            new_offsets.push(*last_offset);
-        })
-    }
+    let end = offsets.buffer()[start + len].to_usize();
+    let start = offsets.buffer()[start].to_usize();
+    let len = end - start;
+    growable.values.extend(index, start, len);
 }
 
 /// Concrete [`Growable`] for the [`ListArray`].
@@ -59,8 +37,7 @@ pub struct GrowableList<'a, O: Offset> {
     arrays: Vec<&'a ListArray<O>>,
     validity: MutableBitmap,
     values: Box<dyn Growable<'a> + 'a>,
-    offsets: Vec<O>,
-    last_offset: O, // always equal to the last offset at `offsets`.
+    offsets: Offsets<O>,
     extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
@@ -86,16 +63,11 @@ impl<'a, O: Offset> GrowableList<'a, O> {
             .collect::<Vec<_>>();
         let values = make_growable(&inner, use_validity, 0);
 
-        let mut offsets = Vec::with_capacity(capacity + 1);
-        let length = O::default();
-        offsets.push(length);
-
         Self {
             arrays,
-            offsets,
+            offsets: Offsets::with_capacity(capacity),
             values,
             validity: MutableBitmap::with_capacity(capacity),
-            last_offset: O::default(),
             extend_null_bits,
         }
     }
@@ -105,20 +77,12 @@ impl<'a, O: Offset> GrowableList<'a, O> {
         let offsets = std::mem::take(&mut self.offsets);
         let values = self.values.as_box();
 
-        #[cfg(debug_assertions)]
-        {
-            crate::array::specification::try_check_offsets(&offsets, values.len()).unwrap();
-        }
-
-        // Safety - the invariant of this struct ensures that this is up-held
-        unsafe {
-            ListArray::<O>::new_unchecked(
-                self.arrays[0].data_type().clone(),
-                offsets.into(),
-                values,
-                validity.into(),
-            )
-        }
+        ListArray::<O>::new(
+            self.arrays[0].data_type().clone(),
+            offsets.into(),
+            values,
+            validity.into(),
+        )
     }
 }
 
@@ -129,8 +93,7 @@ impl<'a, O: Offset> Growable<'a> for GrowableList<'a, O> {
     }
 
     fn extend_validity(&mut self, additional: usize) {
-        self.offsets
-            .resize(self.offsets.len() + additional, self.last_offset);
+        self.offsets.extend_constant(additional);
         self.validity.extend_constant(additional, false);
     }
 

--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use crate::{
-    array::{Array, ListArray, Offset},
+    array::{Array, ListArray},
     bitmap::MutableBitmap,
+    offset::Offset,
 };
 
 use super::{

--- a/src/array/growable/utf8.rs
+++ b/src/array/growable/utf8.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use crate::{
-    array::{Array, Offset, Utf8Array},
+    array::{Array, Utf8Array},
+    offset::Offset,
     bitmap::MutableBitmap,
 };
 

--- a/src/array/growable/utf8.rs
+++ b/src/array/growable/utf8.rs
@@ -52,8 +52,7 @@ impl<'a, O: Offset> GrowableUtf8<'a, O> {
 
         #[cfg(debug_assertions)]
         {
-            crate::array::specification::try_check_offsets_and_utf8(offsets.as_slice(), &values)
-                .unwrap();
+            crate::array::specification::try_check_utf8(&offsets, &values).unwrap();
         }
 
         unsafe {

--- a/src/array/growable/utils.rs
+++ b/src/array/growable/utils.rs
@@ -1,7 +1,4 @@
-use crate::{
-    array::{Array, Offset},
-    bitmap::MutableBitmap,
-};
+use crate::{array::Array, bitmap::MutableBitmap, offset::Offset};
 
 pub(super) fn extend_offsets<T: Offset>(buffer: &mut Vec<T>, last_offset: &mut T, offsets: &[T]) {
     buffer.reserve(offsets.len() - 1);

--- a/src/array/growable/utils.rs
+++ b/src/array/growable/utils.rs
@@ -1,15 +1,5 @@
 use crate::{array::Array, bitmap::MutableBitmap, offset::Offset};
 
-pub(super) fn extend_offsets<T: Offset>(buffer: &mut Vec<T>, last_offset: &mut T, offsets: &[T]) {
-    buffer.reserve(offsets.len() - 1);
-    offsets.windows(2).for_each(|offsets| {
-        // compute the new offset
-        let length = offsets[1] - offsets[0];
-        *last_offset += length;
-        buffer.push(*last_offset);
-    });
-}
-
 // function used to extend nulls from arrays. This function's lifetime is bound to the array
 // because it reads nulls from it.
 pub(super) type ExtendNullBits<'a> = Box<dyn Fn(&mut MutableBitmap, usize, usize) + 'a>;

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -1,6 +1,6 @@
 use crate::{array::FromFfi, bitmap::align, error::Result, ffi};
 
-use crate::offset::Offset;
+use crate::offset::{Offset, OffsetsBuffer};
 
 use super::super::{ffi::ToFfi, Array};
 use super::ListArray;
@@ -9,7 +9,7 @@ unsafe impl<O: Offset> ToFfi for ListArray<O> {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            Some(self.offsets.as_ptr().cast::<u8>()),
+            Some(self.offsets.buffer().as_ptr().cast::<u8>()),
         ]
     }
 
@@ -18,7 +18,7 @@ unsafe impl<O: Offset> ToFfi for ListArray<O> {
     }
 
     fn offset(&self) -> Option<usize> {
-        let offset = self.offsets.offset();
+        let offset = self.offsets.buffer().offset();
         if let Some(bitmap) = self.validity.as_ref() {
             if bitmap.offset() == offset {
                 Some(offset)
@@ -31,7 +31,7 @@ unsafe impl<O: Offset> ToFfi for ListArray<O> {
     }
 
     fn to_ffi_aligned(&self) -> Self {
-        let offset = self.offsets.offset();
+        let offset = self.offsets.buffer().offset();
 
         let validity = self.validity.as_ref().map(|bitmap| {
             if bitmap.offset() == offset {
@@ -58,6 +58,9 @@ impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for ListArray<O> {
         let child = unsafe { array.child(0)? };
         let values = ffi::try_from(child)?;
 
-        Ok(Self::from_data(data_type, offsets, values, validity))
+        // assumption that data from FFI is well constructed
+        let offsets = unsafe { OffsetsBuffer::new_unchecked(offsets) };
+
+        Ok(Self::new(data_type, offsets, values, validity))
     }
 }

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -1,6 +1,8 @@
 use crate::{array::FromFfi, bitmap::align, error::Result, ffi};
 
-use super::super::{ffi::ToFfi, Array, Offset};
+use crate::offset::Offset;
+
+use super::super::{ffi::ToFfi, Array};
 use super::ListArray;
 
 unsafe impl<O: Offset> ToFfi for ListArray<O> {

--- a/src/array/list/fmt.rs
+++ b/src/array/list/fmt.rs
@@ -1,6 +1,6 @@
 use std::fmt::{Debug, Formatter, Result, Write};
 
-use crate::array::Offset;
+use crate::offset::Offset;
 
 use super::super::fmt::{get_display, write_vec};
 use super::ListArray;

--- a/src/array/list/iterator.rs
+++ b/src/array/list/iterator.rs
@@ -1,6 +1,6 @@
-use crate::array::Offset;
 use crate::array::{Array, ArrayAccessor, ArrayValuesIter};
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
+use crate::offset::Offset;
 
 use super::ListArray;
 

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -3,13 +3,14 @@ use crate::{
     buffer::Buffer,
     datatypes::{DataType, Field},
     error::Error,
+    offset::Offset,
 };
 use std::sync::Arc;
 
 use super::{
     new_empty_array,
     specification::{try_check_offsets, try_check_offsets_bounds},
-    Array, Offset,
+    Array,
 };
 
 mod ffi;

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -1,17 +1,12 @@
 use crate::{
     bitmap::Bitmap,
-    buffer::Buffer,
     datatypes::{DataType, Field},
     error::Error,
-    offset::Offset,
+    offset::{Offset, OffsetsBuffer},
 };
 use std::sync::Arc;
 
-use super::{
-    new_empty_array,
-    specification::{try_check_offsets, try_check_offsets_bounds},
-    Array,
-};
+use super::{new_empty_array, specification::try_check_offsets_bounds, Array};
 
 mod ffi;
 pub(super) mod fmt;
@@ -24,7 +19,7 @@ pub use mutable::*;
 #[derive(Clone)]
 pub struct ListArray<O: Offset> {
     data_type: DataType,
-    offsets: Buffer<O>,
+    offsets: OffsetsBuffer<O>,
     values: Box<dyn Array>,
     validity: Option<Bitmap>,
 }
@@ -34,24 +29,23 @@ impl<O: Offset> ListArray<O> {
     ///
     /// # Errors
     /// This function returns an error iff:
-    /// * the offsets are not monotonically increasing
     /// * The last offset is not equal to the values' length.
-    /// * the validity's length is not equal to `offsets.len() - 1`.
+    /// * the validity's length is not equal to `offsets.len()`.
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either [`crate::datatypes::PhysicalType::List`] or [`crate::datatypes::PhysicalType::LargeList`].
     /// * The `data_type`'s inner field's data type is not equal to `values.data_type`.
     /// # Implementation
-    /// This function is `O(N)` - checking monotinicity is `O(N)`
+    /// This function is `O(1)`
     pub fn try_new(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Box<dyn Array>,
         validity: Option<Bitmap>,
     ) -> Result<Self, Error> {
-        try_check_offsets(&offsets, values.len())?;
+        try_check_offsets_bounds(offsets.buffer(), values.len())?;
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != offsets.len() - 1)
+            .map_or(false, |validity| validity.len() != offsets.len())
         {
             return Err(Error::oos(
                 "validity mask length must match the number of values",
@@ -78,16 +72,15 @@ impl<O: Offset> ListArray<O> {
     ///
     /// # Panics
     /// This function panics iff:
-    /// * the offsets are not monotonically increasing
     /// * The last offset is not equal to the values' length.
-    /// * the validity's length is not equal to `offsets.len() - 1`.
+    /// * the validity's length is not equal to `offsets.len()`.
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either [`crate::datatypes::PhysicalType::List`] or [`crate::datatypes::PhysicalType::LargeList`].
     /// * The `data_type`'s inner field's data type is not equal to `values.data_type`.
     /// # Implementation
-    /// This function is `O(N)` - checking monotinicity is `O(N)`
+    /// This function is `O(1)`
     pub fn new(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Box<dyn Array>,
         validity: Option<Bitmap>,
     ) -> Self {
@@ -97,7 +90,7 @@ impl<O: Offset> ListArray<O> {
     /// Alias of `new`
     pub fn from_data(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Box<dyn Array>,
         validity: Option<Bitmap>,
     ) -> Self {
@@ -107,7 +100,7 @@ impl<O: Offset> ListArray<O> {
     /// Returns a new empty [`ListArray`].
     pub fn new_empty(data_type: DataType) -> Self {
         let values = new_empty_array(Self::get_child_type(&data_type).clone());
-        Self::new(data_type, Buffer::from(vec![O::zero()]), values, None)
+        Self::new(data_type, OffsetsBuffer::default(), values, None)
     }
 
     /// Returns a new null [`ListArray`].
@@ -116,7 +109,7 @@ impl<O: Offset> ListArray<O> {
         let child = Self::get_child_type(&data_type).clone();
         Self::new(
             data_type,
-            vec![O::default(); 1 + length].into(),
+            vec![O::zero(); 1 + length].try_into().unwrap(),
             new_empty_array(child),
             Some(Bitmap::new_zeroed(length)),
         )
@@ -130,77 +123,6 @@ impl<O: Offset> ListArray<O> {
     /// Boxes self into a [`Arc<dyn Array>`].
     pub fn arced(self) -> Arc<dyn Array> {
         Arc::new(self)
-    }
-}
-
-// unsafe construtors
-impl<O: Offset> ListArray<O> {
-    /// Creates a new [`ListArray`].
-    ///
-    /// # Errors
-    /// This function returns an error iff:
-    /// * The last offset is not equal to the values' length.
-    /// * the validity's length is not equal to `offsets.len() - 1`.
-    /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either [`crate::datatypes::PhysicalType::List`] or [`crate::datatypes::PhysicalType::LargeList`].
-    /// * The `data_type`'s inner field's data type is not equal to `values.data_type`.
-    /// # Safety
-    /// This function is unsafe iff:
-    /// * the offsets are not monotonically increasing
-    /// # Implementation
-    /// This function is `O(1)`
-    pub unsafe fn try_new_unchecked(
-        data_type: DataType,
-        offsets: Buffer<O>,
-        values: Box<dyn Array>,
-        validity: Option<Bitmap>,
-    ) -> Result<Self, Error> {
-        try_check_offsets_bounds(&offsets, values.len())?;
-
-        if validity
-            .as_ref()
-            .map_or(false, |validity| validity.len() != offsets.len() - 1)
-        {
-            return Err(Error::oos(
-                "validity mask length must match the number of values",
-            ));
-        }
-
-        let child_data_type = Self::try_get_child(&data_type)?.data_type();
-        let values_data_type = values.data_type();
-        if child_data_type != values_data_type {
-            return Err(Error::oos(
-                format!("ListArray's child's DataType must match. However, the expected DataType is {child_data_type:?} while it got {values_data_type:?}."),
-            ));
-        }
-
-        Ok(Self {
-            data_type,
-            offsets,
-            values,
-            validity,
-        })
-    }
-
-    /// Creates a new [`ListArray`].
-    ///
-    /// # Panics
-    /// This function panics iff:
-    /// * The last offset is not equal to the values' length.
-    /// * the validity's length is not equal to `offsets.len() - 1`.
-    /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either [`crate::datatypes::PhysicalType::List`] or [`crate::datatypes::PhysicalType::LargeList`].
-    /// * The `data_type`'s inner field's data type is not equal to `values.data_type`.
-    /// # Safety
-    /// This function is unsafe iff:
-    /// * the offsets are not monotonically increasing
-    /// # Implementation
-    /// This function is `O(1)`
-    pub unsafe fn new_unchecked(
-        data_type: DataType,
-        offsets: Buffer<O>,
-        values: Box<dyn Array>,
-        validity: Option<Bitmap>,
-    ) -> Self {
-        Self::try_new_unchecked(data_type, offsets, values, validity).unwrap()
     }
 }
 
@@ -259,14 +181,14 @@ impl<O: Offset> ListArray<O> {
     /// Returns the length of this array
     #[inline]
     pub fn len(&self) -> usize {
-        self.offsets.len() - 1
+        self.offsets.len()
     }
 
     /// Returns the element at index `i`
     #[inline]
     pub fn value(&self, i: usize) -> Box<dyn Array> {
-        let offset = self.offsets[i];
-        let offset_1 = self.offsets[i + 1];
+        let offset = self.offsets.buffer()[i];
+        let offset_1 = self.offsets.buffer()[i + 1];
         let length = (offset_1 - offset).to_usize();
 
         // Safety:
@@ -280,8 +202,8 @@ impl<O: Offset> ListArray<O> {
     /// Assumes that the `i < self.len`.
     #[inline]
     pub unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array> {
-        let offset = *self.offsets.get_unchecked(i);
-        let offset_1 = *self.offsets.get_unchecked(i + 1);
+        let offset = *self.offsets.buffer().get_unchecked(i);
+        let offset_1 = *self.offsets.buffer().get_unchecked(i + 1);
         let length = (offset_1 - offset).to_usize();
 
         self.values.slice_unchecked(offset.to_usize(), length)
@@ -295,7 +217,7 @@ impl<O: Offset> ListArray<O> {
 
     /// The offsets [`Buffer`].
     #[inline]
-    pub fn offsets(&self) -> &Buffer<O> {
+    pub fn offsets(&self) -> &OffsetsBuffer<O> {
         &self.offsets
     }
 

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -4,11 +4,12 @@ use crate::{
     array::{
         physical_binary::{extend_validity, try_extend_offsets},
         specification::try_check_offsets,
-        Array, MutableArray, Offset, TryExtend, TryExtendFromSelf, TryPush,
+        Array, MutableArray, TryExtend, TryExtendFromSelf, TryPush,
     },
     bitmap::MutableBitmap,
     datatypes::{DataType, Field},
     error::{Error, Result},
+    offset::Offset,
     trusted_len::TrustedLen,
 };
 

--- a/src/array/map/ffi.rs
+++ b/src/array/map/ffi.rs
@@ -1,4 +1,4 @@
-use crate::{array::FromFfi, bitmap::align, error::Result, ffi};
+use crate::{array::FromFfi, bitmap::align, error::Result, ffi, offset::OffsetsBuffer};
 
 use super::super::{ffi::ToFfi, Array};
 use super::MapArray;
@@ -7,7 +7,7 @@ unsafe impl ToFfi for MapArray {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            Some(self.offsets.as_ptr().cast::<u8>()),
+            Some(self.offsets.buffer().as_ptr().cast::<u8>()),
         ]
     }
 
@@ -16,7 +16,7 @@ unsafe impl ToFfi for MapArray {
     }
 
     fn offset(&self) -> Option<usize> {
-        let offset = self.offsets.offset();
+        let offset = self.offsets.buffer().offset();
         if let Some(bitmap) = self.validity.as_ref() {
             if bitmap.offset() == offset {
                 Some(offset)
@@ -29,7 +29,7 @@ unsafe impl ToFfi for MapArray {
     }
 
     fn to_ffi_aligned(&self) -> Self {
-        let offset = self.offsets.offset();
+        let offset = self.offsets.buffer().offset();
 
         let validity = self.validity.as_ref().map(|bitmap| {
             if bitmap.offset() == offset {
@@ -55,6 +55,9 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for MapArray {
         let offsets = unsafe { array.buffer::<i32>(1) }?;
         let child = array.child(0)?;
         let values = ffi::try_from(child)?;
+
+        // assumption that data from FFI is well constructed
+        let offsets = unsafe { OffsetsBuffer::new_unchecked(offsets) };
 
         Self::try_new(data_type, offsets, values, validity)
     }

--- a/src/array/map/mod.rs
+++ b/src/array/map/mod.rs
@@ -1,11 +1,11 @@
 use crate::{
     bitmap::Bitmap,
-    buffer::Buffer,
     datatypes::{DataType, Field},
     error::Error,
+    offset::OffsetsBuffer,
 };
 
-use super::{new_empty_array, specification::try_check_offsets, Array};
+use super::{new_empty_array, specification::try_check_offsets_bounds, Array};
 
 mod ffi;
 mod fmt;
@@ -16,8 +16,8 @@ pub use iterator::*;
 #[derive(Clone)]
 pub struct MapArray {
     data_type: DataType,
-    // invariant: field.len() == offsets.len() - 1
-    offsets: Buffer<i32>,
+    // invariant: field.len() == offsets.len()
+    offsets: OffsetsBuffer<i32>,
     field: Box<dyn Array>,
     // invariant: offsets.len() - 1 == Bitmap::len()
     validity: Option<Bitmap>,
@@ -27,18 +27,17 @@ impl MapArray {
     /// Returns a new [`MapArray`].
     /// # Errors
     /// This function errors iff:
-    /// * the offsets are not monotonically increasing
     /// * The last offset is not equal to the field' length
     /// * The `data_type`'s physical type is not [`crate::datatypes::PhysicalType::Map`]
     /// * The fields' `data_type` is not equal to the inner field of `data_type`
     /// * The validity is not `None` and its length is different from `offsets.len() - 1`.
     pub fn try_new(
         data_type: DataType,
-        offsets: Buffer<i32>,
+        offsets: OffsetsBuffer<i32>,
         field: Box<dyn Array>,
         validity: Option<Bitmap>,
     ) -> Result<Self, Error> {
-        try_check_offsets(&offsets, field.len())?;
+        try_check_offsets_bounds(offsets.buffer(), field.len())?;
 
         let inner_field = Self::try_get_field(&data_type)?;
         if let DataType::Struct(inner) = inner_field.data_type() {
@@ -60,7 +59,7 @@ impl MapArray {
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != offsets.len() - 1)
+            .map_or(false, |validity| validity.len() != offsets.len())
         {
             return Err(Error::oos(
                 "validity mask length must match the number of values",
@@ -77,13 +76,12 @@ impl MapArray {
 
     /// Creates a new [`MapArray`].
     /// # Panics
-    /// * the offsets are not monotonically increasing
     /// * The last offset is not equal to the field' length.
     /// * The `data_type`'s physical type is not [`crate::datatypes::PhysicalType::Map`],
     /// * The validity is not `None` and its length is different from `offsets.len() - 1`.
     pub fn new(
         data_type: DataType,
-        offsets: Buffer<i32>,
+        offsets: OffsetsBuffer<i32>,
         field: Box<dyn Array>,
         validity: Option<Bitmap>,
     ) -> Self {
@@ -93,7 +91,7 @@ impl MapArray {
     /// Alias for `new`
     pub fn from_data(
         data_type: DataType,
-        offsets: Buffer<i32>,
+        offsets: OffsetsBuffer<i32>,
         field: Box<dyn Array>,
         validity: Option<Bitmap>,
     ) -> Self {
@@ -105,7 +103,7 @@ impl MapArray {
         let field = new_empty_array(Self::get_field(&data_type).data_type().clone());
         Self::new(
             data_type,
-            vec![0i32; 1 + length].into(),
+            vec![0i32; 1 + length].try_into().unwrap(),
             field,
             Some(Bitmap::new_zeroed(length)),
         )
@@ -114,7 +112,7 @@ impl MapArray {
     /// Returns a new empty [`MapArray`].
     pub fn new_empty(data_type: DataType) -> Self {
         let field = new_empty_array(Self::get_field(&data_type).data_type().clone());
-        Self::new(data_type, Buffer::from(vec![0i32]), field, None)
+        Self::new(data_type, OffsetsBuffer::default(), field, None)
     }
 
     /// Returns this [`MapArray`] with a new validity.
@@ -197,12 +195,12 @@ impl MapArray {
     /// Returns the length of this array
     #[inline]
     pub fn len(&self) -> usize {
-        self.offsets.len() - 1
+        self.offsets.len()
     }
 
     /// returns the offsets
     #[inline]
-    pub fn offsets(&self) -> &Buffer<i32> {
+    pub fn offsets(&self) -> &OffsetsBuffer<i32> {
         &self.offsets
     }
 
@@ -215,8 +213,8 @@ impl MapArray {
     /// Returns the element at index `i`.
     #[inline]
     pub fn value(&self, i: usize) -> Box<dyn Array> {
-        let offset = self.offsets[i];
-        let offset_1 = self.offsets[i + 1];
+        let offset = self.offsets.buffer()[i];
+        let offset_1 = self.offsets.buffer()[i + 1];
         let length = (offset_1 - offset) as usize;
 
         // Safety:
@@ -230,8 +228,8 @@ impl MapArray {
     /// Assumes that the `i < self.len`.
     #[inline]
     pub unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array> {
-        let offset = *self.offsets.get_unchecked(i);
-        let offset_1 = *self.offsets.get_unchecked(i + 1);
+        let offset = *self.offsets.buffer().get_unchecked(i);
+        let offset_1 = *self.offsets.buffer().get_unchecked(i + 1);
         let length = (offset_1 - offset) as usize;
 
         self.field.slice_unchecked(offset as usize, length)

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -439,7 +439,6 @@ pub use iterator::ArrayValuesIter;
 pub use equal::equal;
 pub use fmt::{get_display, get_value_display};
 
-pub use crate::types::Offset;
 pub use binary::{BinaryArray, BinaryValueIter, MutableBinaryArray, MutableBinaryValuesArray};
 pub use boolean::{BooleanArray, MutableBooleanArray};
 pub use dictionary::{DictionaryArray, DictionaryKey, MutableDictionaryArray};
@@ -483,7 +482,7 @@ pub trait TryExtendFromSelf {
 /// 1. `offsets.len() > 0`
 /// 2. `offsets[i] >= offsets[i-1] for all i`
 /// 3. `offsets[i] < values.len() for all i`
-pub unsafe trait GenericBinaryArray<O: Offset>: Array {
+pub unsafe trait GenericBinaryArray<O: crate::offset::Offset>: Array {
     /// The values of the array
     fn values(&self) -> &[u8];
     /// The offsets of the array

--- a/src/array/ord.rs
+++ b/src/array/ord.rs
@@ -4,6 +4,7 @@ use std::cmp::Ordering;
 
 use crate::datatypes::*;
 use crate::error::{Error, Result};
+use crate::offset::Offset;
 use crate::{array::*, types::NativeType};
 
 /// Compare the values at two arbitrary indices in two arrays.

--- a/src/array/physical_binary.rs
+++ b/src/array/physical_binary.rs
@@ -1,6 +1,5 @@
 use crate::bitmap::MutableBitmap;
-use crate::error::Error;
-use crate::offset::Offset;
+use crate::offset::{Offset, Offsets};
 
 /// # Safety
 /// The caller must ensure that `iterator` is `TrustedLen`.
@@ -8,7 +7,7 @@ use crate::offset::Offset;
 #[allow(clippy::type_complexity)]
 pub(crate) unsafe fn try_trusted_len_unzip<E, I, P, O>(
     iterator: I,
-) -> std::result::Result<(Option<MutableBitmap>, Vec<O>, Vec<u8>), E>
+) -> std::result::Result<(Option<MutableBitmap>, Offsets<O>, Vec<u8>), E>
 where
     O: Offset,
     P: AsRef<[u8]>,
@@ -45,7 +44,7 @@ where
     );
     offsets.set_len(len + 1);
 
-    Ok((null.into(), offsets, values))
+    Ok((null.into(), Offsets::new_unchecked(offsets), values))
 }
 
 /// Creates [`MutableBitmap`] and two [`Vec`]s from an iterator of `Option`.
@@ -56,7 +55,7 @@ where
 #[inline]
 pub(crate) unsafe fn trusted_len_unzip<O, I, P>(
     iterator: I,
-) -> (Option<MutableBitmap>, Vec<O>, Vec<u8>)
+) -> (Option<MutableBitmap>, Offsets<O>, Vec<u8>)
 where
     O: Offset,
     P: AsRef<[u8]>,
@@ -65,11 +64,9 @@ where
     let (_, upper) = iterator.size_hint();
     let len = upper.expect("trusted_len_unzip requires an upper limit");
 
-    let mut offsets = Vec::<O>::with_capacity(len + 1);
+    let mut offsets = Offsets::<O>::with_capacity(len);
     let mut values = Vec::<u8>::new();
     let mut validity = MutableBitmap::new();
-
-    offsets.push(O::default());
 
     extend_from_trusted_len_iter(&mut offsets, &mut values, &mut validity, iterator);
 
@@ -87,7 +84,7 @@ where
 /// # Safety
 /// The caller must ensure that `iterator` is [`TrustedLen`].
 #[inline]
-pub(crate) unsafe fn trusted_len_values_iter<O, I, P>(iterator: I) -> (Vec<O>, Vec<u8>)
+pub(crate) unsafe fn trusted_len_values_iter<O, I, P>(iterator: I) -> (Offsets<O>, Vec<u8>)
 where
     O: Offset,
     P: AsRef<[u8]>,
@@ -96,10 +93,8 @@ where
     let (_, upper) = iterator.size_hint();
     let len = upper.expect("trusted_len_unzip requires an upper limit");
 
-    let mut offsets = Vec::<O>::with_capacity(len + 1);
+    let mut offsets = Offsets::<O>::with_capacity(len);
     let mut values = Vec::<u8>::new();
-
-    offsets.push(O::default());
 
     extend_from_trusted_len_values_iter(&mut offsets, &mut values, iterator);
 
@@ -112,7 +107,7 @@ where
 // The caller must ensure the `iterator` is [`TrustedLen`]
 #[inline]
 pub(crate) unsafe fn extend_from_trusted_len_values_iter<I, P, O>(
-    offsets: &mut Vec<O>,
+    offsets: &mut Offsets<O>,
     values: &mut Vec<u8>,
     iterator: I,
 ) where
@@ -120,42 +115,13 @@ pub(crate) unsafe fn extend_from_trusted_len_values_iter<I, P, O>(
     P: AsRef<[u8]>,
     I: Iterator<Item = P>,
 {
-    let (_, upper) = iterator.size_hint();
-    let additional = upper.expect("extend_from_trusted_len_values_iter requires an upper limit");
-
-    offsets.reserve(additional);
-
-    // Read in the last offset, will be used to increment and store
-    // new values later on
-    let mut length = *offsets.last().unwrap();
-
-    // Get a mutable pointer to the `offsets`, and move the pointer
-    // to the position, where a new value will be written
-    let mut dst = offsets.as_mut_ptr();
-    dst = dst.add(offsets.len());
-
-    for item in iterator {
+    let lengths = iterator.map(|item| {
         let s = item.as_ref();
-
-        // Calculate the new offset value
-        length += O::from_usize(s.len()).unwrap();
-
         // Push new entries for both `values` and `offsets` buffer
         values.extend_from_slice(s);
-        std::ptr::write(dst, length);
-
-        // Move to the next position in offset buffer
-        dst = dst.add(1);
-    }
-
-    debug_assert_eq!(
-        dst.offset_from(offsets.as_ptr()) as usize,
-        offsets.len() + additional,
-        "TrustedLen iterator's length was not accurately reported"
-    );
-
-    // We make sure to set the new length for the `offsets` buffer
-    offsets.set_len(offsets.len() + additional);
+        s.len()
+    });
+    offsets.try_extend_from_lengths(lengths).unwrap();
 }
 
 // Populates `offsets` and `values` [`Vec`]s with information extracted
@@ -163,7 +129,7 @@ pub(crate) unsafe fn extend_from_trusted_len_values_iter<I, P, O>(
 // the return value indicates how many items were added.
 #[inline]
 pub(crate) fn extend_from_values_iter<I, P, O>(
-    offsets: &mut Vec<O>,
+    offsets: &mut Offsets<O>,
     values: &mut Vec<u8>,
     iterator: I,
 ) -> usize
@@ -176,18 +142,12 @@ where
 
     offsets.reserve(size_hint);
 
-    // Read in the last offset, will be used to increment and store
-    // new values later on
-    let mut length = *offsets.last().unwrap();
     let start_index = offsets.len();
 
     for item in iterator {
-        let s = item.as_ref();
-        // Calculate the new offset value
-        length += O::from_usize(s.len()).unwrap();
-
-        values.extend_from_slice(s);
-        offsets.push(length);
+        let bytes = item.as_ref();
+        values.extend_from_slice(bytes);
+        offsets.try_push_usize(bytes.len()).unwrap();
     }
     offsets.len() - start_index
 }
@@ -199,7 +159,7 @@ where
 // The caller must ensure that `iterator` is [`TrustedLen`]
 #[inline]
 pub(crate) unsafe fn extend_from_trusted_len_iter<O, I, P>(
-    offsets: &mut Vec<O>,
+    offsets: &mut Offsets<O>,
     values: &mut Vec<u8>,
     validity: &mut MutableBitmap,
     iterator: I,
@@ -214,51 +174,24 @@ pub(crate) unsafe fn extend_from_trusted_len_iter<O, I, P>(
     offsets.reserve(additional);
     validity.reserve(additional);
 
-    // Read in the last offset, will be used to increment and store
-    // new values later on
-    let mut length = *offsets.last().unwrap();
-
-    // Get a mutable pointer to the `offsets`, and move the pointer
-    // to the position, where a new value will be written
-    let mut dst = offsets.as_mut_ptr();
-    dst = dst.add(offsets.len());
-
-    for item in iterator {
+    let lengths = iterator.map(|item| {
         if let Some(item) = item {
             let bytes = item.as_ref();
-
-            // Calculate new offset value
-            length += O::from_usize(bytes.len()).unwrap();
-
-            // Push new values for `values` and `validity` buffer
             values.extend_from_slice(bytes);
             validity.push_unchecked(true);
+            bytes.len()
         } else {
-            // If `None`, update only `validity`
             validity.push_unchecked(false);
+            0
         }
-
-        // Push new offset or old offset depending on the `item`
-        std::ptr::write(dst, length);
-
-        // Move to the next position in offset buffer
-        dst = dst.add(1);
-    }
-
-    debug_assert_eq!(
-        dst.offset_from(offsets.as_ptr()) as usize,
-        offsets.len() + additional,
-        "TrustedLen iterator's length was not accurately reported"
-    );
-
-    // We make sure to set the new length for the `offsets` buffer
-    offsets.set_len(offsets.len() + additional);
+    });
+    offsets.try_extend_from_lengths(lengths).unwrap();
 }
 
 /// Creates two [`Vec`]s from an iterator of `&[u8]`.
 /// The first buffer corresponds to a offset buffer, the second to a values buffer.
 #[inline]
-pub(crate) fn values_iter<O, I, P>(iterator: I) -> (Vec<O>, Vec<u8>)
+pub(crate) fn values_iter<O, I, P>(iterator: I) -> (Offsets<O>, Vec<u8>)
 where
     O: Offset,
     P: AsRef<[u8]>,
@@ -266,38 +199,15 @@ where
 {
     let (lower, _) = iterator.size_hint();
 
-    let mut offsets = Vec::<O>::with_capacity(lower + 1);
+    let mut offsets = Offsets::<O>::with_capacity(lower);
     let mut values = Vec::<u8>::new();
-
-    let mut length = O::default();
-    offsets.push(length);
 
     for item in iterator {
         let s = item.as_ref();
-        length += O::from_usize(s.len()).unwrap();
         values.extend_from_slice(s);
-
-        offsets.push(length)
+        offsets.try_push_usize(s.len()).unwrap();
     }
     (offsets, values)
-}
-
-/// Extends `offsets` with all offsets from `other`
-#[inline]
-pub(crate) fn try_extend_offsets<O>(offsets: &mut Vec<O>, other: &[O]) -> Result<(), Error>
-where
-    O: Offset,
-{
-    let lengths = other.windows(2).map(|w| w[1] - w[0]);
-    let mut last = *offsets.last().unwrap();
-
-    offsets.reserve(other.len() - 1);
-    for length in lengths {
-        let r = last.checked_add(&length).ok_or(Error::Overflow)?;
-        last += length;
-        offsets.push(r)
-    }
-    Ok(())
 }
 
 /// Extends `validity` with all items from `other`

--- a/src/array/physical_binary.rs
+++ b/src/array/physical_binary.rs
@@ -1,6 +1,6 @@
-use crate::array::Offset;
 use crate::bitmap::MutableBitmap;
 use crate::error::Error;
+use crate::offset::Offset;
 
 /// # Safety
 /// The caller must ensure that `iterator` is `TrustedLen`.

--- a/src/array/specification.rs
+++ b/src/array/specification.rs
@@ -13,23 +13,6 @@ pub fn try_check_offsets_bounds<O: Offset>(offsets: &[O], values_len: usize) -> 
     }
 }
 
-pub fn check_offsets_minimal<O: Offset>(offsets: &[O], values_len: usize) -> usize {
-    assert!(
-        !offsets.is_empty(),
-        "The length of the offset buffer must be larger than 1"
-    );
-    let len = offsets.len() - 1;
-
-    let last_offset = offsets[len];
-    let last_offset = last_offset.to_usize();
-
-    assert_eq!(
-        values_len, last_offset,
-        "The length of the values must be equal to the last offset value"
-    );
-    len
-}
-
 /// # Panics iff:
 /// * the `offsets` is not monotonically increasing, or
 /// * any slice of `values` between two consecutive pairs from `offsets` is invalid `utf8`, or

--- a/src/array/utf8/ffi.rs
+++ b/src/array/utf8/ffi.rs
@@ -1,8 +1,9 @@
 use crate::{
-    array::{FromFfi, Offset, ToFfi},
+    array::{FromFfi, ToFfi},
     bitmap::align,
     error::Result,
     ffi,
+    offset::Offset,
 };
 
 use super::Utf8Array;

--- a/src/array/utf8/ffi.rs
+++ b/src/array/utf8/ffi.rs
@@ -3,7 +3,7 @@ use crate::{
     bitmap::align,
     error::Result,
     ffi,
-    offset::Offset,
+    offset::{Offset, OffsetsBuffer},
 };
 
 use super::Utf8Array;
@@ -12,13 +12,13 @@ unsafe impl<O: Offset> ToFfi for Utf8Array<O> {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            Some(self.offsets.as_ptr().cast::<u8>()),
+            Some(self.offsets.buffer().as_ptr().cast::<u8>()),
             Some(self.values.as_ptr().cast::<u8>()),
         ]
     }
 
     fn offset(&self) -> Option<usize> {
-        let offset = self.offsets.offset();
+        let offset = self.offsets.buffer().offset();
         if let Some(bitmap) = self.validity.as_ref() {
             if bitmap.offset() == offset {
                 Some(offset)
@@ -31,7 +31,7 @@ unsafe impl<O: Offset> ToFfi for Utf8Array<O> {
     }
 
     fn to_ffi_aligned(&self) -> Self {
-        let offset = self.offsets.offset();
+        let offset = self.offsets.buffer().offset();
 
         let validity = self.validity.as_ref().map(|bitmap| {
             if bitmap.offset() == offset {
@@ -57,8 +57,9 @@ impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for Utf8Array<O> {
         let offsets = unsafe { array.buffer::<O>(1) }?;
         let values = unsafe { array.buffer::<u8>(2)? };
 
-        Ok(Self::from_data_unchecked(
-            data_type, offsets, values, validity,
-        ))
+        // assumption that data from FFI is well constructed
+        let offsets = unsafe { OffsetsBuffer::new_unchecked(offsets) };
+
+        Ok(Self::new_unchecked(data_type, offsets, values, validity))
     }
 }

--- a/src/array/utf8/fmt.rs
+++ b/src/array/utf8/fmt.rs
@@ -1,7 +1,8 @@
 use std::fmt::{Debug, Formatter, Result, Write};
 
+use crate::offset::Offset;
+
 use super::super::fmt::write_vec;
-use super::super::Offset;
 use super::Utf8Array;
 
 pub fn write_value<O: Offset, W: Write>(array: &Utf8Array<O>, index: usize, f: &mut W) -> Result {

--- a/src/array/utf8/from.rs
+++ b/src/array/utf8/from.rs
@@ -1,6 +1,6 @@
 use std::iter::FromIterator;
 
-use crate::array::Offset;
+use crate::offset::Offset;
 
 use super::{MutableUtf8Array, Utf8Array};
 

--- a/src/array/utf8/iterator.rs
+++ b/src/array/utf8/iterator.rs
@@ -1,5 +1,6 @@
-use crate::array::{ArrayAccessor, ArrayValuesIter, Offset};
+use crate::array::{ArrayAccessor, ArrayValuesIter};
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
+use crate::offset::Offset;
 
 use super::{MutableUtf8Array, MutableUtf8ValuesArray, Utf8Array};
 

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -51,7 +51,7 @@ impl<T: AsRef<str>> AsRef<[u8]> for StrAsBytes<T> {
 /// // the underlying representation
 /// assert_eq!(array.validity(), Some(&Bitmap::from([true, false, true])));
 /// assert_eq!(array.values(), &Buffer::from(b"hithere".to_vec()));
-/// assert_eq!(array.offsets(), &Buffer::from(vec![0, 2, 2, 2 + 5]));
+/// assert_eq!(array.offsets().buffer(), &Buffer::from(vec![0, 2, 2, 2 + 5]));
 /// # }
 /// ```
 ///

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     buffer::Buffer,
     datatypes::DataType,
     error::{Error, Result},
-    offset::Offset,
+    offset::{Offset, OffsetsBuffer},
     trusted_len::TrustedLen,
 };
 
@@ -69,7 +69,7 @@ impl<T: AsRef<str>> AsRef<[u8]> for StrAsBytes<T> {
 #[derive(Clone)]
 pub struct Utf8Array<O: Offset> {
     data_type: DataType,
-    offsets: Buffer<O>,
+    offsets: OffsetsBuffer<O>,
     values: Buffer<u8>,
     validity: Option<Bitmap>,
 }
@@ -80,23 +80,22 @@ impl<O: Offset> Utf8Array<O> {
     ///
     /// # Errors
     /// This function returns an error iff:
-    /// * the offsets are not monotonically increasing
     /// * The last offset is not equal to the values' length.
-    /// * the validity's length is not equal to `offsets.len() - 1`.
+    /// * the validity's length is not equal to `offsets.len()`.
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either `Utf8` or `LargeUtf8`.
     /// * The `values` between two consecutive `offsets` are not valid utf8
     /// # Implementation
-    /// This function is `O(N)` - checking monotinicity and utf8 is `O(N)`
+    /// This function is `O(N)` - checking utf8 is `O(N)`
     pub fn try_new(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> Result<Self> {
-        try_check_offsets_and_utf8(&offsets, &values)?;
+        try_check_offsets_and_utf8(offsets.buffer(), &values)?;
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != offsets.len() - 1)
+            .map_or(false, |validity| validity.len() != offsets.len())
         {
             return Err(Error::oos(
                 "validity mask length must match the number of values",
@@ -145,7 +144,7 @@ impl<O: Offset> Utf8Array<O> {
     /// Returns the length of this array
     #[inline]
     pub fn len(&self) -> usize {
-        self.offsets.len() - 1
+        self.offsets.len()
     }
 
     /// Returns the value of the element at index `i`, ignoring the array's validity.
@@ -163,8 +162,8 @@ impl<O: Offset> Utf8Array<O> {
     #[inline]
     pub unsafe fn value_unchecked(&self, i: usize) -> &str {
         // soundness: the invariant of the function
-        let start = self.offsets.get_unchecked(i).to_usize();
-        let end = self.offsets.get_unchecked(i + 1).to_usize();
+        let start = self.offsets.buffer().get_unchecked(i).to_usize();
+        let end = self.offsets.buffer().get_unchecked(i + 1).to_usize();
 
         // soundness: the invariant of the struct
         let slice = self.values.get_unchecked(start..end);
@@ -187,7 +186,7 @@ impl<O: Offset> Utf8Array<O> {
 
     /// Returns the offsets of this [`Utf8Array`].
     #[inline]
-    pub fn offsets(&self) -> &Buffer<O> {
+    pub fn offsets(&self) -> &OffsetsBuffer<O> {
         &self.offsets
     }
 
@@ -278,7 +277,7 @@ impl<O: Offset> Utf8Array<O> {
                 }),
                 Right(mutable_bitmap) => match (
                     self.values.get_mut().map(std::mem::take),
-                    self.offsets.get_mut().map(std::mem::take),
+                    self.offsets.get_mut(),
                 ) {
                     (None, None) => {
                         // Safety: invariants are preserved
@@ -326,7 +325,7 @@ impl<O: Offset> Utf8Array<O> {
         } else {
             match (
                 self.values.get_mut().map(std::mem::take),
-                self.offsets.get_mut().map(std::mem::take),
+                self.offsets.get_mut(),
             ) {
                 (None, None) => Left(unsafe {
                     Utf8Array::new_unchecked(self.data_type, self.offsets, self.values, None)
@@ -349,14 +348,7 @@ impl<O: Offset> Utf8Array<O> {
     /// The array is guaranteed to have no elements nor validity.
     #[inline]
     pub fn new_empty(data_type: DataType) -> Self {
-        unsafe {
-            Self::from_data_unchecked(
-                data_type,
-                Buffer::from(vec![O::zero()]),
-                Buffer::new(),
-                None,
-            )
-        }
+        unsafe { Self::from_data_unchecked(data_type, OffsetsBuffer::new(), Buffer::new(), None) }
     }
 
     /// Returns a new [`Utf8Array`] whose all slots are null / `None`.
@@ -364,7 +356,7 @@ impl<O: Offset> Utf8Array<O> {
     pub fn new_null(data_type: DataType, length: usize) -> Self {
         Self::new(
             data_type,
-            vec![O::default(); 1 + length].into(),
+            vec![O::default(); 1 + length].try_into().unwrap(),
             Buffer::new(),
             Some(Bitmap::new_zeroed(length)),
         )
@@ -384,25 +376,24 @@ impl<O: Offset> Utf8Array<O> {
     /// # Errors
     /// This function returns an error iff:
     /// * The last offset is not equal to the values' length.
-    /// * the validity's length is not equal to `offsets.len() - 1`.
+    /// * the validity's length is not equal to `offsets.len()`.
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either `Utf8` or `LargeUtf8`.
     /// # Safety
     /// This function is unsound iff:
-    /// * the offsets are not monotonically increasing
     /// * The `values` between two consecutive `offsets` are not valid utf8
     /// # Implementation
     /// This function is `O(1)`
     pub unsafe fn try_new_unchecked(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> Result<Self> {
-        try_check_offsets_bounds(&offsets, values.len())?;
+        try_check_offsets_bounds(offsets.buffer(), values.len())?;
 
         if validity
             .as_ref()
-            .map_or(false, |validity| validity.len() != offsets.len() - 1)
+            .map_or(false, |validity| validity.len() != offsets.len())
         {
             return Err(Error::oos(
                 "validity mask length must match the number of values",
@@ -426,16 +417,15 @@ impl<O: Offset> Utf8Array<O> {
     /// Creates a new [`Utf8Array`].
     /// # Panics
     /// This function panics iff:
-    /// * the offsets are not monotonically increasing
     /// * The last offset is not equal to the values' length.
-    /// * the validity's length is not equal to `offsets.len() - 1`.
+    /// * the validity's length is not equal to `offsets.len()`.
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either `Utf8` or `LargeUtf8`.
     /// * The `values` between two consecutive `offsets` are not valid utf8
     /// # Implementation
-    /// This function is `O(N)` - checking monotinicity and utf8 is `O(N)`
+    /// This function is `O(N)` - checking utf8 is `O(N)`
     pub fn new(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> Self {
@@ -447,7 +437,7 @@ impl<O: Offset> Utf8Array<O> {
     /// # Errors
     /// This function returns an error iff:
     /// * The last offset is not equal to the values' length.
-    /// * the validity's length is not equal to `offsets.len() - 1`.
+    /// * the validity's length is not equal to `offsets.len()`.
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either `Utf8` or `LargeUtf8`.
     /// # Safety
     /// This function is unsound iff:
@@ -457,7 +447,7 @@ impl<O: Offset> Utf8Array<O> {
     /// This function is `O(1)`
     pub unsafe fn new_unchecked(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> Self {
@@ -530,7 +520,7 @@ impl<O: Offset> Utf8Array<O> {
     /// Alias for `new`
     pub fn from_data(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> Self {
@@ -540,11 +530,10 @@ impl<O: Offset> Utf8Array<O> {
     /// Alias for [`Self::new_unchecked`]
     /// # Safety
     /// This function is unsafe iff:
-    /// * the offsets are not monotonically increasing
     /// * The `values` between two consecutive `offsets` are not valid utf8
     pub unsafe fn from_data_unchecked(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> Self {
@@ -600,7 +589,7 @@ unsafe impl<O: Offset> GenericBinaryArray<O> for Utf8Array<O> {
 
     #[inline]
     fn offsets(&self) -> &[O] {
-        self.offsets()
+        self.offsets().buffer()
     }
 }
 
@@ -611,11 +600,6 @@ impl<O: Offset> Default for Utf8Array<O> {
         } else {
             DataType::Utf8
         };
-        Utf8Array::new(
-            data_type,
-            vec![O::from_usize(0).unwrap()].into(),
-            Default::default(),
-            None,
-        )
+        Utf8Array::new(data_type, Default::default(), Default::default(), None)
     }
 }

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     buffer::Buffer,
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
     trusted_len::TrustedLen,
 };
 
@@ -13,7 +14,7 @@ use either::Either;
 
 use super::{
     specification::{try_check_offsets_and_utf8, try_check_offsets_bounds},
-    Array, GenericBinaryArray, Offset,
+    Array, GenericBinaryArray,
 };
 
 mod ffi;

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     datatypes::DataType,
     error::{Error, Result},
-    offset::Offset,
+    offset::{Offset, Offsets},
     trusted_len::TrustedLen,
 };
 
@@ -53,16 +53,15 @@ impl<O: Offset> MutableUtf8Array<O> {
     ///
     /// # Errors
     /// This function returns an error iff:
-    /// * the offsets are not monotonically increasing
     /// * The last offset is not equal to the values' length.
-    /// * the validity's length is not equal to `offsets.len() - 1`.
+    /// * the validity's length is not equal to `offsets.len()`.
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either `Utf8` or `LargeUtf8`.
     /// * The `values` between two consecutive `offsets` are not valid utf8
     /// # Implementation
-    /// This function is `O(N)` - checking monotinicity and utf8 is `O(N)`
+    /// This function is `O(N)` - checking utf8 is `O(N)`
     pub fn try_new(
         data_type: DataType,
-        offsets: Vec<O>,
+        offsets: Offsets<O>,
         values: Vec<u8>,
         validity: Option<MutableBitmap>,
     ) -> Result<Self> {
@@ -89,7 +88,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     /// * The validity is not `None` and its length is different from `offsets`'s length minus one.
     pub unsafe fn new_unchecked(
         data_type: DataType,
-        offsets: Vec<O>,
+        offsets: Offsets<O>,
         values: Vec<u8>,
         validity: Option<MutableBitmap>,
     ) -> Self {
@@ -105,7 +104,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     /// The caller must ensure that every value between offsets is a valid utf8.
     pub unsafe fn from_data_unchecked(
         data_type: DataType,
-        offsets: Vec<O>,
+        offsets: Offsets<O>,
         values: Vec<u8>,
         validity: Option<MutableBitmap>,
     ) -> Self {
@@ -120,7 +119,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     /// * The validity is not `None` and its length is different from `offsets`'s length minus one.
     pub fn from_data(
         data_type: DataType,
-        offsets: Vec<O>,
+        offsets: Offsets<O>,
         values: Vec<u8>,
         validity: Option<MutableBitmap>,
     ) -> Self {
@@ -231,7 +230,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// Extract the low-end APIs from the [`MutableUtf8Array`].
-    pub fn into_data(self) -> (DataType, Vec<O>, Vec<u8>, Option<MutableBitmap>) {
+    pub fn into_data(self) -> (DataType, Offsets<O>, Vec<u8>, Option<MutableBitmap>) {
         let (data_type, offsets, values) = self.values.into_inner();
         (data_type, offsets, values, self.validity)
     }
@@ -249,7 +248,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// returns its offsets.
-    pub fn offsets(&self) -> &Vec<O> {
+    pub fn offsets(&self) -> &Offsets<O> {
         self.values.offsets()
     }
 }

--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -2,13 +2,14 @@ use std::{iter::FromIterator, sync::Arc};
 
 use crate::array::{physical_binary::*, TryExtendFromSelf};
 use crate::{
-    array::{Array, MutableArray, Offset, TryExtend, TryPush},
+    array::{Array, MutableArray, TryExtend, TryPush},
     bitmap::{
         utils::{BitmapIter, ZipValidity},
         Bitmap, MutableBitmap,
     },
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
     trusted_len::TrustedLen,
 };
 

--- a/src/array/utf8/mutable_values.rs
+++ b/src/array/utf8/mutable_values.rs
@@ -3,11 +3,12 @@ use std::{iter::FromIterator, sync::Arc};
 use crate::{
     array::{
         specification::{check_offsets_minimal, try_check_offsets_and_utf8},
-        Array, ArrayValuesIter, MutableArray, Offset, TryExtend, TryExtendFromSelf, TryPush,
+        Array, ArrayValuesIter, MutableArray, TryExtend, TryExtendFromSelf, TryPush,
     },
     bitmap::MutableBitmap,
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
     trusted_len::TrustedLen,
 };
 

--- a/src/compute/aggregate/memory.rs
+++ b/src/compute/aggregate/memory.rs
@@ -9,7 +9,7 @@ fn validity_size(validity: Option<&Bitmap>) -> usize {
 macro_rules! dyn_binary {
     ($array:expr, $ty:ty, $o:ty) => {{
         let array = $array.as_any().downcast_ref::<$ty>().unwrap();
-        let offsets = array.offsets();
+        let offsets = array.offsets().buffer();
 
         // in case of Binary/Utf8/List the offsets are sliced,
         // not the values buffer

--- a/src/compute/aggregate/min_max.rs
+++ b/src/compute/aggregate/min_max.rs
@@ -1,11 +1,12 @@
 use crate::bitmap::utils::{BitChunkIterExact, BitChunksExact};
 use crate::datatypes::{DataType, PhysicalType, PrimitiveType};
 use crate::error::{Error, Result};
+use crate::offset::Offset;
 use crate::scalar::*;
 use crate::types::simd::*;
 use crate::types::NativeType;
 use crate::{
-    array::{Array, BinaryArray, BooleanArray, Offset, PrimitiveArray, Utf8Array},
+    array::{Array, BinaryArray, BooleanArray, PrimitiveArray, Utf8Array},
     bitmap::Bitmap,
 };
 

--- a/src/compute/cast/binary_to.rs
+++ b/src/compute/cast/binary_to.rs
@@ -1,6 +1,7 @@
 use std::convert::TryFrom;
 
 use crate::error::{Error, Result};
+use crate::offset::Offset;
 use crate::{array::*, datatypes::DataType, types::NativeType};
 
 use super::CastOptions;

--- a/src/compute/cast/binary_to.rs
+++ b/src/compute/cast/binary_to.rs
@@ -1,6 +1,4 @@
-use std::convert::TryFrom;
-
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::offset::Offset;
 use crate::{array::*, datatypes::DataType, types::NativeType};
 
@@ -9,11 +7,9 @@ use super::CastOptions;
 /// Conversion of binary
 pub fn binary_to_large_binary(from: &BinaryArray<i32>, to_data_type: DataType) -> BinaryArray<i64> {
     let values = from.values().clone();
-    let offsets = from.offsets().iter().map(|x| *x as i64).collect::<Vec<_>>();
-    // todo: use `new_unchecked` since all invariants are preserved
     BinaryArray::<i64>::new(
         to_data_type,
-        offsets.into(),
+        from.offsets().into(),
         values,
         from.validity().cloned(),
     )
@@ -25,13 +21,10 @@ pub fn binary_large_to_binary(
     to_data_type: DataType,
 ) -> Result<BinaryArray<i32>> {
     let values = from.values().clone();
-    let _ = i32::try_from(*from.offsets().last().unwrap()).map_err(Error::from_external_error)?;
-
-    let offsets = from.offsets().iter().map(|x| *x as i32).collect::<Vec<_>>();
-    // todo: use `new_unchecked` since all invariants are preserved
+    let offsets = from.offsets().try_into()?;
     Ok(BinaryArray::<i32>::new(
         to_data_type,
-        offsets.into(),
+        offsets,
         values,
         from.validity().cloned(),
     ))
@@ -58,12 +51,7 @@ pub fn binary_to_large_utf8(
     to_data_type: DataType,
 ) -> Result<Utf8Array<i64>> {
     let values = from.values().clone();
-    let offsets = from
-        .offsets()
-        .iter()
-        .map(|x| *x as i64)
-        .collect::<Vec<_>>()
-        .into();
+    let offsets = from.offsets().into();
 
     Utf8Array::<i64>::try_new(to_data_type, offsets, values, from.validity().cloned())
 }

--- a/src/compute/cast/boolean_to.rs
+++ b/src/compute/cast/boolean_to.rs
@@ -1,6 +1,7 @@
 use crate::{
-    array::{Array, BinaryArray, BooleanArray, Offset, PrimitiveArray, Utf8Array},
+    array::{Array, BinaryArray, BooleanArray, PrimitiveArray, Utf8Array},
     error::Result,
+    offset::Offset,
     types::NativeType,
 };
 

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     array::*,
     datatypes::*,
     error::{Error, Result},
+    offset::Offset,
 };
 
 /// options defining how Cast kernels behave

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -4,6 +4,7 @@ use num_traits::{AsPrimitive, Float, ToPrimitive};
 
 use crate::datatypes::IntervalUnit;
 use crate::error::Result;
+use crate::offset::Offset;
 use crate::types::{days_ms, f16, months_days_ns};
 use crate::{
     array::*,

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -1,11 +1,9 @@
-use std::convert::TryFrom;
-
 use chrono::Datelike;
 
 use crate::{
     array::*,
     datatypes::DataType,
-    error::{Error, Result},
+    error::Result,
     offset::Offset,
     temporal_conversions::{
         utf8_to_naive_timestamp_ns as utf8_to_naive_timestamp_ns_,
@@ -150,13 +148,9 @@ pub fn utf8_to_large_utf8(from: &Utf8Array<i32>) -> Utf8Array<i64> {
     let data_type = Utf8Array::<i64>::default_data_type();
     let validity = from.validity().cloned();
     let values = from.values().clone();
-    let offsets = from
-        .offsets()
-        .iter()
-        .map(|x| *x as i64)
-        .collect::<Vec<_>>()
-        .into();
-    // Safety: sound because `offsets` fulfills the same invariants as `from.offsets()`
+
+    let offsets = from.offsets().into();
+    // Safety: sound because `values` fulfills the same invariants as `from.values()`
     unsafe { Utf8Array::<i64>::from_data_unchecked(data_type, offsets, values, validity) }
 }
 
@@ -165,22 +159,17 @@ pub fn utf8_large_to_utf8(from: &Utf8Array<i64>) -> Result<Utf8Array<i32>> {
     let data_type = Utf8Array::<i32>::default_data_type();
     let validity = from.validity().cloned();
     let values = from.values().clone();
-    let _ = i32::try_from(*from.offsets().last().unwrap()).map_err(Error::from_external_error)?;
+    let offsets = from.offsets().try_into()?;
 
-    let offsets = from
-        .offsets()
-        .iter()
-        .map(|x| *x as i32)
-        .collect::<Vec<_>>()
-        .into();
-    // Safety: sound because `offsets` fulfills the same invariants as `from.offsets()`
+    // Safety: sound because `values` fulfills the same invariants as `from.values()`
     Ok(unsafe { Utf8Array::<i32>::from_data_unchecked(data_type, offsets, values, validity) })
 }
 
 /// Conversion to binary
 pub fn utf8_to_binary<O: Offset>(from: &Utf8Array<O>, to_data_type: DataType) -> BinaryArray<O> {
+    // Safety: erasure of an invariant is always safe
     unsafe {
-        BinaryArray::<O>::new_unchecked(
+        BinaryArray::<O>::new(
             to_data_type,
             from.offsets().clone(),
             from.values().clone(),

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -6,6 +6,7 @@ use crate::{
     array::*,
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
     temporal_conversions::{
         utf8_to_naive_timestamp_ns as utf8_to_naive_timestamp_ns_,
         utf8_to_timestamp_ns as utf8_to_timestamp_ns_, EPOCH_DAYS_FROM_CE,

--- a/src/compute/comparison/binary.rs
+++ b/src/compute/comparison/binary.rs
@@ -1,9 +1,10 @@
 //! Comparison functions for [`BinaryArray`]
 use crate::compute::comparison::{finish_eq_validities, finish_neq_validities};
 use crate::{
-    array::{BinaryArray, BooleanArray, Offset},
+    array::{BinaryArray, BooleanArray},
     bitmap::Bitmap,
     datatypes::DataType,
+    offset::Offset,
 };
 
 use super::super::utils::combine_validities;

--- a/src/compute/comparison/utf8.rs
+++ b/src/compute/comparison/utf8.rs
@@ -1,9 +1,10 @@
 //! Comparison functions for [`Utf8Array`]
 use crate::compute::comparison::{finish_eq_validities, finish_neq_validities};
 use crate::{
-    array::{BooleanArray, Offset, Utf8Array},
+    array::{BooleanArray, Utf8Array},
     bitmap::Bitmap,
     datatypes::DataType,
+    offset::Offset,
 };
 
 use super::super::utils::combine_validities;

--- a/src/compute/contains.rs
+++ b/src/compute/contains.rs
@@ -1,10 +1,11 @@
 //! Declares the [`contains`] operator
 
 use crate::{
-    array::{Array, BinaryArray, BooleanArray, ListArray, Offset, PrimitiveArray, Utf8Array},
+    array::{Array, BinaryArray, BooleanArray, ListArray, PrimitiveArray, Utf8Array},
     bitmap::Bitmap,
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
     types::NativeType,
 };
 

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -12,9 +12,10 @@ macro_rules! new_state {
 }
 
 use crate::{
-    array::{Array, BinaryArray, BooleanArray, Offset, PrimitiveArray, Utf8Array},
+    array::{Array, BinaryArray, BooleanArray, PrimitiveArray, Utf8Array},
     datatypes::{DataType, PhysicalType, PrimitiveType},
     error::{Error, Result},
+    offset::Offset,
     types::NativeType,
 };
 

--- a/src/compute/length.rs
+++ b/src/compute/length.rs
@@ -32,6 +32,7 @@ where
 {
     let values = array
         .offsets()
+        .buffer()
         .windows(2)
         .map(|offset| op(offset[1] - offset[0]))
         .collect::<Vec<_>>();

--- a/src/compute/length.rs
+++ b/src/compute/length.rs
@@ -21,6 +21,7 @@ use crate::{
     array::*,
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
     types::NativeType,
 };
 

--- a/src/compute/like.rs
+++ b/src/compute/like.rs
@@ -5,11 +5,12 @@ use regex::bytes::Regex as BytesRegex;
 use regex::Regex;
 
 use crate::{
-    array::{BinaryArray, BooleanArray, Offset, Utf8Array},
+    array::{BinaryArray, BooleanArray, Utf8Array},
     bitmap::Bitmap,
     compute::utils::combine_validities,
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
 };
 
 #[inline]

--- a/src/compute/regex_match.rs
+++ b/src/compute/regex_match.rs
@@ -3,11 +3,13 @@
 use ahash::AHashMap;
 use regex::Regex;
 
-use super::utils::combine_validities;
-use crate::array::{BooleanArray, Offset, Utf8Array};
+use crate::array::{BooleanArray, Utf8Array};
 use crate::bitmap::Bitmap;
 use crate::datatypes::DataType;
 use crate::error::{Error, Result};
+use crate::offset::Offset;
+
+use super::utils::combine_validities;
 
 /// Regex matches
 pub fn regex_match<O: Offset>(values: &Utf8Array<O>, regex: &Utf8Array<O>) -> Result<BooleanArray> {

--- a/src/compute/sort/binary.rs
+++ b/src/compute/sort/binary.rs
@@ -1,4 +1,5 @@
-use crate::array::{BinaryArray, Offset, PrimitiveArray};
+use crate::array::{BinaryArray, PrimitiveArray};
+use crate::offset::Offset;
 use crate::types::Index;
 
 use super::common;

--- a/src/compute/sort/mod.rs
+++ b/src/compute/sort/mod.rs
@@ -5,6 +5,7 @@ use crate::array::ord;
 use crate::compute::take;
 use crate::datatypes::*;
 use crate::error::{Error, Result};
+use crate::offset::Offset;
 use crate::{
     array::*,
     types::{Index, NativeType},

--- a/src/compute/sort/row/mod.rs
+++ b/src/compute/sort/row/mod.rs
@@ -637,9 +637,10 @@ mod tests {
 
     use super::*;
     use crate::{
-        array::{Array, DictionaryKey, Float32Array, Int16Array, NullArray, Offset},
+        array::{Array, DictionaryKey, Float32Array, Int16Array, NullArray},
         compute::sort::build_compare,
         datatypes::DataType,
+        offset::Offset,
         types::NativeType,
     };
 

--- a/src/compute/sort/utf8.rs
+++ b/src/compute/sort/utf8.rs
@@ -1,5 +1,5 @@
-use crate::array::{DictionaryArray, DictionaryKey};
-use crate::array::{Offset, PrimitiveArray, Utf8Array};
+use crate::array::{DictionaryArray, DictionaryKey, PrimitiveArray, Utf8Array};
+use crate::offset::Offset;
 use crate::types::Index;
 
 use super::common;

--- a/src/compute/substring.rs
+++ b/src/compute/substring.rs
@@ -21,6 +21,7 @@ use crate::{
     array::*,
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
 };
 
 fn utf8_substring<O: Offset>(array: &Utf8Array<O>, start: O, length: &Option<O>) -> Utf8Array<O> {

--- a/src/compute/take/binary.rs
+++ b/src/compute/take/binary.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::array::{Array, BinaryArray, Offset, PrimitiveArray};
+use crate::array::{Array, BinaryArray, PrimitiveArray};
+use crate::offset::Offset;
 
 use super::generic_binary::*;
 use super::Index;

--- a/src/compute/take/generic_binary.rs
+++ b/src/compute/take/generic_binary.rs
@@ -1,7 +1,8 @@
 use crate::{
-    array::{GenericBinaryArray, Offset, PrimitiveArray},
+    array::{GenericBinaryArray, PrimitiveArray},
     bitmap::{Bitmap, MutableBitmap},
     buffer::Buffer,
+    offset::Offset,
 };
 
 use super::Index;

--- a/src/compute/take/list.rs
+++ b/src/compute/take/list.rs
@@ -17,8 +17,9 @@
 
 use crate::array::{
     growable::{Growable, GrowableList},
-    ListArray, Offset, PrimitiveArray,
+    ListArray, PrimitiveArray,
 };
+use crate::offset::Offset;
 
 use super::Index;
 

--- a/src/compute/take/utf8.rs
+++ b/src/compute/take/utf8.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::array::{Array, Offset, PrimitiveArray, Utf8Array};
+use crate::array::{Array, PrimitiveArray, Utf8Array};
+use crate::offset::Offset;
 
 use super::generic_binary::*;
 use super::Index;

--- a/src/compute/utf8.rs
+++ b/src/compute/utf8.rs
@@ -1,9 +1,10 @@
 //! Defines common maps to a [`Utf8Array`]
 
 use crate::{
-    array::{Array, Offset, Utf8Array},
+    array::{Array, Utf8Array},
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
 };
 
 /// utf8_apply will apply `Fn(&str) -> String` to every value in Utf8Array.

--- a/src/ffi/mmap.rs
+++ b/src/ffi/mmap.rs
@@ -1,9 +1,10 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
 
-use crate::array::{Array, DictionaryKey, FixedSizeListArray, ListArray, Offset, StructArray};
+use crate::array::{Array, DictionaryKey, FixedSizeListArray, ListArray, StructArray};
 use crate::datatypes::DataType;
 use crate::error::Error;
+use crate::offset::Offset;
 
 use crate::io::ipc::read::{Dictionaries, OutOfSpecKind};
 use crate::io::ipc::read::{IpcBuffer, Node};

--- a/src/io/avro/read/nested.rs
+++ b/src/io/avro/read/nested.rs
@@ -2,6 +2,7 @@ use crate::array::*;
 use crate::bitmap::*;
 use crate::datatypes::*;
 use crate::error::*;
+use crate::offset::Offset;
 
 /// Auxiliary struct
 #[derive(Debug)]

--- a/src/io/avro/write/serialize.rs
+++ b/src/io/avro/write/serialize.rs
@@ -100,6 +100,7 @@ fn list_required<'a, O: Offset>(array: &'a ListArray<O>, schema: &AvroSchema) ->
     let mut inner = new_serializer(array.values().as_ref(), schema);
     let lengths = array
         .offsets()
+        .buffer()
         .windows(2)
         .map(|w| (w[1] - w[0]).to_usize() as i64);
 
@@ -125,6 +126,7 @@ fn list_optional<'a, O: Offset>(array: &'a ListArray<O>, schema: &AvroSchema) ->
     let mut inner = new_serializer(array.values().as_ref(), schema);
     let lengths = array
         .offsets()
+        .buffer()
         .windows(2)
         .map(|w| (w[1] - w[0]).to_usize() as i64);
     let lengths = ZipValidity::new_with_validity(lengths, array.validity());

--- a/src/io/avro/write/serialize.rs
+++ b/src/io/avro/write/serialize.rs
@@ -3,6 +3,7 @@ use avro_schema::write::encode;
 
 use crate::bitmap::utils::ZipValidity;
 use crate::datatypes::{IntervalUnit, PhysicalType, PrimitiveType};
+use crate::offset::Offset;
 use crate::types::months_days_ns;
 use crate::{array::*, datatypes::DataType};
 

--- a/src/io/csv/read_utils.rs
+++ b/src/io/csv/read_utils.rs
@@ -1,22 +1,23 @@
 use chrono::Datelike;
 
+use crate::{
+    array::*,
+    chunk::Chunk,
+    datatypes::*,
+    error::{Error, Result},
+    offset::Offset,
+    temporal_conversions,
+    types::NativeType,
+};
+
+use super::utils::RFC3339;
+
 // Ideally this trait should not be needed and both `csv` and `csv_async` crates would share
 // the same `ByteRecord` struct. Unfortunately, they do not and thus we must use generics
 // over this trait and materialize the generics for each struct.
 pub(crate) trait ByteRecordGeneric {
     fn get(&self, index: usize) -> Option<&[u8]>;
 }
-
-use crate::{
-    array::*,
-    chunk::Chunk,
-    datatypes::*,
-    error::{Error, Result},
-    temporal_conversions,
-    types::NativeType,
-};
-
-use super::utils::RFC3339;
 
 #[inline]
 fn to_utf8(bytes: &[u8]) -> Option<&str> {

--- a/src/io/csv/write/serialize.rs
+++ b/src/io/csv/write/serialize.rs
@@ -5,13 +5,15 @@ use crate::temporal_conversions;
 use crate::types::NativeType;
 use crate::util::lexical_to_bytes_mut;
 use crate::{
-    array::{Array, BinaryArray, BooleanArray, PrimitiveArray, Utf8Array},
+    array::{
+        Array, BinaryArray, BooleanArray, DictionaryArray, DictionaryKey, PrimitiveArray, Utf8Array,
+    },
     datatypes::{DataType, TimeUnit},
     error::Result,
+    offset::Offset,
 };
 
 use super::super::super::iterator::{BufStreamingIterator, StreamingIterator};
-use crate::array::{DictionaryArray, DictionaryKey, Offset};
 use csv_core::WriteResult;
 use std::any::Any;
 use std::fmt::{Debug, Write};

--- a/src/io/ipc/read/array/binary.rs
+++ b/src/io/ipc/read/array/binary.rs
@@ -1,10 +1,11 @@
 use std::collections::VecDeque;
 use std::io::{Read, Seek};
 
-use crate::array::{BinaryArray, Offset};
+use crate::array::BinaryArray;
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
 use crate::error::{Error, Result};
+use crate::offset::Offset;
 
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};

--- a/src/io/ipc/read/array/binary.rs
+++ b/src/io/ipc/read/array/binary.rs
@@ -69,7 +69,7 @@ pub fn read_binary<O: Offset, R: Read + Seek>(
         scratch,
     )?;
 
-    BinaryArray::<O>::try_new(data_type, offsets, values, validity)
+    BinaryArray::<O>::try_new(data_type, offsets.try_into()?, values, validity)
 }
 
 pub fn skip_binary(

--- a/src/io/ipc/read/array/list.rs
+++ b/src/io/ipc/read/array/list.rs
@@ -85,7 +85,7 @@ where
         version,
         scratch,
     )?;
-    ListArray::try_new(data_type, offsets, values, validity)
+    ListArray::try_new(data_type, offsets.try_into()?, values, validity)
 }
 
 pub fn skip_list<O: Offset>(

--- a/src/io/ipc/read/array/list.rs
+++ b/src/io/ipc/read/array/list.rs
@@ -2,10 +2,11 @@ use std::collections::VecDeque;
 use std::convert::TryInto;
 use std::io::{Read, Seek};
 
-use crate::array::{ListArray, Offset};
+use crate::array::ListArray;
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
 use crate::error::{Error, Result};
+use crate::offset::Offset;
 
 use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};

--- a/src/io/ipc/read/array/map.rs
+++ b/src/io/ipc/read/array/map.rs
@@ -80,7 +80,7 @@ pub fn read_map<R: Read + Seek>(
         version,
         scratch,
     )?;
-    MapArray::try_new(data_type, offsets, field, validity)
+    MapArray::try_new(data_type, offsets.try_into()?, field, validity)
 }
 
 pub fn skip_map(

--- a/src/io/ipc/read/array/utf8.rs
+++ b/src/io/ipc/read/array/utf8.rs
@@ -70,7 +70,7 @@ pub fn read_utf8<O: Offset, R: Read + Seek>(
         scratch,
     )?;
 
-    Utf8Array::<O>::try_new(data_type, offsets, values, validity)
+    Utf8Array::<O>::try_new(data_type, offsets.try_into()?, values, validity)
 }
 
 pub fn skip_utf8(

--- a/src/io/ipc/read/array/utf8.rs
+++ b/src/io/ipc/read/array/utf8.rs
@@ -1,10 +1,11 @@
 use std::collections::VecDeque;
 use std::io::{Read, Seek};
 
-use crate::array::{Offset, Utf8Array};
+use crate::array::Utf8Array;
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
 use crate::error::{Error, Result};
+use crate::offset::Offset;
 
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};

--- a/src/io/ipc/write/serialize.rs
+++ b/src/io/ipc/write/serialize.rs
@@ -2,7 +2,8 @@
 use arrow_format::ipc;
 
 use crate::{
-    array::*, bitmap::Bitmap, datatypes::PhysicalType, trusted_len::TrustedLen, types::NativeType,
+    array::*, bitmap::Bitmap, datatypes::PhysicalType, offset::Offset, trusted_len::TrustedLen,
+    types::NativeType,
 };
 
 use super::super::compression;

--- a/src/io/ipc/write/serialize.rs
+++ b/src/io/ipc/write/serialize.rs
@@ -2,7 +2,11 @@
 use arrow_format::ipc;
 
 use crate::{
-    array::*, bitmap::Bitmap, datatypes::PhysicalType, offset::Offset, trusted_len::TrustedLen,
+    array::*,
+    bitmap::Bitmap,
+    datatypes::PhysicalType,
+    offset::{Offset, OffsetsBuffer},
+    trusted_len::TrustedLen,
     types::NativeType,
 };
 
@@ -66,7 +70,7 @@ fn write_boolean(
 #[allow(clippy::too_many_arguments)]
 fn write_generic_binary<O: Offset>(
     validity: Option<&Bitmap>,
-    offsets: &[O],
+    offsets: &OffsetsBuffer<O>,
     values: &[u8],
     buffers: &mut Vec<ipc::Buffer>,
     arrow_data: &mut Vec<u8>,
@@ -74,6 +78,7 @@ fn write_generic_binary<O: Offset>(
     is_little_endian: bool,
     compression: Option<Compression>,
 ) {
+    let offsets = offsets.buffer();
     write_bitmap(
         validity,
         offsets.len() - 1,
@@ -182,7 +187,7 @@ fn write_list<O: Offset>(
     is_little_endian: bool,
     compression: Option<Compression>,
 ) {
-    let offsets = array.offsets();
+    let offsets = array.offsets().buffer();
     let validity = array.validity();
 
     write_bitmap(
@@ -196,7 +201,7 @@ fn write_list<O: Offset>(
 
     let first = *offsets.first().unwrap();
     let last = *offsets.last().unwrap();
-    if first == O::default() {
+    if first == O::zero() {
         write_buffer(
             offsets,
             buffers,
@@ -310,7 +315,7 @@ fn write_map(
     is_little_endian: bool,
     compression: Option<Compression>,
 ) {
-    let offsets = array.offsets();
+    let offsets = array.offsets().buffer();
     let validity = array.validity();
 
     write_bitmap(

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -12,7 +12,7 @@ use crate::{
     chunk::Chunk,
     datatypes::{DataType, Field, IntervalUnit, Schema},
     error::Error,
-    offset::Offset,
+    offset::{Offset, Offsets},
     types::{f16, NativeType},
 };
 
@@ -227,24 +227,19 @@ fn deserialize_list<'a, O: Offset, A: Borrow<Value<'a>>>(
     let child = ListArray::<O>::get_child_type(&data_type);
 
     let mut validity = MutableBitmap::with_capacity(rows.len());
-    let mut offsets = Vec::<O>::with_capacity(rows.len() + 1);
+    let mut offsets = Offsets::<O>::with_capacity(rows.len());
     let mut inner = vec![];
-    offsets.push(O::zero());
-    rows.iter().fold(O::zero(), |mut length, row| {
-        match row.borrow() {
-            Value::Array(value) => {
-                inner.extend(value.iter());
-                validity.push(true);
-                // todo make this an Err
-                length += O::from_usize(value.len()).expect("List offset is too large :/");
-                offsets.push(length);
-                length
-            }
-            _ => {
-                validity.push(false);
-                offsets.push(length);
-                length
-            }
+    rows.iter().for_each(|row| match row.borrow() {
+        Value::Array(value) => {
+            inner.extend(value.iter());
+            validity.push(true);
+            offsets
+                .try_push_usize(value.len())
+                .expect("List offset is too large :/");
+        }
+        _ => {
+            validity.push(false);
+            offsets.extend_constant(1);
         }
     });
 
@@ -259,39 +254,25 @@ fn deserialize_list_into<'a, O: Offset, A: Borrow<Value<'a>>>(
     target: &mut MutableListArray<O, Box<dyn MutableArray>>,
     rows: &[A],
 ) {
-    let start = {
-        let empty = vec![];
-        let inner: Vec<_> = rows
-            .iter()
-            .flat_map(|row| match row.borrow() {
-                Value::Array(value) => value.iter(),
-                _ => empty.iter(),
-            })
-            .collect();
+    let empty = vec![];
+    let inner: Vec<_> = rows
+        .iter()
+        .flat_map(|row| match row.borrow() {
+            Value::Array(value) => value.iter(),
+            _ => empty.iter(),
+        })
+        .collect();
 
-        let child = target.mut_values();
-        let start_len = child.len();
-        deserialize_into(child, &inner);
+    deserialize_into(target.mut_values(), &inner);
 
-        // todo make this an Err
-        O::from_usize(start_len).expect("Child list size too large")
-    };
-
-    let mut position = start;
-    let arrays = rows.iter().map(|row| {
-        match row.borrow() {
-            Value::Array(value) => {
-                // todo make this an Err
-                position += O::from_usize(value.len()).expect("List offset is too large :/");
-                Some(position)
-            }
-            _ => None,
-        }
+    let lengths = rows.iter().map(|row| match row.borrow() {
+        Value::Array(value) => Some(value.len()),
+        _ => None,
     });
 
-    // though this will always be safe, we cannot use unsafe_extend_offsets here
-    // due to `#![forbid(unsafe_code)]` on the io module
-    target.extend_offsets(arrays);
+    target
+        .try_extend_from_lengths(lengths)
+        .expect("Offsets overflow");
 }
 
 fn deserialize_fixed_size_list_into<'a, A: Borrow<Value<'a>>>(
@@ -302,10 +283,7 @@ fn deserialize_fixed_size_list_into<'a, A: Borrow<Value<'a>>>(
         match row.borrow() {
             Value::Array(value) => {
                 if value.len() == target.size() {
-                    {
-                        let child = target.mut_values();
-                        deserialize_into(child, value);
-                    }
+                    deserialize_into(target.mut_values(), value);
                     // unless alignment is already off, the if above should
                     // prevent this from ever happening.
                     target.try_push_valid().expect("unaligned backing array");

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -12,6 +12,7 @@ use crate::{
     chunk::Chunk,
     datatypes::{DataType, Field, IntervalUnit, Schema},
     error::Error,
+    offset::Offset,
     types::{f16, NativeType},
 };
 

--- a/src/io/json/write/serialize.rs
+++ b/src/io/json/write/serialize.rs
@@ -6,6 +6,7 @@ use streaming_iterator::StreamingIterator;
 use crate::bitmap::utils::ZipValidity;
 use crate::datatypes::TimeUnit;
 use crate::io::iterator::BufStreamingIterator;
+use crate::offset::Offset;
 use crate::temporal_conversions::{
     date32_to_date, date64_to_date, timestamp_ms_to_datetime, timestamp_ns_to_datetime,
     timestamp_s_to_datetime, timestamp_us_to_datetime,

--- a/src/io/json/write/serialize.rs
+++ b/src/io/json/write/serialize.rs
@@ -141,7 +141,7 @@ fn list_serializer<'a, O: Offset>(
     let mut serializer = new_serializer(array.values().as_ref());
 
     Box::new(BufStreamingIterator::new(
-        ZipValidity::new_with_validity(array.offsets().windows(2), array.validity()),
+        ZipValidity::new_with_validity(array.offsets().buffer().windows(2), array.validity()),
         move |offset, buf| {
             if let Some(offset) = offset {
                 let length = (offset[1] - offset[0]).to_usize();

--- a/src/io/json_integration/read/array.rs
+++ b/src/io/json_integration/read/array.rs
@@ -10,6 +10,7 @@ use crate::{
     datatypes::{DataType, PhysicalType, PrimitiveType, Schema},
     error::{Error, Result},
     io::ipc::IpcField,
+    offset::Offset,
     types::{days_ms, i256, months_days_ns, NativeType},
 };
 

--- a/src/io/json_integration/read/array.rs
+++ b/src/io/json_integration/read/array.rs
@@ -190,7 +190,7 @@ fn to_binary<O: Offset>(json_col: &ArrowJsonColumn, data_type: DataType) -> Box<
         .iter()
         .flat_map(|value| value.as_str().map(|x| hex::decode(x).unwrap()).unwrap())
         .collect();
-    Box::new(BinaryArray::new(data_type, offsets, values, validity))
+    BinaryArray::new(data_type, offsets.try_into().unwrap(), values, validity).boxed()
 }
 
 fn to_utf8<O: Offset>(json_col: &ArrowJsonColumn, data_type: DataType) -> Box<dyn Array> {
@@ -203,7 +203,7 @@ fn to_utf8<O: Offset>(json_col: &ArrowJsonColumn, data_type: DataType) -> Box<dy
         .iter()
         .flat_map(|value| value.as_str().unwrap().as_bytes().to_vec())
         .collect();
-    Box::new(Utf8Array::new(data_type, offsets, values, validity))
+    Utf8Array::new(data_type, offsets.try_into().unwrap(), values, validity).boxed()
 }
 
 fn to_list<O: Offset>(
@@ -223,9 +223,7 @@ fn to_list<O: Offset>(
         dictionaries,
     )?;
     let offsets = to_offsets::<O>(json_col.offset.as_ref());
-    Ok(Box::new(ListArray::<O>::new(
-        data_type, offsets, values, validity,
-    )))
+    Ok(ListArray::<O>::new(data_type, offsets.try_into()?, values, validity).boxed())
 }
 
 fn to_map(
@@ -245,7 +243,12 @@ fn to_map(
         dictionaries,
     )?;
     let offsets = to_offsets::<i32>(json_col.offset.as_ref());
-    Ok(Box::new(MapArray::new(data_type, offsets, field, validity)))
+    Ok(Box::new(MapArray::new(
+        data_type,
+        offsets.try_into().unwrap(),
+        field,
+        validity,
+    )))
 }
 
 fn to_dictionary<K: DictionaryKey + NumCast>(

--- a/src/io/odbc/write/serialize.rs
+++ b/src/io/odbc/write/serialize.rs
@@ -4,6 +4,7 @@ use crate::array::*;
 use crate::bitmap::Bitmap;
 use crate::datatypes::DataType;
 use crate::error::{Error, Result};
+use crate::offset::Offset;
 use crate::types::NativeType;
 
 use super::super::api;

--- a/src/io/odbc/write/serialize.rs
+++ b/src/io/odbc/write/serialize.rs
@@ -160,6 +160,7 @@ fn fixed_binary(array: &FixedSizeBinaryArray, writer: &mut BinColumnWriter) {
 fn binary<O: Offset>(array: &BinaryArray<O>, writer: &mut BinColumnWriter) {
     let max_len = array
         .offsets()
+        .buffer()
         .windows(2)
         .map(|x| (x[1] - x[0]).to_usize())
         .max()
@@ -171,6 +172,7 @@ fn binary<O: Offset>(array: &BinaryArray<O>, writer: &mut BinColumnWriter) {
 fn utf8<O: Offset>(array: &Utf8Array<O>, writer: &mut TextColumnWriter<u8>) {
     let max_len = array
         .offsets()
+        .buffer()
         .windows(2)
         .map(|x| (x[1] - x[0]).to_usize())
         .max()

--- a/src/io/orc/read/mod.rs
+++ b/src/io/orc/read/mod.rs
@@ -1,12 +1,11 @@
 //! APIs to read from [ORC format](https://orc.apache.org).
 use std::io::Read;
 
-use crate::array::{
-    Array, BinaryArray, BooleanArray, Int64Array, Offset, PrimitiveArray, Utf8Array,
-};
+use crate::array::{Array, BinaryArray, BooleanArray, Int64Array, PrimitiveArray, Utf8Array};
 use crate::bitmap::{Bitmap, MutableBitmap};
 use crate::datatypes::{DataType, Field, Schema};
 use crate::error::Error;
+use crate::offset::Offset;
 use crate::types::NativeType;
 
 use orc_format::proto::stream::Kind;

--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -14,7 +14,7 @@ use crate::{
     buffer::Buffer,
     datatypes::DataType,
     error::{Error, Result},
-    offset::Offset,
+    offset::{Offset, OffsetsBuffer},
 };
 
 use super::super::utils::{
@@ -228,7 +228,7 @@ impl<'a> utils::PageState<'a> for State<'a> {
 pub trait TraitBinaryArray<O: Offset>: Array + 'static {
     fn try_new(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> Result<Self>
@@ -239,7 +239,7 @@ pub trait TraitBinaryArray<O: Offset>: Array + 'static {
 impl<O: Offset> TraitBinaryArray<O> for BinaryArray<O> {
     fn try_new(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> Result<Self> {
@@ -250,7 +250,7 @@ impl<O: Offset> TraitBinaryArray<O> for BinaryArray<O> {
 impl<O: Offset> TraitBinaryArray<O> for Utf8Array<O> {
     fn try_new(
         data_type: DataType,
-        offsets: Buffer<O>,
+        offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> Result<Self> {
@@ -373,22 +373,18 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 let Binary {
                     offsets,
                     values: values_,
-                    last_offset,
                 } = values;
 
-                let offset = *last_offset;
+                let last_offset = *offsets.last();
                 extend_from_decoder(
                     validity,
                     page_validity,
                     Some(additional),
                     offsets,
-                    page_values.lengths.by_ref().map(|x| {
-                        *last_offset += O::from_usize(x).unwrap();
-                        *last_offset
-                    }),
+                    page_values.lengths.by_ref(),
                 );
 
-                let length = *last_offset - offset;
+                let length = *offsets.last() - last_offset;
 
                 let (consumed, remaining) = page_values.values.split_at(length.to_usize());
                 page_values.values = remaining;
@@ -486,7 +482,7 @@ pub(super) fn finish<O: Offset, A: TraitBinaryArray<O>>(
 ) -> Result<A> {
     A::try_new(
         data_type.clone(),
-        values.offsets.0.into(),
+        values.offsets.into(),
         values.values.into(),
         validity.into(),
     )

--- a/src/io/parquet/read/deserialize/binary/basic.rs
+++ b/src/io/parquet/read/deserialize/binary/basic.rs
@@ -9,11 +9,12 @@ use parquet2::{
 };
 
 use crate::{
-    array::{Array, BinaryArray, Offset, Utf8Array},
+    array::{Array, BinaryArray, Utf8Array},
     bitmap::{Bitmap, MutableBitmap},
     buffer::Buffer,
     datatypes::DataType,
     error::{Error, Result},
+    offset::Offset,
 };
 
 use super::super::utils::{

--- a/src/io/parquet/read/deserialize/binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/binary/dictionary.rs
@@ -3,11 +3,12 @@ use std::collections::VecDeque;
 use parquet2::page::DictPage;
 
 use crate::{
-    array::{Array, BinaryArray, DictionaryArray, DictionaryKey, Offset, Utf8Array},
+    array::{Array, BinaryArray, DictionaryArray, DictionaryKey, Utf8Array},
     bitmap::MutableBitmap,
     datatypes::{DataType, PhysicalType},
     error::Result,
     io::parquet::read::deserialize::nested_utils::{InitNested, NestedState},
+    offset::Offset,
 };
 
 use super::super::Pages;

--- a/src/io/parquet/read/deserialize/binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/binary/dictionary.rs
@@ -67,11 +67,10 @@ fn read_dict<O: Offset>(data_type: DataType, dict: &DictPage) -> Box<dyn Array> 
 
     match data_type.to_physical_type() {
         PhysicalType::Utf8 | PhysicalType::LargeUtf8 => {
-            Utf8Array::<O>::new(data_type, data.offsets.0.into(), data.values.into(), None).boxed()
+            Utf8Array::<O>::new(data_type, data.offsets.into(), data.values.into(), None).boxed()
         }
         PhysicalType::Binary | PhysicalType::LargeBinary => {
-            BinaryArray::<O>::new(data_type, data.offsets.0.into(), data.values.into(), None)
-                .boxed()
+            BinaryArray::<O>::new(data_type, data.offsets.into(), data.values.into(), None).boxed()
         }
         _ => unreachable!(),
     }

--- a/src/io/parquet/read/deserialize/binary/nested.rs
+++ b/src/io/parquet/read/deserialize/binary/nested.rs
@@ -7,8 +7,8 @@ use parquet2::{
 };
 
 use crate::{
-    array::Offset, bitmap::MutableBitmap, datatypes::DataType, error::Result,
-    io::parquet::read::Pages,
+    bitmap::MutableBitmap, datatypes::DataType, error::Result, io::parquet::read::Pages,
+    offset::Offset,
 };
 
 use super::super::utils::MaybeNext;

--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -1,4 +1,4 @@
-use crate::array::Offset;
+use crate::offset::Offset;
 
 use super::super::utils::Pushable;
 

--- a/src/io/parquet/read/deserialize/binary/utils.rs
+++ b/src/io/parquet/read/deserialize/binary/utils.rs
@@ -1,4 +1,4 @@
-use crate::offset::Offset;
+use crate::offset::{Offset, Offsets};
 
 use super::super::utils::Pushable;
 
@@ -7,70 +7,51 @@ use super::super::utils::Pushable;
 pub struct Binary<O: Offset> {
     pub offsets: Offsets<O>,
     pub values: Vec<u8>,
-    pub last_offset: O,
 }
 
-#[derive(Debug)]
-pub struct Offsets<O: Offset>(pub Vec<O>);
-
-impl<O: Offset> Offsets<O> {
-    #[inline]
-    pub fn extend_lengths<I: Iterator<Item = usize>>(&mut self, lengths: I) {
-        let mut last_offset = *self.0.last().unwrap();
-        self.0.extend(lengths.map(|length| {
-            last_offset += O::from_usize(length).unwrap();
-            last_offset
-        }));
-    }
-}
-
-impl<O: Offset> Pushable<O> for Offsets<O> {
+impl<O: Offset> Pushable<usize> for Offsets<O> {
     fn reserve(&mut self, additional: usize) {
-        self.0.reserve(additional)
+        self.reserve(additional)
     }
     #[inline]
     fn len(&self) -> usize {
-        self.0.len() - 1
+        self.len()
     }
 
     #[inline]
-    fn push(&mut self, value: O) {
-        self.0.push(value)
+    fn push(&mut self, value: usize) {
+        self.try_push_usize(value).unwrap()
     }
 
     #[inline]
     fn push_null(&mut self) {
-        self.0.push(*self.0.last().unwrap())
+        self.extend_constant(1);
     }
 
     #[inline]
-    fn extend_constant(&mut self, additional: usize, value: O) {
-        self.0.extend_constant(additional, value)
+    fn extend_constant(&mut self, additional: usize, _: usize) {
+        self.extend_constant(additional)
     }
 }
 
 impl<O: Offset> Binary<O> {
     #[inline]
     pub fn with_capacity(capacity: usize) -> Self {
-        let mut offsets = Vec::with_capacity(1 + capacity);
-        offsets.push(O::default());
         Self {
-            offsets: Offsets(offsets),
+            offsets: Offsets::with_capacity(capacity),
             values: Vec::with_capacity(capacity * 24),
-            last_offset: O::default(),
         }
     }
 
     #[inline]
     pub fn push(&mut self, v: &[u8]) {
         self.values.extend(v);
-        self.last_offset += O::from_usize(v.len()).unwrap();
-        self.offsets.push(self.last_offset)
+        self.offsets.try_push_usize(v.len()).unwrap()
     }
 
     #[inline]
     pub fn extend_constant(&mut self, additional: usize) {
-        self.offsets.extend_constant(additional, self.last_offset);
+        self.offsets.extend_constant(additional);
     }
 
     #[inline]
@@ -80,10 +61,10 @@ impl<O: Offset> Binary<O> {
 
     #[inline]
     pub fn extend_lengths<I: Iterator<Item = usize>>(&mut self, lengths: I, values: &mut &[u8]) {
-        let current_offset = self.last_offset;
-        self.offsets.extend_lengths(lengths);
-        self.last_offset = *self.offsets.0.last().unwrap(); // guaranteed to have one
-        let length = self.last_offset.to_usize() - current_offset.to_usize();
+        let current_offset = *self.offsets.last();
+        self.offsets.try_extend_from_lengths(lengths).unwrap();
+        let new_offset = *self.offsets.last();
+        let length = new_offset.to_usize() - current_offset.to_usize();
         let (consumed, remaining) = values.split_at(length);
         *values = remaining;
         self.values.extend_from_slice(consumed);
@@ -93,7 +74,7 @@ impl<O: Offset> Binary<O> {
 impl<'a, O: Offset> Pushable<&'a [u8]> for Binary<O> {
     #[inline]
     fn reserve(&mut self, additional: usize) {
-        let avg_len = self.values.len() / std::cmp::max(self.last_offset.to_usize(), 1);
+        let avg_len = self.values.len() / std::cmp::max(self.offsets.last().to_usize(), 1);
         self.values.reserve(additional * avg_len);
         self.offsets.reserve(additional);
     }

--- a/src/io/parquet/read/deserialize/mod.rs
+++ b/src/io/parquet/read/deserialize/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     array::{Array, DictionaryKey, FixedSizeListArray, ListArray},
     datatypes::{DataType, Field, IntervalUnit},
     error::Result,
+    offset::Offsets,
 };
 
 use self::nested_utils::{InitNested, NestedArrayIter, NestedState};
@@ -53,6 +54,11 @@ fn create_list(
             offsets.push(values.len() as i64);
 
             let offsets = offsets.iter().map(|x| *x as i32).collect::<Vec<_>>();
+
+            let offsets: Offsets<i32> = offsets
+                .try_into()
+                .expect("i64 offsets do not fit in i32 offsets");
+
             Box::new(ListArray::<i32>::new(
                 data_type,
                 offsets.into(),
@@ -65,7 +71,7 @@ fn create_list(
 
             Box::new(ListArray::<i64>::new(
                 data_type,
-                offsets.into(),
+                offsets.try_into().expect("List too large"),
                 values,
                 validity.and_then(|x| x.into()),
             ))

--- a/src/io/parquet/read/deserialize/nested.rs
+++ b/src/io/parquet/read/deserialize/nested.rs
@@ -295,7 +295,7 @@ where
                     let (nested, inner) = x?;
                     let array = MapArray::new(
                         field.data_type().clone(),
-                        vec![0, inner.len() as i32].into(),
+                        vec![0, inner.len() as i32].try_into().unwrap(),
                         inner,
                         None,
                     );

--- a/src/io/parquet/read/statistics/binary.rs
+++ b/src/io/parquet/read/statistics/binary.rs
@@ -1,7 +1,8 @@
-use crate::array::{MutableArray, MutableBinaryArray, Offset};
 use parquet2::statistics::{BinaryStatistics, Statistics as ParquetStatistics};
 
+use crate::array::{MutableArray, MutableBinaryArray};
 use crate::error::Result;
+use crate::offset::Offset;
 
 pub(super) fn push<O: Offset>(
     from: Option<&dyn ParquetStatistics>,

--- a/src/io/parquet/read/statistics/list.rs
+++ b/src/io/parquet/read/statistics/list.rs
@@ -1,6 +1,7 @@
 use crate::array::*;
 use crate::datatypes::DataType;
 use crate::error::Result;
+use crate::offset::Offsets;
 
 use super::make_mutable;
 
@@ -40,19 +41,21 @@ impl MutableArray for DynMutableListArray {
 
         match self.data_type.to_logical_type() {
             DataType::List(_) => {
-                let offsets = (0..=inner.len() as i32).collect::<Vec<_>>().into();
+                let offsets =
+                    Offsets::try_from_lengths(std::iter::repeat(1).take(inner.len())).unwrap();
                 Box::new(ListArray::<i32>::new(
                     self.data_type.clone(),
-                    offsets,
+                    offsets.into(),
                     inner,
                     None,
                 ))
             }
             DataType::LargeList(_) => {
-                let offsets = (0..=inner.len() as i64).collect::<Vec<_>>().into();
+                let offsets =
+                    Offsets::try_from_lengths(std::iter::repeat(1).take(inner.len())).unwrap();
                 Box::new(ListArray::<i64>::new(
                     self.data_type.clone(),
-                    offsets,
+                    offsets.into(),
                     inner,
                     None,
                 ))

--- a/src/io/parquet/read/statistics/map.rs
+++ b/src/io/parquet/read/statistics/map.rs
@@ -40,7 +40,7 @@ impl MutableArray for DynMutableMapArray {
     fn as_box(&mut self) -> Box<dyn Array> {
         Box::new(MapArray::new(
             self.data_type.clone(),
-            vec![0, self.inner.len() as i32].into(),
+            vec![0, self.inner.len() as i32].try_into().unwrap(),
             self.inner.as_box(),
             None,
         ))

--- a/src/io/parquet/read/statistics/utf8.rs
+++ b/src/io/parquet/read/statistics/utf8.rs
@@ -1,7 +1,8 @@
-use crate::array::{MutableArray, MutableUtf8Array, Offset};
 use parquet2::statistics::{BinaryStatistics, Statistics as ParquetStatistics};
 
+use crate::array::{MutableArray, MutableUtf8Array};
 use crate::error::Result;
+use crate::offset::Offset;
 
 pub(super) fn push<O: Offset>(
     from: Option<&dyn ParquetStatistics>,

--- a/src/io/parquet/write/binary/basic.rs
+++ b/src/io/parquet/write/binary/basic.rs
@@ -8,10 +8,11 @@ use parquet2::{
 use super::super::utils;
 use super::super::WriteOptions;
 use crate::{
-    array::{Array, BinaryArray, Offset},
+    array::{Array, BinaryArray},
     bitmap::Bitmap,
     error::{Error, Result},
     io::parquet::read::schema::is_nullable,
+    offset::Offset,
 };
 
 pub(crate) fn encode_plain<O: Offset>(

--- a/src/io/parquet/write/binary/basic.rs
+++ b/src/io/parquet/write/binary/basic.rs
@@ -64,7 +64,7 @@ pub fn array_to_page<O: Offset>(
         Encoding::Plain => encode_plain(array, is_optional, &mut buffer),
         Encoding::DeltaLengthByteArray => encode_delta(
             array.values(),
-            array.offsets(),
+            array.offsets().buffer(),
             array.validity(),
             is_optional,
             &mut buffer,

--- a/src/io/parquet/write/binary/nested.rs
+++ b/src/io/parquet/write/binary/nested.rs
@@ -6,8 +6,9 @@ use super::basic::{build_statistics, encode_plain};
 use crate::io::parquet::read::schema::is_nullable;
 use crate::io::parquet::write::Nested;
 use crate::{
-    array::{Array, BinaryArray, Offset},
+    array::{Array, BinaryArray},
     error::Result,
+    offset::Offset,
 };
 
 pub fn array_to_page<O>(

--- a/src/io/parquet/write/nested/def.rs
+++ b/src/io/parquet/write/nested/def.rs
@@ -1,4 +1,4 @@
-use crate::{array::Offset, bitmap::Bitmap};
+use crate::{bitmap::Bitmap, offset::Offset};
 
 use super::super::pages::{ListNested, Nested};
 use super::rep::num_values;

--- a/src/io/parquet/write/nested/mod.rs
+++ b/src/io/parquet/write/nested/mod.rs
@@ -3,7 +3,7 @@ mod rep;
 
 use parquet2::{encoding::hybrid_rle::encode_u32, read::levels::get_bit_width, write::Version};
 
-use crate::{array::Offset, error::Result};
+use crate::{error::Result, offset::Offset};
 
 use super::Nested;
 

--- a/src/io/parquet/write/pages.rs
+++ b/src/io/parquet/write/pages.rs
@@ -106,7 +106,7 @@ fn to_nested_recursive<'a>(
             };
 
             parents.push(Nested::List(ListNested::new(
-                array.offsets(),
+                array.offsets().buffer(),
                 array.validity(),
                 is_optional,
             )));
@@ -129,7 +129,7 @@ fn to_nested_recursive<'a>(
             };
 
             parents.push(Nested::LargeList(ListNested::new(
-                array.offsets(),
+                array.offsets().buffer(),
                 array.validity(),
                 is_optional,
             )));
@@ -418,7 +418,7 @@ mod tests {
 
         let array = ListArray::new(
             DataType::List(Box::new(Field::new("l", array.data_type().clone(), true))),
-            vec![0i32, 2, 4].into(),
+            vec![0i32, 2, 4].try_into().unwrap(),
             Box::new(array),
             None,
         );

--- a/src/io/parquet/write/pages.rs
+++ b/src/io/parquet/write/pages.rs
@@ -1,10 +1,11 @@
 use parquet2::schema::types::{ParquetType, PrimitiveType as ParquetPrimitiveType};
 use parquet2::{page::Page, write::DynIter};
 
-use crate::array::{ListArray, Offset, StructArray};
+use crate::array::{ListArray, StructArray};
 use crate::bitmap::Bitmap;
 use crate::datatypes::PhysicalType;
 use crate::io::parquet::read::schema::is_nullable;
+use crate::offset::Offset;
 use crate::{
     array::Array,
     error::{Error, Result},

--- a/src/io/parquet/write/utf8/basic.rs
+++ b/src/io/parquet/write/utf8/basic.rs
@@ -63,7 +63,7 @@ pub fn array_to_page<O: Offset>(
         Encoding::Plain => encode_plain(array, is_optional, &mut buffer),
         Encoding::DeltaLengthByteArray => encode_delta(
             array.values(),
-            array.offsets(),
+            array.offsets().buffer(),
             array.validity(),
             is_optional,
             &mut buffer,

--- a/src/io/parquet/write/utf8/basic.rs
+++ b/src/io/parquet/write/utf8/basic.rs
@@ -9,9 +9,10 @@ use super::super::binary::{encode_delta, ord_binary};
 use super::super::utils;
 use super::super::WriteOptions;
 use crate::{
-    array::{Array, Offset, Utf8Array},
+    array::{Array, Utf8Array},
     error::{Error, Result},
     io::parquet::read::schema::is_nullable,
+    offset::Offset,
 };
 
 pub(crate) fn encode_plain<O: Offset>(

--- a/src/io/parquet/write/utf8/nested.rs
+++ b/src/io/parquet/write/utf8/nested.rs
@@ -6,8 +6,9 @@ use super::basic::{build_statistics, encode_plain};
 use crate::io::parquet::read::schema::is_nullable;
 use crate::io::parquet::write::Nested;
 use crate::{
-    array::{Array, Offset, Utf8Array},
+    array::{Array, Utf8Array},
     error::Result,
+    offset::Offset,
 };
 
 pub fn array_to_page<O>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod error;
 #[cfg_attr(docsrs, doc(cfg(feature = "io_ipc")))]
 pub mod mmap;
 
+pub mod offset;
 pub mod scalar;
 pub mod trusted_len;
 pub mod types;

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -144,6 +144,27 @@ impl<O: Offset> Offsets<O> {
         }
     }
 
+    /// Returns a range (start, end) corresponding to the position `index`
+    /// # Panic
+    /// This function panics iff `index >= self.len()`
+    #[inline]
+    pub fn start_end(&self, index: usize) -> (usize, usize) {
+        // soundness: the invariant of the function
+        assert!(index < self.len());
+        unsafe { self.start_end_unchecked(index) }
+    }
+
+    /// Returns a range (start, end) corresponding to the position `index`
+    /// # Safety
+    /// `index` must be `< self.len()`
+    #[inline]
+    pub unsafe fn start_end_unchecked(&self, index: usize) -> (usize, usize) {
+        // soundness: the invariant of the function
+        let start = self.0.get_unchecked(index).to_usize();
+        let end = self.0.get_unchecked(index + 1).to_usize();
+        (start, end)
+    }
+
     /// Returns the length of this container
     #[inline]
     pub fn len(&self) -> usize {
@@ -302,6 +323,7 @@ fn try_check_offsets<O: Offset>(offsets: &[O]) -> Result<(), Error> {
 
 /// A wrapper type of [`Buffer<O>`] that is guaranteed to:
 /// * Always contain an element
+/// * Every element is `>0`
 /// * element at position `i` is >= than element at position `i-1`.
 #[derive(Clone, PartialEq, Debug)]
 pub struct OffsetsBuffer<O: Offset>(Buffer<O>);
@@ -366,6 +388,27 @@ impl<O: Offset> OffsetsBuffer<O> {
             Some(element) => element,
             None => unsafe { unreachable_unchecked() },
         }
+    }
+
+    /// Returns a range (start, end) corresponding to the position `index`
+    /// # Panic
+    /// This function panics iff `index >= self.len()`
+    #[inline]
+    pub fn start_end(&self, index: usize) -> (usize, usize) {
+        // soundness: the invariant of the function
+        assert!(index < self.len());
+        unsafe { self.start_end_unchecked(index) }
+    }
+
+    /// Returns a range (start, end) corresponding to the position `index`
+    /// # Safety
+    /// `index` must be `< self.len()`
+    #[inline]
+    pub unsafe fn start_end_unchecked(&self, index: usize) -> (usize, usize) {
+        // soundness: the invariant of the function
+        let start = self.0.get_unchecked(index).to_usize();
+        let end = self.0.get_unchecked(index + 1).to_usize();
+        (start, end)
     }
 
     /// Returns a new [`OffsetsBuffer`] that is a slice of this buffer starting at `offset`.

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -1,0 +1,2 @@
+//! Contains the declaration of [`Offset`]
+pub use crate::types::Offset;

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -420,6 +420,12 @@ impl<O: Offset> OffsetsBuffer<O> {
         Self(self.0.slice_unchecked(offset, length))
     }
 
+    /// Returns an iterator with the lengths of the offsets
+    #[inline]
+    pub fn lengths(&self) -> impl Iterator<Item = usize> + '_ {
+        self.0.windows(2).map(|w| (w[1] - w[0]).to_usize())
+    }
+
     /// Returns the inner [`Buffer`].
     #[inline]
     pub fn into_inner(self) -> Buffer<O> {

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -1,2 +1,447 @@
 //! Contains the declaration of [`Offset`]
+use std::hint::unreachable_unchecked;
+
+use crate::buffer::Buffer;
+use crate::error::Error;
 pub use crate::types::Offset;
+
+/// A wrapper type of [`Vec<O>`] representing the invariants of Arrow's offsets.
+/// It is guaranteed to (sound to assume that):
+/// * every element is `>= 0`
+/// * element at position `i` is >= than element at position `i-1`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Offsets<O: Offset>(Vec<O>);
+
+impl<O: Offset> Default for Offsets<O> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<O: Offset> TryFrom<Vec<O>> for Offsets<O> {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(offsets: Vec<O>) -> Result<Self, Self::Error> {
+        try_check_offsets(&offsets)?;
+        Ok(Self(offsets))
+    }
+}
+
+impl<O: Offset> TryFrom<Buffer<O>> for OffsetsBuffer<O> {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(offsets: Buffer<O>) -> Result<Self, Self::Error> {
+        try_check_offsets(&offsets)?;
+        Ok(Self(offsets))
+    }
+}
+
+impl<O: Offset> TryFrom<Vec<O>> for OffsetsBuffer<O> {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(offsets: Vec<O>) -> Result<Self, Self::Error> {
+        try_check_offsets(&offsets)?;
+        Ok(Self(offsets.into()))
+    }
+}
+
+impl<O: Offset> From<Offsets<O>> for OffsetsBuffer<O> {
+    #[inline]
+    fn from(offsets: Offsets<O>) -> Self {
+        Self(offsets.0.into())
+    }
+}
+
+impl<O: Offset> Offsets<O> {
+    /// Returns an empty [`Offsets`] (i.e. with a single element, the zero)
+    #[inline]
+    pub fn new() -> Self {
+        Self(vec![O::zero()])
+    }
+
+    /// Creates a new [`Offsets`] from an iterator of lengths
+    #[inline]
+    pub fn try_from_iter<I: IntoIterator<Item = usize>>(iter: I) -> Result<Self, Error> {
+        let iterator = iter.into_iter();
+        let (lower, _) = iterator.size_hint();
+        let mut offsets = Self::with_capacity(lower);
+        for item in iterator {
+            offsets.try_push_usize(item)?
+        }
+        Ok(offsets)
+    }
+
+    /// Returns a new [`Offsets`] with a capacity, allocating at least `capacity + 1` entries.
+    pub fn with_capacity(capacity: usize) -> Self {
+        let mut offsets = Vec::with_capacity(capacity + 1);
+        offsets.push(O::zero());
+        Self(offsets)
+    }
+
+    /// Returns the capacity of [`Offsets`].
+    pub fn capacity(&self) -> usize {
+        self.0.capacity() - 1
+    }
+
+    /// Reserves `additional` entries.
+    pub fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
+
+    /// Shrinks the capacity of self to fit.
+    pub fn shrink_to_fit(&mut self) {
+        self.0.shrink_to_fit();
+    }
+
+    /// Pushes a new element with a given length.
+    /// # Error
+    /// This function errors iff the new last item is larger than what `O` supports.
+    /// # Panic
+    /// This function asserts that `length > 0`.
+    #[inline]
+    pub fn try_push(&mut self, length: O) -> Result<(), Error> {
+        let old_length = self.last();
+        assert!(length >= O::zero());
+        let new_length = old_length.checked_add(&length).ok_or(Error::Overflow)?;
+        self.0.push(new_length);
+        Ok(())
+    }
+
+    /// Pushes a new element with a given length.
+    /// # Error
+    /// This function errors iff the new last item is larger than what `O` supports.
+    /// # Implementation
+    /// This function:
+    /// * checks that this length does not overflow
+    #[inline]
+    pub fn try_push_usize(&mut self, length: usize) -> Result<(), Error> {
+        let length = O::from_usize(length).ok_or(Error::Overflow)?;
+
+        let old_length = self.last();
+        let new_length = old_length.checked_add(&length).ok_or(Error::Overflow)?;
+        self.0.push(new_length);
+        Ok(())
+    }
+
+    /// Returns [`Offsets`] assuming that `offsets` fulfills its invariants
+    /// # Safety
+    /// This is safe iff the invariants of this struct are guaranteed in `offsets`.
+    #[inline]
+    pub unsafe fn new_unchecked(offsets: Vec<O>) -> Self {
+        Self(offsets)
+    }
+
+    /// Returns the last offset of this container.
+    #[inline]
+    pub fn last(&self) -> &O {
+        match self.0.last() {
+            Some(element) => element,
+            None => unsafe { unreachable_unchecked() },
+        }
+    }
+
+    /// Returns the length of this container
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len() - 1
+    }
+
+    /// Returns the byte slice stored in this buffer
+    #[inline]
+    pub fn as_slice(&self) -> &[O] {
+        self.0.as_slice()
+    }
+
+    /// Pops the last element
+    #[inline]
+    pub fn pop(&mut self) -> Option<O> {
+        if self.len() == 0 {
+            None
+        } else {
+            self.0.pop()
+        }
+    }
+
+    /// Extends itself with `additional` elements equal to the last offset.
+    /// This is useful to extend offsets with empty values, e.g. for null slots.
+    #[inline]
+    pub fn extend_constant(&mut self, additional: usize) {
+        let offset = *self.last();
+        if additional == 1 {
+            self.0.push(offset)
+        } else {
+            self.0.resize(self.len() + additional, offset)
+        }
+    }
+
+    /// Try to create a new [`Offsets`] from a sequence of `lengths`
+    /// # Errors
+    /// This function errors iff this operation overflows for the maximum value of `O`.
+    #[inline]
+    pub fn try_from_lengths<I: Iterator<Item = usize>>(lengths: I) -> Result<Self, Error> {
+        let mut self_ = Self::with_capacity(lengths.size_hint().0);
+        self_.try_extend_from_lengths(lengths)?;
+        Ok(self_)
+    }
+
+    /// Try extend from an iterator of lengths
+    /// # Errors
+    /// This function errors iff this operation overflows for the maximum value of `O`.
+    #[inline]
+    pub fn try_extend_from_lengths<I: Iterator<Item = usize>>(
+        &mut self,
+        lengths: I,
+    ) -> Result<(), Error> {
+        let mut total_length = 0;
+        let mut offset = *self.last();
+        let original_offset = offset.to_usize();
+
+        let lengths = lengths.map(|length| {
+            total_length += length;
+            O::from_as_usize(length)
+        });
+
+        let offsets = lengths.map(|length| {
+            offset += length; // this may overflow, checked below
+            offset
+        });
+        self.0.extend(offsets);
+
+        let last_offset = original_offset
+            .checked_add(total_length)
+            .ok_or(Error::Overflow)?;
+        O::from_usize(last_offset).ok_or(Error::Overflow)?;
+        Ok(())
+    }
+
+    /// Extends itself from another [`Offsets`]
+    /// # Errors
+    /// This function errors iff this operation overflows for the maximum value of `O`.
+    pub fn try_extend_from_self(&mut self, other: &Self) -> Result<(), Error> {
+        let mut length = *self.last();
+        let other_length = *other.last();
+        // check if the operation would overflow
+        length.checked_add(&other_length).ok_or(Error::Overflow)?;
+
+        let lengths = other.as_slice().windows(2).map(|w| w[1] - w[0]);
+        let offsets = lengths.map(|new_length| {
+            length += new_length;
+            length
+        });
+        self.0.extend(offsets);
+        Ok(())
+    }
+
+    /// Extends itself from another [`Offsets`] sliced by `start, length`
+    /// # Errors
+    /// This function errors iff this operation overflows for the maximum value of `O`.
+    pub fn try_extend_from_slice(
+        &mut self,
+        other: &OffsetsBuffer<O>,
+        start: usize,
+        length: usize,
+    ) -> Result<(), Error> {
+        if length == 0 {
+            return Ok(());
+        }
+        let other = &other.0[start..start + length + 1];
+        let other_length = other.last().expect("Length to be non-zero");
+        let mut length = *self.last();
+        // check if the operation would overflow
+        length.checked_add(other_length).ok_or(Error::Overflow)?;
+
+        let lengths = other.windows(2).map(|w| w[1] - w[0]);
+        let offsets = lengths.map(|new_length| {
+            length += new_length;
+            length
+        });
+        self.0.extend(offsets);
+        Ok(())
+    }
+
+    /// Returns the inner [`Vec`].
+    #[inline]
+    pub fn into_inner(self) -> Vec<O> {
+        self.0
+    }
+}
+
+/// Checks that `offsets` is monotonically increasing.
+fn try_check_offsets<O: Offset>(offsets: &[O]) -> Result<(), Error> {
+    // this code is carefully constructed to auto-vectorize, don't change naively!
+    match offsets.first() {
+        None => Err(Error::oos("offsets must have at least one element")),
+        Some(first) => {
+            if *first < O::zero() {
+                return Err(Error::oos("offsets must be larger than 0"));
+            }
+            let mut previous = *first;
+            let mut any_invalid = false;
+
+            // This loop will auto-vectorize because there is not any break,
+            // an invalid value will be returned once the whole offsets buffer is processed.
+            for offset in offsets {
+                if previous > *offset {
+                    any_invalid = true
+                }
+                previous = *offset;
+            }
+
+            if any_invalid {
+                Err(Error::oos("offsets must be monotonically increasing"))
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
+
+/// A wrapper type of [`Buffer<O>`] that is guaranteed to:
+/// * Always contain an element
+/// * element at position `i` is >= than element at position `i-1`.
+#[derive(Clone, PartialEq, Debug)]
+pub struct OffsetsBuffer<O: Offset>(Buffer<O>);
+
+impl<O: Offset> Default for OffsetsBuffer<O> {
+    #[inline]
+    fn default() -> Self {
+        Self(vec![O::zero()].into())
+    }
+}
+
+impl<O: Offset> OffsetsBuffer<O> {
+    /// # Safety
+    /// This is safe iff the invariants of this struct are guaranteed in `offsets`.
+    #[inline]
+    pub unsafe fn new_unchecked(offsets: Buffer<O>) -> Self {
+        Self(offsets)
+    }
+
+    /// Returns an empty [`OffsetsBuffer`] (i.e. with a single element, the zero)
+    #[inline]
+    pub fn new() -> Self {
+        Self(vec![O::zero()].into())
+    }
+
+    /// Copy-on-write API to convert [`OffsetsBuffer`] into [`Offsets`].
+    #[inline]
+    pub fn get_mut(&mut self) -> Option<Offsets<O>> {
+        self.0
+            .get_mut()
+            .map(|x| {
+                let mut new = vec![O::zero()];
+                std::mem::swap(x, &mut new);
+                new
+            })
+            // Safety: Offsets and OffsetsBuffer share invariants
+            .map(|offsets| unsafe { Offsets::new_unchecked(offsets) })
+    }
+
+    /// Returns a reference to its internal [`Buffer`].
+    #[inline]
+    pub fn buffer(&self) -> &Buffer<O> {
+        &self.0
+    }
+
+    /// Returns the length of this container
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.len() - 1
+    }
+
+    /// Returns the byte slice stored in this buffer
+    #[inline]
+    pub fn as_slice(&self) -> &[O] {
+        self.0.as_slice()
+    }
+
+    /// Returns the last offset of this container, which is guaranteed to exist.
+    #[inline]
+    pub fn last(&self) -> &O {
+        match self.0.last() {
+            Some(element) => element,
+            None => unsafe { unreachable_unchecked() },
+        }
+    }
+
+    /// Returns a new [`OffsetsBuffer`] that is a slice of this buffer starting at `offset`.
+    /// Doing so allows the same memory region to be shared between buffers.
+    /// # Safety
+    /// The caller must ensure `offset + length <= self.len()`
+    #[inline]
+    pub unsafe fn slice_unchecked(self, offset: usize, length: usize) -> Self {
+        Self(self.0.slice_unchecked(offset, length))
+    }
+
+    /// Returns the inner [`Buffer`].
+    #[inline]
+    pub fn into_inner(self) -> Buffer<O> {
+        self.0
+    }
+}
+
+impl From<&OffsetsBuffer<i32>> for OffsetsBuffer<i64> {
+    fn from(offsets: &OffsetsBuffer<i32>) -> Self {
+        // this conversion is lossless and uphelds all invariants
+        Self(
+            offsets
+                .buffer()
+                .iter()
+                .map(|x| *x as i64)
+                .collect::<Vec<_>>()
+                .into(),
+        )
+    }
+}
+
+impl TryFrom<&OffsetsBuffer<i64>> for OffsetsBuffer<i32> {
+    type Error = Error;
+
+    fn try_from(offsets: &OffsetsBuffer<i64>) -> Result<Self, Self::Error> {
+        i32::try_from(*offsets.last()).map_err(|_| Error::Overflow)?;
+
+        // this conversion is lossless and uphelds all invariants
+        Ok(Self(
+            offsets
+                .buffer()
+                .iter()
+                .map(|x| *x as i32)
+                .collect::<Vec<_>>()
+                .into(),
+        ))
+    }
+}
+
+impl From<Offsets<i32>> for Offsets<i64> {
+    fn from(offsets: Offsets<i32>) -> Self {
+        // this conversion is lossless and uphelds all invariants
+        Self(
+            offsets
+                .as_slice()
+                .iter()
+                .map(|x| *x as i64)
+                .collect::<Vec<_>>(),
+        )
+    }
+}
+
+impl TryFrom<Offsets<i64>> for Offsets<i32> {
+    type Error = Error;
+
+    fn try_from(offsets: Offsets<i64>) -> Result<Self, Self::Error> {
+        i32::try_from(*offsets.last()).map_err(|_| Error::Overflow)?;
+
+        // this conversion is lossless and uphelds all invariants
+        Ok(Self(
+            offsets
+                .as_slice()
+                .iter()
+                .map(|x| *x as i32)
+                .collect::<Vec<_>>(),
+        ))
+    }
+}

--- a/src/scalar/binary.rs
+++ b/src/scalar/binary.rs
@@ -1,4 +1,4 @@
-use crate::{array::*, datatypes::DataType};
+use crate::{datatypes::DataType, offset::Offset};
 
 use super::Scalar;
 

--- a/src/scalar/list.rs
+++ b/src/scalar/list.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use crate::{array::*, datatypes::DataType};
+use crate::{array::*, datatypes::DataType, offset::Offset};
 
 use super::Scalar;
 

--- a/src/scalar/utf8.rs
+++ b/src/scalar/utf8.rs
@@ -1,4 +1,4 @@
-use crate::{array::*, datatypes::DataType};
+use crate::{datatypes::DataType, offset::Offset};
 
 use super::Scalar;
 

--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -7,8 +7,9 @@ use chrono::{
 
 use crate::error::Result;
 use crate::{
-    array::{Offset, PrimitiveArray, Utf8Array},
+    array::{PrimitiveArray, Utf8Array},
     error::Error,
+    offset::Offset,
 };
 use crate::{
     datatypes::{DataType, TimeUnit},

--- a/src/types/index.rs
+++ b/src/types/index.rs
@@ -21,6 +21,9 @@ pub trait Index:
     /// Convert itself from [`usize`].
     fn from_usize(index: usize) -> Option<Self>;
 
+    /// Convert itself from [`usize`].
+    fn from_as_usize(index: usize) -> Self;
+
     /// An iterator from (inclusive) `start` to (exclusive) `end`.
     fn range(start: usize, end: usize) -> Option<IndexRange<Self>> {
         let start = Self::from_usize(start);
@@ -43,6 +46,11 @@ macro_rules! index {
             #[inline]
             fn from_usize(value: usize) -> Option<Self> {
                 Self::try_from(value).ok()
+            }
+
+            #[inline]
+            fn from_as_usize(value: usize) -> Self {
+                value as $t
             }
         }
     };

--- a/src/util/bench_util.rs
+++ b/src/util/bench_util.rs
@@ -3,7 +3,7 @@
 use rand::distributions::{Alphanumeric, Distribution, Standard};
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
-use crate::{array::*, types::NativeType};
+use crate::{array::*, offset::Offset, types::NativeType};
 
 /// Returns fixed seedable RNG
 pub fn seedable_rng() -> StdRng {

--- a/tests/it/array/binary/mod.rs
+++ b/tests/it/array/binary/mod.rs
@@ -3,6 +3,7 @@ use arrow2::{
     bitmap::Bitmap,
     buffer::Buffer,
     datatypes::DataType,
+    offset::OffsetsBuffer,
 };
 
 mod mutable;
@@ -98,7 +99,7 @@ fn with_validity() {
 #[test]
 #[should_panic]
 fn wrong_offsets() {
-    let offsets = Buffer::from(vec![0, 5, 4]); // invalid offsets
+    let offsets = vec![0, 5, 4].try_into().unwrap(); // invalid offsets
     let values = Buffer::from(b"abbbbb".to_vec());
     BinaryArray::<i32>::from_data(DataType::Binary, offsets, values, None);
 }
@@ -106,7 +107,7 @@ fn wrong_offsets() {
 #[test]
 #[should_panic]
 fn wrong_data_type() {
-    let offsets = Buffer::from(vec![0, 4]);
+    let offsets = vec![0, 4].try_into().unwrap();
     let values = Buffer::from(b"abbb".to_vec());
     BinaryArray::<i32>::from_data(DataType::Int8, offsets, values, None);
 }
@@ -114,7 +115,7 @@ fn wrong_data_type() {
 #[test]
 #[should_panic]
 fn value_with_wrong_offsets_panics() {
-    let offsets = Buffer::from(vec![0, 10, 11, 4]);
+    let offsets = vec![0, 10, 11, 4].try_into().unwrap();
     let values = Buffer::from(b"abbb".to_vec());
     // the 10-11 is not checked
     let array = BinaryArray::<i32>::from_data(DataType::Binary, offsets, values, None);
@@ -127,7 +128,7 @@ fn value_with_wrong_offsets_panics() {
 #[test]
 #[should_panic]
 fn index_out_of_bounds_panics() {
-    let offsets = Buffer::from(vec![0, 1, 2, 4]);
+    let offsets = vec![0, 1, 2, 4].try_into().unwrap();
     let values = Buffer::from(b"abbb".to_vec());
     let array = BinaryArray::<i32>::from_data(DataType::Utf8, offsets, values, None);
 
@@ -137,7 +138,7 @@ fn index_out_of_bounds_panics() {
 #[test]
 #[should_panic]
 fn value_unchecked_with_wrong_offsets_panics() {
-    let offsets = Buffer::from(vec![0, 10, 11, 4]);
+    let offsets = vec![0, 10, 11, 4].try_into().unwrap();
     let values = Buffer::from(b"abbb".to_vec());
     // the 10-11 is not checked
     let array = BinaryArray::<i32>::from_data(DataType::Binary, offsets, values, None);
@@ -157,7 +158,7 @@ fn debug() {
 
 #[test]
 fn into_mut_1() {
-    let offsets = Buffer::from(vec![0, 1]);
+    let offsets = vec![0, 1].try_into().unwrap();
     let values = Buffer::from(b"a".to_vec());
     let a = values.clone(); // cloned values
     assert_eq!(a, values);
@@ -167,7 +168,7 @@ fn into_mut_1() {
 
 #[test]
 fn into_mut_2() {
-    let offsets = Buffer::from(vec![0, 1]);
+    let offsets: OffsetsBuffer<i32> = vec![0, 1].try_into().unwrap();
     let values = Buffer::from(b"a".to_vec());
     let a = offsets.clone(); // cloned offsets
     assert_eq!(a, offsets);
@@ -177,7 +178,7 @@ fn into_mut_2() {
 
 #[test]
 fn into_mut_3() {
-    let offsets = Buffer::from(vec![0, 1]);
+    let offsets = vec![0, 1].try_into().unwrap();
     let values = Buffer::from(b"a".to_vec());
     let validity = Some([true].into());
     let a = validity.clone(); // cloned validity
@@ -188,7 +189,7 @@ fn into_mut_3() {
 
 #[test]
 fn into_mut_4() {
-    let offsets = Buffer::from(vec![0, 1]);
+    let offsets = vec![0, 1].try_into().unwrap();
     let values = Buffer::from(b"a".to_vec());
     let validity = Some([true].into());
     let array = BinaryArray::<i32>::new(DataType::Binary, offsets, values, validity);

--- a/tests/it/array/binary/mutable.rs
+++ b/tests/it/array/binary/mutable.rs
@@ -10,12 +10,12 @@ fn new() {
 
     let a = MutableBinaryArray::<i32>::with_capacity(2);
     assert_eq!(a.len(), 0);
-    assert!(a.offsets().capacity() >= 3);
+    assert!(a.offsets().capacity() >= 2);
     assert_eq!(a.values().capacity(), 0);
 
     let a = MutableBinaryArray::<i32>::with_capacities(2, 60);
     assert_eq!(a.len(), 0);
-    assert!(a.offsets().capacity() >= 3);
+    assert!(a.offsets().capacity() >= 2);
     assert!(a.values().capacity() >= 60);
 }
 
@@ -24,12 +24,12 @@ fn from_iter() {
     let iter = (0..3u8).map(|x| Some(vec![x; x as usize]));
     let a: MutableBinaryArray<i32> = iter.clone().collect();
     assert_eq!(a.values().deref(), &[1u8, 2, 2]);
-    assert_eq!(a.offsets().deref(), &[0, 0, 1, 3]);
+    assert_eq!(a.offsets().as_slice(), &[0, 0, 1, 3]);
     assert_eq!(a.validity(), None);
 
     let a = unsafe { MutableBinaryArray::<i32>::from_trusted_len_iter_unchecked(iter) };
     assert_eq!(a.values().deref(), &[1u8, 2, 2]);
-    assert_eq!(a.offsets().deref(), &[0, 0, 1, 3]);
+    assert_eq!(a.offsets().as_slice(), &[0, 0, 1, 3]);
     assert_eq!(a.validity(), None);
 }
 
@@ -38,12 +38,12 @@ fn from_trusted_len_iter() {
     let data = vec![vec![0; 0], vec![1; 1], vec![2; 2]];
     let a: MutableBinaryArray<i32> = data.iter().cloned().map(Some).collect();
     assert_eq!(a.values().deref(), &[1u8, 2, 2]);
-    assert_eq!(a.offsets().deref(), &[0, 0, 1, 3]);
+    assert_eq!(a.offsets().as_slice(), &[0, 0, 1, 3]);
     assert_eq!(a.validity(), None);
 
     let a = MutableBinaryArray::<i32>::from_trusted_len_iter(data.iter().cloned().map(Some));
     assert_eq!(a.values().deref(), &[1u8, 2, 2]);
-    assert_eq!(a.offsets().deref(), &[0, 0, 1, 3]);
+    assert_eq!(a.offsets().as_slice(), &[0, 0, 1, 3]);
     assert_eq!(a.validity(), None);
 
     let a = MutableBinaryArray::<i32>::try_from_trusted_len_iter::<Error, _, _>(
@@ -51,12 +51,12 @@ fn from_trusted_len_iter() {
     )
     .unwrap();
     assert_eq!(a.values().deref(), &[1u8, 2, 2]);
-    assert_eq!(a.offsets().deref(), &[0, 0, 1, 3]);
+    assert_eq!(a.offsets().as_slice(), &[0, 0, 1, 3]);
     assert_eq!(a.validity(), None);
 
     let a = MutableBinaryArray::<i32>::from_trusted_len_values_iter(data.iter().cloned());
     assert_eq!(a.values().deref(), &[1u8, 2, 2]);
-    assert_eq!(a.offsets().deref(), &[0, 0, 1, 3]);
+    assert_eq!(a.offsets().as_slice(), &[0, 0, 1, 3]);
     assert_eq!(a.validity(), None);
 }
 

--- a/tests/it/array/binary/mutable_values.rs
+++ b/tests/it/array/binary/mutable_values.rs
@@ -7,35 +7,28 @@ fn capacity() {
     let mut b = MutableBinaryValuesArray::<i32>::with_capacity(100);
 
     assert_eq!(b.values().capacity(), 0);
-    assert!(b.offsets().capacity() >= 101);
+    assert!(b.offsets().capacity() >= 100);
     b.shrink_to_fit();
-    assert!(b.offsets().capacity() < 101);
-}
-
-#[test]
-fn offsets_must_be_monotonic_increasing() {
-    let offsets = vec![0, 5, 4];
-    let values = b"abbbbb".to_vec();
-    assert!(MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).is_err());
+    assert!(b.offsets().capacity() < 100);
 }
 
 #[test]
 fn offsets_must_be_in_bounds() {
-    let offsets = vec![0, 10];
+    let offsets = vec![0, 10].try_into().unwrap();
     let values = b"abbbbb".to_vec();
     assert!(MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).is_err());
 }
 
 #[test]
 fn data_type_must_be_consistent() {
-    let offsets = vec![0, 4];
+    let offsets = vec![0, 4].try_into().unwrap();
     let values = b"abbb".to_vec();
     assert!(MutableBinaryValuesArray::<i32>::try_new(DataType::Int32, offsets, values).is_err());
 }
 
 #[test]
 fn as_box() {
-    let offsets = vec![0, 2];
+    let offsets = vec![0, 2].try_into().unwrap();
     let values = b"ab".to_vec();
     let mut b =
         MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).unwrap();
@@ -44,7 +37,7 @@ fn as_box() {
 
 #[test]
 fn as_arc() {
-    let offsets = vec![0, 2];
+    let offsets = vec![0, 2].try_into().unwrap();
     let values = b"ab".to_vec();
     let mut b =
         MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).unwrap();
@@ -53,13 +46,13 @@ fn as_arc() {
 
 #[test]
 fn extend_trusted_len() {
-    let offsets = vec![0, 2];
+    let offsets = vec![0, 2].try_into().unwrap();
     let values = b"ab".to_vec();
     let mut b =
         MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).unwrap();
     b.extend_trusted_len(vec!["a", "b"].into_iter());
 
-    let offsets = vec![0, 2, 3, 4];
+    let offsets = vec![0, 2, 3, 4].try_into().unwrap();
     let values = b"abab".to_vec();
     assert_eq!(
         b.as_box(),
@@ -73,7 +66,7 @@ fn extend_trusted_len() {
 fn from_trusted_len() {
     let mut b = MutableBinaryValuesArray::<i32>::from_trusted_len_iter(vec!["a", "b"].into_iter());
 
-    let offsets = vec![0, 1, 2];
+    let offsets = vec![0, 1, 2].try_into().unwrap();
     let values = b"ab".to_vec();
     assert_eq!(
         b.as_box(),
@@ -85,7 +78,7 @@ fn from_trusted_len() {
 
 #[test]
 fn extend_from_iter() {
-    let offsets = vec![0, 2];
+    let offsets = vec![0, 2].try_into().unwrap();
     let values = b"ab".to_vec();
     let mut b =
         MutableBinaryValuesArray::<i32>::try_new(DataType::Binary, offsets, values).unwrap();
@@ -94,7 +87,7 @@ fn extend_from_iter() {
     let a = b.clone();
     b.extend_trusted_len(a.iter());
 
-    let offsets = vec![0, 2, 3, 4, 6, 7, 8];
+    let offsets = vec![0, 2, 3, 4, 6, 7, 8].try_into().unwrap();
     let values = b"abababab".to_vec();
     assert_eq!(
         b.as_box(),

--- a/tests/it/array/binary/to_mutable.rs
+++ b/tests/it/array/binary/to_mutable.rs
@@ -12,7 +12,7 @@ fn shared_validity() {
     let validity = Bitmap::from([true]);
     let array = BinaryArray::<i32>::new(
         DataType::Binary,
-        vec![0, 1].into(),
+        vec![0, 1].try_into().unwrap(),
         b"a".to_vec().into(),
         Some(validity.clone()),
     );
@@ -25,7 +25,7 @@ fn shared_values() {
     let values: Buffer<u8> = b"a".to_vec().into();
     let array = BinaryArray::<i32>::new(
         DataType::Binary,
-        vec![0, 1].into(),
+        vec![0, 1].try_into().unwrap(),
         values.clone(),
         Some(Bitmap::from([true])),
     );
@@ -39,7 +39,7 @@ fn shared_offsets_values() {
     let values: Buffer<u8> = b"a".to_vec().into();
     let array = BinaryArray::<i32>::new(
         DataType::Binary,
-        offsets.clone(),
+        offsets.clone().try_into().unwrap(),
         values.clone(),
         Some(Bitmap::from([true])),
     );
@@ -52,7 +52,7 @@ fn shared_offsets() {
     let offsets: Buffer<i32> = vec![0, 1].into();
     let array = BinaryArray::<i32>::new(
         DataType::Binary,
-        offsets.clone(),
+        offsets.clone().try_into().unwrap(),
         b"a".to_vec().into(),
         Some(Bitmap::from([true])),
     );

--- a/tests/it/array/equal/list.rs
+++ b/tests/it/array/equal/list.rs
@@ -1,6 +1,5 @@
 use arrow2::array::{Int32Array, ListArray, MutableListArray, MutablePrimitiveArray, TryExtend};
 use arrow2::bitmap::Bitmap;
-use arrow2::buffer::Buffer;
 use arrow2::datatypes::DataType;
 
 use super::test_equal;
@@ -67,7 +66,7 @@ fn test_list_offsets() {
 
 #[test]
 fn test_bla() {
-    let offsets = Buffer::from(vec![0, 3, 3, 6]);
+    let offsets = vec![0, 3, 3, 6].try_into().unwrap();
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let values = Box::new(Int32Array::from([
         Some(1),
@@ -81,7 +80,7 @@ fn test_bla() {
     let lhs = ListArray::<i32>::from_data(data_type, offsets, values, Some(validity));
     let lhs = lhs.slice(1, 2);
 
-    let offsets = Buffer::from(vec![0, 0, 3]);
+    let offsets = vec![0, 0, 3].try_into().unwrap();
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let values = Box::new(Int32Array::from([Some(4), None, Some(6)]));
     let validity = Bitmap::from([false, true]);

--- a/tests/it/array/equal/utf8.rs
+++ b/tests/it/array/equal/utf8.rs
@@ -1,4 +1,5 @@
 use arrow2::array::*;
+use arrow2::offset::Offset;
 
 use super::{binary_cases, test_equal};
 

--- a/tests/it/array/list/mod.rs
+++ b/tests/it/array/list/mod.rs
@@ -12,7 +12,7 @@ fn debug() {
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let array = ListArray::<i32>::from_data(
         data_type,
-        Buffer::from(vec![0, 2, 2, 3, 5]),
+        vec![0, 2, 2, 3, 5].try_into().unwrap(),
         Box::new(values),
         None,
     );
@@ -29,7 +29,7 @@ fn test_nested_panic() {
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let array = ListArray::<i32>::from_data(
         data_type.clone(),
-        Buffer::from(vec![0, 2, 2, 3, 5]),
+        vec![0, 2, 2, 3, 5].try_into().unwrap(),
         Box::new(values),
         None,
     );
@@ -38,7 +38,7 @@ fn test_nested_panic() {
     // the nested structure of the child data
     let _ = ListArray::<i32>::from_data(
         data_type,
-        Buffer::from(vec![0, 2, 4]),
+        vec![0, 2, 4].try_into().unwrap(),
         Box::new(array),
         None,
     );
@@ -52,7 +52,7 @@ fn test_nested_display() {
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let array = ListArray::<i32>::from_data(
         data_type,
-        Buffer::from(vec![0, 2, 4, 7, 7, 8, 10]),
+        vec![0, 2, 4, 7, 7, 8, 10].try_into().unwrap(),
         Box::new(values),
         None,
     );
@@ -60,7 +60,7 @@ fn test_nested_display() {
     let data_type = ListArray::<i32>::default_datatype(array.data_type().clone());
     let nested = ListArray::<i32>::from_data(
         data_type,
-        Buffer::from(vec![0, 2, 5, 6]),
+        vec![0, 2, 5, 6].try_into().unwrap(),
         Box::new(array),
         None,
     );

--- a/tests/it/array/list/mutable.rs
+++ b/tests/it/array/list/mutable.rs
@@ -21,7 +21,7 @@ fn basics() {
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let expected = ListArray::<i32>::from_data(
         data_type,
-        Buffer::from(vec![0, 3, 3, 6]),
+        vec![0, 3, 3, 6].try_into().unwrap(),
         Box::new(values),
         Some(Bitmap::from([true, false, true])),
     );
@@ -32,7 +32,7 @@ fn basics() {
 fn with_capacity() {
     let array = MutableListArray::<i32, MutablePrimitiveArray<i32>>::with_capacity(10);
     assert!(array.offsets().capacity() >= 10);
-    assert_eq!(array.offsets().len(), 1);
+    assert_eq!(array.offsets().len(), 0);
     assert_eq!(array.values().values().capacity(), 0);
     assert_eq!(array.validity(), None);
 }
@@ -45,7 +45,7 @@ fn push() {
         .unwrap();
     assert_eq!(array.len(), 1);
     assert_eq!(array.values().values().as_ref(), [1, 2, 3]);
-    assert_eq!(array.offsets().as_ref(), [0, 3]);
+    assert_eq!(array.offsets().as_slice(), [0, 3]);
     assert_eq!(array.validity(), None);
 }
 

--- a/tests/it/array/map/mod.rs
+++ b/tests/it/array/map/mod.rs
@@ -20,7 +20,12 @@ fn basics() {
         None,
     );
 
-    let array = MapArray::new(data_type, vec![0, 1, 2].into(), Box::new(field), None);
+    let array = MapArray::new(
+        data_type,
+        vec![0, 1, 2].try_into().unwrap(),
+        Box::new(field),
+        None,
+    );
 
     assert_eq!(
         array.value(0),

--- a/tests/it/array/utf8/mutable.rs
+++ b/tests/it/array/utf8/mutable.rs
@@ -7,7 +7,7 @@ fn capacities() {
     let b = MutableUtf8Array::<i32>::with_capacities(1, 10);
 
     assert!(b.values().capacity() >= 10);
-    assert!(b.offsets().capacity() >= 2);
+    assert!(b.offsets().capacity() >= 1);
 }
 
 #[test]
@@ -69,24 +69,15 @@ fn pop_all_some() {
 #[test]
 #[should_panic]
 fn not_utf8() {
-    let offsets = vec![0, 4];
+    let offsets = vec![0, 4].try_into().unwrap();
     let values = vec![0, 159, 146, 150]; // invalid utf8
-    MutableUtf8Array::<i32>::from_data(DataType::Utf8, offsets, values, None);
-}
-
-/// Safety guarantee
-#[test]
-#[should_panic]
-fn wrong_offsets() {
-    let offsets = vec![0, 5, 4]; // invalid offsets
-    let values = vec![0, 1, 2, 3, 4, 5];
     MutableUtf8Array::<i32>::from_data(DataType::Utf8, offsets, values, None);
 }
 
 #[test]
 #[should_panic]
 fn wrong_data_type() {
-    let offsets = vec![0, 4]; // invalid offsets
+    let offsets = vec![0, 4].try_into().unwrap();
     let values = vec![1, 2, 3, 4];
     MutableUtf8Array::<i32>::from_data(DataType::Int8, offsets, values, None);
 }

--- a/tests/it/array/utf8/mutable_values.rs
+++ b/tests/it/array/utf8/mutable_values.rs
@@ -7,35 +7,28 @@ fn capacity() {
     let mut b = MutableUtf8ValuesArray::<i32>::with_capacity(100);
 
     assert_eq!(b.values().capacity(), 0);
-    assert!(b.offsets().capacity() >= 101);
+    assert!(b.offsets().capacity() >= 100);
     b.shrink_to_fit();
-    assert!(b.offsets().capacity() < 101);
-}
-
-#[test]
-fn offsets_must_be_monotonic_increasing() {
-    let offsets = vec![0, 5, 4];
-    let values = b"abbbbb".to_vec();
-    assert!(MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).is_err());
+    assert!(b.offsets().capacity() < 100);
 }
 
 #[test]
 fn offsets_must_be_in_bounds() {
-    let offsets = vec![0, 10];
+    let offsets = vec![0, 10].try_into().unwrap();
     let values = b"abbbbb".to_vec();
     assert!(MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).is_err());
 }
 
 #[test]
 fn data_type_must_be_consistent() {
-    let offsets = vec![0, 4];
+    let offsets = vec![0, 4].try_into().unwrap();
     let values = b"abbb".to_vec();
     assert!(MutableUtf8ValuesArray::<i32>::try_new(DataType::Int32, offsets, values).is_err());
 }
 
 #[test]
 fn must_be_utf8() {
-    let offsets = vec![0, 4];
+    let offsets = vec![0, 4].try_into().unwrap();
     let values = vec![0, 159, 146, 150];
     assert!(std::str::from_utf8(&values).is_err());
     assert!(MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).is_err());
@@ -43,7 +36,7 @@ fn must_be_utf8() {
 
 #[test]
 fn as_box() {
-    let offsets = vec![0, 2];
+    let offsets = vec![0, 2].try_into().unwrap();
     let values = b"ab".to_vec();
     let mut b = MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).unwrap();
     let _ = b.as_box();
@@ -51,7 +44,7 @@ fn as_box() {
 
 #[test]
 fn as_arc() {
-    let offsets = vec![0, 2];
+    let offsets = vec![0, 2].try_into().unwrap();
     let values = b"ab".to_vec();
     let mut b = MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).unwrap();
     let _ = b.as_arc();
@@ -59,12 +52,12 @@ fn as_arc() {
 
 #[test]
 fn extend_trusted_len() {
-    let offsets = vec![0, 2];
+    let offsets = vec![0, 2].try_into().unwrap();
     let values = b"ab".to_vec();
     let mut b = MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).unwrap();
     b.extend_trusted_len(vec!["a", "b"].into_iter());
 
-    let offsets = vec![0, 2, 3, 4];
+    let offsets = vec![0, 2, 3, 4].try_into().unwrap();
     let values = b"abab".to_vec();
     assert_eq!(
         b.as_box(),
@@ -78,7 +71,7 @@ fn extend_trusted_len() {
 fn from_trusted_len() {
     let mut b = MutableUtf8ValuesArray::<i32>::from_trusted_len_iter(vec!["a", "b"].into_iter());
 
-    let offsets = vec![0, 1, 2];
+    let offsets = vec![0, 1, 2].try_into().unwrap();
     let values = b"ab".to_vec();
     assert_eq!(
         b.as_box(),
@@ -90,7 +83,7 @@ fn from_trusted_len() {
 
 #[test]
 fn extend_from_iter() {
-    let offsets = vec![0, 2];
+    let offsets = vec![0, 2].try_into().unwrap();
     let values = b"ab".to_vec();
     let mut b = MutableUtf8ValuesArray::<i32>::try_new(DataType::Utf8, offsets, values).unwrap();
     b.extend_trusted_len(vec!["a", "b"].into_iter());
@@ -98,7 +91,7 @@ fn extend_from_iter() {
     let a = b.clone();
     b.extend_trusted_len(a.iter());
 
-    let offsets = vec![0, 2, 3, 4, 6, 7, 8];
+    let offsets = vec![0, 2, 3, 4, 6, 7, 8].try_into().unwrap();
     let values = b"abababab".to_vec();
     assert_eq!(
         b.as_box(),

--- a/tests/it/array/utf8/to_mutable.rs
+++ b/tests/it/array/utf8/to_mutable.rs
@@ -1,4 +1,6 @@
-use arrow2::{array::Utf8Array, bitmap::Bitmap, buffer::Buffer, datatypes::DataType};
+use arrow2::{
+    array::Utf8Array, bitmap::Bitmap, buffer::Buffer, datatypes::DataType, offset::OffsetsBuffer,
+};
 
 #[test]
 fn not_shared() {
@@ -12,7 +14,7 @@ fn shared_validity() {
     let validity = Bitmap::from([true]);
     let array = Utf8Array::<i32>::new(
         DataType::Utf8,
-        vec![0, 1].into(),
+        vec![0, 1].try_into().unwrap(),
         b"a".to_vec().into(),
         Some(validity.clone()),
     );
@@ -25,7 +27,7 @@ fn shared_values() {
     let values: Buffer<u8> = b"a".to_vec().into();
     let array = Utf8Array::<i32>::new(
         DataType::Utf8,
-        vec![0, 1].into(),
+        vec![0, 1].try_into().unwrap(),
         values.clone(),
         Some(Bitmap::from([true])),
     );
@@ -35,7 +37,7 @@ fn shared_values() {
 #[test]
 #[allow(clippy::redundant_clone)]
 fn shared_offsets_values() {
-    let offsets: Buffer<i32> = vec![0, 1].into();
+    let offsets: OffsetsBuffer<i32> = vec![0, 1].try_into().unwrap();
     let values: Buffer<u8> = b"a".to_vec().into();
     let array = Utf8Array::<i32>::new(
         DataType::Utf8,
@@ -49,7 +51,7 @@ fn shared_offsets_values() {
 #[test]
 #[allow(clippy::redundant_clone)]
 fn shared_offsets() {
-    let offsets: Buffer<i32> = vec![0, 1].into();
+    let offsets: OffsetsBuffer<i32> = vec![0, 1].try_into().unwrap();
     let array = Utf8Array::<i32>::new(
         DataType::Utf8,
         offsets.clone(),

--- a/tests/it/compute/length.rs
+++ b/tests/it/compute/length.rs
@@ -1,6 +1,7 @@
 use arrow2::array::*;
 use arrow2::compute::length::*;
 use arrow2::datatypes::*;
+use arrow2::offset::Offset;
 
 fn length_test_string<O: Offset>() {
     vec![

--- a/tests/it/compute/regex_match.rs
+++ b/tests/it/compute/regex_match.rs
@@ -1,6 +1,7 @@
-use arrow2::array::{BooleanArray, Offset, Utf8Array};
+use arrow2::array::{BooleanArray, Utf8Array};
 use arrow2::compute::regex_match::*;
 use arrow2::error::Result;
+use arrow2::offset::Offset;
 
 fn test_generic<O: Offset, F: Fn(&Utf8Array<O>, &Utf8Array<O>) -> Result<BooleanArray>>(
     lhs: Vec<&str>,

--- a/tests/it/compute/substring.rs
+++ b/tests/it/compute/substring.rs
@@ -1,4 +1,4 @@
-use arrow2::{array::*, compute::substring::*, error::Result};
+use arrow2::{array::*, compute::substring::*, error::Result, offset::Offset};
 
 fn with_nulls_utf8<O: Offset>() -> Result<()> {
     let cases = vec![

--- a/tests/it/compute/take.rs
+++ b/tests/it/compute/take.rs
@@ -176,7 +176,7 @@ fn list_with_no_none() {
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let array = ListArray::<i32>::from_data(
         data_type,
-        Buffer::from(vec![0, 2, 2, 6, 9, 10]),
+        vec![0, 2, 2, 6, 9, 10].try_into().unwrap(),
         Box::new(values),
         None,
     );
@@ -189,7 +189,7 @@ fn list_with_no_none() {
     let expected_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let expected = ListArray::<i32>::from_data(
         expected_type,
-        Buffer::from(vec![0, 1, 1, 4]),
+        vec![0, 1, 1, 4].try_into().unwrap(),
         Box::new(expected_values),
         None,
     );
@@ -208,7 +208,7 @@ fn list_with_none() {
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let array = ListArray::<i32>::from_data(
         data_type,
-        Buffer::from(vec![0, 2, 2, 6, 9, 10]),
+        vec![0, 2, 2, 6, 9, 10].try_into().unwrap(),
         Box::new(values),
         Some(validity),
     );
@@ -267,7 +267,7 @@ fn test_nested() {
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let array = ListArray::<i32>::from_data(
         data_type,
-        Buffer::from(vec![0, 2, 4, 7, 7, 8, 10]),
+        vec![0, 2, 4, 7, 7, 8, 10].try_into().unwrap(),
         Box::new(values),
         None,
     );
@@ -275,7 +275,7 @@ fn test_nested() {
     let data_type = ListArray::<i32>::default_datatype(array.data_type().clone());
     let nested = ListArray::<i32>::from_data(
         data_type,
-        Buffer::from(vec![0, 2, 5, 6]),
+        vec![0, 2, 5, 6].try_into().unwrap(),
         Box::new(array),
         None,
     );
@@ -290,7 +290,7 @@ fn test_nested() {
     let expected_data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let expected_array = ListArray::<i32>::from_data(
         expected_data_type,
-        Buffer::from(vec![0, 2, 4, 7, 7, 8]),
+        vec![0, 2, 4, 7, 7, 8].try_into().unwrap(),
         Box::new(expected_values),
         None,
     );
@@ -298,7 +298,7 @@ fn test_nested() {
     let expected_data_type = ListArray::<i32>::default_datatype(expected_array.data_type().clone());
     let expected = ListArray::<i32>::from_data(
         expected_data_type,
-        Buffer::from(vec![0, 2, 5]),
+        vec![0, 2, 5].try_into().unwrap(),
         Box::new(expected_array),
         None,
     );

--- a/tests/it/compute/utf8.rs
+++ b/tests/it/compute/utf8.rs
@@ -1,4 +1,4 @@
-use arrow2::{array::*, compute::utf8::*, error::Result};
+use arrow2::{array::*, compute::utf8::*, error::Result, offset::Offset};
 
 fn with_nulls_utf8_lower<O: Offset>() -> Result<()> {
     let cases = vec![

--- a/tests/it/ffi/data.rs
+++ b/tests/it/ffi/data.rs
@@ -115,7 +115,7 @@ fn utf8_sliced() -> Result<()> {
     let bitmap = Bitmap::from([true, false, false, true]).slice(1, 3);
     let data = Utf8Array::<i32>::try_new(
         DataType::Utf8,
-        vec![0, 1, 1, 2].into(),
+        vec![0, 1, 1, 2].try_into().unwrap(),
         b"ab".to_vec().into(),
         Some(bitmap),
     )?;
@@ -146,7 +146,7 @@ fn binary_sliced() -> Result<()> {
     let bitmap = Bitmap::from([true, false, false, true]).slice(1, 3);
     let data = BinaryArray::<i32>::try_new(
         DataType::Binary,
-        vec![0, 1, 1, 2].into(),
+        vec![0, 1, 1, 2].try_into().unwrap(),
         b"ab".to_vec().into(),
         Some(bitmap),
     )?;
@@ -213,7 +213,7 @@ fn list_sliced() -> Result<()> {
 
     let array = ListArray::<i32>::try_new(
         DataType::List(Box::new(Field::new("a", DataType::Int32, true))),
-        vec![0, 1, 1, 2].into(),
+        vec![0, 1, 1, 2].try_into().unwrap(),
         Box::new(PrimitiveArray::<i32>::from_vec(vec![1, 2])),
         Some(bitmap),
     )?;

--- a/tests/it/io/avro/write.rs
+++ b/tests/it/io/avro/write.rs
@@ -86,7 +86,7 @@ pub(super) fn data() -> Chunk<Box<dyn Array>> {
         ])),
         Box::new(ListArray::<i32>::new(
             list_dt,
-            vec![0, 2, 5].into(),
+            vec![0, 2, 5].try_into().unwrap(),
             Box::new(PrimitiveArray::<i32>::from([
                 None,
                 Some(1),
@@ -98,7 +98,7 @@ pub(super) fn data() -> Chunk<Box<dyn Array>> {
         )),
         Box::new(ListArray::<i32>::new(
             list_dt1,
-            vec![0, 2, 2].into(),
+            vec![0, 2, 2].try_into().unwrap(),
             Box::new(PrimitiveArray::<i32>::from([None, Some(1)])),
             Some([true, false].into()),
         )),

--- a/tests/it/io/ipc/read/file.rs
+++ b/tests/it/io/ipc/read/file.rs
@@ -107,6 +107,12 @@ fn read_generated_100_decimal() -> Result<()> {
 }
 
 #[test]
+fn read_generated_duplicate_fieldnames() -> Result<()> {
+    test_file("1.0.0-littleendian", "generated_duplicate_fieldnames")?;
+    test_file("1.0.0-bigendian", "generated_duplicate_fieldnames")
+}
+
+#[test]
 fn read_generated_100_interval() -> Result<()> {
     test_file("1.0.0-littleendian", "generated_interval")?;
     test_file("1.0.0-bigendian", "generated_interval")

--- a/tests/it/io/json/write.rs
+++ b/tests/it/io/json/write.rs
@@ -321,7 +321,7 @@ fn list_of_struct() -> Result<()> {
     // [{"c11": 5, "c12": {"c121": "g"}}]
     let c1 = ListArray::<i32>::from_data(
         c1_datatype,
-        Buffer::from(vec![0, 2, 2, 3]),
+        Buffer::from(vec![0, 2, 2, 3]).try_into().unwrap(),
         Box::new(s),
         Some(Bitmap::from_u8_slice([0b00000101], 3)),
     );

--- a/tests/it/io/ndjson/mod.rs
+++ b/tests/it/io/ndjson/mod.rs
@@ -2,7 +2,6 @@ mod read;
 
 use arrow2::array::*;
 use arrow2::bitmap::Bitmap;
-use arrow2::buffer::Buffer;
 use arrow2::datatypes::*;
 use arrow2::error::Result;
 use arrow2::io::ndjson::write as ndjson_write;
@@ -286,7 +285,7 @@ fn case_nested_list() -> (String, Box<dyn Array>) {
     );
     let expected = ListArray::from_data(
         a_list_data_type,
-        Buffer::from(vec![0i32, 2, 3, 6, 6, 6]),
+        vec![0i32, 2, 3, 6, 6, 6].try_into().unwrap(),
         a_struct.boxed(),
         Some(Bitmap::from_u8_slice([0b00010111], 5)),
     );

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -10,6 +10,7 @@ use arrow2::{
     io::parquet::read as p_read,
     io::parquet::read::statistics::*,
     io::parquet::write::*,
+    offset::Offset,
     types::{days_ms, NativeType},
 };
 

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -3,7 +3,6 @@ use std::io::{Cursor, Read, Seek};
 use arrow2::{
     array::*,
     bitmap::Bitmap,
-    buffer::Buffer,
     chunk::Chunk,
     datatypes::*,
     error::Result,
@@ -75,7 +74,7 @@ pub fn pyarrow_nested_edge(column: &str) -> Box<dyn Array> {
             // [["a", "b", None, "c"]]
             let a = ListArray::<i32>::new(
                 DataType::List(Box::new(Field::new("item", DataType::Utf8, true))),
-                vec![0, 4].into(),
+                vec![0, 4].try_into().unwrap(),
                 Utf8Array::<i32>::from([Some("a"), Some("b"), None, Some("c")]).boxed(),
                 None,
             );
@@ -91,7 +90,7 @@ pub fn pyarrow_nested_edge(column: &str) -> Box<dyn Array> {
 }
 
 pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
-    let offsets = Buffer::from(vec![0, 2, 2, 5, 8, 8, 11, 11, 12]);
+    let offsets = vec![0, 2, 2, 5, 8, 8, 11, 11, 12].try_into().unwrap();
 
     let values = match column {
         "list_int64" => {
@@ -582,7 +581,7 @@ pub fn pyarrow_nested_nullable_statistics(column: &str) -> Statistics {
                 array.data_type().clone(),
                 nullable,
             ))),
-            vec![0, array.len() as i32].into(),
+            vec![0, array.len() as i32].try_into().unwrap(),
             array,
             None,
         )
@@ -685,7 +684,7 @@ pub fn pyarrow_nested_edge_statistics(column: &str) -> Statistics {
                 array.data_type().clone(),
                 true,
             ))),
-            vec![0, array.len() as i32].into(),
+            vec![0, array.len() as i32].try_into().unwrap(),
             array,
             None,
         )
@@ -990,7 +989,7 @@ pub fn pyarrow_map(column: &str) -> Box<dyn Array> {
             ]);
             MapArray::try_new(
                 DataType::Map(Box::new(Field::new("entries", dt.clone(), false)), false),
-                vec![0, 2].into(),
+                vec![0, 2].try_into().unwrap(),
                 StructArray::try_new(
                     dt,
                     vec![
@@ -1015,7 +1014,7 @@ pub fn pyarrow_map(column: &str) -> Box<dyn Array> {
             ]);
             MapArray::try_new(
                 DataType::Map(Box::new(Field::new("entries", dt.clone(), false)), false),
-                vec![0, 2].into(),
+                vec![0, 2].try_into().unwrap(),
                 StructArray::try_new(
                     dt,
                     vec![
@@ -1047,7 +1046,7 @@ pub fn pyarrow_map_statistics(column: &str) -> Statistics {
                 Box::new(Field::new("items", DataType::Struct(fields.clone()), false)),
                 false,
             ),
-            vec![0, arrays[0].len() as i32].into(),
+            vec![0, arrays[0].len() as i32].try_into().unwrap(),
             StructArray::new(DataType::Struct(fields), arrays, None).boxed(),
             None,
         )
@@ -1511,7 +1510,7 @@ fn nested_dict_data(data_type: DataType) -> Result<(Schema, Chunk<Box<dyn Array>
             values.data_type().clone(),
             false,
         ))),
-        vec![0i32, 0, 0, 2, 3].into(),
+        vec![0i32, 0, 0, 2, 3].try_into().unwrap(),
         values.boxed(),
         Some([true, false, true, true].into()),
     )?;


### PR DESCRIPTION
This PR is a backward incompatible change that improves performance of compute and IO by reducing the number of runtime checks performed to arrays with offsets (Binary, Utf8, List, Map).

It introduces two new structs, `Offsets(Vec<O>)` and `OffsetsBuffer(Buffer<O>)` that upheld the invariants of Arrow offsets (i.e. always contain an element and monotonically increasing).

This is expected to improve performance of:

* Compute `take`
* Compute `substring`
* Compute `cast`
* IO Avro read of lists
* IO Parquet read of binary, utf8 and lists
* IO JSON read of lists

by skipping checks of whether the offsets are well constructed.

It also removes some uses of unsafe (-42 LOC, +22 LOC)