### PR TITLE
Fixed `all` and `any` on empty BooleanArray

### DIFF
--- a/src/compute/boolean.rs
+++ b/src/compute/boolean.rs
@@ -244,7 +244,9 @@ pub fn any(array: &BooleanArray) -> bool {
 
 /// Check if all of the values in the array are `true`
 pub fn all(array: &BooleanArray) -> bool {
-    if array.is_empty() || array.null_count() > 0 {
+    if array.is_empty() {
+        true
+    } else if array.null_count() > 0 {
         false
     } else {
         let vals = array.values();

--- a/src/compute/boolean_kleene.rs
+++ b/src/compute/boolean_kleene.rs
@@ -248,7 +248,9 @@ pub fn any(array: &BooleanArray) -> bool {
 
 /// Returns whether all values in the array are `true`
 pub fn all(array: &BooleanArray) -> bool {
-    if array.is_empty() || array.null_count() > 0 {
+    if array.is_empty() {
+        true
+    } else if array.null_count() > 0 {
         false
     } else {
         let vals = array.values();

--- a/tests/it/compute/boolean_kleene.rs
+++ b/tests/it/compute/boolean_kleene.rs
@@ -214,3 +214,10 @@ fn array_or_none() {
 
     assert_eq!(result, expected);
 }
+
+#[test]
+fn array_empty() {
+    let array = BooleanArray::from(&[]);
+    assert!(!any(&array));
+    assert!(all(&array));
+}


### PR DESCRIPTION
Ensure we behave the same as `rust`, `python` on empty sets.