### PR TITLE
Improve primitive filter performance

### DIFF
--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -1,16 +1,13 @@
 //! Contains operators to filter arrays such as [`filter`].
 use crate::array::growable::{make_growable, Growable};
-use crate::bitmap::utils::{BitChunk, BitChunkIterExact, BitChunksExact};
+use crate::bitmap::utils::{BitChunkIterExact, BitChunksExact};
 use crate::bitmap::{utils::SlicesIterator, Bitmap, MutableBitmap};
 use crate::chunk::Chunk;
 use crate::datatypes::DataType;
 use crate::error::Result;
-use crate::types::simd::{NativeSimd, Simd};
+use crate::types::simd::Simd;
 use crate::types::BitChunkOnes;
 use crate::{array::*, types::NativeType};
-use num_traits::Bounded;
-use num_traits::One;
-use num_traits::Zero;
 
 /// Function that can filter arbitrary arrays
 pub type Filter<'a> = Box<dyn Fn(&dyn Array) -> Box<dyn Array> + 'a + Send + Sync>;

--- a/src/types/bit_chunk.rs
+++ b/src/types/bit_chunk.rs
@@ -129,6 +129,12 @@ impl<T: BitChunk> BitChunkOnes<T> {
             remaining: value.count_ones() as usize,
         }
     }
+
+    #[inline]
+    #[cfg(feature = "compute_filter")]
+    pub(crate) fn from_known_count(value: T, remaining: usize) -> Self {
+        Self { value, remaining }
+    }
 }
 
 impl<T: BitChunk> Iterator for BitChunkOnes<T> {


### PR DESCRIPTION
Several changes to improve performance of filters on primitive arrays.

Main ideas:

1. Simplification of the kernel itself and thereby always take chunks of `64` bits. The datatype dictated how many bits were used in a single pass. So that was 8bits for `u8` and 64 bits for `f64`. This simplifies it by using `64` bits for all numeric types.

2. Use (leading) bit count information to have a single branch and memcopy if leading_ones == total_ones
 

```
filter 2^10 f32         time:   [623.51 ns 623.77 ns 624.01 ns]                             
                        change: [-16.418% -16.296% -16.174%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

filter null 2^10 f32    time:   [2.4161 µs 2.4569 µs 2.4977 µs]                                  
                        change: [-15.140% -14.458% -13.565%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  1 (1.00%) high mild
  15 (15.00%) high severe

filter 2^12 f32         time:   [2.3835 µs 2.3853 µs 2.3874 µs]                             
                        change: [-16.298% -16.184% -16.065%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

filter null 2^12 f32    time:   [10.568 µs 10.602 µs 10.643 µs]                                  
                        change: [-4.5619% -4.2961% -4.0279%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

filter 2^14 f32         time:   [9.8404 µs 9.8559 µs 9.8743 µs]                             
                        change: [-18.997% -18.861% -18.728%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  10 (10.00%) high mild
  4 (4.00%) high severe

filter null 2^14 f32    time:   [47.683 µs 47.700 µs 47.721 µs]                                  
                        change: [-15.516% -15.402% -15.296%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

filter 2^16 f32         time:   [41.144 µs 41.175 µs 41.209 µs]                             
                        change: [-37.321% -37.203% -37.082%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  8 (8.00%) high mild
  6 (6.00%) high severe

filter null 2^16 f32    time:   [213.73 µs 214.01 µs 214.35 µs]                                 
                        change: [-14.420% -14.251% -14.085%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  7 (7.00%) high mild
  2 (2.00%) high severe

filter 2^18 f32         time:   [166.40 µs 166.77 µs 167.35 µs]                            
                        change: [-36.796% -36.705% -36.569%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe

filter null 2^18 f32    time:   [806.12 µs 808.42 µs 812.17 µs]                                 
                        change: [-13.351% -12.972% -12.621%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

filter 2^20 f32         time:   [686.71 µs 688.53 µs 690.58 µs]                            
                        change: [-31.764% -31.492% -31.178%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  5 (5.00%) high mild
  7 (7.00%) high severe

filter null 2^20 f32    time:   [3.4409 ms 3.4441 ms 3.4475 ms]                                  
                        change: [-5.4058% -5.2555% -5.1137%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

filter context u8       time:   [107.85 µs 107.97 µs 108.12 µs]                              
                        change: [-19.619% -19.495% -19.369%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  2 (2.00%) high severe

Benchmarking filter context u8 high selectivity: Collecting 100 samples in estimated 5.0046 s (2.5M iteratio                                                                                                            filter context u8 high selectivity                        
                        time:   [1.9686 µs 1.9737 µs 1.9800 µs]
                        change: [-12.797% -12.583% -12.337%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  7 (7.00%) high mild
  7 (7.00%) high severe

Benchmarking filter context u8 low selectivity: Collecting 100 samples in estimated 5.0004 s (15M iterations                                                                                                            filter context u8 low selectivity                        
                        time:   [336.72 ns 337.03 ns 337.36 ns]
                        change: [-17.581% -17.147% -16.847%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
```