### PR TITLE
feat: add typed dictionary_iter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-07-12
+          toolchain: nightly-2022-12-05
           override: true
       - uses: Swatinem/rust-cache@v1
         with:
@@ -102,7 +102,7 @@ jobs:
           submodules: true # needed to test IPC, which are located in a submodule
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-07-12
+          toolchain: nightly-2022-12-05
           override: true
       - uses: Swatinem/rust-cache@v1
         with:
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-07-12
+          toolchain: nightly-2022-12-05
           override: true
       - uses: Swatinem/rust-cache@v1
         with:
@@ -166,7 +166,7 @@ jobs:
           submodules: true
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-03-16
+          toolchain: nightly-2022-12-05
           target: ${{ matrix.target }}
           override: true
       - uses: Swatinem/rust-cache@v1
@@ -183,7 +183,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-07-24
+          toolchain: nightly-2022-12-05
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: Run

--- a/src/array/dictionary/typed_iterator.rs
+++ b/src/array/dictionary/typed_iterator.rs
@@ -1,0 +1,111 @@
+use crate::array::{Array, PrimitiveArray, Utf8Array};
+use crate::error::{Error, Result};
+use crate::trusted_len::TrustedLen;
+use crate::types::Offset;
+
+use super::DictionaryKey;
+
+pub trait DictValue {
+    type IterValue<'this>
+    where
+        Self: 'this;
+
+    /// # Safety
+    /// Will not do any bound checks but must check validity.
+    unsafe fn get_unchecked(&self, item: usize) -> Self::IterValue<'_>;
+
+    /// Take a [`dyn Array`] an try to downcast it to the type of `DictValue`.
+    fn downcast_values(array: &dyn Array) -> Result<&Self>
+    where
+        Self: Sized;
+}
+
+impl<O: Offset> DictValue for Utf8Array<O> {
+    type IterValue<'a> = &'a str;
+
+    unsafe fn get_unchecked(&self, item: usize) -> Self::IterValue<'_> {
+        self.value_unchecked(item)
+    }
+
+    fn downcast_values(array: &dyn Array) -> Result<&Self>
+    where
+        Self: Sized,
+    {
+        array
+            .as_any()
+            .downcast_ref::<Self>()
+            .ok_or(Error::InvalidArgumentError(
+                "could not convert array to dictionary value".into(),
+            ))
+            .map(|arr| {
+                assert_eq!(
+                    arr.null_count(),
+                    0,
+                    "null values in values not supported in iteration"
+                );
+                arr
+            })
+    }
+}
+
+/// Iterator of values of an `ListArray`.
+pub struct DictionaryValuesIterTyped<'a, K: DictionaryKey, V: DictValue> {
+    keys: &'a PrimitiveArray<K>,
+    values: &'a V,
+    index: usize,
+    end: usize,
+}
+
+impl<'a, K: DictionaryKey, V: DictValue> DictionaryValuesIterTyped<'a, K, V> {
+    pub(super) unsafe fn new(keys: &'a PrimitiveArray<K>, values: &'a V) -> Self {
+        Self {
+            keys,
+            values,
+            index: 0,
+            end: keys.len(),
+        }
+    }
+}
+
+impl<'a, K: DictionaryKey, V: DictValue> Iterator for DictionaryValuesIterTyped<'a, K, V> {
+    type Item = V::IterValue<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index == self.end {
+            return None;
+        }
+        let old = self.index;
+        self.index += 1;
+        unsafe {
+            let key = self.keys.value_unchecked(old);
+            let idx = key.as_usize();
+            Some(self.values.get_unchecked(idx))
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.end - self.index, Some(self.end - self.index))
+    }
+}
+
+unsafe impl<'a, K: DictionaryKey, V: DictValue> TrustedLen for DictionaryValuesIterTyped<'a, K, V> {}
+
+impl<'a, K: DictionaryKey, V: DictValue> DoubleEndedIterator
+    for DictionaryValuesIterTyped<'a, K, V>
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index == self.end {
+            None
+        } else {
+            self.end -= 1;
+            unsafe {
+                let key = self.keys.value_unchecked(self.end);
+                let idx = key.as_usize();
+                Some(self.values.get_unchecked(idx))
+            }
+        }
+    }
+}

--- a/tests/it/array/dictionary/mod.rs
+++ b/tests/it/array/dictionary/mod.rs
@@ -165,3 +165,48 @@ fn keys_values_iter() {
 
     assert_eq!(array.keys_values_iter().collect::<Vec<_>>(), vec![1, 0]);
 }
