### PR TITLE
Made IPC writer take owned schema

### DIFF
--- a/benches/write_ipc.rs
+++ b/benches/write_ipc.rs
@@ -14,7 +14,7 @@ fn write(array: &dyn Array) -> Result<()> {
     let columns = Chunk::try_new(vec![clone(array)])?;
 
     let writer = Cursor::new(vec![]);
-    let mut writer = FileWriter::try_new(writer, &schema, None, Default::default())?;
+    let mut writer = FileWriter::try_new(writer, schema, None, Default::default())?;
 
     writer.write(&columns, None)
 }

--- a/examples/ipc_file_mmap.rs
+++ b/examples/ipc_file_mmap.rs
@@ -27,8 +27,12 @@ fn write(
 ) -> Result<Vec<u8>, Error> {
     let result = vec![];
     let options = arrow2::io::ipc::write::WriteOptions { compression };
-    let mut writer =
-        arrow2::io::ipc::write::FileWriter::try_new(result, schema, ipc_fields.clone(), options)?;
+    let mut writer = arrow2::io::ipc::write::FileWriter::try_new(
+        result,
+        schema.clone(),
+        ipc_fields.clone(),
+        options,
+    )?;
     for chunk in chunks {
         writer.write(chunk, ipc_fields.as_ref().map(|x| x.as_ref()))?;
     }

--- a/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -59,7 +59,7 @@ fn json_to_arrow(json_name: &str, arrow_name: &str, verbose: bool) -> Result<()>
     let options = write::WriteOptions { compression: None };
     let mut writer = write::FileWriter::try_new(
         arrow_file,
-        &json_file.schema,
+        json_file.schema.clone(),
         Some(json_file.fields),
         options,
     )?;

--- a/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
     let options = write::WriteOptions { compression: None };
     let mut writer = write::FileWriter::try_new(
         writer,
-        &metadata.schema,
+        metadata.schema.clone(),
         Some(metadata.ipc_schema.fields),
         options,
     )?;

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -42,7 +42,7 @@
 //! let y_coord = Field::new("y", DataType::Int32, false);
 //! let schema = Schema::from(vec![x_coord, y_coord]);
 //! let options = WriteOptions {compression: None};
-//! let mut writer = FileWriter::try_new(file, &schema, None, options)?;
+//! let mut writer = FileWriter::try_new(file, schema, None, options)?;
 //!
 //! // Setup the data
 //! let x_data = Int32Array::from_slice([-1i32, 1]);

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -47,11 +47,11 @@ impl<W: Write> FileWriter<W> {
     /// Creates a new [`FileWriter`] and writes the header to `writer`
     pub fn try_new(
         writer: W,
-        schema: &Schema,
+        schema: Schema,
         ipc_fields: Option<Vec<IpcField>>,
         options: WriteOptions,
     ) -> Result<Self> {
-        let mut slf = Self::new(writer, schema.clone(), ipc_fields, options);
+        let mut slf = Self::new(writer, schema, ipc_fields, options);
         slf.start()?;
 
         Ok(slf)

--- a/tests/it/io/ipc/write/file.rs
+++ b/tests/it/io/ipc/write/file.rs
@@ -18,7 +18,7 @@ pub(crate) fn write(
 ) -> Result<Vec<u8>> {
     let result = vec![];
     let options = WriteOptions { compression };
-    let mut writer = FileWriter::try_new(result, schema, ipc_fields.clone(), options)?;
+    let mut writer = FileWriter::try_new(result, schema.clone(), ipc_fields.clone(), options)?;
     for batch in batches {
         writer.write(batch, ipc_fields.as_ref().map(|x| x.as_ref()))?;
     }


### PR DESCRIPTION
The ipc writer takes a schema reference, but directly clowns it to an owned schema. This leads to a redundant clone when a user first constructs the arrow schema.