### PR TITLE
Fixed timestamp to datetime conversion for values with fractional seconds before the epoch

### DIFF
--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -112,36 +112,60 @@ pub fn timestamp_s_to_datetime(seconds: i64) -> NaiveDateTime {
 /// converts a `i64` representing a `timestamp(ms)` to [`NaiveDateTime`]
 #[inline]
 pub fn timestamp_ms_to_datetime(v: i64) -> NaiveDateTime {
-    NaiveDateTime::from_timestamp_opt(
-        // extract seconds from milliseconds
-        v / MILLISECONDS,
-        // discard extracted seconds and convert milliseconds to nanoseconds
-        (v % MILLISECONDS * MICROSECONDS) as u32,
-    )
+    if v >= 0 {
+        NaiveDateTime::from_timestamp_opt(
+            // extract seconds from milliseconds
+            v / MILLISECONDS,
+            // discard extracted seconds and convert milliseconds to nanoseconds
+            (v % MILLISECONDS * MICROSECONDS) as u32,
+        )
+    } else {
+        // negative values
+        NaiveDateTime::from_timestamp_opt(
+            (v / MILLISECONDS) - 1,
+            (v % MILLISECONDS * MICROSECONDS).unsigned_abs() as u32,
+        )
+    }
     .expect("invalid or out-of-range datetime")
 }
 
 /// converts a `i64` representing a `timestamp(us)` to [`NaiveDateTime`]
 #[inline]
 pub fn timestamp_us_to_datetime(v: i64) -> NaiveDateTime {
-    NaiveDateTime::from_timestamp_opt(
-        // extract seconds from microseconds
-        v / MICROSECONDS,
-        // discard extracted seconds and convert microseconds to nanoseconds
-        (v % MICROSECONDS * MILLISECONDS) as u32,
-    )
+    if v >= 0 {
+        NaiveDateTime::from_timestamp_opt(
+            // extract seconds from microseconds
+            v / MICROSECONDS,
+            // discard extracted seconds and convert microseconds to nanoseconds
+            (v % MICROSECONDS * MILLISECONDS) as u32,
+        )
+    } else {
+        // negative values
+        NaiveDateTime::from_timestamp_opt(
+            (v / MICROSECONDS) - 1,
+            (v % MICROSECONDS * MILLISECONDS).unsigned_abs() as u32,
+        )
+    }
     .expect("invalid or out-of-range datetime")
 }
 
 /// converts a `i64` representing a `timestamp(ns)` to [`NaiveDateTime`]
 #[inline]
 pub fn timestamp_ns_to_datetime(v: i64) -> NaiveDateTime {
-    NaiveDateTime::from_timestamp_opt(
-        // extract seconds from nanoseconds
-        v / NANOSECONDS,
-        // discard extracted seconds
-        (v % NANOSECONDS) as u32,
-    )
+    if v >= 0 {
+        NaiveDateTime::from_timestamp_opt(
+            // extract seconds from nanoseconds
+            v / NANOSECONDS,
+            // discard extracted seconds
+            (v % NANOSECONDS) as u32,
+        )
+    } else {
+        // negative values
+        NaiveDateTime::from_timestamp_opt(
+            (v / NANOSECONDS) - 1,
+            (v % NANOSECONDS).unsigned_abs() as u32,
+        )
+    }
     .expect("invalid or out-of-range datetime")
 }
 


### PR DESCRIPTION
The `timestamp_XX_to_datetime` functions all panic with _"invalid or out-of-range datetime"_ on conversions of values with fractional seconds before the epoch (where the timestamp becomes negative).

For these timestamps (pre-epoch, fractional secs) the  `(v % <scale_factor>) as u32` formulation is not valid, as
* the result is a _negative_ number
* ... which causes integer wraparound via `as u32`
* ... which then leads to a panic, as we can't init with billions of microseconds (for example).

This PR allows pre-epoch conversions with fractional seconds to be handled correctly, and adds some new tests to provide the missing coverage.