### PR TITLE
Correctly update child-offsets in `GrowableUnion`

### DIFF
--- a/src/array/growable/binary.rs
+++ b/src/array/growable/binary.rs
@@ -81,6 +81,11 @@ impl<'a, O: Offset> Growable<'a> for GrowableBinary<'a, O> {
         self.validity.extend_constant(additional, false);
     }
 
+    #[inline]
+    fn next_offset(&self) -> usize {
+        self.offsets.len() - 1
+    }
+
     fn as_arc(&mut self) -> Arc<dyn Array> {
         self.to().arced()
     }

--- a/src/array/growable/binary.rs
+++ b/src/array/growable/binary.rs
@@ -82,7 +82,7 @@ impl<'a, O: Offset> Growable<'a> for GrowableBinary<'a, O> {
     }
 
     #[inline]
-    fn next_offset(&self) -> usize {
+    fn len(&self) -> usize {
         self.offsets.len() - 1
     }
 

--- a/src/array/growable/boolean.rs
+++ b/src/array/growable/boolean.rs
@@ -71,6 +71,11 @@ impl<'a> Growable<'a> for GrowableBoolean<'a> {
         self.validity.extend_constant(additional, false);
     }
 
+    #[inline]
+    fn next_offset(&self) -> usize {
+        self.values.len()
+    }
+
     fn as_arc(&mut self) -> Arc<dyn Array> {
         Arc::new(self.to())
     }

--- a/src/array/growable/boolean.rs
+++ b/src/array/growable/boolean.rs
@@ -72,7 +72,7 @@ impl<'a> Growable<'a> for GrowableBoolean<'a> {
     }
 
     #[inline]
-    fn next_offset(&self) -> usize {
+    fn len(&self) -> usize {
         self.values.len()
     }
 

--- a/src/array/growable/dictionary.rs
+++ b/src/array/growable/dictionary.rs
@@ -133,6 +133,11 @@ impl<'a, T: DictionaryKey> Growable<'a> for GrowableDictionary<'a, T> {
     }
 
     #[inline]
+    fn next_offset(&self) -> usize {
+        self.key_values.len()
+    }
+
+    #[inline]
     fn extend_validity(&mut self, additional: usize) {
         self.key_values
             .resize(self.key_values.len() + additional, T::default());

--- a/src/array/growable/dictionary.rs
+++ b/src/array/growable/dictionary.rs
@@ -133,7 +133,7 @@ impl<'a, T: DictionaryKey> Growable<'a> for GrowableDictionary<'a, T> {
     }
 
     #[inline]
-    fn next_offset(&self) -> usize {
+    fn len(&self) -> usize {
         self.key_values.len()
     }
 

--- a/src/array/growable/fixed_binary.rs
+++ b/src/array/growable/fixed_binary.rs
@@ -78,6 +78,11 @@ impl<'a> Growable<'a> for GrowableFixedSizeBinary<'a> {
         self.validity.extend_constant(additional, false);
     }
 
+    #[inline]
+    fn next_offset(&self) -> usize {
+        self.values.len() / self.size
+    }
+
     fn as_arc(&mut self) -> Arc<dyn Array> {
         Arc::new(self.to())
     }

--- a/src/array/growable/fixed_binary.rs
+++ b/src/array/growable/fixed_binary.rs
@@ -79,7 +79,7 @@ impl<'a> Growable<'a> for GrowableFixedSizeBinary<'a> {
     }
 
     #[inline]
-    fn next_offset(&self) -> usize {
+    fn len(&self) -> usize {
         self.values.len() / self.size
     }
 

--- a/src/array/growable/fixed_size_list.rs
+++ b/src/array/growable/fixed_size_list.rs
@@ -85,6 +85,11 @@ impl<'a> Growable<'a> for GrowableFixedSizeList<'a> {
         self.validity.extend_constant(additional, false);
     }
 
+    #[inline]
+    fn next_offset(&self) -> usize {
+        self.values.next_offset() / self.size
+    }
+
     fn as_arc(&mut self) -> Arc<dyn Array> {
         Arc::new(self.to())
     }

