### PR TITLE
Fixed capacity of mutable_utf8

### DIFF
--- a/src/array/utf8/mutable_values.rs
+++ b/src/array/utf8/mutable_values.rs
@@ -158,7 +158,7 @@ impl<O: Offset> MutableUtf8ValuesArray<O> {
 
     /// Returns the capacity in number of items
     pub fn capacity(&self) -> usize {
-        self.offsets.capacity() - 1
+        self.offsets.capacity()
     }
 
     /// Returns the length of this array


### PR DESCRIPTION
Already done by offsets, so this underflows on empty arrays and is incorrect.