+
+#[test]
+fn iter_values_typed() {
+    let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
+    let array =
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0, 0]), values.boxed())
+            .unwrap();
+
+    let mut iter = array.values_iter_typed::<Utf8Array<i32>>().unwrap();
+    assert_eq!(iter.size_hint(), (3, Some(3)));
+    assert_eq!(iter.collect::<Vec<_>>(), vec!["aa", "a", "a"]);
+
+    let mut iter = array.iter_typed::<Utf8Array<i32>>().unwrap();
+    assert_eq!(iter.size_hint(), (3, Some(3)));
+    assert_eq!(
+        iter.collect::<Vec<_>>(),
+        vec![Some("aa"), Some("a"), Some("a")]
+    );
+}
+
+#[test]
+#[should_panic]
+fn iter_values_typed_panic() {
+    let values = Utf8Array::<i32>::from_iter([Some("a"), Some("aa"), None]);
+    let array =
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0, 0]), values.boxed())
+            .unwrap();
+
+    // should not be iterating values
+    let mut iter = array.values_iter_typed::<Utf8Array<i32>>().unwrap();
+    let _ = iter.collect::<Vec<_>>();
+}
+
+#[test]
+#[should_panic]
+fn iter_values_typed_panic_2() {
+    let values = Utf8Array::<i32>::from_iter([Some("a"), Some("aa"), None]);
+    let array =
+        DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0, 0]), values.boxed())
+            .unwrap();
+
+    // should not be iterating values
+    let mut iter = array.iter_typed::<Utf8Array<i32>>().unwrap();
+    let _ = iter.collect::<Vec<_>>();
+}

--- a/tests/it/array/dictionary/mod.rs
+++ b/tests/it/array/dictionary/mod.rs
@@ -173,11 +173,11 @@ fn iter_values_typed() {
         DictionaryArray::try_from_keys(PrimitiveArray::from_vec(vec![1, 0, 0]), values.boxed())
             .unwrap();
 
-    let mut iter = array.values_iter_typed::<Utf8Array<i32>>().unwrap();
+    let iter = array.values_iter_typed::<Utf8Array<i32>>().unwrap();
     assert_eq!(iter.size_hint(), (3, Some(3)));
     assert_eq!(iter.collect::<Vec<_>>(), vec!["aa", "a", "a"]);
 
-    let mut iter = array.iter_typed::<Utf8Array<i32>>().unwrap();
+    let iter = array.iter_typed::<Utf8Array<i32>>().unwrap();
     assert_eq!(iter.size_hint(), (3, Some(3)));
     assert_eq!(
         iter.collect::<Vec<_>>(),
@@ -194,7 +194,7 @@ fn iter_values_typed_panic() {
             .unwrap();
 
     // should not be iterating values
-    let mut iter = array.values_iter_typed::<Utf8Array<i32>>().unwrap();
+    let iter = array.values_iter_typed::<Utf8Array<i32>>().unwrap();
     let _ = iter.collect::<Vec<_>>();
 }
 
@@ -207,6 +207,6 @@ fn iter_values_typed_panic_2() {
             .unwrap();
 
     // should not be iterating values
-    let mut iter = array.iter_typed::<Utf8Array<i32>>().unwrap();
+    let iter = array.iter_typed::<Utf8Array<i32>>().unwrap();
     let _ = iter.collect::<Vec<_>>();
 }

--- a/tests/it/bitmap/mutable.rs
+++ b/tests/it/bitmap/mutable.rs
@@ -368,7 +368,11 @@ fn extend_bitmap() {
     assert_eq!(b.len(), 5 + 4);
 }
 
+// TODO! undo miri ignore once issue is fixed in miri
+// this test was a memory hog and lead to OOM in CI
+// given enough memory it was able to pass succesfully on a local
 #[test]
+#[cfg_attr(miri, ignore)]
 fn extend_constant1() {
     use std::iter::FromIterator;
     for i in 0..64 {


### PR DESCRIPTION
Iterating over a `DictionaryArray` is very expensive as it allocates an opaque heap value of each iteration.

This adds a generic typed iterator that only compiles upon instantiation and thus will not add compiler bloat for all types. I want to follow up with a PR that implements writing `DictionaryArrays` to json. That was the reason I stumbled upon this.

The iterator impementation will `panic` iff the `values` contain null values. Otherwise it can become pretty awkward with nested arrays (which is something we could follow up on if needed)>

The existing iterators are flawed IMO. They will happily iterate over a `values` array with null values and return the masked out values. Shall we also add a panic check there? That's much better than return the wrong results. 