### PR TITLE
Updated multiversion and support wider registers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ serde_json = { version = "^1.0", features = ["preserve_order"], optional = true 
 strength_reduce = { version = "0.2", optional = true }
 
 # For instruction multiversioning
-multiversion = { version = "0.6.1", optional = true }
+multiversion = { version = "0.7.1", optional = true }
 
 # For support for odbc
 odbc-api = { version = "0.36", optional = true }

--- a/src/compute/aggregate/min_max.rs
+++ b/src/compute/aggregate/min_max.rs
@@ -9,6 +9,7 @@ use crate::{
     array::{Array, BinaryArray, BooleanArray, PrimitiveArray, Utf8Array},
     bitmap::Bitmap,
 };
+use multiversion::multiversion;
 
 /// Trait describing a type describing multiple lanes with an order relationship
 /// consistent with the same order of `T`.
@@ -31,6 +32,7 @@ pub trait SimdOrd<T> {
     fn new_max() -> Self;
 }
 
+#[multiversion(targets = "simd")]
 fn nonnull_min_primitive<T>(values: &[T]) -> T
 where
     T: NativeType + Simd,
@@ -50,6 +52,7 @@ where
     reduced.min_element()
 }
 
+#[multiversion(targets = "simd")]
 fn null_min_primitive_impl<T, I>(values: &[T], mut validity_masks: I) -> T
 where
     T: NativeType + Simd,
@@ -110,6 +113,7 @@ where
     }
 }
 
+#[multiversion(targets = "simd")]
 fn nonnull_max_primitive<T>(values: &[T]) -> T
 where
     T: NativeType + Simd,
@@ -129,6 +133,7 @@ where
     reduced.max_element()
 }
 
+#[multiversion(targets = "simd")]
 fn null_max_primitive_impl<T, I>(values: &[T], mut validity_masks: I) -> T
 where
     T: NativeType + Simd,

--- a/src/compute/aggregate/sum.rs
+++ b/src/compute/aggregate/sum.rs
@@ -20,8 +20,7 @@ pub trait Sum<T> {
     fn simd_sum(self) -> T;
 }
 
-#[multiversion]
-#[clone(target = "x86_64+avx")]
+#[multiversion(targets = "simd")]
 fn nonnull_sum<T>(values: &[T]) -> T
 where
     T: NativeType + Simd + Add<Output = T> + std::iter::Sum<T>,
@@ -39,8 +38,7 @@ where
 
 /// # Panics
 /// iff `values.len() != bitmap.len()` or the operation overflows.
-#[multiversion]
-#[clone(target = "x86_64+avx")]
+#[multiversion(targets = "simd")]
 fn null_sum_impl<T, I>(values: &[T], mut validity_masks: I) -> T
 where
     T: NativeType + Simd,

--- a/src/compute/hash.rs
+++ b/src/compute/hash.rs
@@ -21,8 +21,7 @@ use crate::{
 
 use super::arity::unary;
 
-#[multiversion]
-#[clone(target = "x86_64+aes+sse3+ssse3+avx+avx2")]
+#[multiversion(targets("x86_64+aes+sse3+ssse3+avx+avx2"))]
 /// Element-wise hash of a [`PrimitiveArray`]. Validity is preserved.
 pub fn hash_primitive<T: NativeType + Hash>(array: &PrimitiveArray<T>) -> PrimitiveArray<u64> {
     let state = new_state!();
@@ -30,8 +29,7 @@ pub fn hash_primitive<T: NativeType + Hash>(array: &PrimitiveArray<T>) -> Primit
     unary(array, |x| state.hash_one(x), DataType::UInt64)
 }
 
-#[multiversion]
-#[clone(target = "x86_64+aes+sse3+ssse3+avx+avx2")]
+#[multiversion(targets("x86_64+aes+sse3+ssse3+avx+avx2"))]
 /// Element-wise hash of a [`BooleanArray`]. Validity is preserved.
 pub fn hash_boolean(array: &BooleanArray) -> PrimitiveArray<u64> {
     let state = new_state!();
@@ -45,8 +43,7 @@ pub fn hash_boolean(array: &BooleanArray) -> PrimitiveArray<u64> {
     PrimitiveArray::<u64>::new(DataType::UInt64, values, array.validity().cloned())
 }
 
-#[multiversion]
-#[clone(target = "x86_64+aes+sse3+ssse3+avx+avx2")]
+#[multiversion(targets("x86_64+aes+sse3+ssse3+avx+avx2"))]
 /// Element-wise hash of a [`Utf8Array`]. Validity is preserved.
 pub fn hash_utf8<O: Offset>(array: &Utf8Array<O>) -> PrimitiveArray<u64> {
     let state = new_state!();


### PR DESCRIPTION
Currently the simd sum only used `128` bit registers via runtime detection. This adds support for all simd available targets. 

Had a 4x improvement on a local compilation. Updated `multiversion` while at it.