### PR TITLE
Added support for JSON serialization of dictionary

### DIFF
--- a/tests/it/io/json/write.rs
+++ b/tests/it/io/json/write.rs
@@ -1,3 +1,4 @@
+use arrow2::datatypes::IntegerType;
 use arrow2::{
     array::*,
     bitmap::Bitmap,
@@ -48,6 +49,22 @@ fn utf8() -> Result<()> {
     let array = Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c"), Some("d"), None]);
 
     let expected = r#"["a","b","c","d",null]"#;
+
+    test!(array, expected)
+}
+
+#[test]
+fn dictionary_utf8() -> Result<()> {
+    let values = Utf8Array::<i64>::from([Some("a"), Some("b"), Some("c"), Some("d")]);
+    let keys = PrimitiveArray::from_slice([0u32, 1, 2, 3, 1]);
+    let array = DictionaryArray::try_new(
+        DataType::Dictionary(IntegerType::UInt32, Box::new(DataType::LargeUtf8), false),
+        keys,
+        Box::new(values),
+    )
+    .unwrap();
+
+    let expected = r#"["a","b","c","d","b"]"#;
 
     test!(array, expected)
 }


### PR DESCRIPTION
A bit of a selfish PR with regard to how many branches are implemented. Given the many combinations of key, value types that can be there, I'd like to have them under a feature flag.

Currently we don't do this yet in arrow2 for dtypes, but given there are many of them I believe there is merit to cherry pick them as we are not light to compile.