--- a/src/array/growable/fixed_size_list.rs
+++ b/src/array/growable/fixed_size_list.rs
@@ -86,8 +86,8 @@ impl<'a> Growable<'a> for GrowableFixedSizeList<'a> {
     }
 
     #[inline]
-    fn next_offset(&self) -> usize {
-        self.values.next_offset() / self.size
+    fn len(&self) -> usize {
+        self.values.len() / self.size
     }
 
     fn as_arc(&mut self) -> Arc<dyn Array> {

--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -97,6 +97,11 @@ impl<'a, O: Offset> Growable<'a> for GrowableList<'a, O> {
         self.validity.extend_constant(additional, false);
     }
 
+    #[inline]
+    fn next_offset(&self) -> usize {
+        self.offsets.len() - 1
+    }
+
     fn as_arc(&mut self) -> Arc<dyn Array> {
         Arc::new(self.to())
     }

--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -98,7 +98,7 @@ impl<'a, O: Offset> Growable<'a> for GrowableList<'a, O> {
     }
 
     #[inline]
-    fn next_offset(&self) -> usize {
+    fn len(&self) -> usize {
         self.offsets.len() - 1
     }
 

--- a/src/array/growable/mod.rs
+++ b/src/array/growable/mod.rs
@@ -43,6 +43,10 @@ pub trait Growable<'a> {
     /// Extends this [`Growable`] with null elements, disregarding the bound arrays
     fn extend_validity(&mut self, additional: usize);
 
+    /// Get the offset of the next value to be added to this [`Growable`].
+    /// Used to remap offsets when building up a [`GrowableUnion`].
+    fn next_offset(&self) -> usize;
+
     /// Converts this [`Growable`] to an [`Arc<dyn Array>`], thereby finishing the mutation.
     /// Self will be empty after such operation.
     fn as_arc(&mut self) -> Arc<dyn Array> {

--- a/src/array/growable/mod.rs
+++ b/src/array/growable/mod.rs
@@ -43,9 +43,8 @@ pub trait Growable<'a> {
     /// Extends this [`Growable`] with null elements, disregarding the bound arrays
     fn extend_validity(&mut self, additional: usize);
 
-    /// Get the offset of the next value to be added to this [`Growable`].
-    /// Used to remap offsets when building up a [`GrowableUnion`].
-    fn next_offset(&self) -> usize;
+    /// The current length of the [`Growable`].
+    fn len(&self) -> usize;
 
     /// Converts this [`Growable`] to an [`Arc<dyn Array>`], thereby finishing the mutation.
     /// Self will be empty after such operation.

--- a/src/array/growable/null.rs
+++ b/src/array/growable/null.rs
@@ -39,7 +39,7 @@ impl<'a> Growable<'a> for GrowableNull {
     }
 
     #[inline]
-    fn next_offset(&self) -> usize {
+    fn len(&self) -> usize {
         self.length
     }
 

--- a/src/array/growable/null.rs
+++ b/src/array/growable/null.rs
@@ -38,6 +38,11 @@ impl<'a> Growable<'a> for GrowableNull {
         self.length += additional;
     }
 
+    #[inline]
+    fn next_offset(&self) -> usize {
+        self.length
+    }
+
     fn as_arc(&mut self) -> Arc<dyn Array> {
         Arc::new(NullArray::new(self.data_type.clone(), self.length))
     }

--- a/src/array/growable/primitive.rs
+++ b/src/array/growable/primitive.rs
@@ -83,7 +83,7 @@ impl<'a, T: NativeType> Growable<'a> for GrowablePrimitive<'a, T> {
     }
 
     #[inline]
-    fn next_offset(&self) -> usize {
+    fn len(&self) -> usize {
         self.values.len()
     }
 

--- a/src/array/growable/primitive.rs
+++ b/src/array/growable/primitive.rs
@@ -83,6 +83,11 @@ impl<'a, T: NativeType> Growable<'a> for GrowablePrimitive<'a, T> {
     }
 
     #[inline]
+    fn next_offset(&self) -> usize {
+        self.values.len()
+    }
+
+    #[inline]
     fn as_arc(&mut self) -> Arc<dyn Array> {
         Arc::new(self.to())
     }

--- a/src/array/growable/structure.rs
+++ b/src/array/growable/structure.rs
@@ -104,6 +104,18 @@ impl<'a> Growable<'a> for GrowableStruct<'a> {
         self.validity.extend_constant(additional, false);
     }
 
+    #[inline]
+    fn next_offset(&self) -> usize {
+        // All children should have the same indexing, so just use the first
+        // one. If we don't have children, we might still have a validity
+        // array, so use that.
+        if let Some(child) = self.values.get(0) {
+            child.next_offset()
+        } else {
+            self.validity.len()
+        }
+    }
+
     fn as_arc(&mut self) -> Arc<dyn Array> {
         Arc::new(self.to())
     }

--- a/src/array/growable/structure.rs
+++ b/src/array/growable/structure.rs
@@ -105,12 +105,12 @@ impl<'a> Growable<'a> for GrowableStruct<'a> {
     }
 
     #[inline]
