### PR TITLE
Updated base64 to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ rand = { version = "0.8", optional = true }
 
 itertools = { version = "^0.10", optional = true }
 
-base64 = { version = "0.13.0", optional = true }
+base64 = { version = "0.21.0", optional = true }
 
 # to write to parquet as a stream
 futures = { version = "0.3", optional = true }

--- a/src/io/parquet/read/schema/metadata.rs
+++ b/src/io/parquet/read/schema/metadata.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine as _};
 pub use parquet2::metadata::KeyValue;
 
 use crate::datatypes::{Metadata, Schema};
@@ -18,7 +19,7 @@ pub fn read_schema_from_metadata(metadata: &mut Metadata) -> Result<Option<Schem
 
 /// Try to convert Arrow schema metadata into a schema
 fn get_arrow_schema_from_metadata(encoded_meta: &str) -> Result<Schema> {
-    let decoded = base64::decode(encoded_meta);
+    let decoded = general_purpose::STANDARD.decode(encoded_meta);
     match decoded {
         Ok(bytes) => {
             let slice = if bytes[0..4] == [255u8; 4] {

--- a/src/io/parquet/write/schema.rs
+++ b/src/io/parquet/write/schema.rs
@@ -8,6 +8,7 @@ use parquet2::{
         Repetition,
     },
 };
+use base64::{Engine as _, engine::general_purpose};
 
 use crate::{
     datatypes::{DataType, Field, Schema, TimeUnit},
@@ -30,7 +31,7 @@ pub fn schema_to_metadata_key(schema: &Schema) -> KeyValue {
     len_prefix_schema.extend_from_slice(&(schema_len as u32).to_le_bytes());
     len_prefix_schema.extend_from_slice(&serialized_schema);
 
-    let encoded = base64::encode(&len_prefix_schema);
+    let encoded = general_purpose::STANDARD.encode(&len_prefix_schema);
 
     KeyValue {
         key: ARROW_SCHEMA_META_KEY.to_string(),

--- a/src/io/parquet/write/schema.rs
+++ b/src/io/parquet/write/schema.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine as _};
 use parquet2::{
     metadata::KeyValue,
     schema::{
@@ -8,7 +9,6 @@ use parquet2::{
         Repetition,
     },
 };
-use base64::{Engine as _, engine::general_purpose};
 
 use crate::{
     datatypes::{DataType, Field, Schema, TimeUnit},


### PR DESCRIPTION
Hi, I found out that the dependency `base64` is not up to date, which may cause some applications (like nushell) to compile it multiple times. It would be nice if base64 was updated and released without breaking semver compatibility in version numbers. Then our echo system will benefit from it too :) What do you think?