### PR TITLE
Added `set_len` method to Buffer

### DIFF
--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -178,6 +178,13 @@ impl<T> Buffer<T> {
         self.offset
     }
 
+    /// # Safety
+    /// The caller must ensure that the buffer was properly initialized up to `len`.
+    #[inline]
+    pub unsafe fn set_len(&mut self, len: usize) {
+        self.length = len;
+    }
+
     /// Returns a mutable reference to its underlying [`Vec`], if possible.
     ///
     /// This operation returns [`Either::Right`] iff this [`Buffer`]:


### PR DESCRIPTION
Adding `set_len` enables to change the length value of the buffer.

This is required if `get_mut` changes the length of the buffer.

I think it will be great to add generic vector method such as `extend_from_slice`, `copy_from_slice`, with the according length change. I can add it to this pull request if interested.