### PR TITLE
allow empty structs

### DIFF
--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -51,9 +51,6 @@ impl StructArray {
         validity: Option<Bitmap>,
     ) -> Result<Self, Error> {
         let fields = Self::try_get_fields(&data_type)?;
-        if fields.is_empty() {
-            return Err(Error::oos("A StructArray must contain at least one field"));
-        }
         if fields.len() != values.len() {
             return Err(Error::oos(
                 "A StructArray must have a number of fields in its DataType equal to the number of child values",


### PR DESCRIPTION
Empty structs are very useful as they map directly to empty objects/ dictionaries in host languages. See: https://github.com/pola-rs/polars/issues/6001

I believe the specification allows for empty structs as pyarrow also is able to generate them:

```python
>>> import pyarrow as pa
>>> pa.struct([])
StructType(struct<>)
```