### PR TITLE
Changed methods to slice arrays

### DIFF
--- a/benches/bitmap_ops.rs
+++ b/benches/bitmap_ops.rs
@@ -26,7 +26,8 @@ fn add_benchmark(c: &mut Criterion) {
             &format!("bitmap count zeros 85% slice 2^{log2_size}"),
             |b| {
                 b.iter(|| {
-                    let r = bitmap.clone().slice(offset, len);
+                    let mut r = bitmap.clone();
+                    r.slice(offset, len);
                     assert!(r.unset_bits() > 0);
                 })
             },
@@ -39,13 +40,15 @@ fn add_benchmark(c: &mut Criterion) {
             &format!("bitmap count zeros 51% slice 2^{log2_size}"),
             |b| {
                 b.iter(|| {
-                    let r = bitmap.clone().slice(offset, len);
+                    let mut r = bitmap.clone();
+                    r.slice(offset, len);
                     assert!(r.unset_bits() > 0);
                 })
             },
         );
 
-        let bitmap1 = bitmap.clone().slice(1, size - 1);
+        let mut bitmap1 = bitmap.clone();
+        bitmap1.slice(1, size - 1);
         c.bench_function(&format!("bitmap not 2^{log2_size}"), |b| {
             b.iter(|| {
                 let r = !&bitmap1;

--- a/guide/src/low_level.md
+++ b/guide/src/low_level.md
@@ -34,7 +34,7 @@ let x = vec![1u32, 2, 3];
 let x: Buffer<u32> = x.into();
 assert_eq!(x.as_slice(), &[1u32, 2, 3]);
 
-let x = x.slice(1, 2); // O(1)
+let x = x.sliced(1, 2); // O(1)
 assert_eq!(x.as_slice(), &[2, 3]);
 # }
 ```

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -291,27 +291,21 @@ impl<K: DictionaryKey> DictionaryArray<K> {
         DataType::Dictionary(K::KEY_TYPE, Box::new(values_datatype), false)
     }
 
-    /// Creates a new [`DictionaryArray`] by slicing the existing [`DictionaryArray`].
+    /// Slices this [`DictionaryArray`].
     /// # Panics
     /// iff `offset + length > self.len()`.
-    pub fn slice(&self, offset: usize, length: usize) -> Self {
-        Self {
-            data_type: self.data_type.clone(),
-            keys: self.keys.clone().slice(offset, length),
-            values: self.values.clone(),
-        }
+    pub fn slice(&mut self, offset: usize, length: usize) {
+        self.keys.slice(offset, length);
     }
 
-    /// Creates a new [`DictionaryArray`] by slicing the existing [`DictionaryArray`].
+    /// Slices this [`DictionaryArray`].
     /// # Safety
     /// Safe iff `offset + length <= self.len()`.
-    pub unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Self {
-        Self {
-            data_type: self.data_type.clone(),
-            keys: self.keys.clone().slice_unchecked(offset, length),
-            values: self.values.clone(),
-        }
+    pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        self.keys.slice_unchecked(offset, length);
     }
+
+    impl_sliced!();
 
     /// Returns this [`DictionaryArray`] with a new validity.
     /// # Panic
@@ -437,12 +431,12 @@ impl<K: DictionaryKey> Array for DictionaryArray<K> {
         self.keys.validity()
     }
 
-    fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
-        Box::new(self.slice(offset, length))
+    fn slice(&mut self, offset: usize, length: usize) {
+        self.slice(offset, length)
     }
 
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
-        Box::new(self.slice_unchecked(offset, length))
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        self.slice_unchecked(offset, length)
     }
 
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {

--- a/src/array/equal/struct_.rs
+++ b/src/array/equal/struct_.rs
@@ -13,7 +13,7 @@ pub(super) fn equal(lhs: &StructArray, rhs: &StructArray) -> bool {
                     l_validity.iter().zip(r_validity.iter()).enumerate().all(
                         |(i, (lhs_is_valid, rhs_is_valid))| {
                             if lhs_is_valid && rhs_is_valid {
-                                lhs.slice(i, 1) == rhs.slice(i, 1)
+                                lhs.sliced(i, 1) == rhs.sliced(i, 1)
                             } else {
                                 lhs_is_valid == rhs_is_valid
                             }
@@ -27,7 +27,7 @@ pub(super) fn equal(lhs: &StructArray, rhs: &StructArray) -> bool {
                     .all(|(lhs, rhs)| {
                         l_validity.iter().enumerate().all(|(i, lhs_is_valid)| {
                             if lhs_is_valid {
-                                lhs.slice(i, 1) == rhs.slice(i, 1)
+                                lhs.sliced(i, 1) == rhs.sliced(i, 1)
                             } else {
                                 // rhs is always valid => different
                                 false
@@ -42,7 +42,7 @@ pub(super) fn equal(lhs: &StructArray, rhs: &StructArray) -> bool {
                     .all(|(lhs, rhs)| {
                         r_validity.iter().enumerate().all(|(i, rhs_is_valid)| {
                             if rhs_is_valid {
-                                lhs.slice(i, 1) == rhs.slice(i, 1)
+                                lhs.sliced(i, 1) == rhs.sliced(i, 1)
                             } else {
                                 // lhs is always valid => different
                                 false

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -106,6 +106,7 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
     /// This operation is `O(1)` over `len`.
     /// # Panic
     /// This function panics iff `offset + length > self.len()`.
+    #[must_use]
     fn sliced(&self, offset: usize, length: usize) -> Box<dyn Array> {
         let mut new = self.to_boxed();
         new.slice(offset, length);
@@ -118,6 +119,7 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
     /// and moving the struct to the heap.
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`
+    #[must_use]
     unsafe fn sliced_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
         let mut new = self.to_boxed();
         new.slice_unchecked(offset, length);
@@ -402,6 +404,7 @@ macro_rules! impl_sliced {
         /// # Panics
         /// iff `offset + length > self.len()`.
         #[inline]
+        #[must_use]
         pub fn sliced(self, offset: usize, length: usize) -> Self {
             assert!(
                 offset + length <= self.len(),
@@ -416,6 +419,7 @@ macro_rules! impl_sliced {
         /// # Safety
         /// The caller must ensure that `offset + length <= self.len()`.
         #[inline]
+        #[must_use]
         pub fn sliced_unchecked(mut self, offset: usize, length: usize) -> Self {
             unsafe { self.slice_unchecked(offset, length) };
             self

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -60,11 +60,8 @@ impl NullArray {
 
 impl NullArray {
     /// Returns a slice of the [`NullArray`].
-    pub fn slice(&self, _offset: usize, length: usize) -> Self {
-        Self {
-            data_type: self.data_type.clone(),
-            length,
-        }
+    pub fn slice(&mut self, _offset: usize, length: usize) {
+        self.length = length;
     }
 
     #[inline]
@@ -91,19 +88,19 @@ impl Array for NullArray {
 
     #[inline]
     fn data_type(&self) -> &DataType {
-        &DataType::Null
+        &self.data_type
     }
 
     fn validity(&self) -> Option<&Bitmap> {
         None
     }
 
-    fn slice(&self, offset: usize, length: usize) -> Box<dyn Array> {
-        Box::new(self.slice(offset, length))
+    fn slice(&mut self, offset: usize, length: usize) {
+        self.slice(offset, length)
     }
 
-    unsafe fn slice_unchecked(&self, offset: usize, length: usize) -> Box<dyn Array> {
-        Box::new(self.slice(offset, length))
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        self.slice(offset, length)
     }
 
     fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {

--- a/src/array/union/ffi.rs
+++ b/src/array/union/ffi.rs
@@ -50,7 +50,7 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for UnionArray {
             .collect::<Result<Vec<Box<dyn Array>>>>()?;
 
         if offset > 0 {
-            types = types.slice(offset, length);
+            types.slice(offset, length);
         };
 
         Self::try_new(data_type, types, fields, offsets)

--- a/src/bitmap/bitmap_ops.rs
+++ b/src/bitmap/bitmap_ops.rs
@@ -160,7 +160,7 @@ pub(crate) fn align(bitmap: &Bitmap, new_offset: usize) -> Bitmap {
         .chain(bitmap.iter())
         .collect();
 
-    bitmap.slice(new_offset, length)
+    bitmap.sliced(new_offset, length)
 }
 
 #[inline]

--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -171,8 +171,7 @@ impl Bitmap {
     /// Panics iff `offset + length > self.length`, i.e. if the offset and `length`
     /// exceeds the allocated capacity of `self`.
     #[inline]
-    #[must_use]
-    pub fn slice(self, offset: usize, length: usize) -> Self {
+    pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(offset + length <= self.length);
         unsafe { self.slice_unchecked(offset, length) }
     }
@@ -181,7 +180,7 @@ impl Bitmap {
     /// # Safety
     /// The caller must ensure that `self.offset + offset + length <= self.len()`
     #[inline]
-    pub unsafe fn slice_unchecked(mut self, offset: usize, length: usize) -> Self {
+    pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
         // count the smallest chunk
         if length < self.length / 2 {
             // count the null values in the slice
@@ -195,6 +194,26 @@ impl Bitmap {
         }
         self.offset += offset;
         self.length = length;
+    }
+
+    /// Slices `self`, offsetting by `offset` and truncating up to `length` bits.
+    /// # Panic
+    /// Panics iff `offset + length > self.length`, i.e. if the offset and `length`
+    /// exceeds the allocated capacity of `self`.
+    #[inline]
+    #[must_use]
+    pub fn sliced(self, offset: usize, length: usize) -> Self {
+        assert!(offset + length <= self.length);
+        unsafe { self.sliced_unchecked(offset, length) }
+    }
+
+    /// Slices `self`, offseting by `offset` and truncating up to `length` bits.
+    /// # Safety
+    /// The caller must ensure that `self.offset + offset + length <= self.len()`
+    #[inline]
+    #[must_use]
+    pub unsafe fn sliced_unchecked(mut self, offset: usize, length: usize) -> Self {
+        self.slice_unchecked(offset, length);
         self
     }
 

--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -35,7 +35,8 @@ use super::{
 ///
 /// // slicing is 'O(1)' (data is shared)
 /// let bitmap = Bitmap::try_new(vec![0b00001101], 5).unwrap();
-/// let sliced = bitmap.slice(1, 4);
+/// let mut sliced = bitmap.clone();
+/// sliced.slice(1, 4);
 /// assert_eq!(sliced.as_slice(), ([0b00001101u8].as_ref(), 1, 4)); // 1 here is the offset:
 /// assert_eq!(format!("{:?}", sliced), "[0b___0110_]".to_string());
 /// // when sliced (or cloned), it is no longer possible to `into_mut`.

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -26,8 +26,9 @@ use super::IntoIter;
 ///
 /// // cloning and slicing is `O(1)` (data is shared)
 /// let mut buffer: Buffer<u32> = vec![1, 2, 3].into();
-/// let slice = buffer.clone().slice(1, 1);
-/// assert_eq!(slice.as_ref(), [2].as_ref());
+/// let mut sliced = buffer.clone();
+/// sliced.slice(1, 1);
+/// assert_eq!(sliced.as_ref(), [2].as_ref());
 /// // but cloning forbids getting mut since `slice` and `buffer` now share data
 /// assert_eq!(buffer.get_mut(), None);
 /// ```

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -121,7 +121,20 @@ impl<T> Buffer<T> {
     /// # Panics
     /// Panics iff `offset` is larger than `len`.
     #[inline]
-    pub fn slice(self, offset: usize, length: usize) -> Self {
+    pub fn sliced(self, offset: usize, length: usize) -> Self {
+        assert!(
+            offset + length <= self.len(),
+            "the offset of the new Buffer cannot exceed the existing length"
+        );
+        // Safety: we just checked bounds
+        unsafe { self.sliced_unchecked(offset, length) }
+    }
+
+    /// Slices this buffer starting at `offset`.
+    /// # Panics
+    /// Panics iff `offset` is larger than `len`.
+    #[inline]
+    pub fn slice(&mut self, offset: usize, length: usize) {
         assert!(
             offset + length <= self.len(),
             "the offset of the new Buffer cannot exceed the existing length"
@@ -135,10 +148,19 @@ impl<T> Buffer<T> {
     /// # Safety
     /// The caller must ensure `offset + length <= self.len()`
     #[inline]
-    pub unsafe fn slice_unchecked(mut self, offset: usize, length: usize) -> Self {
+    #[must_use]
+    pub unsafe fn sliced_unchecked(mut self, offset: usize, length: usize) -> Self {
+        self.slice_unchecked(offset, length);
+        self
+    }
+
+    /// Slices this buffer starting at `offset`.
+    /// # Safety
+    /// The caller must ensure `offset + length <= self.len()`
+    #[inline]
+    pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
         self.offset += offset;
         self.length = length;
-        self
     }
 
     /// Returns a pointer to the start of this buffer.

--- a/src/compute/comparison/primitive.rs
+++ b/src/compute/comparison/primitive.rs
@@ -332,9 +332,9 @@ mod tests {
     #[test]
     fn test_primitive_array_eq_with_slice() {
         let a = Int64Array::from_slice([6, 7, 8, 8, 10]);
-        let b = Int64Array::from_slice([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        let c = b.slice(5, 5);
-        let d = eq(&c, &a);
+        let mut b = Int64Array::from_slice([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        b.slice(5, 5);
+        let d = eq(&b, &a);
         assert_eq!(d, BooleanArray::from_slice([true, true, true, false, true]));
     }
 
@@ -560,10 +560,10 @@ mod tests {
 
     #[test]
     fn test_primitive_array_compare_slice() {
-        let a = (0..100).map(Some).collect::<PrimitiveArray<i32>>();
-        let a = a.slice(50, 50);
-        let b = (100..200).map(Some).collect::<PrimitiveArray<i32>>();
-        let b = b.slice(50, 50);
+        let mut a = (0..100).map(Some).collect::<PrimitiveArray<i32>>();
+        a.slice(50, 50);
+        let mut b = (100..200).map(Some).collect::<PrimitiveArray<i32>>();
+        b.slice(50, 50);
         let actual = lt(&a, &b);
         let expected: BooleanArray = (0..50).map(|_| Some(true)).collect();
         assert_eq!(expected, actual);
@@ -571,8 +571,8 @@ mod tests {
 
     #[test]
     fn test_primitive_array_compare_scalar_slice() {
-        let a = (0..100).map(Some).collect::<PrimitiveArray<i32>>();
-        let a = a.slice(50, 50);
+        let mut a = (0..100).map(Some).collect::<PrimitiveArray<i32>>();
+        a.slice(50, 50);
         let actual = lt_scalar(&a, 200);
         let expected: BooleanArray = (0..50).map(|_| Some(true)).collect();
         assert_eq!(expected, actual);

--- a/src/compute/limit.rs
+++ b/src/compute/limit.rs
@@ -10,5 +10,5 @@ use crate::array::Array;
 /// * it slices from offset 0
 pub fn limit(array: &dyn Array, num_elements: usize) -> Box<dyn Array> {
     let lim = num_elements.min(array.len());
-    array.slice(0, lim)
+    array.sliced(0, lim)
 }

--- a/src/compute/take/fixed_size_list.rs
+++ b/src/compute/take/fixed_size_list.rs
@@ -32,7 +32,7 @@ pub fn take<O: Index>(
         .iter()
         .map(|index| {
             let index = index.to_usize();
-            let slice = values.slice(index, 1);
+            let slice = values.clone().sliced(index, 1);
             capacity += slice.len();
             slice
         })

--- a/src/compute/take/list.rs
+++ b/src/compute/take/list.rs
@@ -34,7 +34,7 @@ pub fn take<I: Offset, O: Index>(
         .iter()
         .map(|index| {
             let index = index.to_usize();
-            let slice = values.slice(index, 1);
+            let slice = values.clone().sliced(index, 1);
             capacity += slice.len();
             slice
         })

--- a/src/compute/window.rs
+++ b/src/compute/window.rs
@@ -49,7 +49,7 @@ pub fn shift(array: &dyn Array, offset: i64) -> Result<Box<dyn Array>> {
     // Compute slice
     let slice_offset = clamp(-offset, 0, array.len() as i64) as usize;
     let length = array.len() - abs(offset) as usize;
-    let slice = array.slice(slice_offset, length);
+    let slice = array.sliced(slice_offset, length);
 
     // Generate array with remaining `null` items
     let nulls = abs(offset) as usize;

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -239,7 +239,7 @@ unsafe fn create_buffer<T: NativeType>(
     let offset = buffer_offset(array, data_type, index);
     let bytes = Bytes::from_foreign(ptr, len, owner);
 
-    Ok(Buffer::from_bytes(bytes).slice(offset, len - offset))
+    Ok(Buffer::from_bytes(bytes).sliced(offset, len - offset))
 }
 
 /// returns the buffer `i` of `array` interpreted as a [`Bitmap`].
@@ -260,7 +260,7 @@ unsafe fn create_bitmap(
     let bytes_len = bytes_for(offset + len);
     let bytes = Bytes::from_foreign(ptr, bytes_len, owner);
 
-    Ok(Bitmap::from_bytes(bytes, offset + len).slice(offset, len))
+    Ok(Bitmap::from_bytes(bytes, offset + len).sliced(offset, len))
 }
 
 fn buffer_offset(array: &ArrowArray, data_type: &DataType, i: usize) -> usize {

--- a/src/io/ipc/write/serialize.rs
+++ b/src/io/ipc/write/serialize.rs
@@ -224,7 +224,7 @@ fn write_list<O: Offset>(
     write(
         array
             .values()
-            .slice(first.to_usize(), last.to_usize() - first.to_usize())
+            .sliced(first.to_usize(), last.to_usize() - first.to_usize())
             .as_ref(),
         buffers,
         arrow_data,
@@ -352,7 +352,7 @@ fn write_map(
     write(
         array
             .field()
-            .slice(first as usize, last as usize - first as usize)
+            .sliced(first as usize, last as usize - first as usize)
             .as_ref(),
         buffers,
         arrow_data,

--- a/src/io/parquet/write/binary/nested.rs
+++ b/src/io/parquet/write/binary/nested.rs
@@ -28,7 +28,7 @@ where
     let (start, len) = slice_nested_leaf(nested);
 
     let mut nested = nested.to_vec();
-    let array = array.slice(start, len);
+    let array = array.clone().sliced(start, len);
     if let Some(Nested::Primitive(_, _, c)) = nested.last_mut() {
         *c = len;
     } else {

--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -24,7 +24,7 @@ pub fn array_to_page(
     let (start, len) = slice_nested_leaf(nested);
 
     let mut nested = nested.to_vec();
-    let array = array.slice(start, len);
+    let array = array.clone().sliced(start, len);
     if let Some(Nested::Primitive(_, _, c)) = nested.last_mut() {
         *c = len;
     } else {

--- a/src/io/parquet/write/dictionary.rs
+++ b/src/io/parquet/write/dictionary.rs
@@ -115,7 +115,7 @@ fn serialize_keys<K: DictionaryKey>(
     let (start, len) = slice_nested_leaf(nested);
 
     let mut nested = nested.to_vec();
-    let array = array.slice(start, len);
+    let array = array.clone().sliced(start, len);
     if let Some(Nested::Primitive(_, _, c)) = nested.last_mut() {
         *c = len;
     } else {

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -186,7 +186,7 @@ pub fn slice_parquet_array<'a>(
     if is_nested {
         (array.to_boxed(), nested)
     } else {
-        (array.slice(offset, length), nested)
+        (array.to_boxed().sliced(offset, length), nested)
     }
 }
 

--- a/src/io/parquet/write/primitive/nested.rs
+++ b/src/io/parquet/write/primitive/nested.rs
@@ -35,7 +35,7 @@ where
     let (start, len) = slice_nested_leaf(nested);
 
     let mut nested = nested.to_vec();
-    let array = array.slice(start, len);
+    let array = array.clone().sliced(start, len);
     if let Some(Nested::Primitive(_, _, c)) = nested.last_mut() {
         *c = len;
     } else {

--- a/src/io/parquet/write/utf8/nested.rs
+++ b/src/io/parquet/write/utf8/nested.rs
@@ -27,7 +27,7 @@ where
     let (start, len) = slice_nested_leaf(nested);
 
     let mut nested = nested.to_vec();
-    let array = array.slice(start, len);
+    let array = array.clone().sliced(start, len);
     if let Some(Nested::Primitive(_, _, c)) = nested.last_mut() {
         *c = len;
     } else {

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -393,7 +393,22 @@ impl<O: Offset> OffsetsBuffer<O> {
         self.0.as_slice()
     }
 
-    /// Returns the last offset of this container, which is guaranteed to exist.
+    /// Returns the range of the offsets.
+    #[inline]
+    pub fn range(&self) -> O {
+        *self.last() - *self.first()
+    }
+
+    /// Returns the first offset.
+    #[inline]
+    pub fn first(&self) -> &O {
+        match self.0.first() {
+            Some(element) => element,
+            None => unsafe { unreachable_unchecked() },
+        }
+    }
+
+    /// Returns the last offset.
     #[inline]
     pub fn last(&self) -> &O {
         match self.0.last() {
@@ -423,13 +438,12 @@ impl<O: Offset> OffsetsBuffer<O> {
         (start, end)
     }
 
-    /// Returns a new [`OffsetsBuffer`] that is a slice of this buffer starting at `offset`.
-    /// Doing so allows the same memory region to be shared between buffers.
+    /// Slices this [`OffsetsBuffer`] starting at `offset`.
     /// # Safety
     /// The caller must ensure `offset + length <= self.len()`
     #[inline]
-    pub unsafe fn slice_unchecked(self, offset: usize, length: usize) -> Self {
-        Self(self.0.slice_unchecked(offset, length))
+    pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        self.0.slice_unchecked(offset, length);
     }
 
     /// Returns an iterator with the lengths of the offsets

--- a/tests/it/array/binary/mod.rs
+++ b/tests/it/array/binary/mod.rs
@@ -38,7 +38,7 @@ fn basics() {
     );
     assert_eq!(array, array2);
 
-    let array = array.slice(1, 2);
+    let array = array.sliced(1, 2);
     assert_eq!(array.value(0), b"");
     assert_eq!(array.value(1), b"hello2");
     // note how this keeps everything: the offsets were sliced

--- a/tests/it/array/boolean/mod.rs
+++ b/tests/it/array/boolean/mod.rs
@@ -34,7 +34,7 @@ fn basics() {
     );
     assert_eq!(array, array2);
 
-    let array = array.slice(1, 2);
+    let array = array.sliced(1, 2);
     assert!(!array.value(0));
     assert!(!array.value(1));
 }

--- a/tests/it/array/equal/boolean.rs
+++ b/tests/it/array/equal/boolean.rs
@@ -31,12 +31,12 @@ fn test_boolean_equal_offset() {
     let b = BooleanArray::from_slice(vec![true, false, false, false, true, false, true, true]);
     test_equal(&a, &b, false);
 
-    let a_slice = a.slice(2, 3);
-    let b_slice = b.slice(3, 3);
+    let a_slice = a.sliced(2, 3);
+    let b_slice = b.sliced(3, 3);
     test_equal(&a_slice, &b_slice, true);
 
-    let a_slice = a.slice(3, 4);
-    let b_slice = b.slice(4, 4);
+    let a_slice = a.sliced(3, 4);
+    let b_slice = b.sliced(4, 4);
     test_equal(&a_slice, &b_slice, false);
 
     // Elements fill in `u8`'s exactly.

--- a/tests/it/array/equal/fixed_size_list.rs
+++ b/tests/it/array/equal/fixed_size_list.rs
@@ -70,15 +70,15 @@ fn test_fixed_list_offsets() {
     let b =
         create_fixed_size_list_array([Some(&[1, 2, 3]), None, None, Some(&[3, 6, 9]), None, None]);
 
-    let a_slice = a.slice(0, 3);
-    let b_slice = b.slice(0, 3);
+    let a_slice = a.clone().sliced(0, 3);
+    let b_slice = b.clone().sliced(0, 3);
     test_equal(&a_slice, &b_slice, true);
 
-    let a_slice = a.slice(0, 5);
-    let b_slice = b.slice(0, 5);
+    let a_slice = a.clone().sliced(0, 5);
+    let b_slice = b.clone().sliced(0, 5);
     test_equal(&a_slice, &b_slice, false);
 
-    let a_slice = a.slice(4, 1);
-    let b_slice = b.slice(4, 1);
+    let a_slice = a.sliced(4, 1);
+    let b_slice = b.sliced(4, 1);
     test_equal(&a_slice, &b_slice, true);
 }

--- a/tests/it/array/equal/list.rs
+++ b/tests/it/array/equal/list.rs
@@ -51,16 +51,16 @@ fn test_list_offsets() {
     let a = create_list_array([Some(&[1, 2]), None, None, Some(&[3, 4]), None, None]);
     let b = create_list_array([Some(&[1, 2]), None, None, Some(&[3, 5]), None, None]);
 
-    let a_slice = a.slice(0, 3);
-    let b_slice = b.slice(0, 3);
+    let a_slice = a.clone().sliced(0, 3);
+    let b_slice = b.clone().sliced(0, 3);
     test_equal(&a_slice, &b_slice, true);
 
-    let a_slice = a.slice(0, 5);
-    let b_slice = b.slice(0, 5);
+    let a_slice = a.clone().sliced(0, 5);
+    let b_slice = b.clone().sliced(0, 5);
     test_equal(&a_slice, &b_slice, false);
 
-    let a_slice = a.slice(4, 1);
-    let b_slice = b.slice(4, 1);
+    let a_slice = a.sliced(4, 1);
+    let b_slice = b.sliced(4, 1);
     test_equal(&a_slice, &b_slice, true);
 }
 
@@ -78,7 +78,7 @@ fn test_bla() {
     ]));
     let validity = Bitmap::from([true, false, true]);
     let lhs = ListArray::<i32>::new(data_type, offsets, values, Some(validity));
-    let lhs = lhs.slice(1, 2);
+    let lhs = lhs.sliced(1, 2);
 
     let offsets = vec![0, 0, 3].try_into().unwrap();
     let data_type = ListArray::<i32>::default_datatype(DataType::Int32);

--- a/tests/it/array/equal/primitive.rs
+++ b/tests/it/array/equal/primitive.rs
@@ -81,9 +81,9 @@ fn test_primitive_slice() {
 
     for (lhs, slice_lhs, rhs, slice_rhs, expected) in cases {
         let lhs = Int32Array::from(&lhs);
-        let lhs = lhs.slice(slice_lhs.0, slice_lhs.1);
+        let lhs = lhs.sliced(slice_lhs.0, slice_lhs.1);
         let rhs = Int32Array::from(&rhs);
-        let rhs = rhs.slice(slice_rhs.0, slice_rhs.1);
+        let rhs = rhs.sliced(slice_rhs.0, slice_rhs.1);
 
         test_equal(&lhs, &rhs, expected);
     }

--- a/tests/it/array/fixed_size_binary/mod.rs
+++ b/tests/it/array/fixed_size_binary/mod.rs
@@ -16,7 +16,7 @@ fn basics() {
     assert_eq!(array.value(0), [1, 2]);
     assert_eq!(array.value(2), [5, 6]);
 
-    let array = array.slice(1, 2);
+    let array = array.sliced(1, 2);
 
     assert_eq!(array.value(1), [5, 6]);
 }

--- a/tests/it/array/fixed_size_list/mod.rs
+++ b/tests/it/array/fixed_size_list/mod.rs
@@ -30,7 +30,7 @@ fn basics() {
     assert_eq!(array.value(0).as_ref(), Int32Array::from_slice([10, 20]));
     assert_eq!(array.value(1).as_ref(), Int32Array::from_slice([0, 0]));
 
-    let array = array.slice(1, 1);
+    let array = array.sliced(1, 1);
 
     assert_eq!(array.value(0).as_ref(), Int32Array::from_slice([0, 0]));
 }

--- a/tests/it/array/growable/binary.rs
+++ b/tests/it/array/growable/binary.rs
@@ -23,7 +23,7 @@ fn no_offsets() {
 #[test]
 fn with_offsets() {
     let array = BinaryArray::<i32>::from([Some("a"), Some("bc"), None, Some("defh")]);
-    let array = array.slice(1, 3);
+    let array = array.sliced(1, 3);
 
     let mut a = GrowableBinary::new(vec![&array], false, 0);
 
@@ -39,7 +39,7 @@ fn with_offsets() {
 #[test]
 fn test_string_offsets() {
     let array = BinaryArray::<i32>::from([Some("a"), Some("bc"), None, Some("defh")]);
-    let array = array.slice(1, 3);
+    let array = array.sliced(1, 3);
 
     let mut a = GrowableBinary::new(vec![&array], false, 0);
 
@@ -72,7 +72,7 @@ fn test_multiple_with_validity() {
 #[test]
 fn test_string_null_offset_validity() {
     let array = BinaryArray::<i32>::from([Some("a"), Some("bc"), None, Some("defh")]);
-    let array = array.slice(1, 3);
+    let array = array.sliced(1, 3);
 
     let mut a = GrowableBinary::new(vec![&array], true, 0);
 

--- a/tests/it/array/growable/fixed_binary.rs
+++ b/tests/it/array/growable/fixed_binary.rs
@@ -26,7 +26,7 @@ fn basic() {
 fn offsets() {
     let array =
         FixedSizeBinaryArray::from_iter(vec![Some(b"ab"), Some(b"bc"), None, Some(b"fh")], 2);
-    let array = array.slice(1, 3);
+    let array = array.sliced(1, 3);
 
     let mut a = GrowableFixedSizeBinary::new(vec![&array], false, 0);
 
@@ -60,7 +60,7 @@ fn multiple_with_validity() {
 #[test]
 fn null_offset_validity() {
     let array = FixedSizeBinaryArray::from_iter(vec![Some("aa"), Some("bc"), None, Some("fh")], 2);
-    let array = array.slice(1, 3);
+    let array = array.sliced(1, 3);
 
     let mut a = GrowableFixedSizeBinary::new(vec![&array], true, 0);
 
@@ -78,7 +78,7 @@ fn null_offset_validity() {
 fn sized_offsets() {
     let array =
         FixedSizeBinaryArray::from_iter(vec![Some(&[0, 0]), Some(&[0, 1]), Some(&[0, 2])], 2);
-    let array = array.slice(1, 2);
+    let array = array.sliced(1, 2);
     // = [[0, 1], [0, 2]] due to the offset = 1
 
     let mut a = GrowableFixedSizeBinary::new(vec![&array], false, 0);

--- a/tests/it/array/growable/fixed_size_list.rs
+++ b/tests/it/array/growable/fixed_size_list.rs
@@ -39,7 +39,7 @@ fn null_offset() {
         Some(vec![Some(6i32), Some(7), Some(8)]),
     ];
     let array = create_list_array(data);
-    let array = array.slice(1, 2);
+    let array = array.sliced(1, 2);
 
     let mut a = GrowableFixedSizeList::new(vec![&array], false, 0);
     a.extend(0, 1, 1);

--- a/tests/it/array/growable/list.rs
+++ b/tests/it/array/growable/list.rs
@@ -70,7 +70,7 @@ fn null_offset() {
         Some(vec![Some(6i32), Some(7), Some(8)]),
     ];
     let array = create_list_array(data);
-    let array = array.slice(1, 2);
+    let array = array.sliced(1, 2);
 
     let mut a = GrowableList::new(vec![&array], false, 0);
     a.extend(0, 1, 1);
@@ -92,7 +92,7 @@ fn null_offsets() {
         Some(vec![Some(6i32), None, Some(8)]),
     ];
     let array = create_list_array(data);
-    let array = array.slice(1, 2);
+    let array = array.sliced(1, 2);
 
     let mut a = GrowableList::new(vec![&array], false, 0);
     a.extend(0, 1, 1);

--- a/tests/it/array/growable/primitive.rs
+++ b/tests/it/array/growable/primitive.rs
@@ -19,7 +19,7 @@ fn basics() {
 #[test]
 fn offset() {
     let b = PrimitiveArray::<u8>::from(vec![Some(1), Some(2), Some(3)]);
-    let b = b.slice(1, 2);
+    let b = b.sliced(1, 2);
     let mut a = GrowablePrimitive::new(vec![&b], false, 2);
     a.extend(0, 0, 2);
     assert_eq!(a.len(), 2);
@@ -32,7 +32,7 @@ fn offset() {
 #[test]
 fn null_offset() {
     let b = PrimitiveArray::<u8>::from(vec![Some(1), None, Some(3)]);
-    let b = b.slice(1, 2);
+    let b = b.sliced(1, 2);
     let mut a = GrowablePrimitive::new(vec![&b], false, 2);
     a.extend(0, 0, 2);
     assert_eq!(a.len(), 2);
@@ -44,7 +44,7 @@ fn null_offset() {
 #[test]
 fn null_offset_validity() {
     let b = PrimitiveArray::<u8>::from(&[Some(1), Some(2), Some(3)]);
-    let b = b.slice(1, 2);
+    let b = b.sliced(1, 2);
     let mut a = GrowablePrimitive::new(vec![&b], true, 2);
     a.extend(0, 0, 2);
     a.extend_validity(3);

--- a/tests/it/array/growable/struct_.rs
+++ b/tests/it/array/growable/struct_.rs
@@ -41,7 +41,7 @@ fn basic() {
 
     let expected = StructArray::new(
         fields,
-        vec![values[0].slice(1, 2), values[1].slice(1, 2)],
+        vec![values[0].sliced(1, 2), values[1].sliced(1, 2)],
         None,
     );
     assert_eq!(result, expected)
@@ -51,7 +51,7 @@ fn basic() {
 fn offset() {
     let (fields, values) = some_values();
 
-    let array = StructArray::new(fields.clone(), values.clone(), None).slice(1, 3);
+    let array = StructArray::new(fields.clone(), values.clone(), None).sliced(1, 3);
 
     let mut a = GrowableStruct::new(vec![&array], false, 0);
 
@@ -61,7 +61,7 @@ fn offset() {
 
     let expected = StructArray::new(
         fields,
-        vec![values[0].slice(2, 2), values[1].slice(2, 2)],
+        vec![values[0].sliced(2, 2), values[1].sliced(2, 2)],
         None,
     );
 
@@ -86,8 +86,8 @@ fn nulls() {
 
     let expected = StructArray::new(
         fields,
-        vec![values[0].slice(1, 2), values[1].slice(1, 2)],
-        Some(Bitmap::from_u8_slice([0b00000010], 5).slice(1, 2)),
+        vec![values[0].sliced(1, 2), values[1].sliced(1, 2)],
+        Some(Bitmap::from_u8_slice([0b00000010], 5).sliced(1, 2)),
     );
 
     assert_eq!(result, expected)

--- a/tests/it/array/growable/union.rs
+++ b/tests/it/array/growable/union.rs
@@ -28,7 +28,7 @@ fn sparse() -> Result<()> {
             a.extend(0, index, length);
             assert_eq!(a.len(), length);
 
-            let expected = array.slice(index, length);
+            let expected = array.clone().sliced(index, length);
 
             let result: UnionArray = a.into();
 
@@ -61,7 +61,7 @@ fn dense() -> Result<()> {
 
             a.extend(0, index, length);
             assert_eq!(a.len(), length);
-            let expected = array.slice(index, length);
+            let expected = array.clone().sliced(index, length);
 
             let result: UnionArray = a.into();
 

--- a/tests/it/array/growable/utf8.rs
+++ b/tests/it/array/growable/utf8.rs
@@ -23,7 +23,7 @@ fn validity() {
 #[test]
 fn offsets() {
     let array = Utf8Array::<i32>::from([Some("a"), Some("bc"), None, Some("defh")]);
-    let array = array.slice(1, 3);
+    let array = array.sliced(1, 3);
 
     let mut a = GrowableUtf8::new(vec![&array], false, 0);
 
@@ -39,7 +39,7 @@ fn offsets() {
 #[test]
 fn offsets2() {
     let array = Utf8Array::<i32>::from([Some("a"), Some("bc"), None, Some("defh")]);
-    let array = array.slice(1, 3);
+    let array = array.sliced(1, 3);
 
     let mut a = GrowableUtf8::new(vec![&array], false, 0);
 
@@ -72,7 +72,7 @@ fn multiple_with_validity() {
 #[test]
 fn null_offset_validity() {
     let array = Utf8Array::<i32>::from([Some("a"), Some("bc"), None, Some("defh")]);
-    let array = array.slice(1, 3);
+    let array = array.sliced(1, 3);
 
     let mut a = GrowableUtf8::new(vec![&array], true, 0);
 

--- a/tests/it/array/map/mod.rs
+++ b/tests/it/array/map/mod.rs
@@ -39,7 +39,7 @@ fn basics() {
         )) as Box<dyn Array>
     );
 
-    let sliced = array.slice(1, 1);
+    let sliced = array.sliced(1, 1);
     assert_eq!(
         sliced.value(0),
         Box::new(StructArray::new(

--- a/tests/it/array/primitive/mod.rs
+++ b/tests/it/array/primitive/mod.rs
@@ -31,7 +31,7 @@ fn basics() {
     );
     assert_eq!(array, array2);
 
-    let array = array.slice(1, 2);
+    let array = array.sliced(1, 2);
     assert_eq!(array.value(0), 0);
     assert_eq!(array.value(1), 10);
     assert_eq!(array.values().as_slice(), &[0, 10]);

--- a/tests/it/array/union.rs
+++ b/tests/it/array/union.rs
@@ -75,7 +75,7 @@ fn slice() -> Result<()> {
 
     let array = UnionArray::new(data_type.clone(), types, fields.clone(), None);
 
-    let result = array.slice(1, 2);
+    let result = array.sliced(1, 2);
 
     let sliced_types = Buffer::from(vec![0, 1]);
     let sliced_fields = vec![
@@ -169,7 +169,7 @@ fn iter_sparse_slice() -> Result<()> {
     ];
 
     let array = UnionArray::new(data_type, types, fields.clone(), None);
-    let array_slice = array.slice(1, 1);
+    let array_slice = array.sliced(1, 1);
     let mut iter = array_slice.iter();
 
     assert_eq!(
@@ -196,7 +196,7 @@ fn iter_dense_slice() -> Result<()> {
     ];
 
     let array = UnionArray::new(data_type, types, fields.clone(), Some(offsets));
-    let array_slice = array.slice(1, 1);
+    let array_slice = array.sliced(1, 1);
     let mut iter = array_slice.iter();
 
     assert_eq!(

--- a/tests/it/array/utf8/mod.rs
+++ b/tests/it/array/utf8/mod.rs
@@ -35,7 +35,7 @@ fn basics() {
     );
     assert_eq!(array, array2);
 
-    let array = array.slice(1, 2);
+    let array = array.sliced(1, 2);
     assert_eq!(array.value(0), "");
     assert_eq!(array.value(1), "hello2");
     // note how this keeps everything: the offsets were sliced

--- a/tests/it/bitmap/assign_ops.rs
+++ b/tests/it/bitmap/assign_ops.rs
@@ -30,10 +30,10 @@ fn binary_assign_oob() {
     let b = MutableBitmap::from_iter(std::iter::repeat(true).take(65));
 
     let a: Bitmap = a.into();
-    let a = a.slice(10, 20);
+    let a = a.sliced(10, 20);
 
     let b: Bitmap = b.into();
-    let b = b.slice(10, 20);
+    let b = b.sliced(10, 20);
 
     let mut a = a.make_mut();
 

--- a/tests/it/bitmap/immutable.rs
+++ b/tests/it/bitmap/immutable.rs
@@ -13,7 +13,7 @@ fn as_slice() {
 #[test]
 fn as_slice_offset() {
     let b = Bitmap::from([true, true, true, true, true, true, true, true, true]);
-    let b = b.slice(8, 1);
+    let b = b.sliced(8, 1);
 
     let (slice, offset, length) = b.as_slice();
     assert_eq!(slice, &[0b1]);
@@ -24,7 +24,7 @@ fn as_slice_offset() {
 #[test]
 fn as_slice_offset_middle() {
     let b = Bitmap::from_u8_slice([0, 0, 0, 0b00010101], 27);
-    let b = b.slice(22, 5);
+    let b = b.sliced(22, 5);
 
     let (slice, offset, length) = b.as_slice();
     assert_eq!(slice, &[0, 0b00010101]);
@@ -35,7 +35,7 @@ fn as_slice_offset_middle() {
 #[test]
 fn debug() {
     let b = Bitmap::from([true, true, false, true, true, true, true, true, true]);
-    let b = b.slice(2, 7);
+    let b = b.sliced(2, 7);
 
     assert_eq!(format!("{b:?}"), "[0b111110__, 0b_______1]");
 }

--- a/tests/it/bitmap/mod.rs
+++ b/tests/it/bitmap/mod.rs
@@ -21,7 +21,7 @@ pub(crate) fn bitmap_strategy() -> impl Strategy<Value = Bitmap> {
         })
         .prop_flat_map(|(vec, index, len)| {
             let bitmap = Bitmap::from(&vec);
-            let bitmap = bitmap.slice(index, len);
+            let bitmap = bitmap.sliced(index, len);
             Just(bitmap)
         })
 }
@@ -49,12 +49,12 @@ fn eq_len() {
 
 #[test]
 fn eq_slice() {
-    let lhs = create_bitmap([0b10101010], 8).slice(1, 7);
-    let rhs = create_bitmap([0b10101011], 8).slice(1, 7);
+    let lhs = create_bitmap([0b10101010], 8).sliced(1, 7);
+    let rhs = create_bitmap([0b10101011], 8).sliced(1, 7);
     assert!(lhs == rhs);
 
-    let lhs = create_bitmap([0b10101010], 8).slice(2, 6);
-    let rhs = create_bitmap([0b10101110], 8).slice(2, 6);
+    let lhs = create_bitmap([0b10101010], 8).sliced(2, 6);
+    let rhs = create_bitmap([0b10101110], 8).sliced(2, 6);
     assert!(lhs != rhs);
 }
 
@@ -89,9 +89,9 @@ fn or_large() {
 
 #[test]
 fn and_offset() {
-    let lhs = create_bitmap([0b01101011], 8).slice(1, 7);
-    let rhs = create_bitmap([0b01001111], 8).slice(1, 7);
-    let expected = create_bitmap([0b01001010], 8).slice(1, 7);
+    let lhs = create_bitmap([0b01101011], 8).sliced(1, 7);
+    let rhs = create_bitmap([0b01001111], 8).sliced(1, 7);
+    let expected = create_bitmap([0b01001010], 8).sliced(1, 7);
     assert_eq!(&lhs & &rhs, expected);
 }
 
@@ -115,11 +115,11 @@ fn subslicing_gives_correct_null_count() {
     let base = Bitmap::from([false, true, true, false, false, true, true, true]);
     assert_eq!(base.unset_bits(), 3);
 
-    let view1 = base.clone().slice(0, 1);
-    let view2 = base.slice(1, 7);
+    let view1 = base.clone().sliced(0, 1);
+    let view2 = base.sliced(1, 7);
     assert_eq!(view1.unset_bits(), 1);
     assert_eq!(view2.unset_bits(), 2);
 
-    let view3 = view2.slice(0, 1);
+    let view3 = view2.sliced(0, 1);
     assert_eq!(view3.unset_bits(), 0);
 }

--- a/tests/it/bitmap/utils/slice_iterator.rs
+++ b/tests/it/bitmap/utils/slice_iterator.rs
@@ -132,7 +132,7 @@ fn past_end_should_not_be_returned() {
 #[test]
 fn sliced() {
     let values = Bitmap::from_u8_slice([0b11111010, 0b11111011], 16);
-    let values = values.slice(8, 2);
+    let values = values.sliced(8, 2);
     let iter = SlicesIterator::new(&values);
 
     let chunks = iter.collect::<Vec<_>>();
@@ -144,7 +144,7 @@ fn sliced() {
 #[test]
 fn remainder_1() {
     let values = Bitmap::from_u8_slice([0, 0, 0b00000000, 0b00010101], 27);
-    let values = values.slice(22, 5);
+    let values = values.sliced(22, 5);
     let iter = SlicesIterator::new(&values);
     let chunks = iter.collect::<Vec<_>>();
     assert_eq!(chunks, vec![(2, 1), (4, 1)]);

--- a/tests/it/bitmap/utils/zip_validity.rs
+++ b/tests/it/bitmap/utils/zip_validity.rs
@@ -71,7 +71,7 @@ fn byte() {
 
 #[test]
 fn offset() {
-    let a = Bitmap::from([true, false, true, false, false, true, true, false, true]).slice(1, 8);
+    let a = Bitmap::from([true, false, true, false, false, true, true, false, true]).sliced(1, 8);
     let a = Some(a.iter());
     let values = vec![0, 1, 2, 3, 4, 5, 6, 7];
     let zip = ZipValidity::new(values.into_iter(), a);
@@ -94,7 +94,7 @@ fn none() {
 
 #[test]
 fn rev() {
-    let a = Bitmap::from([true, false, true, false, false, true, true, false, true]).slice(1, 8);
+    let a = Bitmap::from([true, false, true, false, false, true, true, false, true]).sliced(1, 8);
     let a = Some(a.iter());
     let values = vec![0, 1, 2, 3, 4, 5, 6, 7];
     let zip = ZipValidity::new(values.into_iter(), a);

--- a/tests/it/buffer/immutable.rs
+++ b/tests/it/buffer/immutable.rs
@@ -17,7 +17,7 @@ fn from_slice() {
 #[test]
 fn slice() {
     let buffer = Buffer::<i32>::from(vec![0, 1, 2, 3]);
-    let buffer = buffer.slice(1, 2);
+    let buffer = buffer.sliced(1, 2);
     assert_eq!(buffer.len(), 2);
     assert_eq!(buffer.as_slice(), &[1, 2]);
 }
@@ -32,7 +32,7 @@ fn from_iter() {
 #[test]
 fn debug() {
     let buffer = Buffer::<i32>::from(vec![0, 1, 2, 3]);
-    let buffer = buffer.slice(1, 2);
+    let buffer = buffer.sliced(1, 2);
     let a = format!("{buffer:?}");
     assert_eq!(a, "[1, 2]")
 }

--- a/tests/it/compute/boolean.rs
+++ b/tests/it/compute/boolean.rs
@@ -126,8 +126,8 @@ fn array_and_sliced_same_offset() {
         false, false, false, false, false, false, false, false, false, true, false, true,
     ]);
 
-    let a = a.slice(8, 4);
-    let b = b.slice(8, 4);
+    let a = a.sliced(8, 4);
+    let b = b.sliced(8, 4);
     let c = and(&a, &b);
 
     let expected = BooleanArray::from_slice(vec![false, false, false, true]);
@@ -144,8 +144,8 @@ fn array_and_sliced_same_offset_mod8() {
         false, false, false, false, false, false, false, false, false, true, false, true,
     ]);
 
-    let a = a.slice(0, 4);
-    let b = b.slice(8, 4);
+    let a = a.sliced(0, 4);
+    let b = b.sliced(8, 4);
 
     let c = and(&a, &b);
 
@@ -161,7 +161,7 @@ fn array_and_sliced_offset1() {
     ]);
     let b = BooleanArray::from_slice(vec![false, true, false, true]);
 
-    let a = a.slice(8, 4);
+    let a = a.sliced(8, 4);
 
     let c = and(&a, &b);
 
@@ -177,7 +177,7 @@ fn array_and_sliced_offset2() {
         false, false, false, false, false, false, false, false, false, true, false, true,
     ]);
 
-    let b = b.slice(8, 4);
+    let b = b.sliced(8, 4);
 
     let c = and(&a, &b);
 
@@ -189,7 +189,7 @@ fn array_and_sliced_offset2() {
 #[test]
 fn array_and_validity_offset() {
     let a = BooleanArray::from(vec![None, Some(false), Some(true), None, Some(true)]);
-    let a = a.slice(1, 4);
+    let a = a.sliced(1, 4);
     let a = a.as_any().downcast_ref::<BooleanArray>().unwrap();
 
     let b = BooleanArray::from(vec![
@@ -201,7 +201,7 @@ fn array_and_validity_offset() {
         Some(true),
     ]);
 
-    let b = b.slice(2, 4);
+    let b = b.sliced(2, 4);
     let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
 
     let c = and(a, b);
@@ -225,7 +225,7 @@ fn test_nonnull_array_is_null() {
 #[test]
 fn test_nonnull_array_with_offset_is_null() {
     let a = Int32Array::from_slice(vec![1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 5, 4, 3, 2, 1]);
-    let a = a.slice(8, 4);
+    let a = a.sliced(8, 4);
 
     let res = is_null(&a);
 
@@ -248,7 +248,7 @@ fn test_nonnull_array_is_not_null() {
 #[test]
 fn test_nonnull_array_with_offset_is_not_null() {
     let a = Int32Array::from_slice([1, 2, 3, 4, 5, 6, 7, 8, 7, 6, 5, 4, 3, 2, 1]);
-    let a = a.slice(8, 4);
+    let a = a.sliced(8, 4);
 
     let res = is_not_null(&a);
 
@@ -289,7 +289,7 @@ fn test_nullable_array_with_offset_is_null() {
         None,
         None,
     ]);
-    let a = a.slice(8, 4);
+    let a = a.sliced(8, 4);
 
     let res = is_null(&a);
 
@@ -330,7 +330,7 @@ fn test_nullable_array_with_offset_is_not_null() {
         None,
         None,
     ]);
-    let a = a.slice(8, 4);
+    let a = a.sliced(8, 4);
 
     let res = is_not_null(&a);
 

--- a/tests/it/compute/cast.rs
+++ b/tests/it/compute/cast.rs
@@ -102,7 +102,7 @@ fn i32_to_u8() {
 #[test]
 fn i32_to_u8_sliced() {
     let array = Int32Array::from_slice([-5, 6, -7, 8, 100000000]);
-    let array = array.slice(2, 3);
+    let array = array.sliced(2, 3);
     let b = cast(&array, &DataType::UInt8, CastOptions::default()).unwrap();
     let expected = UInt8Array::from(&[None, Some(8), None]);
     let c = b.as_any().downcast_ref::<UInt8Array>().unwrap();
@@ -170,7 +170,7 @@ fn i32_to_list_f64_nullable_sliced() {
 
     let array = Int32Array::from(input);
 
-    let array = array.slice(2, 4);
+    let array = array.sliced(2, 4);
     let b = cast(
         &array,
         &DataType::List(Box::new(Field::new("item", DataType::Float64, true))),

--- a/tests/it/compute/comparison.rs
+++ b/tests/it/compute/comparison.rs
@@ -114,7 +114,7 @@ fn test_eq_scalar() {
 fn test_eq_with_slice() {
     let a = BooleanArray::from_slice([true, true, false]);
     let b = BooleanArray::from_slice([true, true, true, true, false]);
-    let c = b.slice(2, 3);
+    let c = b.sliced(2, 3);
     let d = eq(&c, &a);
     assert_eq!(d, BooleanArray::from_slice([true, true, true]));
 }

--- a/tests/it/compute/concatenate.rs
+++ b/tests/it/compute/concatenate.rs
@@ -72,9 +72,9 @@ fn primitive_arrays() -> Result<()> {
 
 #[test]
 fn primitive_array_slices() -> Result<()> {
-    let input_1 = Int64Array::from(&[Some(-1), Some(-1), Some(2), None, None]).slice(1, 3);
+    let input_1 = Int64Array::from(&[Some(-1), Some(-1), Some(2), None, None]).sliced(1, 3);
 
-    let input_2 = Int64Array::from(&[Some(101), Some(102), Some(103), None]).slice(1, 3);
+    let input_2 = Int64Array::from(&[Some(101), Some(102), Some(103), None]).sliced(1, 3);
     let arr = concatenate(&[&input_1, &input_2])?;
 
     let expected_output = Int64Array::from(&[Some(-1), Some(2), None, Some(102), Some(103), None]);

--- a/tests/it/compute/filter.rs
+++ b/tests/it/compute/filter.rs
@@ -4,8 +4,8 @@ use arrow2::compute::filter::*;
 
 #[test]
 fn array_slice() {
-    let a = Int32Array::from_slice([5, 6, 7, 8, 9]).slice(1, 4);
-    let b = BooleanArray::from_slice(vec![true, true, false, false, true]).slice(1, 4);
+    let a = Int32Array::from_slice([5, 6, 7, 8, 9]).sliced(1, 4);
+    let b = BooleanArray::from_slice(vec![true, true, false, false, true]).sliced(1, 4);
     let c = filter(&a, &b).unwrap();
 
     let expected = Int32Array::from_slice([6, 9]);

--- a/tests/it/compute/sort/lex_sort.rs
+++ b/tests/it/compute/sort/lex_sort.rs
@@ -8,14 +8,14 @@ fn test_lex_sort_arrays(input: Vec<SortColumn>, expected: Vec<Box<dyn Array>>) {
     let sorted = lexsort::<i32>(&input, Some(4)).unwrap();
     let expected = expected
         .into_iter()
-        .map(|x| x.slice(0, 4))
+        .map(|x| x.sliced(0, 4))
         .collect::<Vec<_>>();
     assert_eq!(sorted, expected);
 
     let sorted = lexsort::<i32>(&input, Some(2)).unwrap();
     let expected = expected
         .into_iter()
-        .map(|x| x.slice(0, 2))
+        .map(|x| x.sliced(0, 2))
         .collect::<Vec<_>>();
     assert_eq!(sorted, expected);
 }

--- a/tests/it/ffi/data.rs
+++ b/tests/it/ffi/data.rs
@@ -27,7 +27,7 @@ fn test_round_trip(expected: impl Array + Clone + 'static) -> Result<()> {
     _test_round_trip(array.clone(), clone(expected.as_ref()))?;
 
     // sliced
-    _test_round_trip(array.slice(1, 2), expected.slice(1, 2))
+    _test_round_trip(array.sliced(1, 2), expected.sliced(1, 2))
 }
 
 fn test_round_trip_schema(field: Field) -> Result<()> {
@@ -53,7 +53,7 @@ fn bool() -> Result<()> {
 
 #[test]
 fn bool_nullable_sliced() -> Result<()> {
-    let bitmap = Bitmap::from([true, false, false, true]).slice(1, 3);
+    let bitmap = Bitmap::from([true, false, false, true]).sliced(1, 3);
     let data = BooleanArray::try_new(DataType::Boolean, [true, true, false].into(), Some(bitmap))?;
     test_round_trip(data)
 }
@@ -72,7 +72,7 @@ fn u32() -> Result<()> {
 
 #[test]
 fn u32_sliced() -> Result<()> {
-    let bitmap = Bitmap::from([true, false, false, true]).slice(1, 3);
+    let bitmap = Bitmap::from([true, false, false, true]).sliced(1, 3);
     let data = Int32Array::try_new(DataType::Int32, vec![1, 2, 3].into(), Some(bitmap))?;
     test_round_trip(data)
 }
@@ -112,7 +112,7 @@ fn utf8() -> Result<()> {
 
 #[test]
 fn utf8_sliced() -> Result<()> {
-    let bitmap = Bitmap::from([true, false, false, true]).slice(1, 3);
+    let bitmap = Bitmap::from([true, false, false, true]).sliced(1, 3);
     let data = Utf8Array::<i32>::try_new(
         DataType::Utf8,
         vec![0, 1, 1, 2].try_into().unwrap(),
@@ -142,7 +142,7 @@ fn binary() -> Result<()> {
 
 #[test]
 fn binary_sliced() -> Result<()> {
-    let bitmap = Bitmap::from([true, false, false, true]).slice(1, 3);
+    let bitmap = Bitmap::from([true, false, false, true]).sliced(1, 3);
     let data = BinaryArray::<i32>::try_new(
         DataType::Binary,
         vec![0, 1, 1, 2].try_into().unwrap(),
@@ -180,7 +180,7 @@ fn fixed_size_binary_nullable() -> Result<()> {
 
 #[test]
 fn fixed_size_binary_sliced() -> Result<()> {
-    let bitmap = Bitmap::from([true, false, false, true]).slice(1, 3);
+    let bitmap = Bitmap::from([true, false, false, true]).sliced(1, 3);
     let data = FixedSizeBinaryArray::try_new(
         DataType::FixedSizeBinary(2),
         b"ababab".to_vec().into(),
@@ -207,7 +207,7 @@ fn list() -> Result<()> {
 
 #[test]
 fn list_sliced() -> Result<()> {
-    let bitmap = Bitmap::from([true, false, false, true]).slice(1, 3);
+    let bitmap = Bitmap::from([true, false, false, true]).sliced(1, 3);
 
     let array = ListArray::<i32>::try_new(
         DataType::List(Box::new(Field::new("a", DataType::Int32, true))),
@@ -253,7 +253,7 @@ fn fixed_size_list() -> Result<()> {
 
 #[test]
 fn fixed_size_list_sliced() -> Result<()> {
-    let bitmap = Bitmap::from([true, false, false, true]).slice(1, 3);
+    let bitmap = Bitmap::from([true, false, false, true]).sliced(1, 3);
 
     let array = FixedSizeListArray::try_new(
         DataType::FixedSizeList(Box::new(Field::new("a", DataType::Int32, true)), 2),

--- a/tests/it/io/ipc/mmap.rs
+++ b/tests/it/io/ipc/mmap.rs
@@ -26,7 +26,7 @@ fn round_trip(array: Box<dyn Array>) -> Result<()> {
 #[test]
 fn utf8() -> Result<()> {
     let array = Utf8Array::<i32>::from([None, None, Some("bb")])
-        .slice(1, 2)
+        .sliced(1, 2)
         .boxed();
     round_trip(array)
 }
@@ -34,24 +34,24 @@ fn utf8() -> Result<()> {
 #[test]
 fn fixed_size_binary() -> Result<()> {
     let array = FixedSizeBinaryArray::from([None, None, Some([1, 2])])
-        .slice(1, 2)
-        .boxed();
+        .boxed()
+        .sliced(1, 2);
     round_trip(array)
 }
 
 #[test]
 fn primitive() -> Result<()> {
     let array = PrimitiveArray::<i32>::from([None, None, Some(3)])
-        .slice(1, 2)
-        .boxed();
+        .boxed()
+        .sliced(1, 2);
     round_trip(array)
 }
 
 #[test]
 fn boolean() -> Result<()> {
     let array = BooleanArray::from([None, None, Some(true)])
-        .slice(1, 2)
-        .boxed();
+        .boxed()
+        .sliced(1, 2);
     round_trip(array)
 }
 
@@ -73,7 +73,7 @@ fn fixed_size_list() -> Result<()> {
     array.try_extend(data)?;
 
     let array: FixedSizeListArray = array.into();
-    round_trip(array.slice(1, 2).boxed())
+    round_trip(array.sliced(1, 2).boxed())
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn list() -> Result<()> {
 
     let mut array = MutableListArray::<i32, MutablePrimitiveArray<i32>>::new();
     array.try_extend(data).unwrap();
-    let array = array.into_box().slice(1, 2);
+    let array = array.into_box().sliced(1, 2);
     round_trip(array)
 }
 
@@ -99,8 +99,8 @@ fn struct_() -> Result<()> {
         vec![array],
         Some([true, true, false, true, false].into()),
     )
-    .slice(1, 4)
-    .boxed();
+    .boxed()
+    .sliced(1, 4);
 
     round_trip(array)
 }
@@ -112,8 +112,8 @@ fn dict() -> Result<()> {
     let values = PrimitiveArray::<i32>::from_slice([0, 1, 2, 3, 4, 5]).boxed();
 
     let array = DictionaryArray::try_from_keys(keys, values)?
-        .slice(1, 4)
-        .boxed();
+        .boxed()
+        .sliced(1, 4);
 
     round_trip(array)
 }

--- a/tests/it/io/ipc/write/file.rs
+++ b/tests/it/io/ipc/write/file.rs
@@ -337,7 +337,7 @@ fn write_boolean() -> Result<()> {
 #[cfg_attr(miri, ignore)] // compression uses FFI, which miri does not support
 fn write_sliced_utf8() -> Result<()> {
     let array = Utf8Array::<i32>::from_slice(["aa", "bb"])
-        .slice(1, 1)
+        .sliced(1, 1)
         .boxed();
     let schema = Schema::from(vec![Field::new("a", array.data_type().clone(), true)]);
     let columns = Chunk::try_new(vec![array])?;
@@ -354,7 +354,7 @@ fn write_sliced_list() -> Result<()> {
 
     let mut array = MutableListArray::<i32, MutablePrimitiveArray<i32>>::new();
     array.try_extend(data).unwrap();
-    let array: Box<dyn Array> = array.into_box().slice(1, 2);
+    let array: Box<dyn Array> = array.into_box().sliced(1, 2);
 
     let schema = Schema::from(vec![Field::new("a", array.data_type().clone(), true)]);
     let columns = Chunk::try_new(vec![array])?;

--- a/tests/it/io/ndjson/read.rs
+++ b/tests/it/io/ndjson/read.rs
@@ -139,7 +139,7 @@ fn read_nested_struct_batched() -> Result<()> {
 
     // create a chunked array by batch_size from the (un-chunked) expected
     let expected: Vec<Box<dyn Array>> = (0..(expected.len() + batch_size - 1) / batch_size)
-        .map(|offset| expected.slice(offset * batch_size, batch_size))
+        .map(|offset| expected.sliced(offset * batch_size, batch_size))
         .collect();
 
     let data_type = infer(&ndjson)?;

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -1553,7 +1553,7 @@ fn assert_roundtrip(
         let expected = chunk
             .into_arrays()
             .into_iter()
-            .map(|x| x.slice(0, limit))
+            .map(|x| x.sliced(0, limit))
             .collect::<Vec<_>>();
         Chunk::new(expected)
     } else {


### PR DESCRIPTION
Currently slicing arrays require cloning. This PR removes that requirement.

# Backward incompatible changes

* `slice(&self, offset: usize, length: usize) -> Self` in all arrays and trait `Array` changed signature to `slice(&mut self, offset: usize, length: usize)`
* New function `sliced(self, offset: usize, length: usize) -> Self` was added to all arrays
* New function `sliced(&self, offset: usize, length: usize) -> Box<dyn Array>` was added to Array trait

With this new API:

* slice an `&mut array` in place via `array.slice(...)`
* slice an `array` via `let array = array.sliced(...);`
* slice an `&array` by cloning it and using `array`