### PR TITLE
fix: correct for endiannes in leading ones compute

### DIFF
--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -12,6 +12,15 @@ use crate::{array::*, types::NativeType};
 /// Function that can filter arbitrary arrays
 pub type Filter<'a> = Box<dyn Fn(&dyn Array) -> Box<dyn Array> + 'a + Send + Sync>;
 
+#[inline]
+fn get_leading_ones(chunk: u64) -> u32 {
+    if cfg!(target_endian = "little") {
+        chunk.trailing_ones()
+    } else {
+        chunk.leading_ones()
+    }
+}
+
 /// # Safety
 /// This assumes that the `mask_chunks` contains a number of set/true items equal
 /// to `filter_count`
@@ -29,7 +38,7 @@ where
         .zip(mask_chunks.by_ref())
         .for_each(|(chunk, mask_chunk)| {
             let ones = mask_chunk.count_ones();
-            let leading_ones = mask_chunk.leading_ones();
+            let leading_ones = get_leading_ones(mask_chunk);
 
             if ones == leading_ones {
                 let size = leading_ones as usize;
@@ -91,7 +100,7 @@ where
         .zip(mask_chunks.by_ref())
         .for_each(|((chunk, validity_chunk), mask_chunk)| {
             let ones = mask_chunk.count_ones();
-            let leading_ones = mask_chunk.leading_ones();
+            let leading_ones = get_leading_ones(mask_chunk);
 
             if ones == leading_ones {
                 let size = leading_ones as usize;

--- a/tests/it/compute/filter.rs
+++ b/tests/it/compute/filter.rs
@@ -15,7 +15,7 @@ fn array_slice() {
 
 #[test]
 fn array_large_filter_chunks() {
-    let len = 65 as usize;
+    let len = 65usize;
     let a = Int32Array::from_iter((0..(len as i32)).map(Some));
 
     let init = vec![true, true, true, false, false, true];

--- a/tests/it/compute/filter.rs
+++ b/tests/it/compute/filter.rs
@@ -14,6 +14,26 @@ fn array_slice() {
 }
 
 #[test]
+fn array_large_filter_chunks() {
+    let len = 65 as usize;
+    let a = Int32Array::from_iter((0..(len as i32)).map(Some));
+
+    let init = vec![true, true, true, false, false, true];
+    let remaining = len - init.len();
+    let iter = init
+        .into_iter()
+        .chain(std::iter::repeat(false).take(remaining))
+        .map(Some);
+    let b = BooleanArray::from_iter(iter);
+
+    let c = filter(&a, &b).unwrap();
+
+    let expected = Int32Array::from_slice([0, 1, 2, 5]);
+
+    assert_eq!(expected, c.as_ref());
+}
+
+#[test]
 fn array_low_density() {
     // this test exercises the all 0's branch of the filter algorithm
     let mut data_values = (1..=65).collect::<Vec<i32>>();
@@ -71,7 +91,7 @@ fn string_array_simple() {
 }
 
 #[test]
-fn primative_array_with_null() {
+fn primitive_array_with_null() {
     let a = Int32Array::from(&[Some(5), None]);
     let b = BooleanArray::from_slice(vec![false, true]);
     let c = filter(&a, &b).unwrap();


### PR DESCRIPTION
Fix a bug introduced with the filter optimization. Trailing `trailing_ones` goes from LSB to MSB whilst I mentally mapped it L -> R. 

This fixes that.