### PR TITLE
Amortized intermediate allocations in IPC writer

### DIFF
--- a/src/io/flight/mod.rs
+++ b/src/io/flight/mod.rs
@@ -89,7 +89,7 @@ pub fn serialize_schema_to_info(
     };
 
     let mut schema = vec![];
-    write::common_sync::write_message(&mut schema, encoded_data)?;
+    write::common_sync::write_message(&mut schema, &encoded_data)?;
     Ok(schema)
 }
 

--- a/src/io/ipc/append/mod.rs
+++ b/src/io/ipc/append/mod.rs
@@ -67,6 +67,7 @@ impl<R: Read + Seek + Write> FileWriter<R> {
                 dictionaries,
                 cannot_replace: true,
             },
+            encoded_message: Default::default(),
         })
     }
 }

--- a/src/io/ipc/compression.rs
+++ b/src/io/ipc/compression.rs
@@ -48,13 +48,13 @@ pub fn compress_zstd(input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
 }
 
 #[cfg(not(feature = "io_ipc_compression"))]
-pub fn compress_lz4(_input_buf: &[u8], _output_buf: &mut Vec<u8>) -> Result<()> {
+pub fn compress_lz4(_input_buf: &[u8], _output_buf: &[u8]) -> Result<()> {
     use crate::error::Error;
     Err(Error::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to write compressed IPC.".to_string()))
 }
 
 #[cfg(not(feature = "io_ipc_compression"))]
-pub fn compress_zstd(_input_buf: &[u8], _output_buf: &mut Vec<u8>) -> Result<()> {
+pub fn compress_zstd(_input_buf: &[u8], _output_buf: &[u8]) -> Result<()> {
     use crate::error::Error;
     Err(Error::OutOfSpec("The crate was compiled without IPC compression. Use `io_ipc_compression` to write compressed IPC.".to_string()))
 }

--- a/src/io/ipc/write/common_sync.rs
+++ b/src/io/ipc/write/common_sync.rs
@@ -21,7 +21,7 @@ pub fn write_message<W: Write>(writer: &mut W, encoded: &EncodedData) -> Result<
 
     // write the flatbuf
     if flatbuf_size > 0 {
-        writer.write_all(&buffer)?;
+        writer.write_all(buffer)?;
     }
     // write padding
     // aligned to a 8 byte boundary, so maximum is [u8;8]

--- a/src/io/ipc/write/common_sync.rs
+++ b/src/io/ipc/write/common_sync.rs
@@ -7,11 +7,11 @@ use super::common::pad_to_64;
 use super::common::EncodedData;
 
 /// Write a message's IPC data and buffers, returning metadata and buffer data lengths written
-pub fn write_message<W: Write>(writer: &mut W, encoded: EncodedData) -> Result<(usize, usize)> {
+pub fn write_message<W: Write>(writer: &mut W, encoded: &EncodedData) -> Result<(usize, usize)> {
     let arrow_data_len = encoded.arrow_data.len();
 
     let a = 8 - 1;
-    let buffer = encoded.ipc_message;
+    let buffer = &encoded.ipc_message;
     let flatbuf_size = buffer.len();
     let prefix_size = 8;
     let aligned_size = (flatbuf_size + prefix_size + a) & !a;
@@ -24,7 +24,9 @@ pub fn write_message<W: Write>(writer: &mut W, encoded: EncodedData) -> Result<(
         writer.write_all(&buffer)?;
     }
     // write padding
-    writer.write_all(&vec![0; padding_bytes])?;
+    // aligned to a 8 byte boundary, so maximum is [u8;8]
+    const PADDING_MAX: [u8; 8] = [0u8; 8];
+    writer.write_all(&PADDING_MAX[..padding_bytes])?;
 
     // write arrow data
     let body_len = if arrow_data_len > 0 {

--- a/src/io/ipc/write/stream.rs
+++ b/src/io/ipc/write/stream.rs
@@ -62,7 +62,7 @@ impl<W: Write> StreamWriter<W> {
             ipc_message: schema_to_bytes(schema, self.ipc_fields.as_ref().unwrap()),
             arrow_data: vec![],
         };
-        write_message(&mut self.writer, encoded_message)?;
+        write_message(&mut self.writer, &encoded_message)?;
         Ok(())
     }
 
@@ -91,10 +91,10 @@ impl<W: Write> StreamWriter<W> {
         )?;
 
         for encoded_dictionary in encoded_dictionaries {
-            write_message(&mut self.writer, encoded_dictionary)?;
+            write_message(&mut self.writer, &encoded_dictionary)?;
         }
 
-        write_message(&mut self.writer, encoded_message)?;
+        write_message(&mut self.writer, &encoded_message)?;
         Ok(())
     }
 

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -43,9 +43,7 @@ pub struct FileWriter<W: Write> {
     /// Keeps track of dictionaries that have been written
     pub(crate) dictionary_tracker: DictionaryTracker,
     /// Buffer/scratch that is reused between writes
-    /// This is public so a user can swap this in between
-    /// creating new writers to save/amortize allocations.
-    pub encoded_message: EncodedData,
+    pub(crate) encoded_message: EncodedData,
 }
 
 impl<W: Write> FileWriter<W> {
@@ -95,6 +93,17 @@ impl<W: Write> FileWriter<W> {
     /// Consumes itself into the inner writer
     pub fn into_inner(self) -> W {
         self.writer
+    }
+
+    /// Get the inner memory scratches so they can be reused in a new writer.
+    /// This can be utilized to save memory allocations for performance reasons.
+    pub fn get_scratches(&mut self) -> EncodedData {
+        std::mem::take(&mut self.encoded_message)
+    }
+    /// Set the inner memory scratches so they can be reused in a new writer.
+    /// This can be utilized to save memory allocations for performance reasons.
+    pub fn set_scratches(&mut self, scratches: EncodedData) {
+        self.encoded_message = scratches;
     }
 
     /// Writes the header and first (schema) message to the file.

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -109,7 +109,7 @@ impl<W: Write> FileWriter<W> {
             arrow_data: vec![],
         };
 
-        let (meta, data) = write_message(&mut self.writer, encoded_message)?;
+        let (meta, data) = write_message(&mut self.writer, &encoded_message)?;
         self.block_offsets += meta + data + 8; // 8 <=> arrow magic + 2 bytes for alignment
         self.state = State::Started;
         Ok(())
@@ -142,7 +142,7 @@ impl<W: Write> FileWriter<W> {
 
         // add all dictionaries
         for encoded_dictionary in encoded_dictionaries {
-            let (meta, data) = write_message(&mut self.writer, encoded_dictionary)?;
+            let (meta, data) = write_message(&mut self.writer, &encoded_dictionary)?;
 
             let block = arrow_format::ipc::Block {
                 offset: self.block_offsets as i64,
@@ -153,7 +153,7 @@ impl<W: Write> FileWriter<W> {
             self.block_offsets += meta + data;
         }
 
-        let (meta, data) = write_message(&mut self.writer, encoded_message)?;
+        let (meta, data) = write_message(&mut self.writer, &encoded_message)?;
         // add a record block for the footer
         let block = arrow_format::ipc::Block {
             offset: self.block_offsets as i64,

--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -295,8 +295,7 @@ fn chrono_tz_utf_to_timestamp_ns<O: Offset>(
     timezone: String,
 ) -> Result<PrimitiveArray<i64>> {
     Err(Error::InvalidArgumentError(format!(
-        "timezone \"{}\" cannot be parsed (feature chrono-tz is not active)",
-        timezone
+        "timezone \"{timezone}\" cannot be parsed (feature chrono-tz is not active)",
     )))
 }
 


### PR DESCRIPTION
This reuses the `encoded_message` per `write` call. Besides from this, the `encoded_message` can also be used in between multiple writers, so that the amount of allocations is reduced.