### PR TITLE
Improved performance of writing to parquet

### DIFF
--- a/src/io/parquet/write/binary/nested.rs
+++ b/src/io/parquet/write/binary/nested.rs
@@ -39,7 +39,6 @@ where
     let (repetition_levels_byte_length, definition_levels_byte_length) =
         nested::write_rep_and_def(options.version, &nested, &mut buffer)?;
 
-    let array = array.slice(start, len);
     encode_plain(&array, is_optional, &mut buffer);
 
     let statistics = if options.write_statistics {

--- a/src/io/parquet/write/binary/nested.rs
+++ b/src/io/parquet/write/binary/nested.rs
@@ -34,10 +34,11 @@ where
     } else {
         unreachable!("")
     }
+    let num_values = nested::num_values(&nested);
 
     let mut buffer = vec![];
     let (repetition_levels_byte_length, definition_levels_byte_length) =
-        nested::write_rep_and_def(options.version, &nested, &mut buffer)?;
+        nested::write_rep_and_def(options.version, &nested, num_values, &mut buffer)?;
 
     encode_plain(&array, is_optional, &mut buffer);
 
@@ -49,7 +50,7 @@ where
 
     utils::build_plain_page(
         buffer,
-        nested::num_values(&nested),
+        num_values,
         nested[0].len(),
         array.null_count(),
         repetition_levels_byte_length,

--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -30,10 +30,11 @@ pub fn array_to_page(
     } else {
         unreachable!("")
     }
+    let num_values = nested::num_values(&nested);
 
     let mut buffer = vec![];
     let (repetition_levels_byte_length, definition_levels_byte_length) =
-        nested::write_rep_and_def(options.version, &nested, &mut buffer)?;
+        nested::write_rep_and_def(options.version, &nested, num_values, &mut buffer)?;
 
     encode_plain(&array, is_optional, &mut buffer)?;
 
@@ -45,7 +46,7 @@ pub fn array_to_page(
 
     utils::build_plain_page(
         buffer,
-        nested::num_values(&nested),
+        num_values,
         nested[0].len(),
         array.null_count(),
         repetition_levels_byte_length,

--- a/src/io/parquet/write/nested/def.rs
+++ b/src/io/parquet/write/nested/def.rs
@@ -1,7 +1,6 @@
 use crate::{bitmap::Bitmap, offset::Offset};
 
 use super::super::pages::{ListNested, Nested};
-use super::rep::num_values;
 use super::to_length;
 
 trait DebugIter: Iterator<Item = (u32, usize)> + std::fmt::Debug {}
@@ -87,9 +86,7 @@ pub struct DefLevelsIter<'a> {
 }
 
 impl<'a> DefLevelsIter<'a> {
-    pub fn new(nested: &'a [Nested]) -> Self {
-        let remaining_values = num_values(nested);
-
+    pub fn new(nested: &'a [Nested], num_values: usize) -> Self {
         let iter = iter(nested);
         let remaining = vec![0; iter.len()];
         let validity = vec![0; iter.len()];
@@ -100,7 +97,7 @@ impl<'a> DefLevelsIter<'a> {
             validity,
             total: 0,
             current_level: 0,
-            remaining_values,
+            remaining_values: num_values,
         }
     }
 }
@@ -170,10 +167,11 @@ impl<'a> Iterator for DefLevelsIter<'a> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::num_values;
     use super::*;
 
     fn test(nested: Vec<Nested>, expected: Vec<u32>) {
-        let mut iter = DefLevelsIter::new(&nested);
+        let mut iter = DefLevelsIter::new(&nested, num_values(&nested));
         assert_eq!(iter.size_hint().0, expected.len());
         let result = iter.by_ref().collect::<Vec<_>>();
         assert_eq!(result, expected);

--- a/src/io/parquet/write/nested/rep.rs
+++ b/src/io/parquet/write/nested/rep.rs
@@ -60,9 +60,7 @@ pub struct RepLevelsIter<'a> {
 }
 
 impl<'a> RepLevelsIter<'a> {
-    pub fn new(nested: &'a [Nested]) -> Self {
-        let remaining_values = num_values(nested);
-
+    pub fn new(nested: &'a [Nested], num_values: usize) -> Self {
         let iter = iter(nested);
         let remaining = vec![0; iter.len()];
 
@@ -71,7 +69,7 @@ impl<'a> RepLevelsIter<'a> {
             remaining,
             total: 0,
             current_level: 0,
-            remaining_values,
+            remaining_values: num_values,
         }
     }
 }
@@ -138,7 +136,7 @@ mod tests {
     use super::*;
 
     fn test(nested: Vec<Nested>, expected: Vec<u32>) {
-        let mut iter = RepLevelsIter::new(&nested);
+        let mut iter = RepLevelsIter::new(&nested, num_values(&nested));
         assert_eq!(iter.size_hint().0, expected.len());
         assert_eq!(iter.by_ref().collect::<Vec<_>>(), expected);
         assert_eq!(iter.size_hint().0, 0);

--- a/src/io/parquet/write/primitive/nested.rs
+++ b/src/io/parquet/write/primitive/nested.rs
@@ -42,8 +42,10 @@ where
         unreachable!("")
     }
 
+    let num_values = nested::num_values(&nested);
+
     let (repetition_levels_byte_length, definition_levels_byte_length) =
-        nested::write_rep_and_def(options.version, &nested, &mut buffer)?;
+        nested::write_rep_and_def(options.version, &nested, num_values, &mut buffer)?;
 
     let buffer = encode_plain(&array, is_optional, buffer);
 
@@ -58,7 +60,7 @@ where
 
     utils::build_plain_page(
         buffer,
-        nested::num_values(&nested),
+        num_values,
         nested[0].len(),
         array.null_count(),
         repetition_levels_byte_length,

--- a/src/io/parquet/write/utf8/nested.rs
+++ b/src/io/parquet/write/utf8/nested.rs
@@ -34,9 +34,11 @@ where
         unreachable!("")
     }
 
+    let num_values = nested::num_values(&nested);
+
     let mut buffer = vec![];
     let (repetition_levels_byte_length, definition_levels_byte_length) =
-        nested::write_rep_and_def(options.version, &nested, &mut buffer)?;
+        nested::write_rep_and_def(options.version, &nested, num_values, &mut buffer)?;
 
     encode_plain(&array, is_optional, &mut buffer);
 
@@ -48,7 +50,7 @@ where
 
     utils::build_plain_page(
         buffer,
-        nested::num_values(&nested),
+        num_values,
         nested[0].len(),
         array.null_count(),
         repetition_levels_byte_length,


### PR DESCRIPTION
By materializing computation of `num_values` of the page and re-use it throughout.