### PR TITLE
Removed `from_data` from all arrays

### DIFF
--- a/arrow-pyarrow-integration-testing/src/c_stream.rs
+++ b/arrow-pyarrow-integration-testing/src/c_stream.rs
@@ -32,7 +32,7 @@ pub fn to_rust_iterator(ob: PyObject, py: Python) -> PyResult<Vec<PyObject>> {
 pub fn from_rust_iterator(py: Python) -> PyResult<PyObject> {
     // initialize an array
     let array = Int32Array::from(&[Some(2), None, Some(1), None]);
-    let array = StructArray::from_data(
+    let array = StructArray::new(
         DataType::Struct(vec![Field::new("a", array.data_type().clone(), true)]),
         vec![array.boxed()],
         None,

--- a/benches/filter_kernels.rs
+++ b/benches/filter_kernels.rs
@@ -37,7 +37,7 @@ fn add_benchmark(c: &mut Criterion) {
 
         let filter_array = create_boolean_array(size, 0.0, 0.9);
         let filter_array =
-            BooleanArray::from_data(DataType::Boolean, filter_array.values().clone(), None);
+            BooleanArray::new(DataType::Boolean, filter_array.values().clone(), None);
 
         let arr_a = create_primitive_array::<f32>(size, 0.0);
         c.bench_function(&format!("filter 2^{} f32", log2_size), |b| {

--- a/benches/iter_list.rs
+++ b/benches/iter_list.rs
@@ -14,7 +14,7 @@ fn add_benchmark(c: &mut Criterion) {
         let size = 2usize.pow(log2_size);
 
         let values = Buffer::from_iter(0..size as i32);
-        let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+        let values = PrimitiveArray::<i32>::new(DataType::Int32, values, None);
 
         let offsets = (0..=size as i32).step_by(2).collect::<Vec<_>>();
 
@@ -23,7 +23,7 @@ fn add_benchmark(c: &mut Criterion) {
             .collect::<Bitmap>();
 
         let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-        let array = ListArray::<i32>::from_data(
+        let array = ListArray::<i32>::new(
             data_type,
             offsets.try_into().unwrap(),
             Box::new(values),

--- a/guide/src/high_level.md
+++ b/guide/src/high_level.md
@@ -253,7 +253,7 @@ where
     let values = array.values().iter().map(|v| op(*v)).collect::<Vec<_>>();
 
     // create the new array, cloning its validity
-    PrimitiveArray::<O>::from_data(data_type.clone(), values.into(), array.validity().cloned())
+    PrimitiveArray::<O>::new(data_type.clone(), values.into(), array.validity().cloned())
 }
 ```
 

--- a/src/array/binary/mutable_values.rs
+++ b/src/array/binary/mutable_values.rs
@@ -37,7 +37,8 @@ impl<O: Offset> From<MutableBinaryValuesArray<O>> for BinaryArray<O> {
 
 impl<O: Offset> From<MutableBinaryValuesArray<O>> for MutableBinaryArray<O> {
     fn from(other: MutableBinaryValuesArray<O>) -> Self {
-        MutableBinaryArray::<O>::from_data(other.data_type, other.offsets, other.values, None)
+        MutableBinaryArray::<O>::try_new(other.data_type, other.offsets, other.values, None)
+            .expect("MutableBinaryValuesArray is consistent with MutableBinaryArray")
     }
 }
 

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -85,6 +85,11 @@ impl BooleanArray {
         })
     }
 
+    /// Alias to `Self::try_new().unwrap()`
+    pub fn new(data_type: DataType, values: Bitmap, validity: Option<Bitmap>) -> Self {
+        Self::try_new(data_type, values, validity).unwrap()
+    }
+
     /// Returns an iterator over the optional values of this [`BooleanArray`].
     #[inline]
     pub fn iter(&self) -> ZipValidity<bool, BitmapIter, BitmapIter> {
@@ -246,21 +251,18 @@ impl BooleanArray {
                         immutable,
                         Some(mutable_bitmap.into()),
                     )),
-                    Right(mutable) => Right(MutableBooleanArray::from_data(
-                        self.data_type,
-                        mutable,
-                        Some(mutable_bitmap),
-                    )),
+                    Right(mutable) => Right(
+                        MutableBooleanArray::try_new(self.data_type, mutable, Some(mutable_bitmap))
+                            .unwrap(),
+                    ),
                 },
             }
         } else {
             match self.values.into_mut() {
                 Left(immutable) => Left(BooleanArray::new(self.data_type, immutable, None)),
-                Right(mutable) => Right(MutableBooleanArray::from_data(
-                    self.data_type,
-                    mutable,
-                    None,
-                )),
+                Right(mutable) => {
+                    Right(MutableBooleanArray::try_new(self.data_type, mutable, None).unwrap())
+                }
             }
         }
     }
@@ -368,20 +370,6 @@ impl BooleanArray {
             validity,
         } = self;
         (data_type, values, validity)
-    }
-
-    /// The canonical method to create a [`BooleanArray`]
-    /// # Panics
-    /// This function errors iff:
-    /// * The validity is not `None` and its length is different from `values`'s length
-    /// * The `data_type`'s [`PhysicalType`] is not equal to [`PhysicalType::Boolean`].
-    pub fn new(data_type: DataType, values: Bitmap, validity: Option<Bitmap>) -> Self {
-        Self::try_new(data_type, values, validity).unwrap()
-    }
-
-    /// Alias for `new`
-    pub fn from_data(data_type: DataType, values: Bitmap, validity: Option<Bitmap>) -> Self {
-        Self::new(data_type, values, validity)
     }
 }
 

--- a/src/array/fixed_size_binary/mod.rs
+++ b/src/array/fixed_size_binary/mod.rs
@@ -69,11 +69,6 @@ impl FixedSizeBinaryArray {
         Self::try_new(data_type, values, validity).unwrap()
     }
 
-    /// Alias for `new`
-    pub fn from_data(data_type: DataType, values: Buffer<u8>, validity: Option<Bitmap>) -> Self {
-        Self::new(data_type, values, validity)
-    }
-
     /// Returns a new empty [`FixedSizeBinaryArray`].
     pub fn new_empty(data_type: DataType) -> Self {
         Self::new(data_type, Buffer::new(), None)

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -74,13 +74,7 @@ impl FixedSizeListArray {
         })
     }
 
-    /// Creates a new [`FixedSizeListArray`].
-    /// # Panics
-    /// This function panics iff:
-    /// * The `data_type`'s physical type is not [`crate::datatypes::PhysicalType::FixedSizeList`]
-    /// * The `data_type`'s inner field's data type is not equal to `values.data_type`.
-    /// * The length of `values` is not a multiple of `size` in `data_type`
-    /// * the validity's length is not equal to `values.len() / size`.
+    /// Alias to `Self::try_new(...).unwrap()`
     pub fn new(data_type: DataType, values: Box<dyn Array>, validity: Option<Bitmap>) -> Self {
         Self::try_new(data_type, values, validity).unwrap()
     }
@@ -88,15 +82,6 @@ impl FixedSizeListArray {
     /// Returns the size (number of elements per slot) of this [`FixedSizeListArray`].
     pub const fn size(&self) -> usize {
         self.size
-    }
-
-    /// Alias for `new`
-    pub fn from_data(
-        data_type: DataType,
-        values: Box<dyn Array>,
-        validity: Option<Bitmap>,
-    ) -> Self {
-        Self::new(data_type, values, validity)
     }
 
     /// Returns a new empty [`FixedSizeListArray`].

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -140,19 +140,21 @@ impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(FixedSizeListArray::new(
+        FixedSizeListArray::new(
             self.data_type.clone(),
             self.values.as_box(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
-        ))
+        )
+        .boxed()
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(FixedSizeListArray::new(
+        FixedSizeListArray::new(
             self.data_type.clone(),
             self.values.as_box(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
-        ))
+        )
+        .arced()
     }
 
     fn data_type(&self) -> &DataType {

--- a/src/array/growable/binary.rs
+++ b/src/array/growable/binary.rs
@@ -82,11 +82,11 @@ impl<'a, O: Offset> Growable<'a> for GrowableBinary<'a, O> {
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
-        Arc::new(self.to())
+        self.to().arced()
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(self.to())
+        self.to().boxed()
     }
 }
 

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, Field},
     error::Error,
-    offset::{Offset, OffsetsBuffer},
+    offset::{Offset, Offsets, OffsetsBuffer},
 };
 use std::sync::Arc;
 
@@ -87,16 +87,6 @@ impl<O: Offset> ListArray<O> {
         Self::try_new(data_type, offsets, values, validity).unwrap()
     }
 
-    /// Alias of `new`
-    pub fn from_data(
-        data_type: DataType,
-        offsets: OffsetsBuffer<O>,
-        values: Box<dyn Array>,
-        validity: Option<Bitmap>,
-    ) -> Self {
-        Self::new(data_type, offsets, values, validity)
-    }
-
     /// Returns a new empty [`ListArray`].
     pub fn new_empty(data_type: DataType) -> Self {
         let values = new_empty_array(Self::get_child_type(&data_type).clone());
@@ -109,7 +99,7 @@ impl<O: Offset> ListArray<O> {
         let child = Self::get_child_type(&data_type).clone();
         Self::new(
             data_type,
-            vec![O::zero(); 1 + length].try_into().unwrap(),
+            Offsets::new_zeroed(length).into(),
             new_empty_array(child),
             Some(Bitmap::new_zeroed(length)),
         )

--- a/src/array/map/mod.rs
+++ b/src/array/map/mod.rs
@@ -88,16 +88,6 @@ impl MapArray {
         Self::try_new(data_type, offsets, field, validity).unwrap()
     }
 
-    /// Alias for `new`
-    pub fn from_data(
-        data_type: DataType,
-        offsets: OffsetsBuffer<i32>,
-        field: Box<dyn Array>,
-        validity: Option<Bitmap>,
-    ) -> Self {
-        Self::new(data_type, offsets, field, validity)
-    }
-
     /// Returns a new null [`MapArray`] of `length`.
     pub fn new_null(data_type: DataType, length: usize) -> Self {
         let field = new_empty_array(Self::get_field(&data_type).data_type().clone());

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -37,11 +37,6 @@ impl NullArray {
         Self::try_new(data_type, length).unwrap()
     }
 
-    /// Alias for `new`
-    pub fn from_data(data_type: DataType, length: usize) -> Self {
-        Self::new(data_type, length)
-    }
-
     /// Returns a new empty [`NullArray`].
     pub fn new_empty(data_type: DataType) -> Self {
         Self::new(data_type, 0)

--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -120,15 +120,6 @@ impl StructArray {
         Self::try_new(data_type, values, validity).unwrap()
     }
 
-    /// Alias for `new`
-    pub fn from_data(
-        data_type: DataType,
-        values: Vec<Box<dyn Array>>,
-        validity: Option<Bitmap>,
-    ) -> Self {
-        Self::new(data_type, values, validity)
-    }
-
     /// Creates an empty [`StructArray`].
     pub fn new_empty(data_type: DataType) -> Self {
         if let DataType::Struct(fields) = &data_type {

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -117,16 +117,6 @@ impl UnionArray {
         Self::try_new(data_type, types, fields, offsets).unwrap()
     }
 
-    /// Alias for `new`
-    pub fn from_data(
-        data_type: DataType,
-        types: Buffer<i8>,
-        fields: Vec<Box<dyn Array>>,
-        offsets: Option<Buffer<i32>>,
-    ) -> Self {
-        Self::new(data_type, types, fields, offsets)
-    }
-
     /// Creates a new null [`UnionArray`].
     pub fn new_null(data_type: DataType, length: usize) -> Self {
         if let DataType::Union(f, _, mode) = &data_type {

--- a/src/array/utf8/mutable_values.rs
+++ b/src/array/utf8/mutable_values.rs
@@ -30,7 +30,7 @@ impl<O: Offset> From<MutableUtf8ValuesArray<O>> for Utf8Array<O> {
         // `MutableUtf8ValuesArray` has the same invariants as `Utf8Array` and thus
         // `Utf8Array` can be safely created from `MutableUtf8ValuesArray` without checks.
         unsafe {
-            Utf8Array::<O>::from_data_unchecked(
+            Utf8Array::<O>::new_unchecked(
                 other.data_type,
                 other.offsets.into(),
                 other.values.into(),
@@ -45,12 +45,7 @@ impl<O: Offset> From<MutableUtf8ValuesArray<O>> for MutableUtf8Array<O> {
         // Safety:
         // `MutableUtf8ValuesArray` has the same invariants as `MutableUtf8Array`
         unsafe {
-            MutableUtf8Array::<O>::from_data_unchecked(
-                other.data_type,
-                other.offsets,
-                other.values,
-                None,
-            )
+            MutableUtf8Array::<O>::new_unchecked(other.data_type, other.offsets, other.values, None)
         }
     }
 }
@@ -244,21 +239,13 @@ impl<O: Offset> MutableArray for MutableUtf8ValuesArray<O> {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        // Safety:
-        // `MutableUtf8ValuesArray` has the same invariants as `Utf8Array` and thus
-        // `Utf8Array` can be safely created from `MutableUtf8ValuesArray` without checks.
-        let (data_type, offsets, values) = std::mem::take(self).into_inner();
-        unsafe { Utf8Array::from_data_unchecked(data_type, offsets.into(), values.into(), None) }
-            .boxed()
+        let array: Utf8Array<O> = std::mem::take(self).into();
+        array.boxed()
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
-        // Safety:
-        // `MutableUtf8ValuesArray` has the same invariants as `Utf8Array` and thus
-        // `Utf8Array` can be safely created from `MutableUtf8ValuesArray` without checks.
-        let (data_type, offsets, values) = std::mem::take(self).into_inner();
-        unsafe { Utf8Array::from_data_unchecked(data_type, offsets.into(), values.into(), None) }
-            .arced()
+        let array: Utf8Array<O> = std::mem::take(self).into();
+        array.arced()
     }
 
     fn data_type(&self) -> &DataType {

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -151,7 +151,7 @@ pub fn utf8_to_large_utf8(from: &Utf8Array<i32>) -> Utf8Array<i64> {
 
     let offsets = from.offsets().into();
     // Safety: sound because `values` fulfills the same invariants as `from.values()`
-    unsafe { Utf8Array::<i64>::from_data_unchecked(data_type, offsets, values, validity) }
+    unsafe { Utf8Array::<i64>::new_unchecked(data_type, offsets, values, validity) }
 }
 
 /// Conversion of utf8
@@ -162,7 +162,7 @@ pub fn utf8_large_to_utf8(from: &Utf8Array<i64>) -> Result<Utf8Array<i32>> {
     let offsets = from.offsets().try_into()?;
 
     // Safety: sound because `values` fulfills the same invariants as `from.values()`
-    Ok(unsafe { Utf8Array::<i32>::from_data_unchecked(data_type, offsets, values, validity) })
+    Ok(unsafe { Utf8Array::<i32>::new_unchecked(data_type, offsets, values, validity) })
 }
 
 /// Conversion to binary

--- a/src/compute/take/utf8.rs
+++ b/src/compute/take/utf8.rs
@@ -38,7 +38,7 @@ pub fn take<O: Offset, I: Index>(
         (false, true) => take_indices_validity(values.offsets(), values.values(), indices),
         (true, true) => take_values_indices_validity(values, indices),
     };
-    unsafe { Utf8Array::<O>::from_data_unchecked(data_type, offsets, values, validity) }
+    unsafe { Utf8Array::<O>::new_unchecked(data_type, offsets, values, validity) }
 }
 
 #[cfg(test)]

--- a/src/io/odbc/read/deserialize.rs
+++ b/src/io/odbc/read/deserialize.rs
@@ -92,7 +92,7 @@ fn bitmap(values: &[isize]) -> Option<Bitmap> {
 }
 
 fn primitive<T: NativeType>(data_type: DataType, values: &[T]) -> PrimitiveArray<T> {
-    PrimitiveArray::from_data(data_type, values.to_vec().into(), None)
+    PrimitiveArray::new(data_type, values.to_vec().into(), None)
 }
 
 fn primitive_optional<T: NativeType>(
@@ -101,20 +101,20 @@ fn primitive_optional<T: NativeType>(
     indicators: &[isize],
 ) -> PrimitiveArray<T> {
     let validity = bitmap(indicators);
-    PrimitiveArray::from_data(data_type, values.to_vec().into(), validity)
+    PrimitiveArray::new(data_type, values.to_vec().into(), validity)
 }
 
 fn bool(data_type: DataType, values: &[Bit]) -> BooleanArray {
     let values = values.iter().map(|x| x.as_bool());
     let values = Bitmap::from_trusted_len_iter(values);
-    BooleanArray::from_data(data_type, values, None)
+    BooleanArray::new(data_type, values, None)
 }
 
 fn bool_optional(data_type: DataType, values: &[Bit], indicators: &[isize]) -> BooleanArray {
     let validity = bitmap(indicators);
     let values = values.iter().map(|x| x.as_bool());
     let values = Bitmap::from_trusted_len_iter(values);
-    BooleanArray::from_data(data_type, values, validity)
+    BooleanArray::new(data_type, values, validity)
 }
 
 fn binary_generic<'a>(
@@ -143,21 +143,19 @@ fn binary_generic<'a>(
 
 fn binary(data_type: DataType, view: BinColumnView) -> BinaryArray<i32> {
     let (offsets, values, validity) = binary_generic(view.iter());
-
-    // this O(N) check is not necessary
-    BinaryArray::from_data(data_type, offsets, values, validity)
+    BinaryArray::new(data_type, offsets, values, validity)
 }
 
 fn utf8(data_type: DataType, view: TextColumnView<u8>) -> Utf8Array<i32> {
     let (offsets, values, validity) = binary_generic(view.iter());
 
     // this O(N) check is necessary for the utf8 validity
-    Utf8Array::from_data(data_type, offsets, values, validity)
+    Utf8Array::new(data_type, offsets, values, validity)
 }
 
 fn date(data_type: DataType, values: &[odbc_api::sys::Date]) -> PrimitiveArray<i32> {
     let values = values.iter().map(days_since_epoch).collect::<Vec<_>>();
-    PrimitiveArray::from_data(data_type, values.into(), None)
+    PrimitiveArray::new(data_type, values.into(), None)
 }
 
 fn date_optional(
@@ -167,7 +165,7 @@ fn date_optional(
 ) -> PrimitiveArray<i32> {
     let values = values.iter().map(days_since_epoch).collect::<Vec<_>>();
     let validity = bitmap(indicators);
-    PrimitiveArray::from_data(data_type, values.into(), validity)
+    PrimitiveArray::new(data_type, values.into(), validity)
 }
 
 fn days_since_epoch(date: &odbc_api::sys::Date) -> i32 {
@@ -180,7 +178,7 @@ fn days_since_epoch(date: &odbc_api::sys::Date) -> i32 {
 
 fn time(data_type: DataType, values: &[odbc_api::sys::Time]) -> PrimitiveArray<i32> {
     let values = values.iter().map(time_since_midnight).collect::<Vec<_>>();
-    PrimitiveArray::from_data(data_type, values.into(), None)
+    PrimitiveArray::new(data_type, values.into(), None)
 }
 
 fn time_since_midnight(date: &odbc_api::sys::Time) -> i32 {
@@ -194,7 +192,7 @@ fn time_optional(
 ) -> PrimitiveArray<i32> {
     let values = values.iter().map(time_since_midnight).collect::<Vec<_>>();
     let validity = bitmap(indicators);
-    PrimitiveArray::from_data(data_type, values.into(), validity)
+    PrimitiveArray::new(data_type, values.into(), validity)
 }
 
 fn timestamp(data_type: DataType, values: &[odbc_api::sys::Timestamp]) -> PrimitiveArray<i64> {
@@ -209,7 +207,7 @@ fn timestamp(data_type: DataType, values: &[odbc_api::sys::Timestamp]) -> Primit
         TimeUnit::Microsecond => values.iter().map(timestamp_us).collect::<Vec<_>>(),
         TimeUnit::Nanosecond => values.iter().map(timestamp_ns).collect::<Vec<_>>(),
     };
-    PrimitiveArray::from_data(data_type, values.into(), None)
+    PrimitiveArray::new(data_type, values.into(), None)
 }
 
 fn timestamp_optional(
@@ -229,7 +227,7 @@ fn timestamp_optional(
         TimeUnit::Nanosecond => values.iter().map(timestamp_ns).collect::<Vec<_>>(),
     };
     let validity = bitmap(indicators);
-    PrimitiveArray::from_data(data_type, values.into(), validity)
+    PrimitiveArray::new(data_type, values.into(), validity)
 }
 
 fn timestamp_to_naive(timestamp: &odbc_api::sys::Timestamp) -> Option<NaiveDateTime> {

--- a/src/io/parquet/read/deserialize/fixed_size_binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/dictionary.rs
@@ -54,7 +54,9 @@ fn read_dict(data_type: DataType, dict: &DictPage) -> Box<dyn Array> {
 
     let values = dict.buffer.clone();
 
-    FixedSizeBinaryArray::from_data(data_type, values.into(), None).boxed()
+    FixedSizeBinaryArray::try_new(data_type, values.into(), None)
+        .unwrap()
+        .boxed()
 }
 
 impl<K, I> Iterator for DictIter<K, I>

--- a/src/io/parquet/read/deserialize/primitive/basic.rs
+++ b/src/io/parquet/read/deserialize/primitive/basic.rs
@@ -281,7 +281,7 @@ pub(super) fn finish<T: NativeType>(
     } else {
         Some(validity)
     };
-    MutablePrimitiveArray::from_data(data_type.clone(), values, validity)
+    MutablePrimitiveArray::try_new(data_type.clone(), values, validity).unwrap()
 }
 
 /// An [`Iterator`] adapter over [`Pages`] assumed to be encoded as primitive arrays

--- a/src/io/parquet/read/deserialize/primitive/nested.rs
+++ b/src/io/parquet/read/deserialize/primitive/nested.rs
@@ -164,7 +164,7 @@ fn finish<T: NativeType>(
     values: Vec<T>,
     validity: MutableBitmap,
 ) -> PrimitiveArray<T> {
-    PrimitiveArray::from_data(data_type.clone(), values.into(), validity.into())
+    PrimitiveArray::new(data_type.clone(), values.into(), validity.into())
 }
 
 /// An iterator adapter over [`Pages`] assumed to be encoded as boolean arrays

--- a/src/io/parquet/read/deserialize/struct_.rs
+++ b/src/io/parquet/read/deserialize/struct_.rs
@@ -47,7 +47,7 @@ impl<'a> Iterator for StructIterator<'a> {
 
         Some(Ok((
             nested,
-            Box::new(StructArray::from_data(
+            Box::new(StructArray::new(
                 DataType::Struct(self.fields.clone()),
                 new_values,
                 validity.and_then(|x| x.into()),

--- a/src/io/parquet/read/indexes/fixed_len_binary.rs
+++ b/src/io/parquet/read/indexes/fixed_len_binary.rs
@@ -43,11 +43,12 @@ fn deserialize_binary_iter<'a, I: TrustedLen<Item = Option<&'a Vec<u8>>>>(
             })))
         }
         _ => {
-            let mut a = MutableFixedSizeBinaryArray::from_data(
+            let mut a = MutableFixedSizeBinaryArray::try_new(
                 data_type,
                 Vec::with_capacity(iter.size_hint().0),
                 None,
-            );
+            )
+            .unwrap();
             for item in iter {
                 a.push(item);
             }

--- a/src/io/parquet/read/statistics/mod.rs
+++ b/src/io/parquet/read/statistics/mod.rs
@@ -174,11 +174,10 @@ fn make_mutable(data_type: &DataType, capacity: usize) -> Result<Box<dyn Mutable
         PhysicalType::LargeUtf8 => {
             Box::new(MutableUtf8Array::<i64>::with_capacity(capacity)) as Box<dyn MutableArray>
         }
-        PhysicalType::FixedSizeBinary => Box::new(MutableFixedSizeBinaryArray::from_data(
-            data_type.clone(),
-            vec![],
-            None,
-        )) as _,
+        PhysicalType::FixedSizeBinary => {
+            Box::new(MutableFixedSizeBinaryArray::try_new(data_type.clone(), vec![], None).unwrap())
+                as _
+        }
         PhysicalType::LargeList | PhysicalType::List => Box::new(
             DynMutableListArray::try_with_capacity(data_type.clone(), capacity)?,
         ) as Box<dyn MutableArray>,

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -450,7 +450,7 @@ pub fn array_to_page_simple(
                 values.extend_from_slice(&[0; 4]); // months
                 values.extend_from_slice(bytes); // days and seconds
             });
-            let array = FixedSizeBinaryArray::from_data(
+            let array = FixedSizeBinaryArray::new(
                 DataType::FixedSizeBinary(12),
                 values.into(),
                 array.validity().cloned(),
@@ -518,7 +518,7 @@ pub fn array_to_page_simple(
                     let bytes = &x.to_be_bytes()[16 - size..];
                     values.extend_from_slice(bytes)
                 });
-                let array = FixedSizeBinaryArray::from_data(
+                let array = FixedSizeBinaryArray::new(
                     DataType::FixedSizeBinary(size),
                     values.into(),
                     array.validity().cloned(),

--- a/src/io/parquet/write/pages.rs
+++ b/src/io/parquet/write/pages.rs
@@ -245,7 +245,7 @@ mod tests {
             Field::new("c", DataType::Int32, false),
         ];
 
-        let array = StructArray::from_data(
+        let array = StructArray::new(
             DataType::Struct(fields),
             vec![boolean.clone(), int.clone()],
             Some(Bitmap::from([true, true, false, true])),
@@ -309,7 +309,7 @@ mod tests {
             Field::new("c", DataType::Int32, false),
         ];
 
-        let array = StructArray::from_data(
+        let array = StructArray::new(
             DataType::Struct(fields),
             vec![boolean.clone(), int.clone()],
             Some(Bitmap::from([true, true, false, true])),
@@ -320,7 +320,7 @@ mod tests {
             Field::new("c", array.data_type().clone(), true),
         ];
 
-        let array = StructArray::from_data(
+        let array = StructArray::new(
             DataType::Struct(fields),
             vec![Box::new(array.clone()), Box::new(array)],
             None,
@@ -412,7 +412,7 @@ mod tests {
             Field::new("c", DataType::Int32, false),
         ];
 
-        let array = StructArray::from_data(
+        let array = StructArray::new(
             DataType::Struct(fields),
             vec![boolean.clone(), int.clone()],
             Some(Bitmap::from([true, true, false, true])),

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -63,6 +63,12 @@ impl<O: Offset> Offsets<O> {
         Self(vec![O::zero()])
     }
 
+    /// Returns an [`Offsets`] whose all lengths are zero.
+    #[inline]
+    pub fn new_zeroed(length: usize) -> Self {
+        Self(vec![O::zero(); length + 1])
+    }
+
     /// Creates a new [`Offsets`] from an iterator of lengths
     #[inline]
     pub fn try_from_iter<I: IntoIterator<Item = usize>>(iter: I) -> Result<Self, Error> {

--- a/tests/it/array/binary/mod.rs
+++ b/tests/it/array/binary/mod.rs
@@ -30,7 +30,7 @@ fn basics() {
     assert!(!array.is_valid(1));
     assert!(array.is_valid(2));
 
-    let array2 = BinaryArray::<i32>::from_data(
+    let array2 = BinaryArray::<i32>::new(
         DataType::Binary,
         array.offsets().clone(),
         array.values().clone(),
@@ -101,7 +101,7 @@ fn with_validity() {
 fn wrong_offsets() {
     let offsets = vec![0, 5, 4].try_into().unwrap(); // invalid offsets
     let values = Buffer::from(b"abbbbb".to_vec());
-    BinaryArray::<i32>::from_data(DataType::Binary, offsets, values, None);
+    BinaryArray::<i32>::new(DataType::Binary, offsets, values, None);
 }
 
 #[test]
@@ -109,7 +109,7 @@ fn wrong_offsets() {
 fn wrong_data_type() {
     let offsets = vec![0, 4].try_into().unwrap();
     let values = Buffer::from(b"abbb".to_vec());
-    BinaryArray::<i32>::from_data(DataType::Int8, offsets, values, None);
+    BinaryArray::<i32>::new(DataType::Int8, offsets, values, None);
 }
 
 #[test]
@@ -118,7 +118,7 @@ fn value_with_wrong_offsets_panics() {
     let offsets = vec![0, 10, 11, 4].try_into().unwrap();
     let values = Buffer::from(b"abbb".to_vec());
     // the 10-11 is not checked
-    let array = BinaryArray::<i32>::from_data(DataType::Binary, offsets, values, None);
+    let array = BinaryArray::<i32>::new(DataType::Binary, offsets, values, None);
 
     // but access is still checked (and panics)
     // without checks, this would result in reading beyond bounds
@@ -130,7 +130,7 @@ fn value_with_wrong_offsets_panics() {
 fn index_out_of_bounds_panics() {
     let offsets = vec![0, 1, 2, 4].try_into().unwrap();
     let values = Buffer::from(b"abbb".to_vec());
-    let array = BinaryArray::<i32>::from_data(DataType::Utf8, offsets, values, None);
+    let array = BinaryArray::<i32>::new(DataType::Utf8, offsets, values, None);
 
     array.value(3);
 }
@@ -141,7 +141,7 @@ fn value_unchecked_with_wrong_offsets_panics() {
     let offsets = vec![0, 10, 11, 4].try_into().unwrap();
     let values = Buffer::from(b"abbb".to_vec());
     // the 10-11 is not checked
-    let array = BinaryArray::<i32>::from_data(DataType::Binary, offsets, values, None);
+    let array = BinaryArray::<i32>::new(DataType::Binary, offsets, values, None);
 
     // but access is still checked (and panics)
     // without checks, this would result in reading beyond bounds,
@@ -162,7 +162,7 @@ fn into_mut_1() {
     let values = Buffer::from(b"a".to_vec());
     let a = values.clone(); // cloned values
     assert_eq!(a, values);
-    let array = BinaryArray::<i32>::from_data(DataType::Binary, offsets, values, None);
+    let array = BinaryArray::<i32>::new(DataType::Binary, offsets, values, None);
     assert!(array.into_mut().is_left());
 }
 
@@ -172,7 +172,7 @@ fn into_mut_2() {
     let values = Buffer::from(b"a".to_vec());
     let a = offsets.clone(); // cloned offsets
     assert_eq!(a, offsets);
-    let array = BinaryArray::<i32>::from_data(DataType::Binary, offsets, values, None);
+    let array = BinaryArray::<i32>::new(DataType::Binary, offsets, values, None);
     assert!(array.into_mut().is_left());
 }
 

--- a/tests/it/array/boolean/mod.rs
+++ b/tests/it/array/boolean/mod.rs
@@ -27,7 +27,7 @@ fn basics() {
     assert!(!array.is_valid(1));
     assert!(array.is_valid(2));
 
-    let array2 = BooleanArray::from_data(
+    let array2 = BooleanArray::new(
         DataType::Boolean,
         array.values().clone(),
         array.validity().cloned(),
@@ -51,7 +51,7 @@ fn try_new_invalid() {
 #[test]
 fn with_validity() {
     let bitmap = Bitmap::from([true, false, true]);
-    let a = BooleanArray::from_data(DataType::Boolean, bitmap, None);
+    let a = BooleanArray::new(DataType::Boolean, bitmap, None);
     let a = a.with_validity(Some(Bitmap::from([true, false, true])));
     assert!(a.validity().is_some());
 }
@@ -65,12 +65,12 @@ fn debug() {
 #[test]
 fn into_mut_valid() {
     let bitmap = Bitmap::from([true, false, true]);
-    let a = BooleanArray::from_data(DataType::Boolean, bitmap, None);
+    let a = BooleanArray::new(DataType::Boolean, bitmap, None);
     let _ = a.into_mut().right().unwrap();
 
     let bitmap = Bitmap::from([true, false, true]);
     let validity = Bitmap::from([true, false, true]);
-    let a = BooleanArray::from_data(DataType::Boolean, bitmap, Some(validity));
+    let a = BooleanArray::new(DataType::Boolean, bitmap, Some(validity));
     let _ = a.into_mut().right().unwrap();
 }
 
@@ -78,13 +78,13 @@ fn into_mut_valid() {
 fn into_mut_invalid() {
     let bitmap = Bitmap::from([true, false, true]);
     let _other = bitmap.clone(); // values is shared
-    let a = BooleanArray::from_data(DataType::Boolean, bitmap, None);
+    let a = BooleanArray::new(DataType::Boolean, bitmap, None);
     let _ = a.into_mut().left().unwrap();
 
     let bitmap = Bitmap::from([true, false, true]);
     let validity = Bitmap::from([true, false, true]);
     let _other = validity.clone(); // validity is shared
-    let a = BooleanArray::from_data(DataType::Boolean, bitmap, Some(validity));
+    let a = BooleanArray::new(DataType::Boolean, bitmap, Some(validity));
     let _ = a.into_mut().left().unwrap();
 }
 

--- a/tests/it/array/boolean/mutable.rs
+++ b/tests/it/array/boolean/mutable.rs
@@ -99,11 +99,12 @@ fn try_from_trusted_len_iter() {
 
 #[test]
 fn reserve() {
-    let mut a = MutableBooleanArray::from_data(
+    let mut a = MutableBooleanArray::try_new(
         DataType::Boolean,
         MutableBitmap::new(),
         Some(MutableBitmap::new()),
-    );
+    )
+    .unwrap();
 
     a.reserve(10);
     assert!(a.validity().unwrap().capacity() > 0);

--- a/tests/it/array/equal/list.rs
+++ b/tests/it/array/equal/list.rs
@@ -77,14 +77,14 @@ fn test_bla() {
         Some(6),
     ]));
     let validity = Bitmap::from([true, false, true]);
-    let lhs = ListArray::<i32>::from_data(data_type, offsets, values, Some(validity));
+    let lhs = ListArray::<i32>::new(data_type, offsets, values, Some(validity));
     let lhs = lhs.slice(1, 2);
 
     let offsets = vec![0, 0, 3].try_into().unwrap();
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
     let values = Box::new(Int32Array::from([Some(4), None, Some(6)]));
     let validity = Bitmap::from([false, true]);
-    let rhs = ListArray::<i32>::from_data(data_type, offsets, values, Some(validity));
+    let rhs = ListArray::<i32>::new(data_type, offsets, values, Some(validity));
 
     assert_eq!(lhs, rhs);
 }

--- a/tests/it/array/fixed_size_binary/mod.rs
+++ b/tests/it/array/fixed_size_binary/mod.rs
@@ -4,7 +4,7 @@ mod mutable;
 
 #[test]
 fn basics() {
-    let array = FixedSizeBinaryArray::from_data(
+    let array = FixedSizeBinaryArray::new(
         DataType::FixedSizeBinary(2),
         Buffer::from(vec![1, 2, 3, 4, 5, 6]),
         Some(Bitmap::from([true, false, true])),
@@ -23,18 +23,20 @@ fn basics() {
 
 #[test]
 fn with_validity() {
-    let values = Buffer::from(vec![1, 2, 3, 4, 5, 6]);
-    let a = FixedSizeBinaryArray::new(DataType::FixedSizeBinary(2), values, None);
+    let a = FixedSizeBinaryArray::new(
+        DataType::FixedSizeBinary(2),
+        vec![1, 2, 3, 4, 5, 6].into(),
+        None,
+    );
     let a = a.with_validity(Some(Bitmap::from([true, false, true])));
     assert!(a.validity().is_some());
 }
 
 #[test]
 fn debug() {
-    let values = Buffer::from(vec![1, 2, 3, 4, 5, 6]);
-    let a = FixedSizeBinaryArray::from_data(
+    let a = FixedSizeBinaryArray::new(
         DataType::FixedSizeBinary(2),
-        values,
+        vec![1, 2, 3, 4, 5, 6].into(),
         Some(Bitmap::from([true, false, true])),
     );
     assert_eq!(

--- a/tests/it/array/fixed_size_binary/mutable.rs
+++ b/tests/it/array/fixed_size_binary/mutable.rs
@@ -4,11 +4,12 @@ use arrow2::datatypes::DataType;
 
 #[test]
 fn basic() {
-    let a = MutableFixedSizeBinaryArray::from_data(
+    let a = MutableFixedSizeBinaryArray::try_new(
         DataType::FixedSizeBinary(2),
         Vec::from([1, 2, 3, 4]),
         None,
-    );
+    )
+    .unwrap();
     assert_eq!(a.len(), 2);
     assert_eq!(a.data_type(), &DataType::FixedSizeBinary(2));
     assert_eq!(a.values(), &Vec::from([1, 2, 3, 4]));
@@ -20,29 +21,30 @@ fn basic() {
 #[allow(clippy::eq_op)]
 #[test]
 fn equal() {
-    let a = MutableFixedSizeBinaryArray::from_data(
+    let a = MutableFixedSizeBinaryArray::try_new(
         DataType::FixedSizeBinary(2),
         Vec::from([1, 2, 3, 4]),
         None,
-    );
+    )
+    .unwrap();
     assert_eq!(a, a);
-    let b = MutableFixedSizeBinaryArray::from_data(
-        DataType::FixedSizeBinary(2),
-        Vec::from([1, 2]),
-        None,
-    );
+    let b =
+        MutableFixedSizeBinaryArray::try_new(DataType::FixedSizeBinary(2), Vec::from([1, 2]), None)
+            .unwrap();
     assert_eq!(b, b);
     assert!(a != b);
-    let a = MutableFixedSizeBinaryArray::from_data(
+    let a = MutableFixedSizeBinaryArray::try_new(
         DataType::FixedSizeBinary(2),
         Vec::from([1, 2, 3, 4]),
         Some(MutableBitmap::from([true, false])),
-    );
-    let b = MutableFixedSizeBinaryArray::from_data(
+    )
+    .unwrap();
+    let b = MutableFixedSizeBinaryArray::try_new(
         DataType::FixedSizeBinary(2),
         Vec::from([1, 2, 3, 4]),
         Some(MutableBitmap::from([false, true])),
-    );
+    )
+    .unwrap();
     assert_eq!(a, a);
     assert_eq!(b, b);
     assert!(a != b);

--- a/tests/it/array/growable/null.rs
+++ b/tests/it/array/growable/null.rs
@@ -15,6 +15,6 @@ fn null() {
 
     let result: NullArray = mutable.into();
 
-    let expected = NullArray::from_data(DataType::Null, 3);
+    let expected = NullArray::new(DataType::Null, 3);
     assert_eq!(result, expected);
 }

--- a/tests/it/array/growable/struct_.rs
+++ b/tests/it/array/growable/struct_.rs
@@ -31,14 +31,14 @@ fn some_values() -> (DataType, Vec<Box<dyn Array>>) {
 fn basic() {
     let (fields, values) = some_values();
 
-    let array = StructArray::from_data(fields.clone(), values.clone(), None);
+    let array = StructArray::new(fields.clone(), values.clone(), None);
 
     let mut a = GrowableStruct::new(vec![&array], false, 0);
 
     a.extend(0, 1, 2);
     let result: StructArray = a.into();
 
-    let expected = StructArray::from_data(
+    let expected = StructArray::new(
         fields,
         vec![values[0].slice(1, 2), values[1].slice(1, 2)],
         None,
@@ -50,14 +50,14 @@ fn basic() {
 fn offset() {
     let (fields, values) = some_values();
 
-    let array = StructArray::from_data(fields.clone(), values.clone(), None).slice(1, 3);
+    let array = StructArray::new(fields.clone(), values.clone(), None).slice(1, 3);
 
     let mut a = GrowableStruct::new(vec![&array], false, 0);
 
     a.extend(0, 1, 2);
     let result: StructArray = a.into();
 
-    let expected = StructArray::from_data(
+    let expected = StructArray::new(
         fields,
         vec![values[0].slice(2, 2), values[1].slice(2, 2)],
         None,
@@ -70,7 +70,7 @@ fn offset() {
 fn nulls() {
     let (fields, values) = some_values();
 
-    let array = StructArray::from_data(
+    let array = StructArray::new(
         fields.clone(),
         values.clone(),
         Some(Bitmap::from_u8_slice([0b00000010], 5)),
@@ -81,7 +81,7 @@ fn nulls() {
     a.extend(0, 1, 2);
     let result: StructArray = a.into();
 
-    let expected = StructArray::from_data(
+    let expected = StructArray::new(
         fields,
         vec![values[0].slice(1, 2), values[1].slice(1, 2)],
         Some(Bitmap::from_u8_slice([0b00000010], 5).slice(1, 2)),
@@ -94,7 +94,7 @@ fn nulls() {
 fn many() {
     let (fields, values) = some_values();
 
-    let array = StructArray::from_data(fields.clone(), values.clone(), None);
+    let array = StructArray::new(fields.clone(), values.clone(), None);
 
     let mut mutable = GrowableStruct::new(vec![&array, &array], true, 0);
 
@@ -118,7 +118,7 @@ fn many() {
         None,
     ]));
 
-    let expected = StructArray::from_data(
+    let expected = StructArray::new(
         fields,
         vec![expected_string, expected_int],
         Some(Bitmap::from([true, true, true, true, false])),

--- a/tests/it/array/growable/union.rs
+++ b/tests/it/array/growable/union.rs
@@ -19,7 +19,7 @@ fn sparse() -> Result<()> {
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
     ];
-    let array = UnionArray::from_data(data_type, types, fields, None);
+    let array = UnionArray::new(data_type, types, fields, None);
 
     for length in 1..2 {
         for index in 0..(array.len() - length + 1) {
@@ -51,7 +51,7 @@ fn dense() -> Result<()> {
     ];
     let offsets = Some(vec![0, 1, 0].into());
 
-    let array = UnionArray::from_data(data_type, types, fields, offsets);
+    let array = UnionArray::new(data_type, types, fields, offsets);
 
     for length in 1..2 {
         for index in 0..(array.len() - length + 1) {

--- a/tests/it/array/list/mod.rs
+++ b/tests/it/array/list/mod.rs
@@ -7,10 +7,10 @@ mod mutable;
 #[test]
 fn debug() {
     let values = Buffer::from(vec![1, 2, 3, 4, 5]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::new(DataType::Int32, values, None);
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-    let array = ListArray::<i32>::from_data(
+    let array = ListArray::<i32>::new(
         data_type,
         vec![0, 2, 2, 3, 5].try_into().unwrap(),
         Box::new(values),
@@ -24,10 +24,10 @@ fn debug() {
 #[should_panic]
 fn test_nested_panic() {
     let values = Buffer::from(vec![1, 2, 3, 4, 5]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::new(DataType::Int32, values, None);
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-    let array = ListArray::<i32>::from_data(
+    let array = ListArray::<i32>::new(
         data_type.clone(),
         vec![0, 2, 2, 3, 5].try_into().unwrap(),
         Box::new(values),
@@ -36,7 +36,7 @@ fn test_nested_panic() {
 
     // The datatype for the nested array has to be created considering
     // the nested structure of the child data
-    let _ = ListArray::<i32>::from_data(
+    let _ = ListArray::<i32>::new(
         data_type,
         vec![0, 2, 4].try_into().unwrap(),
         Box::new(array),
@@ -47,10 +47,10 @@ fn test_nested_panic() {
 #[test]
 fn test_nested_display() {
     let values = Buffer::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::new(DataType::Int32, values, None);
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-    let array = ListArray::<i32>::from_data(
+    let array = ListArray::<i32>::new(
         data_type,
         vec![0, 2, 4, 7, 7, 8, 10].try_into().unwrap(),
         Box::new(values),
@@ -58,7 +58,7 @@ fn test_nested_display() {
     );
 
     let data_type = ListArray::<i32>::default_datatype(array.data_type().clone());
-    let nested = ListArray::<i32>::from_data(
+    let nested = ListArray::<i32>::new(
         data_type,
         vec![0, 2, 5, 6].try_into().unwrap(),
         Box::new(array),

--- a/tests/it/array/list/mutable.rs
+++ b/tests/it/array/list/mutable.rs
@@ -12,14 +12,14 @@ fn basics() {
     array.try_extend(data).unwrap();
     let array: ListArray<i32> = array.into();
 
-    let values = PrimitiveArray::<i32>::from_data(
+    let values = PrimitiveArray::<i32>::new(
         DataType::Int32,
         Buffer::from(vec![1, 2, 3, 4, 0, 6]),
         Some(Bitmap::from([true, true, true, true, false, true])),
     );
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-    let expected = ListArray::<i32>::from_data(
+    let expected = ListArray::<i32>::new(
         data_type,
         vec![0, 3, 3, 6].try_into().unwrap(),
         Box::new(values),

--- a/tests/it/array/primitive/mod.rs
+++ b/tests/it/array/primitive/mod.rs
@@ -24,7 +24,7 @@ fn basics() {
     assert!(!array.is_valid(1));
     assert!(array.is_valid(2));
 
-    let array2 = Int32Array::from_data(
+    let array2 = Int32Array::new(
         DataType::Int32,
         array.values().clone(),
         array.validity().cloned(),

--- a/tests/it/array/primitive/mutable.rs
+++ b/tests/it/array/primitive/mutable.rs
@@ -8,13 +8,14 @@ use std::iter::FromIterator;
 
 #[test]
 fn from_and_into_data() {
-    let a = MutablePrimitiveArray::from_data(
+    let a = MutablePrimitiveArray::try_new(
         DataType::Int32,
         vec![1i32, 0],
         Some(MutableBitmap::from([true, false])),
-    );
+    )
+    .unwrap();
     assert_eq!(a.len(), 2);
-    let (a, b, c) = a.into_data();
+    let (a, b, c) = a.into_inner();
     assert_eq!(a, DataType::Int32);
     assert_eq!(b, Vec::from([1i32, 0]));
     assert_eq!(c, Some(MutableBitmap::from([true, false])));
@@ -28,22 +29,24 @@ fn from_vec() {
 
 #[test]
 fn to() {
-    let a = MutablePrimitiveArray::from_data(
+    let a = MutablePrimitiveArray::try_new(
         DataType::Int32,
         vec![1i32, 0],
         Some(MutableBitmap::from([true, false])),
-    );
+    )
+    .unwrap();
     let a = a.to(DataType::Date32);
     assert_eq!(a.data_type(), &DataType::Date32);
 }
 
 #[test]
 fn values_mut_slice() {
-    let mut a = MutablePrimitiveArray::from_data(
+    let mut a = MutablePrimitiveArray::try_new(
         DataType::Int32,
         vec![1i32, 0],
         Some(MutableBitmap::from([true, false])),
-    );
+    )
+    .unwrap();
     let values = a.values_mut_slice();
 
     values[0] = 10;
@@ -311,10 +314,8 @@ fn try_from_trusted_len_iter() {
 }
 
 #[test]
-#[should_panic]
 fn wrong_data_type() {
-    let values = vec![1u8];
-    MutablePrimitiveArray::from_data(DataType::Utf8, values, None);
+    assert!(MutablePrimitiveArray::<i32>::try_new(DataType::Utf8, vec![], None).is_err());
 }
 
 #[test]

--- a/tests/it/array/primitive/to_mutable.rs
+++ b/tests/it/array/primitive/to_mutable.rs
@@ -6,7 +6,7 @@ use either::Either;
 #[test]
 fn array_to_mutable() {
     let data = vec![1, 2, 3];
-    let arr = PrimitiveArray::from_data(DataType::Int32, data.into(), None);
+    let arr = PrimitiveArray::new(DataType::Int32, data.into(), None);
 
     // to mutable push and freeze again
     let mut mut_arr = arr.into_mut().unwrap_right();
@@ -24,7 +24,7 @@ fn array_to_mutable() {
 #[test]
 fn array_to_mutable_not_owned() {
     let data = vec![1, 2, 3];
-    let arr = PrimitiveArray::from_data(DataType::Int32, data.into(), None);
+    let arr = PrimitiveArray::new(DataType::Int32, data.into(), None);
     let arr2 = arr.clone();
 
     // to the `to_mutable` should fail and we should get back the original array
@@ -43,11 +43,11 @@ fn array_to_mutable_validity() {
 
     // both have a single reference should be ok
     let bitmap = Bitmap::from_iter([true, false, true]);
-    let arr = PrimitiveArray::from_data(DataType::Int32, data.clone().into(), Some(bitmap));
+    let arr = PrimitiveArray::new(DataType::Int32, data.clone().into(), Some(bitmap));
     assert!(matches!(arr.into_mut(), Either::Right(_)));
 
     // now we clone the bitmap increasing the ref count
     let bitmap = Bitmap::from_iter([true, false, true]);
-    let arr = PrimitiveArray::from_data(DataType::Int32, data.into(), Some(bitmap.clone()));
+    let arr = PrimitiveArray::new(DataType::Int32, data.into(), Some(bitmap.clone()));
     assert!(matches!(arr.into_mut(), Either::Left(_)));
 }

--- a/tests/it/array/struct_/iterator.rs
+++ b/tests/it/array/struct_/iterator.rs
@@ -12,7 +12,7 @@ fn test_simple_iter() {
         Field::new("c", DataType::Int32, false),
     ];
 
-    let array = StructArray::from_data(
+    let array = StructArray::new(
         DataType::Struct(fields),
         vec![boolean.clone(), int.clone()],
         None,

--- a/tests/it/array/struct_/mod.rs
+++ b/tests/it/array/struct_/mod.rs
@@ -15,7 +15,7 @@ fn debug() {
         Field::new("c", DataType::Int32, false),
     ];
 
-    let array = StructArray::from_data(
+    let array = StructArray::new(
         DataType::Struct(fields),
         vec![boolean.clone(), int.clone()],
         Some(Bitmap::from([true, true, false, true])),

--- a/tests/it/array/union.rs
+++ b/tests/it/array/union.rs
@@ -32,7 +32,7 @@ fn sparse_debug() -> Result<()> {
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
     ];
 
-    let array = UnionArray::from_data(data_type, types, fields, None);
+    let array = UnionArray::new(data_type, types, fields, None);
 
     assert_eq!(format!("{:?}", array), "UnionArray[1, None, c]");
 
@@ -53,7 +53,7 @@ fn dense_debug() -> Result<()> {
     ];
     let offsets = Some(vec![0, 1, 0].into());
 
-    let array = UnionArray::from_data(data_type, types, fields, offsets);
+    let array = UnionArray::new(data_type, types, fields, offsets);
 
     assert_eq!(format!("{:?}", array), "UnionArray[1, None, c]");
 
@@ -73,7 +73,7 @@ fn slice() -> Result<()> {
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
     ];
 
-    let array = UnionArray::from_data(data_type.clone(), types, fields.clone(), None);
+    let array = UnionArray::new(data_type.clone(), types, fields.clone(), None);
 
     let result = array.slice(1, 2);
 
@@ -82,7 +82,7 @@ fn slice() -> Result<()> {
         Int32Array::from(&[None, Some(2)]).boxed(),
         Utf8Array::<i32>::from([Some("b"), Some("c")]).boxed(),
     ];
-    let expected = UnionArray::from_data(data_type, sliced_types, sliced_fields, None);
+    let expected = UnionArray::new(data_type, sliced_types, sliced_fields, None);
 
     assert_eq!(expected, result);
     Ok(())
@@ -101,7 +101,7 @@ fn iter_sparse() -> Result<()> {
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
     ];
 
-    let array = UnionArray::from_data(data_type, types, fields.clone(), None);
+    let array = UnionArray::new(data_type, types, fields.clone(), None);
     let mut iter = array.iter();
 
     assert_eq!(
@@ -135,7 +135,7 @@ fn iter_dense() -> Result<()> {
         Utf8Array::<i32>::from([Some("c")]).boxed(),
     ];
 
-    let array = UnionArray::from_data(data_type, types, fields.clone(), Some(offsets));
+    let array = UnionArray::new(data_type, types, fields.clone(), Some(offsets));
     let mut iter = array.iter();
 
     assert_eq!(
@@ -168,7 +168,7 @@ fn iter_sparse_slice() -> Result<()> {
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
     ];
 
-    let array = UnionArray::from_data(data_type, types, fields.clone(), None);
+    let array = UnionArray::new(data_type, types, fields.clone(), None);
     let array_slice = array.slice(1, 1);
     let mut iter = array_slice.iter();
 
@@ -195,7 +195,7 @@ fn iter_dense_slice() -> Result<()> {
         Utf8Array::<i32>::from([Some("c")]).boxed(),
     ];
 
-    let array = UnionArray::from_data(data_type, types, fields.clone(), Some(offsets));
+    let array = UnionArray::new(data_type, types, fields.clone(), Some(offsets));
     let array_slice = array.slice(1, 1);
     let mut iter = array_slice.iter();
 
@@ -222,7 +222,7 @@ fn scalar() -> Result<()> {
         Utf8Array::<i32>::from([Some("c")]).boxed(),
     ];
 
-    let array = UnionArray::from_data(data_type, types, fields.clone(), Some(offsets));
+    let array = UnionArray::new(data_type, types, fields.clone(), Some(offsets));
 
     let scalar = new_scalar(&array, 0);
     let union_scalar = scalar.as_any().downcast_ref::<UnionScalar>().unwrap();

--- a/tests/it/array/utf8/mod.rs
+++ b/tests/it/array/utf8/mod.rs
@@ -27,7 +27,7 @@ fn basics() {
     assert!(!array.is_valid(1));
     assert!(array.is_valid(2));
 
-    let array2 = Utf8Array::<i32>::from_data(
+    let array2 = Utf8Array::<i32>::new(
         DataType::Utf8,
         array.offsets().clone(),
         array.values().clone(),
@@ -67,7 +67,7 @@ fn from_slice() {
     let values = b"abcc".to_vec().into();
     assert_eq!(
         b,
-        Utf8Array::<i32>::from_data(DataType::Utf8, offsets, values, None)
+        Utf8Array::<i32>::new(DataType::Utf8, offsets, values, None)
     );
 }
 
@@ -79,7 +79,7 @@ fn from_iter_values() {
     let values = b"abcc".to_vec().into();
     assert_eq!(
         b,
-        Utf8Array::<i32>::from_data(DataType::Utf8, offsets, values, None)
+        Utf8Array::<i32>::new(DataType::Utf8, offsets, values, None)
     );
 }
 
@@ -92,7 +92,7 @@ fn from_trusted_len_iter() {
     let values = b"abcc".to_vec().into();
     assert_eq!(
         b,
-        Utf8Array::<i32>::from_data(DataType::Utf8, offsets, values, None)
+        Utf8Array::<i32>::new(DataType::Utf8, offsets, values, None)
     );
 }
 
@@ -109,7 +109,7 @@ fn try_from_trusted_len_iter() {
     let values = b"abcc".to_vec().into();
     assert_eq!(
         b,
-        Utf8Array::<i32>::from_data(DataType::Utf8, offsets, values, None)
+        Utf8Array::<i32>::new(DataType::Utf8, offsets, values, None)
     );
 }
 
@@ -147,7 +147,7 @@ fn out_of_bounds_offsets_panics() {
 fn index_out_of_bounds_panics() {
     let offsets = vec![0, 1, 2, 4].try_into().unwrap();
     let values = b"abbb".to_vec().into();
-    let array = Utf8Array::<i32>::from_data(DataType::Utf8, offsets, values, None);
+    let array = Utf8Array::<i32>::new(DataType::Utf8, offsets, values, None);
 
     array.value(3);
 }
@@ -165,7 +165,7 @@ fn into_mut_1() {
     let values = Buffer::from(b"a".to_vec());
     let a = values.clone(); // cloned values
     assert_eq!(a, values);
-    let array = Utf8Array::<i32>::from_data(DataType::Utf8, offsets, values, None);
+    let array = Utf8Array::<i32>::new(DataType::Utf8, offsets, values, None);
     assert!(array.into_mut().is_left());
 }
 
@@ -175,7 +175,7 @@ fn into_mut_2() {
     let values = b"a".to_vec().into();
     let a = offsets.clone(); // cloned offsets
     assert_eq!(a, offsets);
-    let array = Utf8Array::<i32>::from_data(DataType::Utf8, offsets, values, None);
+    let array = Utf8Array::<i32>::new(DataType::Utf8, offsets, values, None);
     assert!(array.into_mut().is_left());
 }
 

--- a/tests/it/array/utf8/mutable.rs
+++ b/tests/it/array/utf8/mutable.rs
@@ -67,19 +67,17 @@ fn pop_all_some() {
 
 /// Safety guarantee
 #[test]
-#[should_panic]
 fn not_utf8() {
     let offsets = vec![0, 4].try_into().unwrap();
     let values = vec![0, 159, 146, 150]; // invalid utf8
-    MutableUtf8Array::<i32>::from_data(DataType::Utf8, offsets, values, None);
+    assert!(MutableUtf8Array::<i32>::try_new(DataType::Utf8, offsets, values, None).is_err());
 }
 
 #[test]
-#[should_panic]
 fn wrong_data_type() {
     let offsets = vec![0, 4].try_into().unwrap();
     let values = vec![1, 2, 3, 4];
-    MutableUtf8Array::<i32>::from_data(DataType::Int8, offsets, values, None);
+    assert!(MutableUtf8Array::<i32>::try_new(DataType::Int8, offsets, values, None).is_err());
 }
 
 #[test]

--- a/tests/it/compute/take.rs
+++ b/tests/it/compute/take.rs
@@ -71,7 +71,7 @@ fn create_test_struct() -> StructArray {
         Field::new("a", DataType::Boolean, true),
         Field::new("b", DataType::Int32, true),
     ];
-    StructArray::from_data(
+    StructArray::new(
         DataType::Struct(fields),
         vec![boolean.boxed(), int.boxed()],
         validity,
@@ -92,7 +92,7 @@ fn test_struct_with_nulls() {
         .into_iter()
         .collect::<MutableBitmap>()
         .into();
-    let expected = StructArray::from_data(
+    let expected = StructArray::new(
         array.data_type().clone(),
         vec![boolean.boxed(), int.boxed()],
         validity,
@@ -171,10 +171,10 @@ fn unsigned_take() {
 #[test]
 fn list_with_no_none() {
     let values = Buffer::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::new(DataType::Int32, values, None);
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-    let array = ListArray::<i32>::from_data(
+    let array = ListArray::<i32>::new(
         data_type,
         vec![0, 2, 2, 6, 9, 10].try_into().unwrap(),
         Box::new(values),
@@ -185,9 +185,9 @@ fn list_with_no_none() {
     let result = take(&array, &indices).unwrap();
 
     let expected_values = Buffer::from(vec![9, 6, 7, 8]);
-    let expected_values = PrimitiveArray::<i32>::from_data(DataType::Int32, expected_values, None);
+    let expected_values = PrimitiveArray::<i32>::new(DataType::Int32, expected_values, None);
     let expected_type = ListArray::<i32>::default_datatype(DataType::Int32);
-    let expected = ListArray::<i32>::from_data(
+    let expected = ListArray::<i32>::new(
         expected_type,
         vec![0, 1, 1, 4].try_into().unwrap(),
         Box::new(expected_values),
@@ -200,13 +200,13 @@ fn list_with_no_none() {
 #[test]
 fn list_with_none() {
     let values = Buffer::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::new(DataType::Int32, values, None);
 
     let validity_values = vec![true, false, true, true, true];
     let validity = Bitmap::from_trusted_len_iter(validity_values.into_iter());
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-    let array = ListArray::<i32>::from_data(
+    let array = ListArray::<i32>::new(
         data_type,
         vec![0, 2, 2, 6, 9, 10].try_into().unwrap(),
         Box::new(values),
@@ -262,10 +262,10 @@ fn list_both_validity() {
 #[test]
 fn test_nested() {
     let values = Buffer::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    let values = PrimitiveArray::<i32>::from_data(DataType::Int32, values, None);
+    let values = PrimitiveArray::<i32>::new(DataType::Int32, values, None);
 
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-    let array = ListArray::<i32>::from_data(
+    let array = ListArray::<i32>::new(
         data_type,
         vec![0, 2, 4, 7, 7, 8, 10].try_into().unwrap(),
         Box::new(values),
@@ -273,7 +273,7 @@ fn test_nested() {
     );
 
     let data_type = ListArray::<i32>::default_datatype(array.data_type().clone());
-    let nested = ListArray::<i32>::from_data(
+    let nested = ListArray::<i32>::new(
         data_type,
         vec![0, 2, 5, 6].try_into().unwrap(),
         Box::new(array),
@@ -285,10 +285,10 @@ fn test_nested() {
 
     // expected data
     let expected_values = Buffer::from(vec![1, 2, 3, 4, 5, 6, 7, 8]);
-    let expected_values = PrimitiveArray::<i32>::from_data(DataType::Int32, expected_values, None);
+    let expected_values = PrimitiveArray::<i32>::new(DataType::Int32, expected_values, None);
 
     let expected_data_type = ListArray::<i32>::default_datatype(DataType::Int32);
-    let expected_array = ListArray::<i32>::from_data(
+    let expected_array = ListArray::<i32>::new(
         expected_data_type,
         vec![0, 2, 4, 7, 7, 8].try_into().unwrap(),
         Box::new(expected_values),
@@ -296,7 +296,7 @@ fn test_nested() {
     );
 
     let expected_data_type = ListArray::<i32>::default_datatype(expected_array.data_type().clone());
-    let expected = ListArray::<i32>::from_data(
+    let expected = ListArray::<i32>::new(
         expected_data_type,
         vec![0, 2, 5].try_into().unwrap(),
         Box::new(expected_array),

--- a/tests/it/ffi/data.rs
+++ b/tests/it/ffi/data.rs
@@ -293,7 +293,7 @@ fn struct_() -> Result<()> {
     let values = vec![Int32Array::from([Some(1), None, Some(3)]).boxed()];
     let validity = Bitmap::from([true, false, true]);
 
-    let array = StructArray::from_data(data_type, values, validity.into());
+    let array = StructArray::new(data_type, values, validity.into());
 
     test_round_trip(array)
 }

--- a/tests/it/io/avro/read.rs
+++ b/tests/it/io/avro/read.rs
@@ -116,24 +116,24 @@ pub(super) fn data() -> Chunk<Box<dyn Array>> {
         BooleanArray::from_slice([true, false]).boxed(),
         Utf8Array::<i32>::from([Some("foo"), None]).boxed(),
         array.into_box(),
-        StructArray::from_data(
+        StructArray::new(
             DataType::Struct(vec![Field::new("e", DataType::Float64, false)]),
-            vec![Box::new(PrimitiveArray::<f64>::from_slice([1.0, 2.0]))],
+            vec![PrimitiveArray::<f64>::from_slice([1.0, 2.0]).boxed()],
             None,
         )
         .boxed(),
         DictionaryArray::try_from_keys(
             Int32Array::from_slice([1, 0]),
-            Box::new(Utf8Array::<i32>::from_slice(["SPADES", "HEARTS"])),
+            Utf8Array::<i32>::from_slice(["SPADES", "HEARTS"]).boxed(),
         )
         .unwrap()
         .boxed(),
         PrimitiveArray::<i128>::from_slice([12345678i128, -12345678i128])
             .to(DataType::Decimal(18, 5))
             .boxed(),
-        StructArray::from_data(
+        StructArray::new(
             DataType::Struct(vec![Field::new("e", DataType::Float64, false)]),
-            vec![Box::new(PrimitiveArray::<f64>::from_slice([1.0, 0.0]))],
+            vec![PrimitiveArray::<f64>::from_slice([1.0, 0.0]).boxed()],
             Some([true, false].into()),
         )
         .boxed(),

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -23,7 +23,7 @@ fn read_json() -> Result<()> {
 
     let result = read::deserialize(&json, data_type)?;
 
-    let expected = StructArray::from_data(
+    let expected = StructArray::new(
         DataType::Struct(vec![Field::new("a", DataType::Int64, true)]),
         vec![Box::new(Int64Array::from_slice([1, 2, 3])) as _],
         None,

--- a/tests/it/io/json/write.rs
+++ b/tests/it/io/json/write.rs
@@ -19,7 +19,6 @@ macro_rules! test {
 #[test]
 fn int32() -> Result<()> {
     let array = Int32Array::from([Some(1), Some(2), Some(3), None, Some(5)]);
-    //let b = Utf8Array::<i32>::from(&vec![Some("a"), Some("b"), Some("c"), Some("d"), None]);
 
     let expected = r#"[1,2,3,null,5]"#;
 
@@ -62,7 +61,7 @@ fn struct_() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
+    let array = StructArray::new(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
 
     let expected = r#"[{"c1":1,"c2":"a"},{"c1":2,"c2":"b"},{"c1":3,"c2":"c"},{"c1":null,"c2":"d"},{"c1":5,"c2":null}]"#;
 
@@ -80,18 +79,19 @@ fn nested_struct_with_validity() -> Result<()> {
         Field::new("c12", DataType::Struct(inner.clone()), false),
     ];
 
-    let c1 = StructArray::from_data(
+    let c1 = StructArray::new(
         DataType::Struct(fields),
         vec![
-            Box::new(Int32Array::from(&[Some(1), None, Some(5)])),
-            Box::new(StructArray::from_data(
+            Int32Array::from(&[Some(1), None, Some(5)]).boxed(),
+            StructArray::new(
                 DataType::Struct(inner),
                 vec![
-                    Box::new(Utf8Array::<i32>::from(&vec![None, Some("f"), Some("g")])),
-                    Box::new(Int32Array::from(&[Some(20), None, Some(43)])),
+                    Utf8Array::<i32>::from(&vec![None, Some("f"), Some("g")]).boxed(),
+                    Int32Array::from(&[Some(20), None, Some(43)]).boxed(),
                 ],
                 Some(Bitmap::from([false, true, true])),
-            )),
+            )
+            .boxed(),
         ],
         Some(Bitmap::from([true, true, false])),
     );
@@ -101,7 +101,7 @@ fn nested_struct_with_validity() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
+    let array = StructArray::new(data_type, vec![c1.boxed(), c2.boxed()], None);
 
     let expected = r#"[{"c1":{"c11":1,"c12":null},"c2":"a"},{"c1":{"c11":null,"c12":{"c121":"f","c122":null}},"c2":"b"},{"c1":null,"c2":"c"}]"#;
 
@@ -116,11 +116,11 @@ fn nested_struct() -> Result<()> {
         Field::new("c12", DataType::Struct(vec![c121.clone()]), false),
     ];
 
-    let c1 = StructArray::from_data(
+    let c1 = StructArray::new(
         DataType::Struct(fields),
         vec![
-            Box::new(Int32Array::from(&[Some(1), None, Some(5)])),
-            Box::new(StructArray::from_data(
+            Int32Array::from(&[Some(1), None, Some(5)]).boxed(),
+            StructArray::new(
                 DataType::Struct(vec![c121]),
                 vec![Box::new(Utf8Array::<i32>::from(&vec![
                     Some("e"),
@@ -128,7 +128,8 @@ fn nested_struct() -> Result<()> {
                     Some("g"),
                 ]))],
                 None,
-            )),
+            )
+            .boxed(),
         ],
         None,
     );
@@ -139,7 +140,7 @@ fn nested_struct() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
+    let array = StructArray::new(data_type, vec![c1.boxed(), c2.boxed()], None);
 
     let expected = r#"[{"c1":{"c11":1,"c12":{"c121":"e"}},"c2":"a"},{"c1":{"c11":null,"c12":{"c121":"f"}},"c2":"b"},{"c1":{"c11":5,"c12":{"c121":"g"}},"c2":"c"}]"#;
 
@@ -168,7 +169,7 @@ fn struct_with_list_field() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
+    let array = StructArray::new(data_type, vec![c1.boxed(), c2.boxed()], None);
 
     let expected = r#"[{"c1":["a","a1"],"c2":1},{"c1":["b"],"c2":2},{"c1":["c"],"c2":3},{"c1":["d"],"c2":4},{"c1":["e"],"c2":5}]"#;
 
@@ -203,7 +204,7 @@ fn nested_list() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
+    let array = StructArray::new(data_type, vec![c1.boxed(), c2.boxed()], None);
 
     let expected =
         r#"[{"c1":[[1,2],[3]],"c2":"foo"},{"c1":[],"c2":"bar"},{"c1":[[4,5,6]],"c2":null}]"#;
@@ -298,11 +299,11 @@ fn list_of_struct() -> Result<()> {
         false,
     )));
 
-    let s = StructArray::from_data(
+    let s = StructArray::new(
         DataType::Struct(fields),
         vec![
-            Box::new(Int32Array::from(&[Some(1), None, Some(5)])),
-            Box::new(StructArray::from_data(
+            Int32Array::from(&[Some(1), None, Some(5)]).boxed(),
+            StructArray::new(
                 DataType::Struct(inner),
                 vec![Box::new(Utf8Array::<i32>::from(&vec![
                     Some("e"),
@@ -310,7 +311,8 @@ fn list_of_struct() -> Result<()> {
                     Some("g"),
                 ]))],
                 Some(Bitmap::from([false, true, true])),
-            )),
+            )
+            .boxed(),
         ],
         Some(Bitmap::from([true, true, false])),
     );
@@ -319,11 +321,11 @@ fn list_of_struct() -> Result<()> {
     // [{"c11": 1, "c12": {"c121": "e"}}, {"c12": {"c121": "f"}}],
     // null,
     // [{"c11": 5, "c12": {"c121": "g"}}]
-    let c1 = ListArray::<i32>::from_data(
+    let c1 = ListArray::<i32>::new(
         c1_datatype,
         Buffer::from(vec![0, 2, 2, 3]).try_into().unwrap(),
-        Box::new(s),
-        Some(Bitmap::from_u8_slice([0b00000101], 3)),
+        s.boxed(),
+        Some(Bitmap::from([true, false, true])),
     );
 
     let c2 = Int32Array::from_slice([1, 2, 3]);
@@ -332,7 +334,7 @@ fn list_of_struct() -> Result<()> {
         Field::new("c1", c1.data_type().clone(), true),
         Field::new("c2", c2.data_type().clone(), true),
     ]);
-    let array = StructArray::from_data(data_type, vec![Box::new(c1) as _, Box::new(c2)], None);
+    let array = StructArray::new(data_type, vec![c1.boxed(), c2.boxed()], None);
 
     let expected = r#"[{"c1":[{"c11":1,"c12":null},{"c11":null,"c12":{"c121":"f"}}],"c2":1},{"c1":null,"c2":2},{"c1":[null],"c2":3}]"#;
 
@@ -359,8 +361,7 @@ fn escaped_quotation_marks_in_utf8() -> Result<()> {
 
 #[test]
 fn write_date32() -> Result<()> {
-    let array =
-        PrimitiveArray::from_data(DataType::Date32, vec![1000i32, 8000, 10000].into(), None);
+    let array = PrimitiveArray::new(DataType::Date32, vec![1000i32, 8000, 10000].into(), None);
 
     let expected = r#"["1972-09-27","1991-11-27","1997-05-19"]"#;
 
@@ -369,7 +370,7 @@ fn write_date32() -> Result<()> {
 
 #[test]
 fn write_timestamp() -> Result<()> {
-    let array = PrimitiveArray::from_data(
+    let array = PrimitiveArray::new(
         DataType::Timestamp(TimeUnit::Second, None),
         vec![10i64, 1 << 32, 1 << 33].into(),
         None,

--- a/tests/it/io/ndjson/read.rs
+++ b/tests/it/io/ndjson/read.rs
@@ -103,9 +103,9 @@ fn case_nested_struct() -> (String, Box<dyn Array>) {
         BooleanArray::from([None, None, Some(true), None]).boxed(),
     ];
 
-    let values = vec![StructArray::from_data(inner, values, None).boxed()];
+    let values = vec![StructArray::new(inner, values, None).boxed()];
 
-    let array = Box::new(StructArray::from_data(data_type, values, None));
+    let array = StructArray::new(data_type, values, None).boxed();
 
     (ndjson.to_string(), array)
 }

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -201,9 +201,7 @@ pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
         ])),
         "list_nested_i64"
         | "list_nested_inner_required_i64"
-        | "list_nested_inner_required_required_i64" => {
-            Box::new(NullArray::from_data(DataType::Null, 1))
-        }
+        | "list_nested_inner_required_required_i64" => Box::new(NullArray::new(DataType::Null, 1)),
         other => unreachable!("{}", other),
     };
 
@@ -211,16 +209,12 @@ pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
         "list_int64_required_required" => {
             // [[0, 1], [], [2, 0, 3], [4, 5, 6], [], [7, 8, 9], [], [10]]
             let data_type = DataType::List(Box::new(Field::new("item", DataType::Int64, false)));
-            Box::new(ListArray::<i32>::from_data(
-                data_type, offsets, values, None,
-            ))
+            ListArray::<i32>::new(data_type, offsets, values, None).boxed()
         }
         "list_int64_optional_required" => {
             // [[0, 1], [], [2, 0, 3], [4, 5, 6], [], [7, 8, 9], [], [10]]
             let data_type = DataType::List(Box::new(Field::new("item", DataType::Int64, true)));
-            Box::new(ListArray::<i32>::from_data(
-                data_type, offsets, values, None,
-            ))
+            ListArray::<i32>::new(data_type, offsets, values, None).boxed()
         }
         "list_nested_i64" => {
             // [[0, 1]], None, [[2, None], [3]], [[4, 5], [6]], [], [[7], None, [9]], [[], [None], None], [[10]]
@@ -295,9 +289,7 @@ pub fn pyarrow_nested_nullable(column: &str) -> Box<dyn Array> {
             // [0, 2, 2, 5, 8, 8, 11, 11, 12]
             // [[a1, a2], None, [a3, a4, a5], [a6, a7, a8], [], [a9, a10, a11], None, [a12]]
             let data_type = DataType::List(Box::new(field));
-            Box::new(ListArray::<i32>::from_data(
-                data_type, offsets, values, validity,
-            ))
+            ListArray::<i32>::new(data_type, offsets, values, validity).boxed()
         }
     }
 }
@@ -1197,7 +1189,7 @@ fn generic_data() -> Result<(Schema, Chunk<Box<dyn Array>>)> {
     let values = BinaryArray::<i32>::from_slice([b"ab", b"ac"]).boxed();
     let array4 = DictionaryArray::try_from_keys(indices.clone(), values).unwrap();
 
-    let values = FixedSizeBinaryArray::from_data(
+    let values = FixedSizeBinaryArray::new(
         DataType::FixedSizeBinary(2),
         vec![b'a', b'b', b'a', b'c'].into(),
         None,

--- a/tests/it/io/print.rs
+++ b/tests/it/io/print.rs
@@ -327,7 +327,7 @@ fn write_struct() -> Result<()> {
 
     let validity = Some(Bitmap::from(&[true, false, true]));
 
-    let array = StructArray::from_data(DataType::Struct(fields), values, validity);
+    let array = StructArray::new(DataType::Struct(fields), values, validity);
 
     let columns = Chunk::new(vec![&array as &dyn Array]);
 
@@ -363,7 +363,7 @@ fn write_union() -> Result<()> {
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
     ];
 
-    let array = UnionArray::from_data(data_type, types, fields, None);
+    let array = UnionArray::new(data_type, types, fields, None);
 
     let batch = Chunk::new(vec![&array as &dyn Array]);
 


### PR DESCRIPTION
This function is a very old artifact from `ArrayData` and has been superseded by either `new` or `try_new`, which are more idiomatic.
