### PR TITLE
Removed flushing during arrow IPC writing to improve performance when using a buffered writer

### DIFF
--- a/src/io/ipc/write/common_async.rs
+++ b/src/io/ipc/write/common_async.rs
@@ -48,7 +48,6 @@ pub async fn write_continuation<W: AsyncWrite + Unpin + Send>(
 ) -> Result<usize> {
     writer.write_all(&CONTINUATION_MARKER).await?;
     writer.write_all(&total_len.to_le_bytes()[..]).await?;
-    writer.flush().await?;
     Ok(8)
 }
 
@@ -66,6 +65,5 @@ async fn write_body_buffers<W: AsyncWrite + Unpin + Send>(
         writer.write_all(&vec![0u8; pad_len][..]).await?;
     }
 
-    writer.flush().await?;
     Ok(total_len)
 }

--- a/src/io/ipc/write/common_sync.rs
+++ b/src/io/ipc/write/common_sync.rs
@@ -47,7 +47,6 @@ fn write_body_buffers<W: Write>(mut writer: W, data: &[u8]) -> Result<usize> {
         writer.write_all(&vec![0u8; pad_len][..])?;
     }
 
-    writer.flush()?;
     Ok(total_len)
 }
 
@@ -56,6 +55,5 @@ fn write_body_buffers<W: Write>(mut writer: W, data: &[u8]) -> Result<usize> {
 pub fn write_continuation<W: Write>(writer: &mut W, total_len: i32) -> Result<usize> {
     writer.write_all(&CONTINUATION_MARKER)?;
     writer.write_all(&total_len.to_le_bytes()[..])?;
-    writer.flush()?;
     Ok(8)
 }


### PR DESCRIPTION
As per https://github.com/jorgecarleitao/arrow2/issues/1317

This actually boost performance by a whole heap, getting close to 30% higher speeds when writing with a 1mb buffered writer during my own testing.