### PR TITLE
Added impl_mutable_array_mut_validity macro for mutable arrays

### DIFF
--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -160,6 +160,8 @@ impl<O: Offset> MutableBinaryArray<O> {
             validity.shrink_to_fit()
         }
     }
+
+    impl_mutable_array_mut_validity!();
 }
 
 impl<O: Offset> MutableBinaryArray<O> {

--- a/tests/it/array/binary/mutable.rs
+++ b/tests/it/array/binary/mutable.rs
@@ -163,3 +163,53 @@ fn extend_from_self() {
         MutableBinaryArray::<i32>::from([Some(b"aa"), None, Some(b"aa"), None])
     );
 }
+
+#[test]
+fn test_set_validity() {
+    let mut array = MutableBinaryArray::<i32>::new();
+    array.push(Some(b"first"));
+    array.push(Some(b"second"));
+    array.push(Some(b"third"));
+    array.set_validity(Some([false, false, true].into()));
+
+    assert!(!array.is_valid(0));
+    assert!(!array.is_valid(1));
+    assert!(array.is_valid(2));
+}
+
+#[test]
+fn test_apply_validity() {
+    let mut array = MutableBinaryArray::<i32>::new();
+    array.push(Some(b"first"));
+    array.push(Some(b"second"));
+    array.push(Some(b"third"));
+    array.set_validity(Some([true, true, true].into()));
+
+    array.apply_validity(|mut mut_bitmap| {
+        mut_bitmap.set(1, false);
+        mut_bitmap.set(2, false);
+        mut_bitmap
+    });
+
+    assert!(array.is_valid(0));
+    assert!(!array.is_valid(1));
+    assert!(!array.is_valid(2));
+}
+
+#[test]
+fn test_apply_validity_with_no_validity_inited() {
+    let mut array = MutableBinaryArray::<i32>::new();
+    array.push(Some(b"first"));
+    array.push(Some(b"second"));
+    array.push(Some(b"third"));
+
+    array.apply_validity(|mut mut_bitmap| {
+        mut_bitmap.set(1, false);
+        mut_bitmap.set(2, false);
+        mut_bitmap
+    });
+
+    assert!(array.is_valid(0));
+    assert!(array.is_valid(1));
+    assert!(array.is_valid(2));
+}


### PR DESCRIPTION
I am adding `set_validity`, `apply_validity`, and `with_validity` to mutable binary arrays. 

I am using a macro so it can be reused for other mutable arrays.

The macro for immutable arrays is called: `impl_mut_validity` so I tried sticking with that convention and called it `impl_mutable_array_mut_validity` But if there is a better name to describe this macro I will take it. 