### PR TITLE
Fix calculation of nested rep levels

### DIFF
--- a/src/io/parquet/write/nested/rep.rs
+++ b/src/io/parquet/write/nested/rep.rs
@@ -5,21 +5,31 @@ trait DebugIter: Iterator<Item = usize> + std::fmt::Debug {}
 
 impl<A: Iterator<Item = usize> + std::fmt::Debug> DebugIter for A {}
 
-fn iter<'a>(nested: &'a [Nested]) -> Vec<Box<dyn DebugIter + 'a>> {
+enum RepIter<'a> {
+    Required(Box<dyn DebugIter + 'a>),
+    Repeated(Box<dyn DebugIter + 'a>),
+}
+
+fn iter<'a>(nested: &'a [Nested]) -> Vec<RepIter<'a>> {
     nested
         .iter()
         .enumerate()
         .filter_map(|(i, nested)| match nested {
             Nested::Primitive(_, _, _) => None,
-            Nested::List(nested) => Some(Box::new(to_length(nested.offsets)) as Box<dyn DebugIter>),
-            Nested::LargeList(nested) => {
-                Some(Box::new(to_length(nested.offsets)) as Box<dyn DebugIter>)
-            }
-            Nested::Struct(_, _, length) => {
-                // only return 1, 1, 1, (x len) if struct is outer structure.
-                // otherwise treat as leaf
+            Nested::List(nested) => Some(RepIter::Repeated(
+                Box::new(to_length(nested.offsets)) as Box<dyn DebugIter>
+            )),
+            Nested::LargeList(nested) => Some(RepIter::Repeated(
+                Box::new(to_length(nested.offsets)) as Box<dyn DebugIter>,
+            )),
+            Nested::Struct(_, is_optional, length) => {
+                let iter = Box::new(std::iter::repeat(1usize).take(*length)) as Box<dyn DebugIter>;
                 if i == 0 {
-                    Some(Box::new(std::iter::repeat(1usize).take(*length)) as Box<dyn DebugIter>)
+                    if *is_optional {
+                        Some(RepIter::Repeated(iter))
+                    } else {
+                        Some(RepIter::Required(iter))
+                    }
                 } else {
                     None
                 }
@@ -29,6 +39,10 @@ fn iter<'a>(nested: &'a [Nested]) -> Vec<Box<dyn DebugIter + 'a>> {
 }
 
 pub fn num_values(nested: &[Nested]) -> usize {
+    _num_values(nested, true)
+}
+
+fn _num_values(nested: &[Nested], count_required: bool) -> usize {
     let iterators = iter(nested);
     let depth = iterators.len();
 
@@ -36,6 +50,17 @@ pub fn num_values(nested: &[Nested]) -> usize {
         .into_iter()
         .enumerate()
         .map(|(index, lengths)| {
+            let lengths = match lengths {
+                RepIter::Repeated(i) => i,
+                RepIter::Required(i) => {
+                    if count_required {
+                        i
+                    } else {
+                        Box::new(std::iter::empty()) as Box<dyn DebugIter>
+                    }
+                }
+            };
+
             if index == depth - 1 {
                 lengths
                     .map(|length| if length == 0 { 1 } else { length })
@@ -73,9 +98,16 @@ pub struct RepLevelsIter<'a> {
 
 impl<'a> RepLevelsIter<'a> {
     pub fn new(nested: &'a [Nested]) -> Self {
-        let remaining_values = num_values(nested);
+        let remaining_values = _num_values(nested, false);
 
-        let iter = iter(nested);
+        let iter: Vec<_> = iter(nested)
+            .into_iter()
+            .flat_map(|i| match i {
+                RepIter::Repeated(ls) => Some(ls),
+                _ => None,
+            })
+            .collect();
+
         let remaining = std::iter::repeat(0).take(iter.len()).collect();
 
         Self {
@@ -92,25 +124,30 @@ impl<'a> Iterator for RepLevelsIter<'a> {
     type Item = u32;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if *self.remaining.last().unwrap() > 0 {
-            *self.remaining.last_mut().unwrap() -= 1;
+        match self.remaining.last() {
+            Some(v) => {
+                if *v > 0 {
+                    *self.remaining.last_mut().unwrap() -= 1;
 
-            let total = self.total;
-            self.total = 0;
-            let r = Some((self.current_level - total) as u32);
+                    let total = self.total;
+                    self.total = 0;
+                    let r = Some((self.current_level - total) as u32);
 
-            for level in 0..self.current_level - 1 {
-                let level = self.remaining.len() - level - 1;
-                if self.remaining[level] == 0 {
-                    self.current_level -= 1;
-                    self.remaining[level.saturating_sub(1)] -= 1;
+                    for level in 0..self.current_level - 1 {
+                        let level = self.remaining.len() - level - 1;
+                        if self.remaining[level] == 0 {
+                            self.current_level -= 1;
+                            self.remaining[level.saturating_sub(1)] -= 1;
+                        }
+                    }
+                    if self.remaining[0] == 0 {
+                        self.current_level -= 1;
+                    }
+                    self.remaining_values -= 1;
+                    return r;
                 }
             }
-            if self.remaining[0] == 0 {
-                self.current_level -= 1;
-            }
-            self.remaining_values -= 1;
-            return r;
+            None => return None,
         }
 
         self.total = 0;
@@ -158,7 +195,23 @@ mod tests {
             Nested::Struct(None, false, 10),
             Nested::Primitive(None, true, 10),
         ];
-        let expected = vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let expected = vec![];
+
+        test(nested, expected)
+    }
+
+    #[test]
+    fn struct_required_nested_list() {
+        let nested = vec![
+            Nested::Struct(None, false, 5),
+            Nested::List(ListNested {
+                is_optional: false,
+                offsets: &[0i32, 2, 2, 4, 6, 8],
+                validity: None,
+            }),
+            Nested::Primitive(None, false, 10),
+        ];
+        let expected = vec![0, 1, 0, 0, 1, 0, 1, 0, 1];
 
         test(nested, expected)
     }


### PR DESCRIPTION
This one was fun. Porting back from WallarooLabs/arrow2#7, with tests we can share upstream. I see there was a fix in here already, but it is not sufficient for our use case. I'm not sure if it clashes with our fix; with this both-fixes version, our internal tests pass along with the new unit test.

Parquet is a complex format, and I am not super familiar with this area of code. The solution here feels directionally correct, but incomplete. I have several concerns which I will elaborate on later.

First: the problem. A list array within a struct array was yielding incorrect and odd results.

I traced the root cause back to the rep level encoder in the writer. It was mistakenly adding rep levels for required values. A required value only has one valid repetition count: 1. Parquet is a space-conscious format and therefore nominally omits repetition counts when they are known. The `parquet2` library would thus calculate the max rep encoding length from parquet types and get one value. This max length would not match the max length emitted by the writer.

So, if a struct required an inner array, the writer would treat values in that array as level-2 values instead of the appropriate level-1 value. The `parquet2` library would calculate the max rep encoding length from parquet types and get one value. The encodings emitted by the rep level encoder in arrow2 would have a different, higher max level. The end result would basically just emit garbage when writing out rep levels, which would result in the results back being the correct underlying values with apparently random breaks between nested lists.

The fix is to omit rep levels for any required fields in the nesting stack. The resulting rep level width then matches what parquet2 expects, and we get the correct nested values.

There are a few further concerns:

- The fix is complicated by the usage of `num_values` from `rep.rs` throughout the write code. This feels like an overloaded concept, as there are many cases (required values) where values are present but a rep level tape out is unnecessary.
- There are probably several issues with this code when you start mixing nested null and empty values. As far as I can tell, the Dremel standard provides no way to distinguish between a null list and an empty list. I think this makes arbitrary round-trip conversions between arrow and parquet impossible? I can't find any examples of Dremel encoding that preserves the difference between the two, but my Google searches may be missing something.
- I'm somewhat worried that this fix is incomplete. This is the second persistence bug we've discovered while using this library to read/write parquet. Would there be any concerns if we were to develop and donate property tests to the project? I'm thinking of using [quickcheck](https://github.com/BurntSushi/quickcheck) to check that a random sample of arbitrarily nested arrow arrays round-trip properly to and from the parquet format, possibly modulo the concerns around null / empty lists discussed above.