### PR TITLE
Fixed issue with Time32/Time64 datatype in csv reader

### DIFF
--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -60,7 +60,7 @@ pub fn date64_to_date(milliseconds: i64) -> NaiveDate {
     date64_to_datetime(milliseconds).date()
 }
 
-/// converts a `i32` representing a `time32(s)` to [`NaiveDateTime`]
+/// converts a `i32` representing a `time32(s)` to [`NaiveTime`]
 #[inline]
 pub fn time32s_to_time(v: i32) -> NaiveTime {
     NaiveTime::from_num_seconds_from_midnight_opt(v as u32, 0).expect("invalid time")
@@ -78,7 +78,7 @@ pub fn time32ms_to_time(v: i32) -> NaiveTime {
         .expect("invalid time")
 }
 
-/// converts a `i64` representing a `time64(us)` to [`NaiveDateTime`]
+/// converts a `i64` representing a `time64(us)` to [`NaiveTime`]
 #[inline]
 pub fn time64us_to_time(v: i64) -> NaiveTime {
     NaiveTime::from_num_seconds_from_midnight_opt(
@@ -91,7 +91,7 @@ pub fn time64us_to_time(v: i64) -> NaiveTime {
     .expect("invalid time")
 }
 
-/// converts a `i64` representing a `time64(ns)` to [`NaiveDateTime`]
+/// converts a `i64` representing a `time64(ns)` to [`NaiveTime`]
 #[inline]
 pub fn time64ns_to_time(v: i64) -> NaiveTime {
     NaiveTime::from_num_seconds_from_midnight_opt(

--- a/tests/it/io/csv/read.rs
+++ b/tests/it/io/csv/read.rs
@@ -327,6 +327,30 @@ fn time32_ms() -> Result<()> {
 }
 
 #[test]
+fn time64_us() -> Result<()> {
+    let result = test_deserialize(
+        "00:00:00.000000,\n23:59:59.999999,\n00:00:00.000001,\n",
+        DataType::Time64(TimeUnit::Microsecond),
+    )?;
+    let expected = Int64Array::from(&[Some(0), Some(86_399_999_999), Some(1)])
+        .to(DataType::Time64(TimeUnit::Microsecond));
+    assert_eq!(expected, result.as_ref());
+    Ok(())
+}
+
+#[test]
+fn time64_ns() -> Result<()> {
+    let result = test_deserialize(
+        "00:00:00.000000000,\n23:59:59.999999999,\n00:00:00.000000001,\n",
+        DataType::Time64(TimeUnit::Nanosecond),
+    )?;
+    let expected = Int64Array::from(&[Some(0), Some(86_399_999_999_999), Some(1)])
+        .to(DataType::Time64(TimeUnit::Nanosecond));
+    assert_eq!(expected, result.as_ref());
+    Ok(())
+}
+
+#[test]
 fn decimal() -> Result<()> {
     let result = test_deserialize("1.1,\n1.2,\n1.22,\n1.3,\n", DataType::Decimal(2, 1))?;
     let expected =

--- a/tests/it/io/csv/read.rs
+++ b/tests/it/io/csv/read.rs
@@ -303,6 +303,30 @@ fn date64() -> Result<()> {
 }
 
 #[test]
+fn time32_s() -> Result<()> {
+    let result = test_deserialize(
+        "00:00:00,\n23:59:59,\n11:00:11,\n",
+        DataType::Time32(TimeUnit::Second),
+    )?;
+    let expected = Int32Array::from(&[Some(0), Some(86399), Some(39611)])
+        .to(DataType::Time32(TimeUnit::Second));
+    assert_eq!(expected, result.as_ref());
+    Ok(())
+}
+
+#[test]
+fn time32_ms() -> Result<()> {
+    let result = test_deserialize(
+        "00:00:00.000,\n23:59:59.999,\n00:00:00.999,\n",
+        DataType::Time32(TimeUnit::Millisecond),
+    )?;
+    let expected = Int32Array::from(&[Some(0), Some(86_399_999), Some(999)])
+        .to(DataType::Time32(TimeUnit::Millisecond));
+    assert_eq!(expected, result.as_ref());
+    Ok(())
+}
+
+#[test]
 fn decimal() -> Result<()> {
     let result = test_deserialize("1.1,\n1.2,\n1.22,\n1.3,\n", DataType::Decimal(2, 1))?;
     let expected =


### PR DESCRIPTION
This PR fixed an issue (https://github.com/jorgecarleitao/arrow2/issues/1379) with CSV reader when column are of datatype Time32 or Time64.

This is my first PR in the OSS world and in Rust so I may have made some obvious mistakes either in the process or in the code. 