### PR TITLE
Fixed ahash dependency for wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ multiversion = { version = "0.6.1", optional = true }
 odbc-api = { version = "0.36", optional = true }
 
 # Faster hashing
-ahash = { version = "0.8", features=["runtime-rng"] }
+ahash = "0.8"
 
 [target.wasm32-unknown-unknown.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,13 +97,11 @@ multiversion = { version = "0.6.1", optional = true }
 # For support for odbc
 odbc-api = { version = "0.36", optional = true }
 
-# faster hashing
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-ahash = { version = "0.8", features=["compile-time-rng"] }
-getrandom = { version = "0.2", features = ["js"] }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Faster hashing
 ahash = { version = "0.8", features=["runtime-rng"] }
+
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 
 # parquet support
 [dependencies.parquet2]


### PR DESCRIPTION
The WASM special-casing for `ahash` introduced by #1297 is problematic for a couple of reasons:
1. The `compile-time-rng` feature [is useless](https://github.com/tkaitchuck/aHash/blob/f9acd508bd89e7c5b2877a9510098100f9018d64/Cargo.toml#L33-L37) without first disabling `runtime-rng` (which is enabled as a default feature). When both are enabled, `runtime-rng` takes precendence but we end up bringing in extraneous dependencies for `compile-time-rng`. It's also misleading to see "compile-time-rng" when in reality it's still runtime-rng.
2. If we really wanted to use `compile-time-rng` (which we could by setting `default-features = false`), there's no reason to include `getrandom` at all since there's no need to get randomness at runtime. But IMO it's a bad default since it leads to non-deterministic / uncacheable builds - see https://github.com/rust-lang/hashbrown/pull/155.
3. This broke my use-case since using `target_arch` also made this config apply to `wasm32-unknown-emscripten` builds too, even though no special-casing is required for Emscripten. See getrandom's [docs on WASM support](https://docs.rs/getrandom/latest/getrandom/#webassembly-support).