### PR TITLE
Fixed nested boolean offset

### DIFF
--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -4,7 +4,7 @@ use parquet2::{encoding::Encoding, page::DataPage};
 use super::super::{nested, utils, WriteOptions};
 use super::basic::{build_statistics, encode_plain};
 use crate::io::parquet::read::schema::is_nullable;
-use crate::io::parquet::write::{slice_nested_leaf, Nested};
+use crate::io::parquet::write::Nested;
 use crate::{
     array::{Array, BooleanArray},
     error::Result,
@@ -18,23 +18,21 @@ pub fn array_to_page(
 ) -> Result<DataPage> {
     let is_optional = is_nullable(&type_.field_info);
 
-    let mut nested = nested.to_vec();
-
     let mut buffer = vec![];
     let (repetition_levels_byte_length, definition_levels_byte_length) =
-        nested::write_rep_and_def(options.version, &nested, &mut buffer)?;
+        nested::write_rep_and_def(options.version, nested, &mut buffer)?;
 
-    encode_plain(&array, is_optional, &mut buffer)?;
+    encode_plain(array, is_optional, &mut buffer)?;
 
     let statistics = if options.write_statistics {
-        Some(build_statistics(&array))
+        Some(build_statistics(array))
     } else {
         None
     };
 
     utils::build_plain_page(
         buffer,
-        nested::num_values(&nested),
+        nested::num_values(nested),
         nested[0].len(),
         array.null_count(),
         repetition_levels_byte_length,

--- a/src/io/parquet/write/boolean/nested.rs
+++ b/src/io/parquet/write/boolean/nested.rs
@@ -18,18 +18,7 @@ pub fn array_to_page(
 ) -> Result<DataPage> {
     let is_optional = is_nullable(&type_.field_info);
 
-    // we slice the leaf by the offsets as dremel only computes lengths and thus
-    // does NOT take the starting offset into account.
-    // By slicing the leaf array we also don't write too many values.
-    let (start, len) = slice_nested_leaf(nested);
-
     let mut nested = nested.to_vec();
-    let array = array.clone().sliced(start, len);
-    if let Some(Nested::Primitive(_, _, c)) = nested.last_mut() {
-        *c = len;
-    } else {
-        unreachable!("")
-    }
 
     let mut buffer = vec![];
     let (repetition_levels_byte_length, definition_levels_byte_length) =


### PR DESCRIPTION
Simply ensure we do the same as on primitive arrays. This fixed this panic:

```python
df = pl.Series([[None, True], [False, False], [True, True]]).slice(2, 2).to_frame()
f = io.BytesIO()
df.write_parquet(f)
```

```
thread '<unnamed>' panicked at 'the offset of the new Buffer cannot exceed the existing length', /home/ritchie46/.cargo/git/checkouts/arrow2-945af624853845da/f510012/src/array/boolean/mod.rs:174:5
stack backtrace:
   0: rust_begin_unwind
             at /rustc/333ee6c466972185973d5097f8b5fb0f9fb13fa5/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/333ee6c466972185973d5097f8b5fb0f9fb13fa5/library/core/src/panicking.rs:64:14
   2: arrow2::array::boolean::BooleanArray::sliced
             at /home/ritchie46/.cargo/git/checkouts/arrow2-945af624853845da/f510012/src/array/mod.rs:410:13
   3: arrow2::io::parquet::write::boolean::nested::array_to_page
             at /home/ritchie46/.cargo/git/checkouts/arrow2-945af624853845da/f510012/src/io/parquet/write/boolean/nested.rs:27:17
   4: arrow2::io::parquet::write::array_to_page_nested
             at /home/ritchie46/.cargo/git/checkouts/arrow2-945af624853845da/f510012/src/io/parquet/write/mod.rs:541:13
   5: arrow2::io::parquet::write::array_to_page
             at /home/ritchie46/.cargo/git/checkouts/arrow2-945af624853845da/f510012/src/io/parquet/write/mod.rs:293:5
   6: arrow2::io::parquet::write::array_to_pages::{{closure}}
             at /home/ritchie46/.cargo/git/checkouts/arrow2-945af624853845da/f510012/src/io/parquet/write/mod.rs:269:13
   7: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &mut F>::call_once
             at /rustc/333ee6c466972185973d5097f8b5fb0f9fb13fa5/library/core/src/ops/function.rs:310:13
   8: core::option::Option<T>::map
             at /rustc/333ee6c466972185973d5097f8b5fb0f9fb13fa5/library/core/src/option.rs:970:29
   9: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/333ee6c466972185973d5097f8b5fb0f9fb13fa5/library/core/src/iter/adapters/map.rs:103:9
  10: <alloc::boxed::Box<I,A> as core::iter::traits::iterator::Iterator>::next
             at /rustc/333ee6c466972185973d5097f8b5fb0f9fb13fa5/library/alloc/src/boxed.rs:1922:9
  11: <parquet2::write::dyn_iter::DynIter<V> as core::iter::traits::iterator::Iterator>::next
             at /home/ritchie46/.cargo/registry/src/github.com-1ecc6299db9ec823/parquet2-0.17.1/src/write/dyn_iter.rs:13:9
  12: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/333ee6c466972185973d5097f8b5fb0f9fb13fa5/library/core/src/iter/adapters/map.rs:103:9
  13: <parquet2::write::compression::Compressor<I> as fallible_streaming_iterator::FallibleStreamingIterator>::advance
             at /home/ritchie46/.cargo/registry/src/github.com-1ecc6299db9ec823/parquet2-0.17.1/src/write/compression.rs:149:20
  14: <fallible_streaming_iterator::MapErr<I,F> as fallible_streaming_iterator::FallibleStreamingIterator>::advance
             at /home/ritchie46/.cargo/registry/src/github.com-1ecc6299db9ec823/fallible-streaming-iterator-0.1.9/src/lib.rs:684:9
  15: <parquet2::write::dyn_iter::DynStreamingIterator<V,E> as fallible_streaming_iterator::FallibleStreamingIterator>::advance
             at /home/ritchie46/.cargo/registry/src/github.com-1ecc6299db9ec823/parquet2-0.17.1/src/write/dyn_iter.rs:43:9
  16: fallible_streaming_iterator::FallibleStreamingIterator::next
             at /home/ritchie46/.cargo/registry/src/github.com-1ecc6299db9ec823/fallible-streaming-iterator-0.1.9/src/lib.rs:52:9
  17: parquet2::write::column_chunk::write_column_chunk
             at /home/ritchie46/.cargo/registry/src/github.com-1ecc6299db9ec823/parquet2-0.17.1/src/write/column_chunk.rs:45:39
  18: parquet2::write::row_group::write_row_group::{{closure}}
             at /home/ritchie46/.cargo/registry/src/github.com-1ecc6299db9ec823/parquet2-0.17.1/src/write/row_group.rs:100:17
  19: core::iter::adapters::map::map_try_fold::{{closure}}
             at /rustc/333ee6c466972185973d5097f8b5fb0f9fb13fa5/library/core/src/iter/adapters/map.rs:91:28
  20: core::iter::traits::iterator::Iterator::try_fold
             at /rustc/333ee6c466972185973d5097f8b5fb0f9fb13fa5/library/core/src/iter/traits/iterator.rs:2262:21
  21: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try
```

So I assume we `slice_nested_leaf` already on `dyn Array`?

However I am not sure. So feel free to dismiss this as I can be entirely wrong here.