### PR TITLE
Fix incorrect downcast in `estimated_size_bytes`

### DIFF
--- a/src/compute/aggregate/memory.rs
+++ b/src/compute/aggregate/memory.rs
@@ -67,7 +67,7 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
                 + validity_size(array.validity())
         }
         FixedSizeList => {
-            let array = array.as_any().downcast_ref::<ListArray<i64>>().unwrap();
+            let array = array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
             estimated_bytes_size(array.values().as_ref()) + validity_size(array.validity())
         }
         LargeList => {

--- a/tests/it/compute/aggregate/memory.rs
+++ b/tests/it/compute/aggregate/memory.rs
@@ -1,4 +1,4 @@
-use arrow2::{array::*, compute::aggregate::estimated_bytes_size};
+use arrow2::{array::*, compute::aggregate::estimated_bytes_size, datatypes::{DataType, Field}};
 
 #[test]
 fn primitive() {
@@ -16,4 +16,12 @@ fn boolean() {
 fn utf8() {
     let a = Utf8Array::<i32>::from_slice(["aaa"]);
     assert_eq!(3 + 2 * std::mem::size_of::<i32>(), estimated_bytes_size(&a));
+}
+
+#[test]
+fn fixed_size_list() {
+    let data_type = DataType::FixedSizeList(Box::new(Field::new("elem", DataType::Float32, false)), 3);
+    let values = Box::new(Float32Array::from_slice([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]));
+    let a = FixedSizeListArray::new(data_type, values, None);
+    assert_eq!(6 * std::mem::size_of::<f32>(), estimated_bytes_size(&a));
 }

--- a/tests/it/compute/aggregate/memory.rs
+++ b/tests/it/compute/aggregate/memory.rs
@@ -1,4 +1,8 @@
-use arrow2::{array::*, compute::aggregate::estimated_bytes_size, datatypes::{DataType, Field}};
+use arrow2::{
+    array::*,
+    compute::aggregate::estimated_bytes_size,
+    datatypes::{DataType, Field},
+};
 
 #[test]
 fn primitive() {
@@ -20,7 +24,8 @@ fn utf8() {
 
 #[test]
 fn fixed_size_list() {
-    let data_type = DataType::FixedSizeList(Box::new(Field::new("elem", DataType::Float32, false)), 3);
+    let data_type =
+        DataType::FixedSizeList(Box::new(Field::new("elem", DataType::Float32, false)), 3);
     let values = Box::new(Float32Array::from_slice([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]));
     let a = FixedSizeListArray::new(data_type, values, None);
     assert_eq!(6 * std::mem::size_of::<f32>(), estimated_bytes_size(&a));


### PR DESCRIPTION
Looks like this might have been a copy-and-paste error?

Added a unit-test for fixed_size_list as well.