### PR TITLE
Fixed timestamp to datetime conversion error

### DIFF
--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -120,7 +120,8 @@ pub fn timestamp_ms_to_datetime(v: i64) -> NaiveDateTime {
             (v % MILLISECONDS * MICROSECONDS) as u32,
         )
     } else {
-        // negative values
+        // note: negative values require 'div_floor' rounding behaviour, which isn't
+        // yet stabilised (see - https://github.com/rust-lang/rust/issues/88581).
         let secs_rem = (v / MILLISECONDS, v % MILLISECONDS);
         NaiveDateTime::from_timestamp_opt(
             secs_rem.0 - (secs_rem.1 != 0) as i64,
@@ -141,7 +142,8 @@ pub fn timestamp_us_to_datetime(v: i64) -> NaiveDateTime {
             (v % MICROSECONDS * MILLISECONDS) as u32,
         )
     } else {
-        // negative values
+        // note: negative values require 'div_floor' rounding behaviour, which isn't
+        // yet stabilised (see - https://github.com/rust-lang/rust/issues/88581).
         let secs_rem = (v / MICROSECONDS, v % MICROSECONDS);
         NaiveDateTime::from_timestamp_opt(
             secs_rem.0 - (secs_rem.1 != 0) as i64,
@@ -162,7 +164,8 @@ pub fn timestamp_ns_to_datetime(v: i64) -> NaiveDateTime {
             (v % NANOSECONDS) as u32,
         )
     } else {
-        // negative values
+        // note: negative values require 'div_floor' rounding behaviour, which isn't
+        // yet stabilised (see - https://github.com/rust-lang/rust/issues/88581).
         let secs_rem = (v / NANOSECONDS, v % NANOSECONDS);
         NaiveDateTime::from_timestamp_opt(
             secs_rem.0 - (secs_rem.1 != 0) as i64,

--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -121,8 +121,9 @@ pub fn timestamp_ms_to_datetime(v: i64) -> NaiveDateTime {
         )
     } else {
         // negative values
+        let secs_rem = (v / MILLISECONDS, v % MILLISECONDS);
         NaiveDateTime::from_timestamp_opt(
-            (v / MILLISECONDS) - 1,
+            secs_rem.0 - (secs_rem.1 != 0) as i64,
             (v % MILLISECONDS * MICROSECONDS).unsigned_abs() as u32,
         )
     }
@@ -141,8 +142,9 @@ pub fn timestamp_us_to_datetime(v: i64) -> NaiveDateTime {
         )
     } else {
         // negative values
+        let secs_rem = (v / MICROSECONDS, v % MICROSECONDS);
         NaiveDateTime::from_timestamp_opt(
-            (v / MICROSECONDS) - 1,
+            secs_rem.0 - (secs_rem.1 != 0) as i64,
             (v % MICROSECONDS * MILLISECONDS).unsigned_abs() as u32,
         )
     }
@@ -161,8 +163,9 @@ pub fn timestamp_ns_to_datetime(v: i64) -> NaiveDateTime {
         )
     } else {
         // negative values
+        let secs_rem = (v / NANOSECONDS, v % NANOSECONDS);
         NaiveDateTime::from_timestamp_opt(
-            (v / NANOSECONDS) - 1,
+            secs_rem.0 - (secs_rem.1 != 0) as i64,
             (v % NANOSECONDS).unsigned_abs() as u32,
         )
     }

--- a/tests/it/temporal_conversions.rs
+++ b/tests/it/temporal_conversions.rs
@@ -127,46 +127,68 @@ fn naive_no_tz() {
 #[test]
 fn timestamp_to_datetime() {
     let fmt = "%Y-%m-%dT%H:%M:%S.%9f";
+    let ts = 1680870214123456789;
 
     // positive milliseconds
-    let ts = 1680870214123456789;
-    let r = temporal_conversions::timestamp_ms_to_datetime(ts / 1_000_000);
     assert_eq!(
-        r,
+        temporal_conversions::timestamp_ms_to_datetime(ts / 1_000_000),
         NaiveDateTime::parse_from_str("2023-04-07T12:23:34.123000000", fmt).unwrap()
     );
     // positive microseconds
-    let r = temporal_conversions::timestamp_us_to_datetime(ts / 1_000);
     assert_eq!(
-        r,
+        temporal_conversions::timestamp_us_to_datetime(ts / 1_000),
         NaiveDateTime::parse_from_str("2023-04-07T12:23:34.123456000", fmt).unwrap()
     );
     // positive nanoseconds
-    let r = temporal_conversions::timestamp_ns_to_datetime(ts);
     assert_eq!(
-        r,
+        temporal_conversions::timestamp_ns_to_datetime(ts),
         NaiveDateTime::parse_from_str("2023-04-07T12:23:34.123456789", fmt).unwrap()
     );
 
-    // negative milliseconds
     let ts = -15548276987654321;
-    let r = temporal_conversions::timestamp_ms_to_datetime(ts / 1_000_000);
+
+    // negative milliseconds
     assert_eq!(
-        r,
+        temporal_conversions::timestamp_ms_to_datetime(ts / 1_000_000),
         NaiveDateTime::parse_from_str("1969-07-05T01:02:03.987000000", fmt).unwrap()
     );
     // negative microseconds
-    let r = temporal_conversions::timestamp_us_to_datetime(ts / 1_000);
     assert_eq!(
-        r,
+        temporal_conversions::timestamp_us_to_datetime(ts / 1_000),
         NaiveDateTime::parse_from_str("1969-07-05T01:02:03.987654000", fmt).unwrap()
     );
     // negative nanoseconds
-    let r = temporal_conversions::timestamp_ns_to_datetime(ts);
     assert_eq!(
-        r,
+        temporal_conversions::timestamp_ns_to_datetime(ts),
         NaiveDateTime::parse_from_str("1969-07-05T01:02:03.987654321", fmt).unwrap()
     );
+
+    let fmt = "%Y-%m-%dT%H:%M:%S";
+    let ts = -2209075200000000000;
+    let expected = NaiveDateTime::parse_from_str("1899-12-31T00:00:00", fmt).unwrap();
+
+    assert_eq!(
+        temporal_conversions::timestamp_ms_to_datetime(ts / 1_000_000),
+        expected
+    );
+    assert_eq!(
+        temporal_conversions::timestamp_us_to_datetime(ts / 1_000),
+        expected
+    );
+    assert_eq!(temporal_conversions::timestamp_ns_to_datetime(ts), expected);
+}
+
+#[test]
+fn timestamp_to_negative_datetime() {
+    let fmt = "%Y-%m-%d %H:%M:%S";
+    let ts = -63135596800000000;
+    let expected = NaiveDateTime::parse_from_str("-0031-04-24 22:13:20", fmt).unwrap();
+
+    assert_eq!(
+        temporal_conversions::timestamp_ms_to_datetime(ts / 1_000),
+        expected
+    );
+    assert_eq!(temporal_conversions::timestamp_us_to_datetime(ts), expected);
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to the [previous](https://github.com/jorgecarleitao/arrow2/pull/1467) PR, which was incomplete; this update now properly handles _both_ fractional and non-fractional pre-epoch (negative) value conversions. Apologies for missing this first time round 😅 

Added new tests to ensure that both cases are properly covered. 

(Note that `div_floor` hasn't been standardised yet[^1], so this checks the remainder and applies the equivalent "-1" adjustment for fractional seconds in the negative timestamp case; default behaviour is round-to-zero, meaning we'd otherwise be off by one second).

[^1]: Tracking Issue for int_roundings: https://github.com/rust-lang/rust/issues/88581