### PR TITLE
Implement writing `FixedSizeList` to Parquet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,7 @@ io_ipc_compression = ["lz4", "zstd"]
 io_flight = ["io_ipc", "arrow-format/flight-data"]
 
 # base64 + io_ipc because arrow schemas are stored as base64-encoded ipc format.
-io_parquet = ["parquet2", "io_ipc", "base64", "futures", "streaming-iterator", "fallible-streaming-iterator"]
+io_parquet = ["parquet2", "io_ipc", "base64", "futures", "streaming-iterator", "fallible-streaming-iterator", "compute_take"]
 
 io_parquet_compression = [
     "io_parquet_zstd",

--- a/arrow-parquet-integration-testing/main.py
+++ b/arrow-parquet-integration-testing/main.py
@@ -73,6 +73,7 @@ def variations():
             "generated_datetime",
             "generated_decimal",
             "generated_interval",
+            "generated_nested",
             # see https://issues.apache.org/jira/browse/ARROW-13486 and
             # https://issues.apache.org/jira/browse/ARROW-13487
             # "generated_dictionary",

--- a/src/compute/take/fixed_size_list.rs
+++ b/src/compute/take/fixed_size_list.rs
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::array::growable::GrowableFixedSizeList;
+use crate::array::FixedSizeListArray;
+use crate::array::{growable::Growable, PrimitiveArray};
+
+use super::Index;
+
+/// `take` implementation for FixedSizeListArrays
+pub fn take<O: Index>(
+    values: &FixedSizeListArray,
+    indices: &PrimitiveArray<O>,
+) -> FixedSizeListArray {
+    let mut capacity = 0;
+    let arrays = indices
+        .values()
+        .iter()
+        .map(|index| {
+            let index = index.to_usize();
+            let slice = values.slice(index, 1);
+            capacity += slice.len();
+            slice
+        })
+        .collect::<Vec<FixedSizeListArray>>();
+
+    let arrays = arrays.iter().collect();
+
+    if let Some(validity) = indices.validity() {
+        let mut growable: GrowableFixedSizeList =
+            GrowableFixedSizeList::new(arrays, true, capacity);
+
+        for index in 0..indices.len() {
+            if validity.get_bit(index) {
+                growable.extend(index, 0, 1);
+            } else {
+                growable.extend_validity(1)
+            }
+        }
+
+        growable.into()
+    } else {
+        let mut growable: GrowableFixedSizeList =
+            GrowableFixedSizeList::new(arrays, false, capacity);
+        for index in 0..indices.len() {
+            growable.extend(index, 0, 1);
+        }
+
+        growable.into()
+    }
+}

--- a/src/compute/take/mod.rs
+++ b/src/compute/take/mod.rs
@@ -27,6 +27,7 @@ use crate::{
 mod binary;
 mod boolean;
 mod dict;
+mod fixed_size_list;
 mod generic_binary;
 mod list;
 mod primitive;
@@ -90,6 +91,10 @@ pub fn take<O: Index>(values: &dyn Array, indices: &PrimitiveArray<O>) -> Result
             let array = values.as_any().downcast_ref().unwrap();
             Ok(Box::new(list::take::<i64, O>(array, indices)))
         }
+        FixedSizeList => {
+            let array = values.as_any().downcast_ref().unwrap();
+            Ok(Box::new(fixed_size_list::take::<O>(array, indices)))
+        }
         t => unimplemented!("Take not supported for data type {:?}", t),
     }
 }
@@ -135,6 +140,7 @@ pub fn can_take(data_type: &DataType) -> bool {
             | DataType::Struct(_)
             | DataType::List(_)
             | DataType::LargeList(_)
+            | DataType::FixedSizeList(_, _)
             | DataType::Dictionary(..)
     )
 }

--- a/tests/it/compute/take.rs
+++ b/tests/it/compute/take.rs
@@ -260,6 +260,25 @@ fn list_both_validity() {
 }
 
 #[test]
+fn fixed_size_list_with_no_none() {
+    let values = Buffer::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    let values = PrimitiveArray::<i32>::new(DataType::Int32, values, None);
+
+    let data_type = FixedSizeListArray::default_datatype(DataType::Int32, 2);
+    let array = FixedSizeListArray::new(data_type, Box::new(values), None);
+
+    let indices = PrimitiveArray::from([Some(4i32), Some(1), Some(3)]);
+    let result = take(&array, &indices).unwrap();
+
+    let expected_values = Buffer::from(vec![8, 9, 2, 3, 6, 7]);
+    let expected_values = PrimitiveArray::<i32>::new(DataType::Int32, expected_values, None);
+    let expected_type = FixedSizeListArray::default_datatype(DataType::Int32, 2);
+    let expected = FixedSizeListArray::new(expected_type, Box::new(expected_values), None);
+
+    assert_eq!(expected, result.as_ref());
+}
+
+#[test]
 fn test_nested() {
     let values = Buffer::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     let values = PrimitiveArray::<i32>::new(DataType::Int32, values, None);


### PR DESCRIPTION
This is building on top of #1386 to attempt to write a packed array of values from a fixed size list array to a parquet leaf. 

I'm getting a dreaded `borrowed value does not live long enough` that I was hoping you'd be able to give some advice on
```
error[E0597]: `*new_array` does not live long enough
   --> src/io/parquet/write/pages.rs:193:33
    |
159 |   fn to_leaves_recursive<'a>(array: &'a dyn Array, leaves: &mut Vec<&'a dyn Array>) {
    |                          -- lifetime `'a` defined here
...
193 |                   let new_array = new_array
    |  _________________________________^
194 | |                     .as_any()
    | |_____________________________^ borrowed value does not live long enough
...
197 |                   to_leaves_recursive(new_array.values().as_ref(), leaves);
    |                   -------------------------------------------------------- argument requires that `*new_array` is borrowed for `'a`
198 |               } else {
    |               - `*new_array` dropped here while still borrowed


```