### PR TITLE
Added apply_validity and set_validity to mutable utf8 array

### DIFF
--- a/src/array/utf8/mutable.rs
+++ b/src/array/utf8/mutable.rs
@@ -212,6 +212,27 @@ impl<O: Offset> MutableUtf8Array<O> {
     pub fn values_iter(&self) -> MutableUtf8ValuesIter<O> {
         self.values.iter()
     }
+
+    /// Sets the validity.
+    /// # Panic
+    /// Panics iff the validity's len is not equal to the existing values' length.
+    pub fn set_validity(&mut self, validity: Option<MutableBitmap>) {
+        if let Some(validity) = &validity {
+            assert_eq!(self.values.len(), validity.len())
+        }
+        self.validity = validity;
+    }
+
+    /// Applies a function `f` to the validity of this array.
+    ///
+    /// This is an API to leverage clone-on-write
+    /// # Panics
+    /// This function panics if the function `f` modifies the length of the [`Bitmap`].
+    pub fn apply_validity<F: FnOnce(MutableBitmap) -> MutableBitmap>(&mut self, f: F) {
+        if let Some(validity) = std::mem::take(&mut self.validity) {
+            self.set_validity(Some(f(validity)))
+        }
+    }
 }
 
 impl<O: Offset> MutableUtf8Array<O> {

--- a/tests/it/array/utf8/mutable.rs
+++ b/tests/it/array/utf8/mutable.rs
@@ -199,3 +199,44 @@ fn extend_from_self() {
         MutableUtf8Array::<i32>::from([Some("aa"), None, Some("aa"), None])
     );
 }
+
+#[test]
+fn test_set_validity() {
+    let mut array = MutableUtf8Array::<i32>::from([Some("Red"), Some("Green"), Some("Blue")]);
+    array.set_validity(Some([false, false, true].into()));
+
+    assert!(!array.is_valid(0));
+    assert!(!array.is_valid(1));
+    assert!(array.is_valid(2));
+}
+
+#[test]
+fn test_apply_validity() {
+    let mut array = MutableUtf8Array::<i32>::from([Some("Red"), Some("Green"), Some("Blue")]);
+    array.set_validity(Some([true, true, true].into()));
+
+    array.apply_validity(|mut mut_bitmap| {
+        mut_bitmap.set(1, false);
+        mut_bitmap.set(2, false);
+        mut_bitmap
+    });
+
+    assert!(array.is_valid(0));
+    assert!(!array.is_valid(1));
+    assert!(!array.is_valid(2));
+}
+
+#[test]
+fn test_apply_validity_with_no_validity_inited() {
+    let mut array = MutableUtf8Array::<i32>::from([Some("Red"), Some("Green"), Some("Blue")]);
+
+    array.apply_validity(|mut mut_bitmap| {
+        mut_bitmap.set(1, false);
+        mut_bitmap.set(2, false);
+        mut_bitmap
+    });
+
+    assert!(array.is_valid(0));
+    assert!(array.is_valid(1));
+    assert!(array.is_valid(2));
+}


### PR DESCRIPTION
This is similar to my previous pr for `Utf8Array` 

I am adding two methods: 
`set_validity` and `apply_validity` for `MutableUtf8Array`

This was pretty straightforward to add so I preemptively created a pr without double checking if it is something that would be accepted.

@jorgecarleitao Let me know if this looks good.

