### PR TITLE
Enable predicate push down for nested types.

### DIFF
--- a/src/io/parquet/read/deserialize/binary/nested.rs
+++ b/src/io/parquet/read/deserialize/binary/nested.rs
@@ -65,14 +65,14 @@ impl<'a, O: Offset> NestedDecoder<'a> for BinaryDecoder<O> {
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, false) => {
                 ValuesDictionary::try_new(page, dict).map(State::OptionalDictionary)
             }
-            (Encoding::Plain, _, true, false) => {
+            (Encoding::Plain, _, true, _) => {
                 let (_, _, values) = split_buffer(page)?;
 
                 let values = BinaryIter::new(values);
 
                 Ok(State::Optional(values))
             }
-            (Encoding::Plain, _, false, false) => {
+            (Encoding::Plain, _, false, _) => {
                 let (_, _, values) = split_buffer(page)?;
 
                 let values = BinaryIter::new(values);

--- a/src/io/parquet/read/deserialize/boolean/nested.rs
+++ b/src/io/parquet/read/deserialize/boolean/nested.rs
@@ -56,16 +56,15 @@ impl<'a> NestedDecoder<'a> for BooleanDecoder {
     ) -> Result<Self::State> {
         let is_optional =
             page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
-        let is_filtered = page.selected_rows().is_some();
 
-        match (page.encoding(), is_optional, is_filtered) {
-            (Encoding::Plain, true, false) => {
+        match (page.encoding(), is_optional) {
+            (Encoding::Plain, true) => {
                 let (_, _, values) = split_buffer(page)?;
                 let values = BitmapIter::new(values, 0, values.len() * 8);
 
                 Ok(State::Optional(values))
             }
-            (Encoding::Plain, false, false) => {
+            (Encoding::Plain, false) => {
                 let (_, _, values) = split_buffer(page)?;
                 let values = BitmapIter::new(values, 0, values.len() * 8);
 

--- a/src/io/parquet/read/deserialize/primitive/nested.rs
+++ b/src/io/parquet/read/deserialize/primitive/nested.rs
@@ -99,8 +99,8 @@ where
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, false) => {
                 ValuesDictionary::try_new(page, dict).map(State::OptionalDictionary)
             }
-            (Encoding::Plain, _, true, false) => Values::try_new::<P>(page).map(State::Optional),
-            (Encoding::Plain, _, false, false) => Values::try_new::<P>(page).map(State::Required),
+            (Encoding::Plain, _, true, _) => Values::try_new::<P>(page).map(State::Optional),
+            (Encoding::Plain, _, false, _) => Values::try_new::<P>(page).map(State::Required),
             _ => Err(utils::not_implemented(page)),
         }
     }


### PR DESCRIPTION
Enable predicate push down for nested types.

But the result of the unit test is not right. 

Need some help to figure out the problem. Did I construct the pages for tests wrongly? Or `FilteredPage` has a bug?

PTAL @jorgecarleitao 