### PR TITLE
Fixed csv infer_schema on empty fields

### DIFF
--- a/src/io/csv/read/infer_schema.rs
+++ b/src/io/csv/read/infer_schema.rs
@@ -46,7 +46,9 @@ pub fn infer_schema<R: Read + Seek, F: Fn(&[u8]) -> DataType>(
 
         for (i, column) in column_types.iter_mut().enumerate() {
             if let Some(string) = record.get(i) {
-                column.insert(infer(string));
+                if !string.is_empty() {
+                    column.insert(infer(string));
+                }
             }
         }
     }

--- a/tests/it/io/csv/read.rs
+++ b/tests/it/io/csv/read.rs
@@ -88,6 +88,24 @@ fn infer_ints() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn infer_ints_with_empty_fields() -> Result<()> {
+    let file = Cursor::new("1,2,3\n1,3,5\n2,,4");
+    let mut reader = ReaderBuilder::new().from_reader(file);
+
+    let (fields, _) = infer_schema(&mut reader, Some(10), false, &infer)?;
+
+    assert_eq!(
+        fields,
+        vec![
+            Field::new("column_1", DataType::Int64, true),
+            Field::new("column_2", DataType::Int64, true),
+            Field::new("column_3", DataType::Int64, true),
+        ]
+    );
+    Ok(())
+}
+
 fn test_deserialize(input: &str, data_type: DataType) -> Result<Box<dyn Array>> {
     let reader = std::io::Cursor::new(input);
     let mut reader = ReaderBuilder::new().has_headers(false).from_reader(reader);


### PR DESCRIPTION
The default `infer` function provided by `src/io/csv/utils.rs` infers an empty field as `DataType::Utf8`. If the same column contains non empty fields containing valid `DataType::Float64` data the column in `infer_schema` will then contain both DataTypes. When `merge_schema` is called it will decide that `DataType::Utf8` has precedence over `DataType::Float64` and set the column type to `DataType::Float64`.

If we instead decline to infer anything for a field without any data we will in the end get `DataType::Float64` if the column contained other fields with valid f64 data and if we only had empty data for the column it will still default to `DataType::Utf8`. 