### PR TITLE
Made some structs and functions public

### DIFF
--- a/src/io/parquet/read/deserialize/mod.rs
+++ b/src/io/parquet/read/deserialize/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     offset::Offsets,
 };
 
-use self::nested_utils::{InitNested, NestedArrayIter, NestedState};
+pub use self::nested_utils::{init_nested, InitNested, NestedArrayIter, NestedState};
 use simple::page_iter_to_arrays;
 
 use super::*;
@@ -43,7 +43,7 @@ pub fn get_page_iterator<R: Read + Seek>(
     )?)
 }
 
-fn create_list(
+pub fn create_list(
     data_type: DataType,
     nested: &mut NestedState,
     values: Box<dyn Array>,
@@ -128,7 +128,7 @@ where
 }
 
 /// Returns the number of (parquet) columns that a [`DataType`] contains.
-fn n_columns(data_type: &DataType) -> usize {
+pub fn n_columns(data_type: &DataType) -> usize {
     use crate::datatypes::PhysicalType::*;
     match data_type.to_physical_type() {
         Null | Boolean | Primitive(_) | Binary | FixedSizeBinary | LargeBinary | Utf8

--- a/src/io/parquet/read/deserialize/mod.rs
+++ b/src/io/parquet/read/deserialize/mod.rs
@@ -43,6 +43,7 @@ pub fn get_page_iterator<R: Read + Seek>(
     )?)
 }
 
+/// Creates a new [`ListArray`] or [`FixedSizeListArray`].
 pub fn create_list(
     data_type: DataType,
     nested: &mut NestedState,

--- a/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/src/io/parquet/read/deserialize/nested_utils.rs
@@ -271,7 +271,7 @@ pub enum InitNested {
     Struct(bool),
 }
 
-fn init_nested(init: &[InitNested], capacity: usize) -> NestedState {
+pub fn init_nested(init: &[InitNested], capacity: usize) -> NestedState {
     let container = init
         .iter()
         .map(|init| match init {

--- a/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/src/io/parquet/read/deserialize/nested_utils.rs
@@ -264,6 +264,7 @@ pub(super) trait NestedDecoder<'a> {
     fn deserialize_dict(&self, page: &DictPage) -> Self::Dictionary;
 }
 
+/// The initial info of nested data types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InitNested {
     Primitive(bool),
@@ -271,6 +272,7 @@ pub enum InitNested {
     Struct(bool),
 }
 
+/// Initialize [`NestedState`] from `&[InitNested]`.
 pub fn init_nested(init: &[InitNested], capacity: usize) -> NestedState {
     let container = init
         .iter()
@@ -324,12 +326,14 @@ impl<'a> NestedPage<'a> {
     }
 }
 
+/// The state of nested data types.
 #[derive(Debug)]
 pub struct NestedState {
     pub nested: Vec<Box<dyn Nested>>,
 }
 
 impl NestedState {
+    /// Creates a new [`NestedState`].
     pub fn new(nested: Vec<Box<dyn Nested>>) -> Self {
         Self { nested }
     }

--- a/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/src/io/parquet/read/deserialize/nested_utils.rs
@@ -267,8 +267,11 @@ pub(super) trait NestedDecoder<'a> {
 /// The initial info of nested data types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InitNested {
+    /// Primitive data types
     Primitive(bool),
+    /// List data types
     List(bool),
+    /// Struct data types
     Struct(bool),
 }
 
@@ -329,6 +332,7 @@ impl<'a> NestedPage<'a> {
 /// The state of nested data types.
 #[derive(Debug)]
 pub struct NestedState {
+    /// The nesteds composing `NestedState`.
     pub nested: Vec<Box<dyn Nested>>,
 }
 

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -34,7 +34,10 @@ pub use parquet2::{
 
 use crate::{array::Array, error::Result};
 
-pub use deserialize::{column_iter_to_arrays, get_page_iterator};
+pub use deserialize::{
+    column_iter_to_arrays, create_list, get_page_iterator, init_nested, n_columns, InitNested,
+    NestedState,
+};
 pub use file::{FileReader, RowGroupReader};
 pub use row_group::*;
 pub use schema::{infer_schema, FileMetaData};

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -157,6 +157,7 @@ pub fn can_encode(data_type: &DataType, encoding: Encoding) -> bool {
     )
 }
 
+/// Slices the [`Array`] to `Box<dyn Array>` and `Vec<Nested>`.
 pub fn slice_parquet_array<'a>(
     array: &'a dyn Array,
     nested: &'a [Nested<'a>],
@@ -189,9 +190,9 @@ pub fn slice_parquet_array<'a>(
     }
 }
 
+/// Get the length of [`Array`] that should be sliced.
 pub fn get_max_length(array: &dyn Array, nested: &[Nested]) -> usize {
-    // get the length that should be sliced.
-    // that is the inner nested structure that
+    // the inner nested structure that
     // dictates how often the primitive should be repeated
     for nested in nested.iter().rev() {
         match nested {

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -32,6 +32,8 @@ use crate::error::{Error, Result};
 use crate::types::days_ms;
 use crate::types::NativeType;
 
+pub use nested::write_rep_and_def;
+pub use pages::{to_leaves, to_nested, to_parquet_leaves};
 use parquet2::schema::types::PrimitiveType as ParquetPrimitiveType;
 pub use parquet2::{
     compression::{BrotliLevel, CompressionOptions, GzipLevel, ZstdLevel},
@@ -46,6 +48,7 @@ pub use parquet2::{
     },
     FallibleStreamingIterator,
 };
+pub use utils::write_def_levels;
 
 /// Currently supported options to write to parquet
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -70,7 +73,7 @@ pub use pages::array_to_columns;
 pub use pages::Nested;
 
 /// returns offset and length to slice the leaf values
-pub(self) fn slice_nested_leaf(nested: &[Nested]) -> (usize, usize) {
+pub fn slice_nested_leaf(nested: &[Nested]) -> (usize, usize) {
     // find the deepest recursive dremel structure as that one determines how many values we must
     // take
     let mut out = (0, 0);
@@ -154,7 +157,7 @@ pub fn can_encode(data_type: &DataType, encoding: Encoding) -> bool {
     )
 }
 
-fn slice_parquet_array<'a>(
+pub fn slice_parquet_array<'a>(
     array: &'a dyn Array,
     nested: &'a [Nested<'a>],
     offset: usize,
@@ -186,7 +189,7 @@ fn slice_parquet_array<'a>(
     }
 }
 
-fn get_max_length(array: &dyn Array, nested: &[Nested]) -> usize {
+pub fn get_max_length(array: &dyn Array, nested: &[Nested]) -> usize {
     // get the length that should be sliced.
     // that is the inner nested structure that
     // dictates how often the primitive should be repeated

--- a/src/io/parquet/write/nested/mod.rs
+++ b/src/io/parquet/write/nested/mod.rs
@@ -106,6 +106,7 @@ fn to_length<O: Offset>(
         .map(|w| w[1].to_usize() - w[0].to_usize())
 }
 
+/// Write `repetition_levels` and `definition_levels` to buffer.
 pub fn write_rep_and_def(
     page_version: Version,
     nested: &[Nested],

--- a/src/io/parquet/write/pages.rs
+++ b/src/io/parquet/write/pages.rs
@@ -149,7 +149,7 @@ fn to_nested_recursive<'a>(
     Ok(())
 }
 
-fn to_leaves(array: &dyn Array) -> Vec<&dyn Array> {
+pub fn to_leaves(array: &dyn Array) -> Vec<&dyn Array> {
     let mut leaves = vec![];
     to_leaves_recursive(array, &mut leaves);
     leaves
@@ -179,7 +179,7 @@ fn to_leaves_recursive<'a>(array: &'a dyn Array, leaves: &mut Vec<&'a dyn Array>
     }
 }
 
-fn to_parquet_leaves(type_: ParquetType) -> Vec<ParquetPrimitiveType> {
+pub fn to_parquet_leaves(type_: ParquetType) -> Vec<ParquetPrimitiveType> {
     let mut leaves = vec![];
     to_parquet_leaves_recursive(type_, &mut leaves);
     leaves

--- a/src/io/parquet/write/pages.rs
+++ b/src/io/parquet/write/pages.rs
@@ -149,6 +149,7 @@ fn to_nested_recursive<'a>(
     Ok(())
 }
 
+/// Convert [`Array`] to `Vec<&dyn Array>` leaves in DFS order.
 pub fn to_leaves(array: &dyn Array) -> Vec<&dyn Array> {
     let mut leaves = vec![];
     to_leaves_recursive(array, &mut leaves);
@@ -179,6 +180,7 @@ fn to_leaves_recursive<'a>(array: &'a dyn Array, leaves: &mut Vec<&'a dyn Array>
     }
 }
 
+/// Convert `ParquetType` to `Vec<ParquetPrimitiveType>` leaves in DFS order.
 pub fn to_parquet_leaves(type_: ParquetType) -> Vec<ParquetPrimitiveType> {
     let mut leaves = vec![];
     to_parquet_leaves_recursive(type_, &mut leaves);


### PR DESCRIPTION
make some structs and functions related to reading and writing nested array public to use them downstream.

`InitNested`
`NestedState`

`init_nested`
`create_list`
`n_columns`
`create_list`
`write_rep_and_def`
`write_def_levels`
`to_leaves`
`to_nested`
`to_parquet_leaves`
`slice_nested_leaf`
`slice_parquet_array`
`get_max_length`