-    fn next_offset(&self) -> usize {
+    fn len(&self) -> usize {
         // All children should have the same indexing, so just use the first
         // one. If we don't have children, we might still have a validity
         // array, so use that.
         if let Some(child) = self.values.get(0) {
-            child.next_offset()
+            child.len()
         } else {
             self.validity.len()
         }

--- a/src/array/growable/union.rs
+++ b/src/array/growable/union.rs
@@ -76,7 +76,11 @@ impl<'a> Growable<'a> for GrowableUnion<'a> {
             // in a dense union, each slot has its own offset. We extend the fields accordingly.
             for (&type_, &offset) in types.iter().zip(offsets.iter()) {
                 let field = &mut self.fields[type_ as usize];
-                x.push(field.next_offset() as i32);
+                // The offset for the element that is about to be extended is the current length
+                // of the child field of the corresponding type. Note that this may be very
+                // different than the original offset from the array we are extending from as
+                // it is a function of the previous extensions to this child.
+                x.push(field.len() as i32);
                 field.extend(index, offset as usize, 1);
             }
         } else {
@@ -90,7 +94,7 @@ impl<'a> Growable<'a> for GrowableUnion<'a> {
     fn extend_validity(&mut self, _additional: usize) {}
 
     #[inline]
-    fn next_offset(&self) -> usize {
+    fn len(&self) -> usize {
         self.types.len()
     }
 

--- a/src/array/growable/utf8.rs
+++ b/src/array/growable/utf8.rs
@@ -88,6 +88,11 @@ impl<'a, O: Offset> Growable<'a> for GrowableUtf8<'a, O> {
         self.validity.extend_constant(additional, false);
     }
 
+    #[inline]
+    fn next_offset(&self) -> usize {
+        self.offsets.len() - 1
+    }
+
     fn as_arc(&mut self) -> Arc<dyn Array> {
         Arc::new(self.to())
     }

--- a/src/array/growable/utf8.rs
+++ b/src/array/growable/utf8.rs
@@ -89,7 +89,7 @@ impl<'a, O: Offset> Growable<'a> for GrowableUtf8<'a, O> {
     }
 
     #[inline]
-    fn next_offset(&self) -> usize {
+    fn len(&self) -> usize {
         self.offsets.len() - 1
     }
 

--- a/tests/it/array/growable/binary.rs
+++ b/tests/it/array/growable/binary.rs
@@ -10,6 +10,7 @@ fn no_offsets() {
     let mut a = GrowableBinary::new(vec![&array], false, 0);
 
     a.extend(0, 1, 2);
+    assert_eq!(a.len(), 2);
 
     let result: BinaryArray<i32> = a.into();
 
@@ -27,6 +28,7 @@ fn with_offsets() {
     let mut a = GrowableBinary::new(vec![&array], false, 0);
 
     a.extend(0, 0, 3);
+    assert_eq!(a.len(), 3);
 
     let result: BinaryArray<i32> = a.into();
 
@@ -42,6 +44,7 @@ fn test_string_offsets() {
     let mut a = GrowableBinary::new(vec![&array], false, 0);
 
     a.extend(0, 0, 3);
+    assert_eq!(a.len(), 3);
 
     let result: BinaryArray<i32> = a.into();
 
@@ -58,6 +61,7 @@ fn test_multiple_with_validity() {
 
     a.extend(0, 0, 2);
     a.extend(1, 0, 2);
+    assert_eq!(a.len(), 4);
 
     let result: BinaryArray<i32> = a.into();
 
@@ -74,6 +78,7 @@ fn test_string_null_offset_validity() {
 
     a.extend(0, 1, 2);
     a.extend_validity(1);
+    assert_eq!(a.len(), 3);
 
     let result: BinaryArray<i32> = a.into();
 

--- a/tests/it/array/growable/boolean.rs
+++ b/tests/it/array/growable/boolean.rs
@@ -8,6 +8,7 @@ fn test_bool() {
     let mut a = GrowableBoolean::new(vec![&array], false, 0);
 
     a.extend(0, 1, 2);
+    assert_eq!(a.len(), 2);
 
     let result: BooleanArray = a.into();
 

--- a/tests/it/array/growable/dictionary.rs
+++ b/tests/it/array/growable/dictionary.rs
@@ -21,6 +21,7 @@ fn test_single() -> Result<()> {
     let mut growable = GrowableDictionary::new(&[&array], false, 0);
 
     growable.extend(0, 1, 2);
+    assert_eq!(growable.len(), 2);
 
     let result: DictionaryArray<i32> = growable.into();
 
@@ -56,6 +57,7 @@ fn test_multi() -> Result<()> {
 
     growable.extend(0, 1, 2);
     growable.extend(1, 1, 2);
+    assert_eq!(growable.len(), 4);
 
     let result: DictionaryArray<i32> = growable.into();
 

--- a/tests/it/array/growable/fixed_binary.rs
+++ b/tests/it/array/growable/fixed_binary.rs
@@ -12,6 +12,7 @@ fn basic() {
     let mut a = GrowableFixedSizeBinary::new(vec![&array], false, 0);
 
     a.extend(0, 1, 2);
+    assert_eq!(a.len(), 2);
 
     let result: FixedSizeBinaryArray = a.into();
 
@@ -30,6 +31,7 @@ fn offsets() {
     let mut a = GrowableFixedSizeBinary::new(vec![&array], false, 0);
 
     a.extend(0, 0, 3);
+    assert_eq!(a.len(), 3);
 
     let result: FixedSizeBinaryArray = a.into();
 
@@ -46,6 +48,7 @@ fn multiple_with_validity() {
 
     a.extend(0, 0, 2);
     a.extend(1, 0, 2);
+    assert_eq!(a.len(), 4);
 
     let result: FixedSizeBinaryArray = a.into();
 
@@ -63,6 +66,7 @@ fn null_offset_validity() {
 
     a.extend(0, 1, 2);
     a.extend_validity(1);
+    assert_eq!(a.len(), 3);
 
     let result: FixedSizeBinaryArray = a.into();
 
@@ -81,6 +85,7 @@ fn sized_offsets() {
 
     a.extend(0, 1, 1);
     a.extend(0, 0, 1);
+    assert_eq!(a.len(), 2);
 
     let result: FixedSizeBinaryArray = a.into();
 

--- a/tests/it/array/growable/fixed_size_list.rs
+++ b/tests/it/array/growable/fixed_size_list.rs
@@ -21,6 +21,7 @@ fn basic() {
 
     let mut a = GrowableFixedSizeList::new(vec![&array], false, 0);
     a.extend(0, 0, 1);
+    assert_eq!(a.len(), 1);
 
     let result: FixedSizeListArray = a.into();
 
@@ -42,6 +43,7 @@ fn null_offset() {
 
     let mut a = GrowableFixedSizeList::new(vec![&array], false, 0);
     a.extend(0, 1, 1);
+    assert_eq!(a.len(), 1);
 
     let result: FixedSizeListArray = a.into();
 
@@ -70,6 +72,7 @@ fn test_from_two_lists() {
     let mut a = GrowableFixedSizeList::new(vec![&array_1, &array_2], false, 6);
     a.extend(0, 0, 2);
     a.extend(1, 1, 1);
+    assert_eq!(a.len(), 3);
 
     let result: FixedSizeListArray = a.into();
 

--- a/tests/it/array/growable/list.rs
+++ b/tests/it/array/growable/list.rs
@@ -33,6 +33,7 @@ fn extension() {
 
     let mut a = GrowableList::new(vec![&array_ext], false, 0);
     a.extend(0, 0, 1);
+    assert_eq!(a.len(), 1);
 
     let result: ListArray<i32> = a.into();
     assert_eq!(array_ext.data_type(), result.data_type());
@@ -51,6 +52,7 @@ fn basic() {
 
     let mut a = GrowableList::new(vec![&array], false, 0);
     a.extend(0, 0, 1);
+    assert_eq!(a.len(), 1);
 
     let result: ListArray<i32> = a.into();
 
@@ -72,6 +74,7 @@ fn null_offset() {
 
     let mut a = GrowableList::new(vec![&array], false, 0);
     a.extend(0, 1, 1);
+    assert_eq!(a.len(), 1);
 
     let result: ListArray<i32> = a.into();
 
@@ -93,6 +96,7 @@ fn null_offsets() {
 
     let mut a = GrowableList::new(vec![&array], false, 0);
     a.extend(0, 1, 1);
+    assert_eq!(a.len(), 1);
 
     let result: ListArray<i32> = a.into();
 
@@ -121,6 +125,7 @@ fn test_from_two_lists() {
     let mut a = GrowableList::new(vec![&array_1, &array_2], false, 6);
     a.extend(0, 0, 2);
     a.extend(1, 1, 1);
+    assert_eq!(a.len(), 3);
 
     let result: ListArray<i32> = a.into();
 

--- a/tests/it/array/growable/null.rs
+++ b/tests/it/array/growable/null.rs
@@ -12,6 +12,7 @@ fn null() {
 
     mutable.extend(0, 1, 2);
     mutable.extend(1, 0, 1);
+    assert_eq!(mutable.len(), 3);
 
     let result: NullArray = mutable.into();
 

--- a/tests/it/array/growable/primitive.rs
+++ b/tests/it/array/growable/primitive.rs
@@ -9,6 +9,7 @@ fn basics() {
     let b = PrimitiveArray::<u8>::from(vec![Some(1), Some(2), Some(3)]);
     let mut a = GrowablePrimitive::new(vec![&b], false, 3);
     a.extend(0, 0, 2);
+    assert_eq!(a.len(), 2);
     let result: PrimitiveArray<u8> = a.into();
     let expected = PrimitiveArray::<u8>::from(vec![Some(1), Some(2)]);
     assert_eq!(result, expected);
@@ -21,6 +22,7 @@ fn offset() {
     let b = b.slice(1, 2);
     let mut a = GrowablePrimitive::new(vec![&b], false, 2);
     a.extend(0, 0, 2);
+    assert_eq!(a.len(), 2);
     let result: PrimitiveArray<u8> = a.into();
     let expected = PrimitiveArray::<u8>::from(vec![Some(2), Some(3)]);
     assert_eq!(result, expected);
@@ -33,6 +35,7 @@ fn null_offset() {
     let b = b.slice(1, 2);
     let mut a = GrowablePrimitive::new(vec![&b], false, 2);
     a.extend(0, 0, 2);
+    assert_eq!(a.len(), 2);
     let result: PrimitiveArray<u8> = a.into();
     let expected = PrimitiveArray::<u8>::from(vec![None, Some(3)]);
     assert_eq!(result, expected);
@@ -46,6 +49,7 @@ fn null_offset_validity() {
     a.extend(0, 0, 2);
     a.extend_validity(3);
     a.extend(0, 1, 1);
+    assert_eq!(a.len(), 6);
     let result: PrimitiveArray<u8> = a.into();
     let expected = PrimitiveArray::<u8>::from(&[Some(2), Some(3), None, None, None, Some(3)]);
     assert_eq!(result, expected);
@@ -58,6 +62,7 @@ fn joining_arrays() {
     let mut a = GrowablePrimitive::new(vec![&b, &c], false, 4);
     a.extend(0, 0, 2);
     a.extend(1, 1, 2);
+    assert_eq!(a.len(), 4);
     let result: PrimitiveArray<u8> = a.into();
 
     let expected = PrimitiveArray::<u8>::from(&[Some(1), Some(2), Some(5), Some(6)]);

--- a/tests/it/array/growable/struct_.rs
+++ b/tests/it/array/growable/struct_.rs
@@ -36,6 +36,7 @@ fn basic() {
     let mut a = GrowableStruct::new(vec![&array], false, 0);
 
     a.extend(0, 1, 2);
+    assert_eq!(a.len(), 2);
     let result: StructArray = a.into();
 
     let expected = StructArray::new(
@@ -55,6 +56,7 @@ fn offset() {
     let mut a = GrowableStruct::new(vec![&array], false, 0);
 
     a.extend(0, 1, 2);
+    assert_eq!(a.len(), 2);
     let result: StructArray = a.into();
 
     let expected = StructArray::new(
@@ -79,6 +81,7 @@ fn nulls() {
     let mut a = GrowableStruct::new(vec![&array], false, 0);
 
     a.extend(0, 1, 2);
+    assert_eq!(a.len(), 2);
     let result: StructArray = a.into();
 
     let expected = StructArray::new(
@@ -101,6 +104,7 @@ fn many() {
     mutable.extend(0, 1, 2);
     mutable.extend(1, 0, 2);
     mutable.extend_validity(1);
+    assert_eq!(mutable.len(), 5);
     let result = mutable.as_box();
 
     let expected_string: Box<dyn Array> = Box::new(Utf8Array::<i32>::from([

--- a/tests/it/array/growable/union.rs
+++ b/tests/it/array/growable/union.rs
@@ -131,7 +131,7 @@ fn complex_dense() -> Result<()> {
         Int32Array::from(&[Some(1), Some(2), Some(3)]).boxed(),
         Utf8Array::<i32>::from([Some("abcd"), Some("ef"), Some("ghijk")]).boxed(),
         FixedSizeListArray::try_new(
-            fixed_size_type.clone(),
+            fixed_size_type,
             UInt16Array::from_iter([11, 12, 13, 21, 22, 23, 41, 42, 43].into_iter().map(Some))
                 .boxed(),
             None,
@@ -141,7 +141,7 @@ fn complex_dense() -> Result<()> {
     ];
     let offsets = Some(vec![0, 0, 0, 1, 1, 2, 1, 2, 2].into());
 
-    let expected = UnionArray::new(data_type.clone(), types, fields, offsets);
+    let expected = UnionArray::new(data_type, types, fields, offsets);
 
     assert_eq!(expected, result);
 

--- a/tests/it/array/growable/union.rs
+++ b/tests/it/array/growable/union.rs
@@ -26,6 +26,8 @@ fn sparse() -> Result<()> {
             let mut a = GrowableUnion::new(vec![&array], 10);
 
             a.extend(0, index, length);
+            assert_eq!(a.len(), length);
+
             let expected = array.slice(index, length);
 
             let result: UnionArray = a.into();
@@ -58,6 +60,7 @@ fn dense() -> Result<()> {
             let mut a = GrowableUnion::new(vec![&array], 10);
 
             a.extend(0, index, length);
+            assert_eq!(a.len(), length);
             let expected = array.slice(index, length);
 
             let result: UnionArray = a.into();
@@ -122,6 +125,7 @@ fn complex_dense() -> Result<()> {
     a.extend(0, 0, 5);
     // Skip the first value from the second array: [31, 32, 33]
     a.extend(1, 1, 4);
+    assert_eq!(a.len(), 9);
 
     let result: UnionArray = a.into();
 

--- a/tests/it/array/growable/union.rs
+++ b/tests/it/array/growable/union.rs
@@ -68,3 +68,52 @@ fn dense() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn complex_dense() -> Result<()> {
+    let fields = vec![
+        Field::new("a", DataType::Int32, true),
+        Field::new("b", DataType::Utf8, true),
+    ];
+
+    let data_type = DataType::Union(fields, None, UnionMode::Dense);
+
+    let types = vec![0, 0, 1].into();
+    let fields = vec![
+        Int32Array::from(&[Some(1), Some(2)]).boxed(),
+        Utf8Array::<i32>::from([Some("c")]).boxed(),
+    ];
+    let offsets = Some(vec![0, 1, 0].into());
+
+    let array1 = UnionArray::new(data_type.clone(), types, fields, offsets);
+
+    let types = vec![1, 1, 0].into();
+    let fields = vec![
+        Int32Array::from(&[Some(6)]).boxed(),
+        Utf8Array::<i32>::from([Some("d"), Some("e")]).boxed(),
+    ];
+    let offsets = Some(vec![0, 1, 0].into());
+
+    let array2 = UnionArray::new(data_type.clone(), types, fields, offsets);
+
+    let mut a = GrowableUnion::new(vec![&array1, &array2], 10);
+
+    // Effective concat
+    a.extend(0, 0, 3);
+    a.extend(1, 0, 3);
+
+    let result: UnionArray = a.into();
+
+    let types = vec![0, 0, 1, 1, 1, 0].into();
+    let fields = vec![
+        Int32Array::from(&[Some(1), Some(2), Some(6)]).boxed(),
+        Utf8Array::<i32>::from([Some("c"), Some("d"), Some("e")]).boxed(),
+    ];
+    let offsets = Some(vec![0, 1, 0, 1, 2, 2].into());
+
+    let expected = UnionArray::new(data_type.clone(), types, fields, offsets);
+
+    assert_eq!(expected, result);
+
+    Ok(())
+}

--- a/tests/it/array/growable/utf8.rs
+++ b/tests/it/array/growable/utf8.rs
@@ -28,6 +28,7 @@ fn offsets() {
     let mut a = GrowableUtf8::new(vec![&array], false, 0);
 
     a.extend(0, 0, 3);
+    assert_eq!(a.len(), 3);
 
     let result: Utf8Array<i32> = a.into();
 
@@ -43,6 +44,7 @@ fn offsets2() {
     let mut a = GrowableUtf8::new(vec![&array], false, 0);
 
     a.extend(0, 0, 3);
+    assert_eq!(a.len(), 3);
 
     let result: Utf8Array<i32> = a.into();
 
@@ -59,6 +61,7 @@ fn multiple_with_validity() {
 
     a.extend(0, 0, 2);
     a.extend(1, 0, 2);
+    assert_eq!(a.len(), 4);
 
     let result: Utf8Array<i32> = a.into();
 
@@ -75,6 +78,7 @@ fn null_offset_validity() {
 
     a.extend(0, 1, 2);
     a.extend_validity(1);
+    assert_eq!(a.len(), 3);
 
     let result: Utf8Array<i32> = a.into();
 


### PR DESCRIPTION
This resolves: https://github.com/jorgecarleitao/arrow2/issues/1359

As mentioned in the ticket, union offsets weren't being correctly updated to reflect positions in the new child fields. This adds a new method to the `Growable` interface: `len()`.  I believe I've got the right interpretation for the different growable implementations but would very much appreciate a sanity check there. 