### PR TITLE
add toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2022-12-05"


### PR DESCRIPTION
This ensures that everyone uses the same rustc as we have defined in CI.