### PR TITLE
Fixed bug in mmap of empty FixedSizeBinaryArray

### DIFF
--- a/src/io/ipc/read/error.rs
+++ b/src/io/ipc/read/error.rs
@@ -95,7 +95,7 @@ pub enum OutOfSpecKind {
         /// The requested dictionary id
         requested_id: i64,
     },
-    /// FixedLengthBinaryArray has invalid datatype.
+    /// FixedSizeBinaryArray has invalid datatype.
     InvalidDataType,
 }
 

--- a/src/io/ipc/read/error.rs
+++ b/src/io/ipc/read/error.rs
@@ -95,6 +95,8 @@ pub enum OutOfSpecKind {
         /// The requested dictionary id
         requested_id: i64,
     },
+    /// FixedLengthBinaryArray has invalid datatype.
+    InvalidDataType,
 }
 
 impl From<OutOfSpecKind> for Error {

--- a/src/mmap/array.rs
+++ b/src/mmap/array.rs
@@ -141,7 +141,8 @@ fn mmap_fixed_size_binary<T: AsRef<[u8]>>(
     let data_ref = data.as_ref().as_ref();
 
     let validity = get_validity(data_ref, block_offset, buffers, null_count)?.map(|x| x.as_ptr());
-    let values = get_buffer::<u8>(data_ref, block_offset, buffers, num_rows * bytes_per_row)?.as_ptr();
+    let values =
+        get_buffer::<u8>(data_ref, block_offset, buffers, num_rows * bytes_per_row)?.as_ptr();
 
     Ok(unsafe {
         create_array(

--- a/tests/it/io/ipc/mmap.rs
+++ b/tests/it/io/ipc/mmap.rs
@@ -36,6 +36,10 @@ fn fixed_size_binary() -> Result<()> {
     let array = FixedSizeBinaryArray::from([None, None, Some([1, 2])])
         .boxed()
         .sliced(1, 2);
+    round_trip(array)?;
+
+    let array = FixedSizeBinaryArray::new_empty(DataType::FixedSizeBinary(20))
+        .boxed();
     round_trip(array)
 }
 

--- a/tests/it/io/ipc/mmap.rs
+++ b/tests/it/io/ipc/mmap.rs
@@ -38,8 +38,7 @@ fn fixed_size_binary() -> Result<()> {
         .sliced(1, 2);
     round_trip(array)?;
 
-    let array = FixedSizeBinaryArray::new_empty(DataType::FixedSizeBinary(20))
-        .boxed();
+    let array = FixedSizeBinaryArray::new_empty(DataType::FixedSizeBinary(20)).boxed();
     round_trip(array)
 }
 


### PR DESCRIPTION
This PR fixes #1453 

When mmap'ing a `FixedSizeBinaryArray`, the length in bytes was miscalculated.

This was only used for a check, but to avoid UB, this should be rigourous.

The problem manifested as an `OutOfSpec` error mapping zero length `FixedSizeBinaryArray`

This fix uses the `DataType` to determine the row length.