### PR TITLE
Added `Utf8Array::apply_validity`

### DIFF
--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -515,6 +515,17 @@ impl<O: Offset> Utf8Array<O> {
     {
         MutableUtf8Array::<O>::try_from_trusted_len_iter(iter).map(|x| x.into())
     }
+
+    /// Applies a function `f` to the validity of this array.
+    ///
+    /// This is an API to leverage clone-on-write
+    /// # Panics
+    /// This function panics if the function `f` modifies the length of the [`Bitmap`].
+    pub fn apply_validity<F: FnOnce(Bitmap) -> Bitmap>(&mut self, f: F) {
+        if let Some(validity) = std::mem::take(&mut self.validity) {
+            self.set_validity(Some(f(validity)))
+        }
+    }
 }
 
 impl<O: Offset> Array for Utf8Array<O> {

--- a/tests/it/array/utf8/mod.rs
+++ b/tests/it/array/utf8/mod.rs
@@ -216,3 +216,20 @@ fn iter_nth() {
     assert_eq!(array.iter().nth(1), Some(Some(" ")));
     assert_eq!(array.iter().nth(10), None);
 }
+
+#[test]
+fn test_apply_validity() {
+    let mut array = Utf8Array::<i32>::from([Some("Red"), Some("Green"), Some("Blue")]);
+    array.set_validity(Some([true, true, true].into()));
+
+    array.apply_validity(|bitmap| {
+        let mut mut_bitmap = bitmap.into_mut().right().unwrap();
+        mut_bitmap.set(1, false);
+        mut_bitmap.set(2, false);
+        mut_bitmap.into()
+    });
+
+    assert!(array.is_valid(0));
+    assert!(!array.is_valid(1));
+    assert!(!array.is_valid(2));
+}


### PR DESCRIPTION
I added an `apply_validity` function to the Utf8Array. Basically I just copied the functionality from PrimitiveArray. If there is a better way of doing this Im open to suggestions. 

I also was not sure where to put the test for it, so I added it in the same file under a test module.