### PR TITLE
Fixed writing nested/sliced arrays to parquet

### DIFF
--- a/src/io/parquet/write/binary/nested.rs
+++ b/src/io/parquet/write/binary/nested.rs
@@ -22,14 +22,15 @@ where
 {
     let is_optional = is_nullable(&type_.field_info);
 
-    let mut buffer = vec![];
-    let (repetition_levels_byte_length, definition_levels_byte_length) =
-        nested::write_rep_and_def(options.version, nested, &mut buffer)?;
-
     // we slice the leaf by the offsets as dremel only computes lengths and thus
     // does NOT take the starting offset into account.
     // By slicing the leaf array we also don't write too many values.
     let (start, len) = slice_nested_leaf(nested);
+
+    let mut buffer = vec![];
+    let (repetition_levels_byte_length, definition_levels_byte_length) =
+        nested::write_rep_and_def(options.version, nested, &mut buffer, start)?;
+
     let array = array.slice(start, len);
     encode_plain(&array, is_optional, &mut buffer);
 

--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -18,14 +18,14 @@ pub fn array_to_page(
 ) -> Result<DataPage> {
     let is_optional = is_nullable(&type_.field_info);
 
-    let mut buffer = vec![];
-    let (repetition_levels_byte_length, definition_levels_byte_length) =
-        nested::write_rep_and_def(options.version, nested, &mut buffer)?;
-
     // we slice the leaf by the offsets as dremel only computes lengths and thus
     // does NOT take the starting offset into account.
     // By slicing the leaf array we also don't write too many values.
     let (start, len) = slice_nested_leaf(nested);
+
+    let mut buffer = vec![];
+    let (repetition_levels_byte_length, definition_levels_byte_length) =
+        nested::write_rep_and_def(options.version, nested, &mut buffer, start)?;
     let array = array.slice(start, len);
     encode_plain(&array, is_optional, &mut buffer)?;
 

--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -4,7 +4,7 @@ use parquet2::{encoding::Encoding, page::DataPage};
 use super::super::{nested, utils, WriteOptions};
 use super::basic::{build_statistics, encode_plain};
 use crate::io::parquet::read::schema::is_nullable;
-use crate::io::parquet::write::Nested;
+use crate::io::parquet::write::{slice_nested_leaf, Nested};
 use crate::{
     array::{Array, BooleanArray},
     error::Result,
@@ -22,10 +22,15 @@ pub fn array_to_page(
     let (repetition_levels_byte_length, definition_levels_byte_length) =
         nested::write_rep_and_def(options.version, nested, &mut buffer)?;
 
-    encode_plain(array, is_optional, &mut buffer)?;
+    // we slice the leaf by the offsets as dremel only computes lengths and thus
+    // does NOT take the starting offset into account.
+    // By slicing the leaf array we also don't write too many values.
+    let (start, len) = slice_nested_leaf(nested);
+    let array = array.slice(start, len);
+    encode_plain(&array, is_optional, &mut buffer)?;
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(array))
+        Some(build_statistics(&array))
     } else {
         None
     };

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -187,23 +187,17 @@ fn slice_parquet_array<'a>(
 }
 
 fn get_max_length(array: &dyn Array, nested: &[Nested]) -> usize {
-    let mut sum = 0;
-    for nested in nested.iter() {
+    // get the length that should be sliced.
+    // that is the inner nested structure that
+    // dictates how often the primitive should be repeated
+    for nested in nested.iter().rev() {
         match nested {
-            Nested::LargeList(l_nested) => {
-                sum += l_nested.offsets.len() - 1;
-            }
-            Nested::List(l_nested) => {
-                sum += l_nested.offsets.len() - 1;
-            }
+            Nested::LargeList(l_nested) => return l_nested.offsets.len() - 1,
+            Nested::List(l_nested) => return l_nested.offsets.len() - 1,
             _ => {}
         }
     }
-    if sum > 0 {
-        sum
-    } else {
-        array.len()
-    }
+    array.len()
 }
 
 /// Returns an iterator of [`Page`].

--- a/src/io/parquet/write/nested/def.rs
+++ b/src/io/parquet/write/nested/def.rs
@@ -86,10 +86,13 @@ pub struct DefLevelsIter<'a> {
 }
 
 impl<'a> DefLevelsIter<'a> {
-    pub fn new(nested: &'a [Nested]) -> Self {
+    pub fn new(nested: &'a [Nested], offset: usize) -> Self {
         let remaining_values = num_values(nested);
 
-        let primitive_validity = iter(&nested[nested.len() - 1..]).pop().unwrap();
+        let mut primitive_validity = iter(&nested[nested.len() - 1..]).pop().unwrap();
+        if offset > 0 {
+            primitive_validity.nth(offset - 1);
+        }
 
         let iter = iter(&nested[..nested.len() - 1]);
         let remaining = std::iter::repeat(0).take(iter.len()).collect();
@@ -164,7 +167,7 @@ mod tests {
     use super::*;
 
     fn test(nested: Vec<Nested>, expected: Vec<u32>) {
-        let mut iter = DefLevelsIter::new(&nested);
+        let mut iter = DefLevelsIter::new(&nested, 0);
         assert_eq!(iter.size_hint().0, expected.len());
         let result = iter.by_ref().collect::<Vec<_>>();
         assert_eq!(result, expected);

--- a/src/io/parquet/write/pages.rs
+++ b/src/io/parquet/write/pages.rs
@@ -150,12 +150,12 @@ fn to_nested_recursive<'a>(
 }
 
 fn to_leaves(array: &dyn Array) -> Vec<&dyn Array> {
-    let mut leafs = vec![];
-    to_leaves_recursive(array, &mut leafs);
-    leafs
+    let mut leaves = vec![];
+    to_leaves_recursive(array, &mut leaves);
+    leaves
 }
 
-fn to_leaves_recursive<'a>(array: &'a dyn Array, leafs: &mut Vec<&'a dyn Array>) {
+fn to_leaves_recursive<'a>(array: &'a dyn Array, leaves: &mut Vec<&'a dyn Array>) {
     use PhysicalType::*;
     match array.data_type().to_physical_type() {
         Struct => {
@@ -163,35 +163,35 @@ fn to_leaves_recursive<'a>(array: &'a dyn Array, leafs: &mut Vec<&'a dyn Array>)
             array
                 .values()
                 .iter()
-                .for_each(|a| to_leaves_recursive(a.as_ref(), leafs));
+                .for_each(|a| to_leaves_recursive(a.as_ref(), leaves));
         }
         List => {
             let array = array.as_any().downcast_ref::<ListArray<i32>>().unwrap();
-            to_leaves_recursive(array.values().as_ref(), leafs);
+            to_leaves_recursive(array.values().as_ref(), leaves);
         }
         LargeList => {
             let array = array.as_any().downcast_ref::<ListArray<i64>>().unwrap();
-            to_leaves_recursive(array.values().as_ref(), leafs);
+            to_leaves_recursive(array.values().as_ref(), leaves);
         }
         Null | Boolean | Primitive(_) | Binary | FixedSizeBinary | LargeBinary | Utf8
-        | LargeUtf8 | Dictionary(_) => leafs.push(array),
+        | LargeUtf8 | Dictionary(_) => leaves.push(array),
         other => todo!("Writing {:?} to parquet not yet implemented", other),
     }
 }
 
-fn to_parquet_leafs(type_: ParquetType) -> Vec<ParquetPrimitiveType> {
-    let mut leafs = vec![];
-    to_parquet_leafs_recursive(type_, &mut leafs);
-    leafs
+fn to_parquet_leaves(type_: ParquetType) -> Vec<ParquetPrimitiveType> {
+    let mut leaves = vec![];
+    to_parquet_leaves_recursive(type_, &mut leaves);
+    leaves
 }
 
-fn to_parquet_leafs_recursive(type_: ParquetType, leafs: &mut Vec<ParquetPrimitiveType>) {
+fn to_parquet_leaves_recursive(type_: ParquetType, leaves: &mut Vec<ParquetPrimitiveType>) {
     match type_ {
-        ParquetType::PrimitiveType(primitive) => leafs.push(primitive),
+        ParquetType::PrimitiveType(primitive) => leaves.push(primitive),
         ParquetType::GroupType { fields, .. } => {
             fields
                 .into_iter()
-                .for_each(|type_| to_parquet_leafs_recursive(type_, leafs));
+                .for_each(|type_| to_parquet_leaves_recursive(type_, leaves));
         }
     }
 }
@@ -206,7 +206,7 @@ pub fn array_to_columns<A: AsRef<dyn Array> + Send + Sync>(
     let array = array.as_ref();
     let nested = to_nested(array, &type_)?;
 
-    let types = to_parquet_leafs(type_);
+    let types = to_parquet_leaves(type_);
 
     let values = to_leaves(array);
 

--- a/src/io/parquet/write/primitive/nested.rs
+++ b/src/io/parquet/write/primitive/nested.rs
@@ -28,13 +28,15 @@ where
     let is_optional = is_nullable(&type_.field_info);
 
     let mut buffer = vec![];
-    let (repetition_levels_byte_length, definition_levels_byte_length) =
-        nested::write_rep_and_def(options.version, nested, &mut buffer)?;
 
     // we slice the leaf by the offsets as dremel only computes lengths and thus
     // does NOT take the starting offset into account.
     // By slicing the leaf array we also don't write too many values.
     let (start, len) = slice_nested_leaf(nested);
+
+    let (repetition_levels_byte_length, definition_levels_byte_length) =
+        nested::write_rep_and_def(options.version, nested, &mut buffer, start)?;
+
     let array = array.slice(start, len);
     let buffer = encode_plain(&array, is_optional, buffer);
 

--- a/src/io/parquet/write/utf8/nested.rs
+++ b/src/io/parquet/write/utf8/nested.rs
@@ -21,15 +21,15 @@ where
     O: Offset,
 {
     let is_optional = is_nullable(&type_.field_info);
-
-    let mut buffer = vec![];
-    let (repetition_levels_byte_length, definition_levels_byte_length) =
-        nested::write_rep_and_def(options.version, nested, &mut buffer)?;
-
     // we slice the leaf by the offsets as dremel only computes lengths and thus
     // does NOT take the starting offset into account.
     // By slicing the leaf array we also don't write too many values.
     let (start, len) = slice_nested_leaf(nested);
+
+    let mut buffer = vec![];
+    let (repetition_levels_byte_length, definition_levels_byte_length) =
+        nested::write_rep_and_def(options.version, nested, &mut buffer, start)?;
+
     let array = array.slice(start, len);
     encode_plain(&array, is_optional, &mut buffer);
 

--- a/src/io/parquet/write/utf8/nested.rs
+++ b/src/io/parquet/write/utf8/nested.rs
@@ -4,7 +4,7 @@ use parquet2::{encoding::Encoding, page::DataPage};
 use super::super::{nested, utils, WriteOptions};
 use super::basic::{build_statistics, encode_plain};
 use crate::io::parquet::read::schema::is_nullable;
-use crate::io::parquet::write::Nested;
+use crate::io::parquet::write::{slice_nested_leaf, Nested};
 use crate::{
     array::{Array, Utf8Array},
     error::Result,
@@ -26,10 +26,15 @@ where
     let (repetition_levels_byte_length, definition_levels_byte_length) =
         nested::write_rep_and_def(options.version, nested, &mut buffer)?;
 
-    encode_plain(array, is_optional, &mut buffer);
+    // we slice the leaf by the offsets as dremel only computes lengths and thus
+    // does NOT take the starting offset into account.
+    // By slicing the leaf array we also don't write too many values.
+    let (start, len) = slice_nested_leaf(nested);
+    let array = array.slice(start, len);
+    encode_plain(&array, is_optional, &mut buffer);
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(array, type_.clone()))
+        Some(build_statistics(&array, type_.clone()))
     } else {
         None
     };

--- a/tests/it/io/parquet/write.rs
+++ b/tests/it/io/parquet/write.rs
@@ -12,6 +12,17 @@ fn round_trip(
     compression: CompressionOptions,
     encodings: Vec<Encoding>,
 ) -> Result<()> {
+    round_trip_opt_stats(column, file, version, compression, encodings, true)
+}
+
+fn round_trip_opt_stats(
+    column: &str,
+    file: &str,
+    version: Version,
+    compression: CompressionOptions,
+    encodings: Vec<Encoding>,
+    check_stats: bool,
+) -> Result<()> {
     let (array, statistics) = match file {
         "nested" => (
             pyarrow_nested_nullable(column),
@@ -56,7 +67,9 @@ fn round_trip(
 
     let (result, stats) = read_column(&mut Cursor::new(data), "a1")?;
     assert_eq!(array.as_ref(), result.as_ref());
-    assert_eq!(statistics, stats);
+    if check_stats {
+        assert_eq!(statistics, stats);
+    }
     Ok(())
 }
 
@@ -363,12 +376,13 @@ fn list_large_binary_optional_v1() -> Result<()> {
 
 #[test]
 fn list_nested_inner_required_required_i64() -> Result<()> {
-    round_trip(
+    round_trip_opt_stats(
         "list_nested_inner_required_required_i64",
         "nested",
         Version::V1,
         CompressionOptions::Uncompressed,
         vec![Encoding::Plain],
+        false,
     )
 }
 

--- a/tests/it/io/parquet/write.rs
+++ b/tests/it/io/parquet/write.rs
@@ -362,6 +362,17 @@ fn list_large_binary_optional_v1() -> Result<()> {
 }
 
 #[test]
+fn list_nested_inner_required_required_i64() -> Result<()> {
+    round_trip(
+        "list_nested_inner_required_required_i64",
+        "nested",
+        Version::V1,
+        CompressionOptions::Uncompressed,
+        vec![Encoding::Plain],
+    )
+}
+
+#[test]
 fn utf8_optional_v2_delta() -> Result<()> {
     round_trip(
         "string",


### PR DESCRIPTION
fixes #1323 

We wrote invalid arrays to parquet because we did not take the offset of the list arrays into account. This got worse as we now slice leaf arrays when we write to pages and the offsets don't belong to the pages written anymore.

Because we don't use offsets, but dremel during reading/writing of the parquet this still read values, but just way too many.

This PR fixes the huges memory usage/ huge files and incorrect files as observed in #1323. 