### PR TITLE
Reduce the overhead of `DataType`s

### DIFF
--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -1,4 +1,4 @@
-use std::hint::unreachable_unchecked;
+use std::{hint::unreachable_unchecked, sync::Arc};
 
 use crate::{
     bitmap::{
@@ -290,7 +290,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     }
 
     pub(crate) fn default_data_type(values_datatype: DataType) -> DataType {
-        DataType::Dictionary(K::KEY_TYPE, Box::new(values_datatype), false)
+        DataType::Dictionary(K::KEY_TYPE, Arc::new(values_datatype), false)
     }
 
     /// Slices this [`DictionaryArray`].

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -55,7 +55,7 @@ impl<K: DictionaryKey, M: MutableArray> From<M> for MutableDictionaryArray<K, M>
         Self {
             data_type: DataType::Dictionary(
                 K::KEY_TYPE,
-                Box::new(values.data_type().clone()),
+                std::sync::Arc::new(values.data_type().clone()),
                 false,
             ),
             keys: MutablePrimitiveArray::<K>::new(),
@@ -72,7 +72,7 @@ impl<K: DictionaryKey, M: MutableArray + Default> MutableDictionaryArray<K, M> {
         Self {
             data_type: DataType::Dictionary(
                 K::KEY_TYPE,
-                Box::new(values.data_type().clone()),
+                std::sync::Arc::new(values.data_type().clone()),
                 false,
             ),
             keys: MutablePrimitiveArray::<K>::new(),

--- a/src/array/fixed_size_list/mod.rs
+++ b/src/array/fixed_size_list/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, Field},
@@ -204,7 +206,7 @@ impl FixedSizeListArray {
 
     /// Returns a [`DataType`] consistent with [`FixedSizeListArray`].
     pub fn default_datatype(data_type: DataType, size: usize) -> DataType {
-        let field = Box::new(Field::new("item", data_type, true));
+        let field = Arc::new(Field::new("item", data_type, true));
         DataType::FixedSizeList(field, size)
     }
 }

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -41,7 +41,7 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
     /// Creates a new [`MutableFixedSizeListArray`] from a [`MutableArray`] and size.
     pub fn new_with_field(values: M, name: &str, nullable: bool, size: usize) -> Self {
         let data_type = DataType::FixedSizeList(
-            Box::new(Field::new(name, values.data_type().clone(), nullable)),
+            Arc::new(Field::new(name, values.data_type().clone(), nullable)),
             size,
         );
         Self::new_from(values, data_type, size)

--- a/src/array/list/mod.rs
+++ b/src/array/list/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, Field},
@@ -188,7 +190,7 @@ impl<O: Offset> ListArray<O> {
 impl<O: Offset> ListArray<O> {
     /// Returns a default [`DataType`]: inner field is named "item" and is nullable
     pub fn default_datatype(data_type: DataType) -> DataType {
-        let field = Box::new(Field::new("item", data_type, true));
+        let field = Arc::new(Field::new("item", data_type, true));
         if O::IS_LARGE {
             DataType::LargeList(field)
         } else {

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -127,7 +127,7 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
 
     /// Creates a new [`MutableListArray`] from a [`MutableArray`].
     pub fn new_with_field(values: M, name: &str, nullable: bool) -> Self {
-        let field = Box::new(Field::new(name, values.data_type().clone(), nullable));
+        let field = Arc::new(Field::new(name, values.data_type().clone(), nullable));
         let data_type = if O::IS_LARGE {
             DataType::LargeList(field)
         } else {

--- a/src/array/struct_/mod.rs
+++ b/src/array/struct_/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
     bitmap::Bitmap,
     datatypes::{DataType, Field},
@@ -28,7 +30,7 @@ pub use mutable::*;
 ///     Field::new("c", DataType::Int32, false),
 /// ];
 ///
-/// let array = StructArray::new(DataType::Struct(fields), vec![boolean, int], None);
+/// let array = StructArray::new(DataType::Struct(std::sync::Arc::new(fields)), vec![boolean, int], None);
 /// ```
 #[derive(Clone)]
 pub struct StructArray {
@@ -69,7 +71,7 @@ impl StructArray {
             .try_for_each(|(index, (data_type, child))| {
                 if data_type != child {
                     Err(Error::oos(format!(
-                        "The children DataTypes of a StructArray must equal the children data types. 
+                        "The children DataTypes of a StructArray must equal the children data types.
                          However, the field {index} has data type {data_type:?} but the value has data type {child:?}"
                     )))
                 } else {
@@ -153,7 +155,7 @@ impl StructArray {
 impl StructArray {
     /// Deconstructs the [`StructArray`] into its individual components.
     #[must_use]
-    pub fn into_data(self) -> (Vec<Field>, Vec<Box<dyn Array>>, Option<Bitmap>) {
+    pub fn into_data(self) -> (Arc<Vec<Field>>, Vec<Box<dyn Array>>, Option<Bitmap>) {
         let Self {
             data_type,
             values,

--- a/src/array/union/mod.rs
+++ b/src/array/union/mod.rs
@@ -73,7 +73,7 @@ impl UnionArray {
             .try_for_each(|(index, (data_type, child))| {
                 if data_type != child {
                     Err(Error::oos(format!(
-                        "The children DataTypes of a UnionArray must equal the children data types. 
+                        "The children DataTypes of a UnionArray must equal the children data types.
                          However, the field {index} has data type {data_type:?} but the value has data type {child:?}"
                     )))
                 } else {
@@ -352,7 +352,7 @@ impl UnionArray {
     fn try_get_all(data_type: &DataType) -> Result<UnionComponents, Error> {
         match data_type.to_logical_type() {
             DataType::Union(fields, ids, mode) => {
-                Ok((fields, ids.as_ref().map(|x| x.as_ref()), *mode))
+                Ok((fields, ids.as_ref().map(|x| x.as_slice()), *mode))
             }
             _ => Err(Error::oos(
                 "The UnionArray requires a logical type of DataType::Union",

--- a/src/compute/arithmetics/time.rs
+++ b/src/compute/arithmetics/time.rs
@@ -81,7 +81,7 @@ fn create_scale(lhs: &DataType, rhs: &DataType) -> Result<f64> {
 /// ])
 /// .to(DataType::Timestamp(
 ///     TimeUnit::Second,
-///     Some("America/New_York".to_string()),
+///     Some(std::sync::Arc::new("America/New_york".to_string())),
 /// ));
 ///
 /// let duration = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)])
@@ -96,7 +96,7 @@ fn create_scale(lhs: &DataType, rhs: &DataType) -> Result<f64> {
 /// ])
 /// .to(DataType::Timestamp(
 ///     TimeUnit::Second,
-///     Some("America/New_York".to_string()),
+///     Some(std::sync::Arc::new("America/New_york".to_string())),
 /// ));
 ///
 /// assert_eq!(result, expected);
@@ -161,7 +161,7 @@ where
 /// ])
 /// .to(DataType::Timestamp(
 ///     TimeUnit::Second,
-///     Some("America/New_York".to_string()),
+///     Some(std::sync::Arc::new("America/New_york".to_string())),
 /// ));
 ///
 /// let duration = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)])
@@ -176,7 +176,7 @@ where
 /// ])
 /// .to(DataType::Timestamp(
 ///     TimeUnit::Second,
-///     Some("America/New_York".to_string()),
+///     Some(std::sync::Arc::new("America/New_york".to_string())),
 /// ));
 ///
 /// assert_eq!(result, expected);

--- a/src/compute/cast/dictionary_to.rs
+++ b/src/compute/cast/dictionary_to.rs
@@ -89,7 +89,7 @@ where
     } else {
         let data_type = DataType::Dictionary(
             K2::KEY_TYPE,
-            Box::new(values.data_type().clone()),
+            std::sync::Arc::new(values.data_type().clone()),
             is_ordered,
         );
         // Safety: this is safe because given a type `T` that fits in a `usize`, casting it to type `P` either overflows or also fits in a `usize`
@@ -116,7 +116,7 @@ where
     } else {
         let data_type = DataType::Dictionary(
             K2::KEY_TYPE,
-            Box::new(values.data_type().clone()),
+            std::sync::Arc::new(values.data_type().clone()),
             is_ordered,
         );
         // some of the values may not fit in `usize` and thus this needs to be checked

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -389,7 +389,7 @@ fn cast_list_to_fixed_size_list(
         None => {
             let new_values = cast(list.values().as_ref(), inner.data_type(), options)?;
             Ok(FixedSizeListArray::new(
-                DataType::FixedSizeList(Box::new(inner.clone()), size),
+                DataType::FixedSizeList(std::sync::Arc::new(inner.clone()), size),
                 new_values,
                 list.validity().cloned(),
             ))

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -1,4 +1,5 @@
 use std::hash::Hash;
+use std::sync::Arc;
 
 use num_traits::{AsPrimitive, Float, ToPrimitive};
 
@@ -406,7 +407,7 @@ pub fn timestamp_to_timestamp(
     from: &PrimitiveArray<i64>,
     from_unit: TimeUnit,
     to_unit: TimeUnit,
-    tz: &Option<String>,
+    tz: &Option<Arc<String>>,
 ) -> PrimitiveArray<i64> {
     let from_size = time_unit_multiple(from_unit);
     let to_size = time_unit_multiple(to_unit);

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::Datelike;
 
 use crate::{
@@ -127,7 +129,7 @@ pub fn utf8_to_naive_timestamp_ns<O: Offset>(from: &Utf8Array<O>) -> PrimitiveAr
 
 pub(super) fn utf8_to_timestamp_ns_dyn<O: Offset>(
     from: &dyn Array,
-    timezone: String,
+    timezone: Arc<String>,
 ) -> Result<Box<dyn Array>> {
     let from = from.as_any().downcast_ref().unwrap();
     utf8_to_timestamp_ns::<O>(from, timezone)
@@ -138,7 +140,7 @@ pub(super) fn utf8_to_timestamp_ns_dyn<O: Offset>(
 /// [`crate::temporal_conversions::utf8_to_timestamp_ns`] applied for RFC3339 formatting
 pub fn utf8_to_timestamp_ns<O: Offset>(
     from: &Utf8Array<O>,
-    timezone: String,
+    timezone: Arc<String>,
 ) -> Result<PrimitiveArray<i64>> {
     utf8_to_timestamp_ns_(from, RFC3339, timezone)
 }

--- a/src/datatypes/mod.rs
+++ b/src/datatypes/mod.rs
@@ -111,7 +111,7 @@ pub enum DataType {
     /// * An absolute time zone offset of the form +XX:XX or -XX:XX, such as +07:30
     /// When the timezone is not specified, the timestamp is considered to have no timezone
     /// and is represented _as is_
-    Timestamp(TimeUnit, Option<String>),
+    Timestamp(TimeUnit, Option<Arc<String>>),
     /// An [`i32`] representing the elapsed time since UNIX epoch (1970-01-01)
     /// in days.
     Date32,
@@ -218,7 +218,9 @@ impl From<DataType> for arrow_schema::DataType {
             DataType::Float16 => Self::Float16,
             DataType::Float32 => Self::Float32,
             DataType::Float64 => Self::Float64,
-            DataType::Timestamp(unit, tz) => Self::Timestamp(unit.into(), tz),
+            DataType::Timestamp(unit, tz) => {
+                Self::Timestamp(unit.into(), tz.map(Arc::unwrap_or_clone_polyfill))
+            }
             DataType::Date32 => Self::Date32,
             DataType::Date64 => Self::Date64,
             DataType::Time32(unit) => Self::Time32(unit.into()),
@@ -280,7 +282,7 @@ impl From<arrow_schema::DataType> for DataType {
             DataType::Float16 => Self::Float16,
             DataType::Float32 => Self::Float32,
             DataType::Float64 => Self::Float64,
-            DataType::Timestamp(unit, tz) => Self::Timestamp(unit.into(), tz),
+            DataType::Timestamp(unit, tz) => Self::Timestamp(unit.into(), tz.map(Arc::new)),
             DataType::Date32 => Self::Date32,
             DataType::Date64 => Self::Date64,
             DataType::Time32(unit) => Self::Time32(unit.into()),

--- a/src/io/avro/read/nested.rs
+++ b/src/io/avro/read/nested.rs
@@ -129,7 +129,7 @@ impl FixedItemsUtf8Dictionary {
         Self {
             data_type: DataType::Dictionary(
                 IntegerType::Int32,
-                Box::new(values.data_type().clone()),
+                std::sync::Arc::new(values.data_type().clone()),
                 false,
             ),
             keys: MutablePrimitiveArray::<i32>::with_capacity(capacity),

--- a/src/io/avro/read/schema.rs
+++ b/src/io/avro/read/schema.rs
@@ -105,7 +105,7 @@ fn schema_to_field(schema: &AvroSchema, name: Option<&str>, props: Metadata) -> 
                     .iter()
                     .map(|s| schema_to_field(s, None, Metadata::default()))
                     .collect::<Result<Vec<Field>>>()?;
-                DataType::Union(fields, None, UnionMode::Dense)
+                DataType::Union(Arc::new(fields), None, UnionMode::Dense)
             }
         }
         AvroSchema::Record(Record { fields, .. }) => {
@@ -119,12 +119,12 @@ fn schema_to_field(schema: &AvroSchema, name: Option<&str>, props: Metadata) -> 
                     schema_to_field(&field.schema, Some(&field.name), props)
                 })
                 .collect::<Result<_>>()?;
-            DataType::Struct(fields)
+            DataType::Struct(std::sync::Arc::new(fields))
         }
         AvroSchema::Enum { .. } => {
             return Ok(Field::new(
                 name.unwrap_or_default(),
-                DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Utf8), false),
+                DataType::Dictionary(IntegerType::Int32, Arc::new(DataType::Utf8), false),
                 false,
             ))
         }

--- a/src/io/avro/read/schema.rs
+++ b/src/io/avro/read/schema.rs
@@ -77,7 +77,7 @@ fn schema_to_field(schema: &AvroSchema, name: Option<&str>, props: Metadata) -> 
             None => DataType::Binary,
         },
         AvroSchema::String(_) => DataType::Utf8,
-        AvroSchema::Array(item_schema) => DataType::List(Box::new(schema_to_field(
+        AvroSchema::Array(item_schema) => DataType::List(std::sync::Arc::new(schema_to_field(
             item_schema,
             Some("item"), // default name for list items
             Metadata::default(),

--- a/src/io/avro/read/schema.rs
+++ b/src/io/avro/read/schema.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use avro_schema::schema::{Enum, Fixed, Record, Schema as AvroSchema};
 
 use crate::datatypes::*;
@@ -52,10 +54,10 @@ fn schema_to_field(schema: &AvroSchema, name: Option<&str>, props: Metadata) -> 
             Some(logical) => match logical {
                 avro_schema::schema::LongLogical::Time => DataType::Time64(TimeUnit::Microsecond),
                 avro_schema::schema::LongLogical::TimestampMillis => {
-                    DataType::Timestamp(TimeUnit::Millisecond, Some("00:00".to_string()))
+                    DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::new("00:00".to_string())))
                 }
                 avro_schema::schema::LongLogical::TimestampMicros => {
-                    DataType::Timestamp(TimeUnit::Microsecond, Some("00:00".to_string()))
+                    DataType::Timestamp(TimeUnit::Microsecond, Some(Arc::new("00:00".to_string())))
                 }
                 avro_schema::schema::LongLogical::LocalTimestampMillis => {
                     DataType::Timestamp(TimeUnit::Millisecond, None)

--- a/src/io/csv/utils.rs
+++ b/src/io/csv/utils.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::datatypes::{DataType, Field, TimeUnit};
 use ahash::AHashSet;
 
@@ -27,15 +29,18 @@ fn is_naive_datetime(string: &str) -> bool {
     string.parse::<chrono::NaiveDateTime>().is_ok()
 }
 
-fn is_datetime(string: &str) -> Option<String> {
+fn is_datetime(string: &str) -> Option<Arc<String>> {
     let mut parsed = chrono::format::Parsed::new();
     let fmt = chrono::format::StrftimeItems::new(RFC3339);
     if chrono::format::parse(&mut parsed, string, fmt).is_ok() {
-        parsed.offset.map(|x| {
-            let hours = x / 60 / 60;
-            let minutes = x / 60 - hours * 60;
-            format!("{hours:03}:{minutes:02}")
-        })
+        parsed
+            .offset
+            .map(|x| {
+                let hours = x / 60 / 60;
+                let minutes = x / 60 - hours * 60;
+                format!("{hours:03}:{minutes:02}")
+            })
+            .map(Arc::new)
     } else {
         None
     }

--- a/src/io/ipc/read/schema.rs
+++ b/src/io/ipc/read/schema.rs
@@ -145,7 +145,7 @@ fn deserialize_map(map: MapRef, field: FieldRef) -> Result<(DataType, IpcField)>
         .ok_or_else(|| Error::oos("IPC: Map must contain one child"))??;
     let (field, ipc_field) = deserialize_field(inner)?;
 
-    let data_type = DataType::Map(Box::new(field), is_sorted);
+    let data_type = DataType::Map(std::sync::Arc::new(field), is_sorted);
     Ok((
         data_type,
         IpcField {
@@ -183,7 +183,7 @@ fn deserialize_list(field: FieldRef) -> Result<(DataType, IpcField)> {
     let (field, ipc_field) = deserialize_field(inner)?;
 
     Ok((
-        DataType::List(Box::new(field)),
+        DataType::List(std::sync::Arc::new(field)),
         IpcField {
             fields: vec![ipc_field],
             dictionary_id: None,
@@ -201,7 +201,7 @@ fn deserialize_large_list(field: FieldRef) -> Result<(DataType, IpcField)> {
     let (field, ipc_field) = deserialize_field(inner)?;
 
     Ok((
-        DataType::LargeList(Box::new(field)),
+        DataType::LargeList(std::sync::Arc::new(field)),
         IpcField {
             fields: vec![ipc_field],
             dictionary_id: None,
@@ -227,7 +227,7 @@ fn deserialize_fixed_size_list(
         .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
 
     Ok((
-        DataType::FixedSizeList(Box::new(field), size),
+        DataType::FixedSizeList(std::sync::Arc::new(field), size),
         IpcField {
             fields: vec![ipc_field],
             dictionary_id: None,

--- a/src/io/ipc/read/schema.rs
+++ b/src/io/ipc/read/schema.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow_format::ipc::{
     planus::ReadAsRoot, FieldRef, FixedSizeListRef, MapRef, TimeRef, TimestampRef, UnionRef,
 };
@@ -104,7 +106,7 @@ fn deserialize_time(time: TimeRef) -> Result<(DataType, IpcField)> {
 }
 
 fn deserialize_timestamp(timestamp: TimestampRef) -> Result<(DataType, IpcField)> {
-    let timezone = timestamp.timezone()?.map(|tz| tz.to_string());
+    let timezone = timestamp.timezone()?.map(|tz| Arc::new(tz.to_string()));
     let time_unit = deserialize_timeunit(timestamp.unit()?)?;
     Ok((
         DataType::Timestamp(time_unit, timezone),

--- a/src/io/ipc/write/schema.rs
+++ b/src/io/ipc/write/schema.rs
@@ -228,7 +228,7 @@ fn serialize_type(data_type: &DataType) -> arrow_format::ipc::Type {
         })),
         Timestamp(unit, tz) => ipc::Type::Timestamp(Box::new(ipc::Timestamp {
             unit: serialize_time_unit(unit),
-            timezone: tz.as_ref().cloned(),
+            timezone: tz.as_ref().map(|tz| tz.as_str().to_owned()),
         })),
         Interval(unit) => ipc::Type::Interval(Box::new(ipc::Interval {
             unit: match unit {

--- a/src/io/ipc/write/schema.rs
+++ b/src/io/ipc/write/schema.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow_format::ipc::planus::Builder;
 
 use crate::datatypes::{
@@ -71,14 +73,14 @@ fn write_metadata(metadata: &Metadata, kv_vec: &mut Vec<arrow_format::ipc::KeyVa
 
 fn write_extension(
     name: &str,
-    metadata: &Option<String>,
+    metadata: &Option<Arc<String>>,
     kv_vec: &mut Vec<arrow_format::ipc::KeyValue>,
 ) {
     // metadata
     if let Some(metadata) = metadata {
         let entry = arrow_format::ipc::KeyValue {
             key: Some("ARROW:extension:metadata".to_string()),
-            value: Some(metadata.clone()),
+            value: Some(metadata.to_string()),
         };
         kv_vec.push(entry);
     }
@@ -247,7 +249,7 @@ fn serialize_type(data_type: &DataType) -> arrow_format::ipc::Type {
                 UnionMode::Dense => ipc::UnionMode::Dense,
                 UnionMode::Sparse => ipc::UnionMode::Sparse,
             },
-            type_ids: type_ids.clone(),
+            type_ids: type_ids.as_ref().map(|type_ids| type_ids.to_vec()),
         })),
         Map(_, keys_sorted) => ipc::Type::Map(Box::new(ipc::Map {
             keys_sorted: *keys_sorted,

--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -535,10 +535,10 @@ pub(crate) fn _deserialize<'a, A: Borrow<Value<'a>>>(
             let iter = rows.iter().map(|row| match row.borrow() {
                 Value::Number(v) => Some(deserialize_int_single(*v)),
                 Value::String(v) => match (tu, tz) {
-                    (_, None) => temporal_conversions::utf8_to_naive_timestamp_scalar(v, "%+", &tu),
+                    (_, None) => temporal_conversions::utf8_to_naive_timestamp_scalar(v, "%+", tu),
                     (_, Some(ref tz)) => {
                         let tz = temporal_conversions::parse_offset(tz).unwrap();
-                        temporal_conversions::utf8_to_timestamp_scalar(v, "%+", &tz, &tu)
+                        temporal_conversions::utf8_to_timestamp_scalar(v, "%+", &tz, tu)
                     }
                 },
                 _ => None,
@@ -599,7 +599,7 @@ pub fn deserialize(json: &Value, data_type: DataType) -> Result<Box<dyn Array>, 
     match json {
         Value::Array(rows) => match data_type {
             DataType::List(inner) | DataType::LargeList(inner) => {
-                Ok(_deserialize(rows, inner.data_type))
+                Ok(_deserialize(rows, inner.data_type.clone()))
             }
             _ => Err(Error::nyi("read an Array from a non-Array data type")),
         },

--- a/src/io/json/read/infer_schema.rs
+++ b/src/io/json/read/infer_schema.rs
@@ -38,7 +38,7 @@ pub fn infer_records_schema(json: &Value) -> Result<Schema> {
 
                 Ok(Field {
                     name: name.clone(),
-                    data_type: DataType::List(Box::new(Field {
+                    data_type: DataType::List(std::sync::Arc::new(Field {
                         name: format!("{name}-records"),
                         data_type,
                         is_nullable: true,
@@ -105,7 +105,7 @@ fn infer_array(values: &[Value]) -> Result<DataType> {
     Ok(if dt == DataType::Null {
         dt
     } else {
-        DataType::List(Box::new(Field::new(ITEM_NAME, dt, true)))
+        DataType::List(std::sync::Arc::new(Field::new(ITEM_NAME, dt, true)))
     })
 }
 
@@ -180,15 +180,15 @@ pub(crate) fn coerce_data_type<A: Borrow<DataType>>(datatypes: &[A]) -> DataType
         (lhs, rhs) if lhs == rhs => lhs.clone(),
         (List(lhs), List(rhs)) => {
             let inner = coerce_data_type(&[lhs.data_type(), rhs.data_type()]);
-            List(Box::new(Field::new(ITEM_NAME, inner, true)))
+            List(std::sync::Arc::new(Field::new(ITEM_NAME, inner, true)))
         }
         (scalar, List(list)) => {
             let inner = coerce_data_type(&[scalar, list.data_type()]);
-            List(Box::new(Field::new(ITEM_NAME, inner, true)))
+            List(std::sync::Arc::new(Field::new(ITEM_NAME, inner, true)))
         }
         (List(list), scalar) => {
             let inner = coerce_data_type(&[scalar, list.data_type()]);
-            List(Box::new(Field::new(ITEM_NAME, inner, true)))
+            List(std::sync::Arc::new(Field::new(ITEM_NAME, inner, true)))
         }
         (Float64, Int64) => Float64,
         (Int64, Float64) => Float64,
@@ -209,25 +209,25 @@ mod test {
         assert_eq!(
             coerce_data_type(&[
                 Float64,
-                List(Box::new(Field::new(ITEM_NAME, Float64, true)))
+                List(std::sync::Arc::new(Field::new(ITEM_NAME, Float64, true)))
             ]),
-            List(Box::new(Field::new(ITEM_NAME, Float64, true))),
+            List(std::sync::Arc::new(Field::new(ITEM_NAME, Float64, true))),
         );
         assert_eq!(
-            coerce_data_type(&[Float64, List(Box::new(Field::new(ITEM_NAME, Int64, true)))]),
-            List(Box::new(Field::new(ITEM_NAME, Float64, true))),
+            coerce_data_type(&[Float64, List(std::sync::Arc::new(Field::new(ITEM_NAME, Int64, true)))]),
+            List(std::sync::Arc::new(Field::new(ITEM_NAME, Float64, true))),
         );
         assert_eq!(
-            coerce_data_type(&[Int64, List(Box::new(Field::new(ITEM_NAME, Int64, true)))]),
-            List(Box::new(Field::new(ITEM_NAME, Int64, true))),
+            coerce_data_type(&[Int64, List(std::sync::Arc::new(Field::new(ITEM_NAME, Int64, true)))]),
+            List(std::sync::Arc::new(Field::new(ITEM_NAME, Int64, true))),
         );
         // boolean and number are incompatible, return utf8
         assert_eq!(
             coerce_data_type(&[
                 Boolean,
-                List(Box::new(Field::new(ITEM_NAME, Float64, true)))
+                List(std::sync::Arc::new(Field::new(ITEM_NAME, Float64, true)))
             ]),
-            List(Box::new(Field::new(ITEM_NAME, Utf8, true))),
+            List(std::sync::Arc::new(Field::new(ITEM_NAME, Utf8, true))),
         );
     }
 

--- a/src/io/json_integration/read/schema.rs
+++ b/src/io/json_integration/read/schema.rs
@@ -259,7 +259,7 @@ fn to_data_type(item: &Value, mut children: Vec<Field>) -> Result<DataType> {
                 ));
             }
         }
-        "struct" => DataType::Struct(children),
+        "struct" => DataType::Struct(Arc::new(children)),
         "union" => {
             let mode = if let Some(Value::String(mode)) = item.get("mode") {
                 UnionMode::sparse(mode == "SPARSE")
@@ -267,11 +267,13 @@ fn to_data_type(item: &Value, mut children: Vec<Field>) -> Result<DataType> {
                 return Err(Error::OutOfSpec("union requires mode".to_string()));
             };
             let ids = if let Some(Value::Array(ids)) = item.get("typeIds") {
-                Some(ids.iter().map(|x| x.as_i64().unwrap() as i32).collect())
+                Some(Arc::new(
+                    ids.iter().map(|x| x.as_i64().unwrap() as i32).collect(),
+                ))
             } else {
                 return Err(Error::OutOfSpec("union requires ids".to_string()));
             };
-            DataType::Union(children, ids, mode)
+            DataType::Union(Arc::new(children), ids, mode)
         }
         "map" => {
             let sorted_keys = if let Some(Value::Bool(sorted_keys)) = item.get("keysSorted") {
@@ -370,7 +372,7 @@ fn deserialize_field(value: &Value) -> Result<Field> {
     let data_type = to_data_type(type_, children)?;
 
     let data_type = if let Some((name, metadata)) = extension {
-        DataType::Extension(name, Box::new(data_type), metadata)
+        DataType::Extension(name, Arc::new(data_type), metadata.map(Arc::new))
     } else {
         data_type
     };
@@ -392,7 +394,7 @@ fn deserialize_field(value: &Value) -> Result<Field> {
                 ));
             }
         };
-        DataType::Dictionary(index_type, Box::new(data_type), is_ordered)
+        DataType::Dictionary(index_type, Arc::new(data_type), is_ordered)
     } else {
         data_type
     };

--- a/src/io/json_integration/read/schema.rs
+++ b/src/io/json_integration/read/schema.rs
@@ -211,7 +211,7 @@ fn to_data_type(item: &Value, mut children: Vec<Field>) -> Result<DataType> {
                 Some(Value::String(tz)) => Ok(Some(tz.clone())),
                 _ => Err(Error::OutOfSpec("timezone must be a string".to_string())),
             }?;
-            DataType::Timestamp(unit, tz)
+            DataType::Timestamp(unit, tz.map(Arc::new))
         }
         "date" => match item.get("unit") {
             Some(p) if p == "DAY" => DataType::Date32,

--- a/src/io/json_integration/read/schema.rs
+++ b/src/io/json_integration/read/schema.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use serde_derive::Deserialize;
 use serde_json::Value;
 
@@ -243,12 +245,12 @@ fn to_data_type(item: &Value, mut children: Vec<Field>) -> Result<DataType> {
             }
         },
         "int" => to_int(item).map(|x| x.into())?,
-        "list" => DataType::List(Box::new(children.pop().unwrap())),
-        "largelist" => DataType::LargeList(Box::new(children.pop().unwrap())),
+        "list" => DataType::List(std::sync::Arc::new(children.pop().unwrap())),
+        "largelist" => DataType::LargeList(std::sync::Arc::new(children.pop().unwrap())),
         "fixedsizelist" => {
             if let Some(Value::Number(size)) = item.get("listSize") {
                 DataType::FixedSizeList(
-                    Box::new(children.pop().unwrap()),
+                    Arc::new(children.pop().unwrap()),
                     size.as_i64().unwrap() as usize,
                 )
             } else {
@@ -277,7 +279,7 @@ fn to_data_type(item: &Value, mut children: Vec<Field>) -> Result<DataType> {
             } else {
                 return Err(Error::OutOfSpec("sorted keys not defined".to_string()));
             };
-            DataType::Map(Box::new(children.pop().unwrap()), sorted_keys)
+            DataType::Map(std::sync::Arc::new(children.pop().unwrap()), sorted_keys)
         }
         other => {
             return Err(Error::NotYetImplemented(format!(

--- a/src/io/parquet/read/deserialize/binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/binary/dictionary.rs
@@ -1,11 +1,11 @@
-use std::collections::VecDeque;
+use std::{collections::VecDeque, sync::Arc};
 
 use parquet2::page::DictPage;
 
 use crate::{
     array::{Array, BinaryArray, DictionaryArray, DictionaryKey, Utf8Array},
     bitmap::MutableBitmap,
-    datatypes::{DataType, PhysicalType},
+    datatypes::{ArcExt, DataType, PhysicalType},
     error::Result,
     io::parquet::read::deserialize::nested_utils::{InitNested, NestedState},
     offset::Offset,
@@ -53,7 +53,7 @@ where
 
 fn read_dict<O: Offset>(data_type: DataType, dict: &DictPage) -> Box<dyn Array> {
     let data_type = match data_type {
-        DataType::Dictionary(_, values, _) => *values,
+        DataType::Dictionary(_, values, _) => Arc::unwrap_or_clone_polyfill(values),
         _ => data_type,
     };
 

--- a/src/io/parquet/read/deserialize/fixed_size_binary/dictionary.rs
+++ b/src/io/parquet/read/deserialize/fixed_size_binary/dictionary.rs
@@ -1,11 +1,11 @@
-use std::collections::VecDeque;
+use std::{collections::VecDeque, sync::Arc};
 
 use parquet2::page::DictPage;
 
 use crate::{
     array::{Array, DictionaryArray, DictionaryKey, FixedSizeBinaryArray},
     bitmap::MutableBitmap,
-    datatypes::DataType,
+    datatypes::{ArcExt, DataType},
     error::Result,
     io::parquet::read::deserialize::nested_utils::{InitNested, NestedState},
 };
@@ -48,7 +48,7 @@ where
 
 fn read_dict(data_type: DataType, dict: &DictPage) -> Box<dyn Array> {
     let data_type = match data_type {
-        DataType::Dictionary(_, values, _) => *values,
+        DataType::Dictionary(_, values, _) => Arc::unwrap_or_clone_polyfill(values),
         _ => data_type,
     };
 

--- a/src/io/parquet/read/deserialize/primitive/dictionary.rs
+++ b/src/io/parquet/read/deserialize/primitive/dictionary.rs
@@ -1,11 +1,11 @@
-use std::collections::VecDeque;
+use std::{collections::VecDeque, sync::Arc};
 
 use parquet2::{page::DictPage, types::NativeType as ParquetNativeType};
 
 use crate::{
     array::{Array, DictionaryArray, DictionaryKey, PrimitiveArray},
     bitmap::MutableBitmap,
-    datatypes::DataType,
+    datatypes::{ArcExt, DataType},
     error::Result,
     types::NativeType,
 };
@@ -24,7 +24,7 @@ where
     F: Copy + Fn(P) -> T,
 {
     let data_type = match data_type {
-        DataType::Dictionary(_, values, _) => *values,
+        DataType::Dictionary(_, values, _) => Arc::unwrap_or_clone_polyfill(values),
         _ => data_type,
     };
     let values = deserialize_plain(&dict.buffer, op);

--- a/src/io/parquet/read/deserialize/struct_.rs
+++ b/src/io/parquet/read/deserialize/struct_.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::array::{Array, StructArray};
 use crate::datatypes::{DataType, Field};
 use crate::error::Error;
@@ -7,12 +9,12 @@ use super::nested_utils::{NestedArrayIter, NestedState};
 /// An iterator adapter over [`NestedArrayIter`] assumed to be encoded as Struct arrays
 pub struct StructIterator<'a> {
     iters: Vec<NestedArrayIter<'a>>,
-    fields: Vec<Field>,
+    fields: Arc<Vec<Field>>,
 }
 
 impl<'a> StructIterator<'a> {
     /// Creates a new [`StructIterator`] with `iters` and `fields`.
-    pub fn new(iters: Vec<NestedArrayIter<'a>>, fields: Vec<Field>) -> Self {
+    pub fn new(iters: Vec<NestedArrayIter<'a>>, fields: Arc<Vec<Field>>) -> Self {
         assert_eq!(iters.len(), fields.len());
         Self { iters, fields }
     }

--- a/src/io/parquet/read/schema/convert.rs
+++ b/src/io/parquet/read/schema/convert.rs
@@ -238,7 +238,7 @@ fn to_struct(fields: &[ParquetType]) -> Option<DataType> {
     if fields.is_empty() {
         None
     } else {
-        Some(DataType::Struct(fields))
+        Some(DataType::Struct(std::sync::Arc::new(fields)))
     }
 }
 
@@ -623,10 +623,10 @@ mod tests {
         //   };
         // }
         {
-            let arrow_struct = DataType::Struct(vec![
+            let arrow_struct = DataType::Struct(Arc::new(vec![
                 Field::new("str", DataType::Utf8, false),
                 Field::new("num", DataType::Int32, false),
-            ]);
+            ]));
             arrow_fields.push(Field::new(
                 "my_list",
                 DataType::List(std::sync::Arc::new(Field::new(
@@ -646,7 +646,8 @@ mod tests {
         // }
         // Special case: group is named array
         {
-            let arrow_struct = DataType::Struct(vec![Field::new("str", DataType::Utf8, false)]);
+            let arrow_struct =
+                DataType::Struct(Arc::new(vec![Field::new("str", DataType::Utf8, false)]));
             arrow_fields.push(Field::new(
                 "my_list",
                 DataType::List(std::sync::Arc::new(Field::new("array", arrow_struct, true))),
@@ -662,7 +663,8 @@ mod tests {
         // }
         // Special case: group named ends in _tuple
         {
-            let arrow_struct = DataType::Struct(vec![Field::new("str", DataType::Utf8, false)]);
+            let arrow_struct =
+                DataType::Struct(Arc::new(vec![Field::new("str", DataType::Utf8, false)]));
             arrow_fields.push(Field::new(
                 "my_list",
                 DataType::List(std::sync::Arc::new(Field::new(
@@ -784,10 +786,10 @@ mod tests {
     fn test_nested_schema() -> Result<()> {
         let mut arrow_fields = Vec::new();
         {
-            let group1_fields = vec![
+            let group1_fields = Arc::new(vec![
                 Field::new("leaf1", DataType::Boolean, false),
                 Field::new("leaf2", DataType::Int32, false),
-            ];
+            ]);
             let group1_struct = Field::new("group1", DataType::Struct(group1_fields), false);
             arrow_fields.push(group1_struct);
 
@@ -822,7 +824,7 @@ mod tests {
                 "innerGroup",
                 DataType::List(std::sync::Arc::new(Field::new(
                     "innerGroup",
-                    DataType::Struct(vec![Field::new("leaf3", DataType::Int32, true)]),
+                    DataType::Struct(Arc::new(vec![Field::new("leaf3", DataType::Int32, true)])),
                     true,
                 ))),
                 true,
@@ -832,10 +834,10 @@ mod tests {
                 "outerGroup",
                 DataType::List(std::sync::Arc::new(Field::new(
                     "outerGroup",
-                    DataType::Struct(vec![
+                    DataType::Struct(Arc::new(vec![
                         Field::new("leaf2", DataType::Int32, true),
                         inner_group_list,
-                    ]),
+                    ])),
                     true,
                 ))),
                 true,
@@ -1016,7 +1018,7 @@ mod tests {
             ),
             Field::new(
                 "struct",
-                DataType::Struct(vec![
+                DataType::Struct(Arc::new(vec![
                     Field::new("bools", DataType::Boolean, false),
                     Field::new("uint32", DataType::UInt32, false),
                     Field::new(
@@ -1028,7 +1030,7 @@ mod tests {
                         ))),
                         false,
                     ),
-                ]),
+                ])),
                 false,
             ),
             Field::new("dictionary_strings", DataType::Utf8, false),

--- a/src/io/parquet/read/schema/convert.rs
+++ b/src/io/parquet/read/schema/convert.rs
@@ -1,4 +1,6 @@
 //! This module has a single entry point, [`parquet_to_arrow_schema`].
+use std::sync::Arc;
+
 use parquet2::schema::{
     types::{
         FieldInfo, GroupConvertedType, GroupLogicalType, IntegerType, ParquetType, PhysicalType,
@@ -95,12 +97,14 @@ fn from_int64(
 
             match unit {
                 ParquetTimeUnit::Milliseconds => {
-                    DataType::Timestamp(TimeUnit::Millisecond, timezone)
+                    DataType::Timestamp(TimeUnit::Millisecond, timezone.map(Arc::new))
                 }
                 ParquetTimeUnit::Microseconds => {
-                    DataType::Timestamp(TimeUnit::Microsecond, timezone)
+                    DataType::Timestamp(TimeUnit::Microsecond, timezone.map(Arc::new))
                 }
-                ParquetTimeUnit::Nanoseconds => DataType::Timestamp(TimeUnit::Nanosecond, timezone),
+                ParquetTimeUnit::Nanoseconds => {
+                    DataType::Timestamp(TimeUnit::Nanosecond, timezone.map(Arc::new))
+                }
             }
         }
         (Some(Time { unit, .. }), _) => match unit {
@@ -521,7 +525,11 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, true))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "element",
+                    DataType::Utf8,
+                    true,
+                ))),
                 false,
             ));
         }
@@ -535,7 +543,11 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, false))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "element",
+                    DataType::Utf8,
+                    false,
+                ))),
                 true,
             ));
         }
@@ -553,11 +565,18 @@ mod tests {
         //   }
         // }
         {
-            let arrow_inner_list =
-                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Int32, false)));
+            let arrow_inner_list = DataType::List(std::sync::Arc::new(Field::new(
+                "element",
+                DataType::Int32,
+                false,
+            )));
             arrow_fields.push(Field::new(
                 "array_of_arrays",
-                DataType::List(std::sync::Arc::new(Field::new("element", arrow_inner_list, false))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "element",
+                    arrow_inner_list,
+                    false,
+                ))),
                 true,
             ));
         }
@@ -571,7 +590,11 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, true))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "element",
+                    DataType::Utf8,
+                    true,
+                ))),
                 true,
             ));
         }
@@ -583,7 +606,11 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Int32, true))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "element",
+                    DataType::Int32,
+                    true,
+                ))),
                 true,
             ));
         }
@@ -602,7 +629,11 @@ mod tests {
             ]);
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(std::sync::Arc::new(Field::new("element", arrow_struct, true))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "element",
+                    arrow_struct,
+                    true,
+                ))),
                 true,
             ));
         }
@@ -634,7 +665,11 @@ mod tests {
             let arrow_struct = DataType::Struct(vec![Field::new("str", DataType::Utf8, false)]);
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(std::sync::Arc::new(Field::new("my_list_tuple", arrow_struct, true))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "my_list_tuple",
+                    arrow_struct,
+                    true,
+                ))),
                 true,
             ));
         }
@@ -644,7 +679,11 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "name",
-                DataType::List(std::sync::Arc::new(Field::new("name", DataType::Int32, true))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "name",
+                    DataType::Int32,
+                    true,
+                ))),
                 true,
             ));
         }
@@ -689,7 +728,11 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list1",
-                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, true))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "element",
+                    DataType::Utf8,
+                    true,
+                ))),
                 false,
             ));
         }
@@ -703,7 +746,11 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list2",
-                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, false))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "element",
+                    DataType::Utf8,
+                    false,
+                ))),
                 true,
             ));
         }
@@ -717,7 +764,11 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list3",
-                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, false))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "element",
+                    DataType::Utf8,
+                    false,
+                ))),
                 false,
             ));
         }
@@ -848,7 +899,11 @@ mod tests {
             Field::new("string", DataType::Utf8, true),
             Field::new(
                 "bools",
-                DataType::List(std::sync::Arc::new(Field::new("bools", DataType::Boolean, true))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "bools",
+                    DataType::Boolean,
+                    true,
+                ))),
                 true,
             ),
             Field::new("date", DataType::Date32, true),
@@ -867,7 +922,7 @@ mod tests {
             ),
             Field::new(
                 "ts_nano",
-                DataType::Timestamp(TimeUnit::Nanosecond, Some("+00:00".to_string())),
+                DataType::Timestamp(TimeUnit::Nanosecond, Some(Arc::new("+00:00".to_string()))),
                 false,
             ),
         ];
@@ -930,12 +985,20 @@ mod tests {
             Field::new("string", DataType::Utf8, true),
             Field::new(
                 "bools",
-                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Boolean, true))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "element",
+                    DataType::Boolean,
+                    true,
+                ))),
                 true,
             ),
             Field::new(
                 "bools_non_null",
-                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Boolean, false))),
+                DataType::List(std::sync::Arc::new(Field::new(
+                    "element",
+                    DataType::Boolean,
+                    false,
+                ))),
                 false,
             ),
             Field::new("date", DataType::Date32, true),
@@ -958,7 +1021,11 @@ mod tests {
                     Field::new("uint32", DataType::UInt32, false),
                     Field::new(
                         "int32",
-                        DataType::List(std::sync::Arc::new(Field::new("element", DataType::Int32, true))),
+                        DataType::List(std::sync::Arc::new(Field::new(
+                            "element",
+                            DataType::Int32,
+                            true,
+                        ))),
                         false,
                     ),
                 ]),

--- a/src/io/parquet/read/schema/convert.rs
+++ b/src/io/parquet/read/schema/convert.rs
@@ -199,7 +199,7 @@ fn to_primitive_type(primitive_type: &PrimitiveType) -> DataType {
     let base_type = to_primitive_type_inner(primitive_type);
 
     if primitive_type.field_info.repetition == Repetition::Repeated {
-        DataType::List(Box::new(Field::new(
+        DataType::List(std::sync::Arc::new(Field::new(
             &primitive_type.field_info.name,
             base_type,
             is_nullable(&primitive_type.field_info),
@@ -242,7 +242,7 @@ fn to_struct(fields: &[ParquetType]) -> Option<DataType> {
 /// Returns [`None`] if all its fields are empty
 fn to_map(fields: &[ParquetType]) -> Option<DataType> {
     let inner = to_field(&fields[0])?;
-    Some(DataType::Map(Box::new(inner), false))
+    Some(DataType::Map(std::sync::Arc::new(inner), false))
 }
 
 /// Entry point for converting parquet group type.
@@ -257,7 +257,7 @@ fn to_group_type(
 ) -> Option<DataType> {
     debug_assert!(!fields.is_empty());
     if field_info.repetition == Repetition::Repeated {
-        Some(DataType::List(Box::new(Field::new(
+        Some(DataType::List(std::sync::Arc::new(Field::new(
             &field_info.name,
             to_struct(fields)?,
             is_nullable(field_info),
@@ -330,7 +330,7 @@ fn to_list(fields: &[ParquetType], parent_name: &str) -> Option<DataType> {
         ),
     };
 
-    Some(DataType::List(Box::new(Field::new(
+    Some(DataType::List(std::sync::Arc::new(Field::new(
         list_item_name,
         item_type,
         item_is_optional,
@@ -521,7 +521,7 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(Box::new(Field::new("element", DataType::Utf8, true))),
+                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, true))),
                 false,
             ));
         }
@@ -535,7 +535,7 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(Box::new(Field::new("element", DataType::Utf8, false))),
+                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, false))),
                 true,
             ));
         }
@@ -554,10 +554,10 @@ mod tests {
         // }
         {
             let arrow_inner_list =
-                DataType::List(Box::new(Field::new("element", DataType::Int32, false)));
+                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Int32, false)));
             arrow_fields.push(Field::new(
                 "array_of_arrays",
-                DataType::List(Box::new(Field::new("element", arrow_inner_list, false))),
+                DataType::List(std::sync::Arc::new(Field::new("element", arrow_inner_list, false))),
                 true,
             ));
         }
@@ -571,7 +571,7 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(Box::new(Field::new("element", DataType::Utf8, true))),
+                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, true))),
                 true,
             ));
         }
@@ -583,7 +583,7 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(Box::new(Field::new("element", DataType::Int32, true))),
+                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Int32, true))),
                 true,
             ));
         }
@@ -602,7 +602,7 @@ mod tests {
             ]);
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(Box::new(Field::new("element", arrow_struct, true))),
+                DataType::List(std::sync::Arc::new(Field::new("element", arrow_struct, true))),
                 true,
             ));
         }
@@ -618,7 +618,7 @@ mod tests {
             let arrow_struct = DataType::Struct(vec![Field::new("str", DataType::Utf8, false)]);
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(Box::new(Field::new("array", arrow_struct, true))),
+                DataType::List(std::sync::Arc::new(Field::new("array", arrow_struct, true))),
                 true,
             ));
         }
@@ -634,7 +634,7 @@ mod tests {
             let arrow_struct = DataType::Struct(vec![Field::new("str", DataType::Utf8, false)]);
             arrow_fields.push(Field::new(
                 "my_list",
-                DataType::List(Box::new(Field::new("my_list_tuple", arrow_struct, true))),
+                DataType::List(std::sync::Arc::new(Field::new("my_list_tuple", arrow_struct, true))),
                 true,
             ));
         }
@@ -644,7 +644,7 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "name",
-                DataType::List(Box::new(Field::new("name", DataType::Int32, true))),
+                DataType::List(std::sync::Arc::new(Field::new("name", DataType::Int32, true))),
                 true,
             ));
         }
@@ -689,7 +689,7 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list1",
-                DataType::List(Box::new(Field::new("element", DataType::Utf8, true))),
+                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, true))),
                 false,
             ));
         }
@@ -703,7 +703,7 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list2",
-                DataType::List(Box::new(Field::new("element", DataType::Utf8, false))),
+                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, false))),
                 true,
             ));
         }
@@ -717,7 +717,7 @@ mod tests {
         {
             arrow_fields.push(Field::new(
                 "my_list3",
-                DataType::List(Box::new(Field::new("element", DataType::Utf8, false))),
+                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Utf8, false))),
                 false,
             ));
         }
@@ -769,7 +769,7 @@ mod tests {
 
             let inner_group_list = Field::new(
                 "innerGroup",
-                DataType::List(Box::new(Field::new(
+                DataType::List(std::sync::Arc::new(Field::new(
                     "innerGroup",
                     DataType::Struct(vec![Field::new("leaf3", DataType::Int32, true)]),
                     true,
@@ -779,7 +779,7 @@ mod tests {
 
             let outer_group_list = Field::new(
                 "outerGroup",
-                DataType::List(Box::new(Field::new(
+                DataType::List(std::sync::Arc::new(Field::new(
                     "outerGroup",
                     DataType::Struct(vec![
                         Field::new("leaf2", DataType::Int32, true),
@@ -848,7 +848,7 @@ mod tests {
             Field::new("string", DataType::Utf8, true),
             Field::new(
                 "bools",
-                DataType::List(Box::new(Field::new("bools", DataType::Boolean, true))),
+                DataType::List(std::sync::Arc::new(Field::new("bools", DataType::Boolean, true))),
                 true,
             ),
             Field::new("date", DataType::Date32, true),
@@ -930,12 +930,12 @@ mod tests {
             Field::new("string", DataType::Utf8, true),
             Field::new(
                 "bools",
-                DataType::List(Box::new(Field::new("element", DataType::Boolean, true))),
+                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Boolean, true))),
                 true,
             ),
             Field::new(
                 "bools_non_null",
-                DataType::List(Box::new(Field::new("element", DataType::Boolean, false))),
+                DataType::List(std::sync::Arc::new(Field::new("element", DataType::Boolean, false))),
                 false,
             ),
             Field::new("date", DataType::Date32, true),
@@ -958,7 +958,7 @@ mod tests {
                     Field::new("uint32", DataType::UInt32, false),
                     Field::new(
                         "int32",
-                        DataType::List(Box::new(Field::new("element", DataType::Int32, true))),
+                        DataType::List(std::sync::Arc::new(Field::new("element", DataType::Int32, true))),
                         false,
                     ),
                 ]),

--- a/src/io/parquet/read/statistics/mod.rs
+++ b/src/io/parquet/read/statistics/mod.rs
@@ -204,12 +204,12 @@ fn make_mutable(data_type: &DataType, capacity: usize) -> Result<Box<dyn Mutable
 
 fn create_dt(data_type: &DataType) -> DataType {
     if let DataType::Struct(fields) = data_type.to_logical_type() {
-        DataType::Struct(
+        DataType::Struct(Arc::new(
             fields
                 .iter()
                 .map(|f| Field::new(&f.name, create_dt(&f.data_type), f.is_nullable))
                 .collect(),
-        )
+        ))
     } else if let DataType::Map(f, ordered) = data_type.to_logical_type() {
         DataType::Map(
             Arc::new(Field::new(&f.name, create_dt(&f.data_type), f.is_nullable)),

--- a/src/io/parquet/read/statistics/mod.rs
+++ b/src/io/parquet/read/statistics/mod.rs
@@ -212,17 +212,17 @@ fn create_dt(data_type: &DataType) -> DataType {
         )
     } else if let DataType::Map(f, ordered) = data_type.to_logical_type() {
         DataType::Map(
-            Box::new(Field::new(&f.name, create_dt(&f.data_type), f.is_nullable)),
+            Arc::new(Field::new(&f.name, create_dt(&f.data_type), f.is_nullable)),
             *ordered,
         )
     } else if let DataType::List(f) = data_type.to_logical_type() {
-        DataType::List(Box::new(Field::new(
+        DataType::List(std::sync::Arc::new(Field::new(
             &f.name,
             create_dt(&f.data_type),
             f.is_nullable,
         )))
     } else if let DataType::LargeList(f) = data_type.to_logical_type() {
-        DataType::LargeList(Box::new(Field::new(
+        DataType::LargeList(std::sync::Arc::new(Field::new(
             &f.name,
             create_dt(&f.data_type),
             f.is_nullable,

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -741,7 +741,7 @@ fn transverse_recursive<T, F: Fn(&DataType) -> T + Clone>(
 ///
 /// let dt = DataType::Struct(vec![
 ///     Field::new("a", DataType::Int64, true),
-///     Field::new("b", DataType::List(Box::new(Field::new("item", DataType::Int32, true))), true),
+///     Field::new("b", DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true))), true),
 /// ]);
 ///
 /// let encodings = transverse(&dt, |dt| Encoding::Plain);

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -707,7 +707,7 @@ fn transverse_recursive<T, F: Fn(&DataType) -> T + Clone>(
         }
         Struct => {
             if let DataType::Struct(fields) = data_type.to_logical_type() {
-                for field in fields {
+                for field in fields.as_slice() {
                     transverse_recursive(&field.data_type, map.clone(), encodings)
                 }
             } else {
@@ -717,7 +717,7 @@ fn transverse_recursive<T, F: Fn(&DataType) -> T + Clone>(
         Map => {
             if let DataType::Map(field, _) = data_type.to_logical_type() {
                 if let DataType::Struct(fields) = field.data_type.to_logical_type() {
-                    for field in fields {
+                    for field in fields.as_slice() {
                         transverse_recursive(&field.data_type, map.clone(), encodings)
                     }
                 } else {

--- a/src/io/parquet/write/pages.rs
+++ b/src/io/parquet/write/pages.rs
@@ -258,6 +258,8 @@ pub fn array_to_columns<A: AsRef<dyn Array> + Send + Sync>(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use parquet2::schema::types::{GroupLogicalType, PrimitiveConvertedType, PrimitiveLogicalType};
     use parquet2::schema::Repetition;
 
@@ -280,7 +282,7 @@ mod tests {
         ];
 
         let array = StructArray::new(
-            DataType::Struct(fields),
+            DataType::Struct(std::sync::Arc::new(fields)),
             vec![boolean.clone(), int.clone()],
             Some(Bitmap::from([true, true, false, true])),
         );
@@ -344,7 +346,7 @@ mod tests {
         ];
 
         let array = StructArray::new(
-            DataType::Struct(fields),
+            DataType::Struct(std::sync::Arc::new(fields)),
             vec![boolean.clone(), int.clone()],
             Some(Bitmap::from([true, true, false, true])),
         );
@@ -355,7 +357,7 @@ mod tests {
         ];
 
         let array = StructArray::new(
-            DataType::Struct(fields),
+            DataType::Struct(std::sync::Arc::new(fields)),
             vec![Box::new(array.clone()), Box::new(array)],
             None,
         );
@@ -447,13 +449,17 @@ mod tests {
         ];
 
         let array = StructArray::new(
-            DataType::Struct(fields),
+            DataType::Struct(std::sync::Arc::new(fields)),
             vec![boolean.clone(), int.clone()],
             Some(Bitmap::from([true, true, false, true])),
         );
 
         let array = ListArray::new(
-            DataType::List(std::sync::Arc::new(Field::new("l", array.data_type().clone(), true))),
+            DataType::List(std::sync::Arc::new(Field::new(
+                "l",
+                array.data_type().clone(),
+                true,
+            ))),
             vec![0i32, 2, 4].try_into().unwrap(),
             Box::new(array),
             None,
@@ -540,10 +546,10 @@ mod tests {
 
     #[test]
     fn test_map() {
-        let kv_type = DataType::Struct(vec![
+        let kv_type = DataType::Struct(Arc::new(vec![
             Field::new("k", DataType::Utf8, false),
             Field::new("v", DataType::Int32, false),
-        ]);
+        ]));
         let kv_field = Field::new("kv", kv_type.clone(), false);
         let map_type = DataType::Map(std::sync::Arc::new(kv_field), false);
 

--- a/src/io/parquet/write/pages.rs
+++ b/src/io/parquet/write/pages.rs
@@ -453,7 +453,7 @@ mod tests {
         );
 
         let array = ListArray::new(
-            DataType::List(Box::new(Field::new("l", array.data_type().clone(), true))),
+            DataType::List(std::sync::Arc::new(Field::new("l", array.data_type().clone(), true))),
             vec![0i32, 2, 4].try_into().unwrap(),
             Box::new(array),
             None,
@@ -545,7 +545,7 @@ mod tests {
             Field::new("v", DataType::Int32, false),
         ]);
         let kv_field = Field::new("kv", kv_type.clone(), false);
-        let map_type = DataType::Map(Box::new(kv_field), false);
+        let map_type = DataType::Map(std::sync::Arc::new(kv_field), false);
 
         let key_array = Utf8Array::<i32>::from_slice(["k1", "k2", "k3", "k4", "k5", "k6"]).boxed();
         let val_array = Int32Array::from_slice([42, 28, 19, 31, 21, 17]).boxed();

--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -1,5 +1,7 @@
 //! Conversion methods for dates and times.
 
+use std::sync::Arc;
+
 use chrono::{
     format::{parse, Parsed, StrftimeItems},
     Datelike, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime,
@@ -287,7 +289,7 @@ pub fn utf8_to_naive_timestamp_scalar(value: &str, fmt: &str, tu: &TimeUnit) -> 
 fn utf8_to_timestamp_ns_impl<O: Offset, T: chrono::TimeZone>(
     array: &Utf8Array<O>,
     fmt: &str,
-    timezone: String,
+    timezone: Arc<String>,
     tz: T,
 ) -> PrimitiveArray<i64> {
     let iter = array
@@ -312,9 +314,9 @@ pub fn parse_offset_tz(timezone: &str) -> Result<chrono_tz::Tz> {
 fn chrono_tz_utf_to_timestamp_ns<O: Offset>(
     array: &Utf8Array<O>,
     fmt: &str,
-    timezone: String,
+    timezone: Arc<String>,
 ) -> Result<PrimitiveArray<i64>> {
-    let tz = parse_offset_tz(&timezone)?;
+    let tz = parse_offset_tz(timezone.as_str())?;
     Ok(utf8_to_timestamp_ns_impl(array, fmt, timezone, tz))
 }
 
@@ -322,7 +324,7 @@ fn chrono_tz_utf_to_timestamp_ns<O: Offset>(
 fn chrono_tz_utf_to_timestamp_ns<O: Offset>(
     _: &Utf8Array<O>,
     _: &str,
-    timezone: String,
+    timezone: Arc<String>,
 ) -> Result<PrimitiveArray<i64>> {
     Err(Error::InvalidArgumentError(format!(
         "timezone \"{timezone}\" cannot be parsed (feature chrono-tz is not active)",
@@ -340,7 +342,7 @@ fn chrono_tz_utf_to_timestamp_ns<O: Offset>(
 pub fn utf8_to_timestamp_ns<O: Offset>(
     array: &Utf8Array<O>,
     fmt: &str,
-    timezone: String,
+    timezone: Arc<String>,
 ) -> Result<PrimitiveArray<i64>> {
     let tz = parse_offset(timezone.as_str());
 

--- a/tests/it/array/dictionary/mod.rs
+++ b/tests/it/array/dictionary/mod.rs
@@ -1,12 +1,17 @@
 mod mutable;
 
+use std::sync::Arc;
+
 use arrow2::{array::*, datatypes::DataType};
 
 #[test]
 fn try_new_ok() {
     let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
-    let data_type =
-        DataType::Dictionary(i32::KEY_TYPE, Box::new(values.data_type().clone()), false);
+    let data_type = DataType::Dictionary(
+        i32::KEY_TYPE,
+        std::sync::Arc::new(values.data_type().clone()),
+        false,
+    );
     let array = DictionaryArray::try_new(
         data_type,
         PrimitiveArray::from_vec(vec![1, 0]),
@@ -27,8 +32,11 @@ fn try_new_ok() {
 #[test]
 fn try_new_incorrect_key() {
     let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
-    let data_type =
-        DataType::Dictionary(i16::KEY_TYPE, Box::new(values.data_type().clone()), false);
+    let data_type = DataType::Dictionary(
+        i16::KEY_TYPE,
+        std::sync::Arc::new(values.data_type().clone()),
+        false,
+    );
 
     let r = DictionaryArray::try_new(
         data_type,
@@ -47,8 +55,11 @@ fn try_new_nulls() {
     let value: &[&str] = &[];
     let values = Utf8Array::<i32>::from_slice(value);
 
-    let data_type =
-        DataType::Dictionary(u32::KEY_TYPE, Box::new(values.data_type().clone()), false);
+    let data_type = DataType::Dictionary(
+        u32::KEY_TYPE,
+        std::sync::Arc::new(values.data_type().clone()),
+        false,
+    );
     let r = DictionaryArray::try_new(data_type, keys, values.boxed()).is_ok();
 
     assert!(r);
@@ -72,7 +83,7 @@ fn try_new_incorrect_dt() {
 #[test]
 fn try_new_incorrect_values_dt() {
     let values = Utf8Array::<i32>::from_slice(["a", "aa"]);
-    let data_type = DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::LargeUtf8), false);
+    let data_type = DataType::Dictionary(i32::KEY_TYPE, Arc::new(DataType::LargeUtf8), false);
 
     let r = DictionaryArray::try_new(
         data_type,
@@ -106,7 +117,7 @@ fn try_new_out_of_bounds_neg() {
 
 #[test]
 fn new_null() {
-    let dt = DataType::Dictionary(i16::KEY_TYPE, Box::new(DataType::Int32), false);
+    let dt = DataType::Dictionary(i16::KEY_TYPE, Arc::new(DataType::Int32), false);
     let array = DictionaryArray::<i16>::new_null(dt, 2);
 
     assert_eq!(format!("{array:?}"), "DictionaryArray[None, None]");
@@ -114,7 +125,7 @@ fn new_null() {
 
 #[test]
 fn new_empty() {
-    let dt = DataType::Dictionary(i16::KEY_TYPE, Box::new(DataType::Int32), false);
+    let dt = DataType::Dictionary(i16::KEY_TYPE, Arc::new(DataType::Int32), false);
     let array = DictionaryArray::<i16>::new_empty(dt);
 
     assert_eq!(format!("{array:?}"), "DictionaryArray[]");

--- a/tests/it/array/fixed_size_binary/mod.rs
+++ b/tests/it/array/fixed_size_binary/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::{array::FixedSizeBinaryArray, bitmap::Bitmap, buffer::Buffer, datatypes::DataType};
 
 mod mutable;
@@ -89,7 +91,7 @@ fn to() {
 
     let extension = DataType::Extension(
         "a".to_string(),
-        Box::new(DataType::FixedSizeBinary(2)),
+        Arc::new(DataType::FixedSizeBinary(2)),
         None,
     );
     let _ = a.to(extension);

--- a/tests/it/array/fixed_size_list/mod.rs
+++ b/tests/it/array/fixed_size_list/mod.rs
@@ -1,5 +1,7 @@
 mod mutable;
 
+use std::sync::Arc;
+
 use arrow2::{
     array::*,
     bitmap::Bitmap,
@@ -11,7 +13,7 @@ fn data() -> FixedSizeListArray {
 
     FixedSizeListArray::try_new(
         DataType::FixedSizeList(
-            Box::new(Field::new("a", values.data_type().clone(), true)),
+            Arc::new(Field::new("a", values.data_type().clone(), true)),
             2,
         ),
         values.boxed(),
@@ -53,7 +55,7 @@ fn debug() {
 #[test]
 fn empty() {
     let array = FixedSizeListArray::new_empty(DataType::FixedSizeList(
-        Box::new(Field::new("a", DataType::Int32, true)),
+        Arc::new(Field::new("a", DataType::Int32, true)),
         2,
     ));
     assert_eq!(array.values().len(), 0);
@@ -63,7 +65,10 @@ fn empty() {
 #[test]
 fn null() {
     let array = FixedSizeListArray::new_null(
-        DataType::FixedSizeList(Box::new(Field::new("a", DataType::Int32, true)), 2),
+        DataType::FixedSizeList(
+            std::sync::Arc::new(Field::new("a", DataType::Int32, true)),
+            2,
+        ),
         2,
     );
     assert_eq!(array.values().len(), 4);
@@ -74,7 +79,10 @@ fn null() {
 fn wrong_size() {
     let values = Int32Array::from_slice([10, 20, 0]);
     assert!(FixedSizeListArray::try_new(
-        DataType::FixedSizeList(Box::new(Field::new("a", DataType::Int32, true)), 2),
+        DataType::FixedSizeList(
+            std::sync::Arc::new(Field::new("a", DataType::Int32, true)),
+            2
+        ),
         values.boxed(),
         None
     )
@@ -85,7 +93,10 @@ fn wrong_size() {
 fn wrong_len() {
     let values = Int32Array::from_slice([10, 20, 0]);
     assert!(FixedSizeListArray::try_new(
-        DataType::FixedSizeList(Box::new(Field::new("a", DataType::Int32, true)), 2),
+        DataType::FixedSizeList(
+            std::sync::Arc::new(Field::new("a", DataType::Int32, true)),
+            2
+        ),
         values.boxed(),
         Some([true, false, false].into()), // it should be 2
     )

--- a/tests/it/array/fixed_size_list/mutable.rs
+++ b/tests/it/array/fixed_size_list/mutable.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::array::*;
 use arrow2::datatypes::{DataType, Field};
 
@@ -46,7 +48,7 @@ fn new_with_field() {
     assert_eq!(
         list.data_type(),
         &DataType::FixedSizeList(
-            Box::new(Field::new("custom_items", DataType::Int32, false)),
+            Arc::new(Field::new("custom_items", DataType::Int32, false)),
             3
         )
     );

--- a/tests/it/array/growable/list.rs
+++ b/tests/it/array/growable/list.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::{
     array::{
         growable::{Growable, GrowableList},
@@ -23,7 +25,7 @@ fn extension() {
     let array = create_list_array(data);
 
     let data_type =
-        DataType::Extension("ext".to_owned(), Box::new(array.data_type().clone()), None);
+        DataType::Extension("ext".to_owned(), Arc::new(array.data_type().clone()), None);
     let array_ext = ListArray::new(
         data_type,
         array.offsets().clone(),

--- a/tests/it/array/growable/map.rs
+++ b/tests/it/array/growable/map.rs
@@ -38,7 +38,7 @@ fn basic() {
 
     let kv_array = StructArray::new(fields.clone(), values, None).boxed();
     let kv_field = Field::new("kv", fields, false);
-    let data_type = DataType::Map(Box::new(kv_field), false);
+    let data_type = DataType::Map(std::sync::Arc::new(kv_field), false);
     let offsets = OffsetsBuffer::try_from(vec![0, 1, 2, 4, 6]).unwrap();
 
     let array = MapArray::new(data_type.clone(), offsets, kv_array.clone(), None);
@@ -62,7 +62,7 @@ fn offset() {
 
     let kv_array = StructArray::new(fields.clone(), values, None).boxed();
     let kv_field = Field::new("kv", fields, false);
-    let data_type = DataType::Map(Box::new(kv_field), false);
+    let data_type = DataType::Map(std::sync::Arc::new(kv_field), false);
     let offsets = OffsetsBuffer::try_from(vec![0, 1, 2, 4, 6]).unwrap();
 
     let array = MapArray::new(data_type.clone(), offsets, kv_array.clone(), None).sliced(1, 3);
@@ -86,7 +86,7 @@ fn nulls() {
 
     let kv_array = StructArray::new(fields.clone(), values, None).boxed();
     let kv_field = Field::new("kv", fields, false);
-    let data_type = DataType::Map(Box::new(kv_field), false);
+    let data_type = DataType::Map(std::sync::Arc::new(kv_field), false);
     let offsets = OffsetsBuffer::try_from(vec![0, 1, 2, 4, 6]).unwrap();
 
     let array = MapArray::new(

--- a/tests/it/array/growable/map.rs
+++ b/tests/it/array/growable/map.rs
@@ -29,7 +29,7 @@ fn some_values() -> (DataType, Vec<Box<dyn Array>>) {
         Field::new("key", DataType::Utf8, true),
         Field::new("val", DataType::Int32, true),
     ];
-    (DataType::Struct(fields), vec![strings, ints])
+    (DataType::Struct(std::sync::Arc::new(fields)), vec![strings, ints])
 }
 
 #[test]

--- a/tests/it/array/growable/mod.rs
+++ b/tests/it/array/growable/mod.rs
@@ -11,6 +11,8 @@ mod struct_;
 mod union;
 mod utf8;
 
+use std::sync::Arc;
+
 use arrow2::array::growable::make_growable;
 use arrow2::array::*;
 use arrow2::datatypes::{DataType, Field};
@@ -49,18 +51,18 @@ fn test_make_growable_extension() {
     .unwrap();
     make_growable(&[&array], false, 2);
 
-    let data_type = DataType::Extension("ext".to_owned(), Box::new(DataType::Int32), None);
+    let data_type = DataType::Extension("ext".to_owned(), Arc::new(DataType::Int32), None);
     let array = Int32Array::from_slice([1, 2]).to(data_type.clone());
     let array_grown = make_growable(&[&array], false, 2).as_box();
     assert_eq!(array_grown.data_type(), &data_type);
 
     let data_type = DataType::Extension(
         "ext".to_owned(),
-        Box::new(DataType::Struct(vec![Field::new(
+        Arc::new(DataType::Struct(Arc::new(vec![Field::new(
             "a",
             DataType::Int32,
             false,
-        )])),
+        )]))),
         None,
     );
     let array = StructArray::new(

--- a/tests/it/array/growable/struct_.rs
+++ b/tests/it/array/growable/struct_.rs
@@ -24,7 +24,7 @@ fn some_values() -> (DataType, Vec<Box<dyn Array>>) {
         Field::new("f1", DataType::Utf8, true),
         Field::new("f2", DataType::Int32, true),
     ];
-    (DataType::Struct(fields), vec![strings, ints])
+    (DataType::Struct(std::sync::Arc::new(fields)), vec![strings, ints])
 }
 
 #[test]

--- a/tests/it/array/growable/union.rs
+++ b/tests/it/array/growable/union.rs
@@ -13,7 +13,7 @@ fn sparse() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Sparse);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Sparse);
     let types = vec![0, 0, 1].into();
     let fields = vec![
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
@@ -45,7 +45,7 @@ fn dense() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Dense);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Dense);
     let types = vec![0, 0, 1].into();
     let fields = vec![
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
@@ -83,7 +83,7 @@ fn complex_dense() -> Result<()> {
         Field::new("c", fixed_size_type.clone(), true),
     ];
 
-    let data_type = DataType::Union(fields, None, UnionMode::Dense);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Dense);
 
     // UnionArray[1, [11, 12, 13], abcd, [21, 22, 23], 2]
     let types = vec![0, 2, 1, 2, 0].into();

--- a/tests/it/array/growable/union.rs
+++ b/tests/it/array/growable/union.rs
@@ -75,7 +75,7 @@ fn dense() -> Result<()> {
 #[test]
 fn complex_dense() -> Result<()> {
     let fixed_size_type =
-        DataType::FixedSizeList(Box::new(Field::new("i", DataType::UInt16, true)), 3);
+        DataType::FixedSizeList(std::sync::Arc::new(Field::new("i", DataType::UInt16, true)), 3);
 
     let fields = vec![
         Field::new("a", DataType::Int32, true),

--- a/tests/it/array/map/mod.rs
+++ b/tests/it/array/map/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::{
     array::*,
     datatypes::{DataType, Field},
@@ -5,11 +7,14 @@ use arrow2::{
 
 #[test]
 fn basics() {
-    let dt = DataType::Struct(vec![
+    let dt = DataType::Struct(Arc::new(vec![
         Field::new("a", DataType::Utf8, true),
         Field::new("b", DataType::Utf8, true),
-    ]);
-    let data_type = DataType::Map(std::sync::Arc::new(Field::new("a", dt.clone(), true)), false);
+    ]));
+    let data_type = DataType::Map(
+        std::sync::Arc::new(Field::new("a", dt.clone(), true)),
+        false,
+    );
 
     let field = StructArray::new(
         dt.clone(),

--- a/tests/it/array/map/mod.rs
+++ b/tests/it/array/map/mod.rs
@@ -9,7 +9,7 @@ fn basics() {
         Field::new("a", DataType::Utf8, true),
         Field::new("b", DataType::Utf8, true),
     ]);
-    let data_type = DataType::Map(Box::new(Field::new("a", dt.clone(), true)), false);
+    let data_type = DataType::Map(std::sync::Arc::new(Field::new("a", dt.clone(), true)), false);
 
     let field = StructArray::new(
         dt.clone(),

--- a/tests/it/array/mod.rs
+++ b/tests/it/array/mod.rs
@@ -24,7 +24,7 @@ fn nulls() {
         DataType::Float64,
         DataType::Utf8,
         DataType::Binary,
-        DataType::List(Box::new(Field::new("a", DataType::Binary, true))),
+        DataType::List(std::sync::Arc::new(Field::new("a", DataType::Binary, true))),
     ];
     let a = datatypes
         .into_iter()
@@ -57,8 +57,8 @@ fn empty() {
         DataType::Float64,
         DataType::Utf8,
         DataType::Binary,
-        DataType::List(Box::new(Field::new("a", DataType::Binary, true))),
-        DataType::List(Box::new(Field::new(
+        DataType::List(std::sync::Arc::new(Field::new("a", DataType::Binary, true))),
+        DataType::List(std::sync::Arc::new(Field::new(
             "a",
             DataType::Extension("ext".to_owned(), Box::new(DataType::Int32), None),
             true,
@@ -86,7 +86,7 @@ fn empty_extension() {
         DataType::Float64,
         DataType::Utf8,
         DataType::Binary,
-        DataType::List(Box::new(Field::new("a", DataType::Binary, true))),
+        DataType::List(std::sync::Arc::new(Field::new("a", DataType::Binary, true))),
         DataType::Union(
             vec![Field::new("a", DataType::Binary, true)],
             None,
@@ -116,7 +116,7 @@ fn test_clone() {
         DataType::Float64,
         DataType::Utf8,
         DataType::Binary,
-        DataType::List(Box::new(Field::new("a", DataType::Binary, true))),
+        DataType::List(std::sync::Arc::new(Field::new("a", DataType::Binary, true))),
     ];
     let a = datatypes
         .into_iter()

--- a/tests/it/array/mod.rs
+++ b/tests/it/array/mod.rs
@@ -13,6 +13,8 @@ mod struct_;
 mod union;
 mod utf8;
 
+use std::sync::Arc;
+
 use arrow2::array::{clone, new_empty_array, new_null_array, Array, PrimitiveArray};
 use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::{DataType, Field, UnionMode};
@@ -34,12 +36,12 @@ fn nulls() {
     // unions' null count is always 0
     let datatypes = vec![
         DataType::Union(
-            vec![Field::new("a", DataType::Binary, true)],
+            Arc::new(vec![Field::new("a", DataType::Binary, true)]),
             None,
             UnionMode::Dense,
         ),
         DataType::Union(
-            vec![Field::new("a", DataType::Binary, true)],
+            Arc::new(vec![Field::new("a", DataType::Binary, true)]),
             None,
             UnionMode::Sparse,
         ),
@@ -60,20 +62,20 @@ fn empty() {
         DataType::List(std::sync::Arc::new(Field::new("a", DataType::Binary, true))),
         DataType::List(std::sync::Arc::new(Field::new(
             "a",
-            DataType::Extension("ext".to_owned(), Box::new(DataType::Int32), None),
+            DataType::Extension("ext".to_owned(), Arc::new(DataType::Int32), None),
             true,
         ))),
         DataType::Union(
-            vec![Field::new("a", DataType::Binary, true)],
+            Arc::new(vec![Field::new("a", DataType::Binary, true)]),
             None,
             UnionMode::Sparse,
         ),
         DataType::Union(
-            vec![Field::new("a", DataType::Binary, true)],
+            Arc::new(vec![Field::new("a", DataType::Binary, true)]),
             None,
             UnionMode::Dense,
         ),
-        DataType::Struct(vec![Field::new("a", DataType::Int32, true)]),
+        DataType::Struct(Arc::new(vec![Field::new("a", DataType::Int32, true)])),
     ];
     let a = datatypes.into_iter().all(|x| new_empty_array(x).len() == 0);
     assert!(a);
@@ -88,20 +90,20 @@ fn empty_extension() {
         DataType::Binary,
         DataType::List(std::sync::Arc::new(Field::new("a", DataType::Binary, true))),
         DataType::Union(
-            vec![Field::new("a", DataType::Binary, true)],
+            Arc::new(vec![Field::new("a", DataType::Binary, true)]),
             None,
             UnionMode::Sparse,
         ),
         DataType::Union(
-            vec![Field::new("a", DataType::Binary, true)],
+            Arc::new(vec![Field::new("a", DataType::Binary, true)]),
             None,
             UnionMode::Dense,
         ),
-        DataType::Struct(vec![Field::new("a", DataType::Int32, true)]),
+        DataType::Struct(Arc::new(vec![Field::new("a", DataType::Int32, true)])),
     ];
     let a = datatypes
         .into_iter()
-        .map(|dt| DataType::Extension("ext".to_owned(), Box::new(dt), None))
+        .map(|dt| DataType::Extension("ext".to_owned(), Arc::new(dt), None))
         .all(|x| {
             let a = new_empty_array(x);
             a.len() == 0 && matches!(a.data_type(), DataType::Extension(_, _, _))

--- a/tests/it/array/primitive/fmt.rs
+++ b/tests/it/array/primitive/fmt.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::{
     array::*,
     datatypes::*,
@@ -118,7 +120,7 @@ fn debug_timestamp_ns() {
 fn debug_timestamp_tz_ns() {
     let array = Int64Array::from(&[Some(1), None, Some(2)]).to(DataType::Timestamp(
         TimeUnit::Nanosecond,
-        Some("+02:00".to_string()),
+        Some(Arc::new("+02:00".to_string())),
     ));
     assert_eq!(
         format!("{array:?}"),
@@ -130,7 +132,7 @@ fn debug_timestamp_tz_ns() {
 fn debug_timestamp_tz_not_parsable() {
     let array = Int64Array::from(&[Some(1), None, Some(2)]).to(DataType::Timestamp(
         TimeUnit::Nanosecond,
-        Some("aa".to_string()),
+        Some(Arc::new("aa".to_string())),
     ));
     assert_eq!(
         format!("{array:?}"),
@@ -143,7 +145,7 @@ fn debug_timestamp_tz_not_parsable() {
 fn debug_timestamp_tz1_ns() {
     let array = Int64Array::from(&[Some(1), None, Some(2)]).to(DataType::Timestamp(
         TimeUnit::Nanosecond,
-        Some("Europe/Lisbon".to_string()),
+        Some(Arc::new("Europe/Lisbon".to_string())),
     ));
     assert_eq!(
         format!("{array:?}"),

--- a/tests/it/array/struct_/iterator.rs
+++ b/tests/it/array/struct_/iterator.rs
@@ -13,7 +13,7 @@ fn test_simple_iter() {
     ];
 
     let array = StructArray::new(
-        DataType::Struct(fields),
+        DataType::Struct(std::sync::Arc::new(fields)),
         vec![boolean.clone(), int.clone()],
         None,
     );

--- a/tests/it/array/struct_/mod.rs
+++ b/tests/it/array/struct_/mod.rs
@@ -16,7 +16,7 @@ fn debug() {
     ];
 
     let array = StructArray::new(
-        DataType::Struct(fields),
+        DataType::Struct(std::sync::Arc::new(fields)),
         vec![boolean.clone(), int.clone()],
         Some(Bitmap::from([true, true, false, true])),
     );

--- a/tests/it/array/struct_/mutable.rs
+++ b/tests/it/array/struct_/mutable.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::{
     array::*,
     datatypes::{DataType, Field},
@@ -7,7 +9,7 @@ use arrow2::{
 fn push() {
     let c1 = Box::new(MutablePrimitiveArray::<i32>::new()) as Box<dyn MutableArray>;
     let values = vec![c1];
-    let data_type = DataType::Struct(vec![Field::new("f1", DataType::Int32, true)]);
+    let data_type = DataType::Struct(Arc::new(vec![Field::new("f1", DataType::Int32, true)]));
     let mut a = MutableStructArray::new(data_type, values);
 
     a.value::<MutablePrimitiveArray<i32>>(0)

--- a/tests/it/array/union.rs
+++ b/tests/it/array/union.rs
@@ -25,7 +25,7 @@ fn sparse_debug() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Sparse);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Sparse);
     let types = vec![0, 0, 1].into();
     let fields = vec![
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
@@ -45,7 +45,7 @@ fn dense_debug() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Dense);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Dense);
     let types = vec![0, 0, 1].into();
     let fields = vec![
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
@@ -66,7 +66,7 @@ fn slice() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Sparse);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Sparse);
     let types = Buffer::from(vec![0, 0, 1]);
     let fields = vec![
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
@@ -94,7 +94,7 @@ fn iter_sparse() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Sparse);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Sparse);
     let types = Buffer::from(vec![0, 0, 1]);
     let fields = vec![
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),
@@ -127,7 +127,7 @@ fn iter_dense() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Dense);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Dense);
     let types = Buffer::from(vec![0, 0, 1]);
     let offsets = Buffer::<i32>::from(vec![0, 1, 0]);
     let fields = vec![
@@ -161,7 +161,7 @@ fn iter_sparse_slice() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Sparse);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Sparse);
     let types = Buffer::from(vec![0, 0, 1]);
     let fields = vec![
         Int32Array::from(&[Some(1), Some(3), Some(2)]).boxed(),
@@ -187,7 +187,7 @@ fn iter_dense_slice() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Dense);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Dense);
     let types = Buffer::from(vec![0, 0, 1]);
     let offsets = Buffer::<i32>::from(vec![0, 1, 0]);
     let fields = vec![
@@ -214,7 +214,7 @@ fn scalar() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Dense);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Dense);
     let types = Buffer::from(vec![0, 0, 1]);
     let offsets = Buffer::<i32>::from(vec![0, 1, 0]);
     let fields = vec![
@@ -271,7 +271,7 @@ fn dense_without_offsets_is_error() {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Dense);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Dense);
     let types = vec![0, 0, 1].into();
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
@@ -287,7 +287,7 @@ fn fields_must_match() {
         Field::new("a", DataType::Int64, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Sparse);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Sparse);
     let types = vec![0, 0, 1].into();
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
@@ -303,7 +303,7 @@ fn sparse_with_offsets_is_error() {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Sparse);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Sparse);
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
@@ -321,7 +321,7 @@ fn offsets_must_be_in_bounds() {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Sparse);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Sparse);
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
@@ -340,7 +340,7 @@ fn sparse_with_wrong_offsets1_is_error() {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Sparse);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Sparse);
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),
@@ -359,7 +359,7 @@ fn types_must_be_in_bounds() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Sparse);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Sparse);
     let fields = vec![
         Int32Array::from([Some(1), Some(3), Some(2)]).boxed(),
         Utf8Array::<i32>::from([Some("a"), Some("b"), Some("c")]).boxed(),

--- a/tests/it/arrow.rs
+++ b/tests/it/arrow.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::array::*;
 use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::{DataType, Field, IntegerType, TimeUnit, UnionMode};
@@ -169,7 +171,11 @@ fn test_list() {
 
     let validity = [true, true, false, false, true].into_iter().collect();
     let offsets = Offsets::try_from_iter(vec![0, 2, 2, 2, 0]).unwrap();
-    let data_type = DataType::List(Box::new(Field::new("element", DataType::Utf8, true)));
+    let data_type = DataType::List(std::sync::Arc::new(Field::new(
+        "element",
+        DataType::Utf8,
+        true,
+    )));
     let list = ListArray::<i32>::new(
         data_type.clone(),
         offsets.into(),
@@ -184,7 +190,11 @@ fn test_list() {
 
     let validity = [true, true, false, false, true].into_iter().collect();
     let offsets = Offsets::try_from_iter(vec![0, 2, 2, 2, 0]).unwrap();
-    let data_type = DataType::LargeList(Box::new(Field::new("element", DataType::Utf8, true)));
+    let data_type = DataType::LargeList(std::sync::Arc::new(Field::new(
+        "element",
+        DataType::Utf8,
+        true,
+    )));
     let list = ListArray::<i64>::new(
         data_type.clone(),
         offsets.into(),
@@ -204,7 +214,7 @@ fn test_list_struct() {
     let validity = [true, true, false, true].into_iter().collect();
     let offsets = Offsets::try_from_iter(vec![0, 1, 0, 2]).unwrap();
     let list = ListArray::<i32>::new(
-        DataType::List(Box::new(Field::new(
+        DataType::List(std::sync::Arc::new(Field::new(
             "element",
             values.data_type().clone(),
             true,
@@ -257,7 +267,10 @@ fn test_fixed_size_list() {
 
     let nulls = [true, true, false, true].into_iter().collect();
     let array = FixedSizeListArray::new(
-        DataType::FixedSizeList(Box::new(Field::new("element", DataType::Int64, true)), 2),
+        DataType::FixedSizeList(
+            std::sync::Arc::new(Field::new("element", DataType::Int64, true)),
+            2,
+        ),
         Box::new(values),
         Some(nulls),
     );
@@ -285,7 +298,7 @@ fn test_map() {
     let validity = [true, true, false, false].into_iter().collect();
     let offsets = Offsets::try_from_iter(vec![0, 2, 0, 2]).unwrap();
     let data_type = DataType::Map(
-        Box::new(Field::new("entries", fields.data_type().clone(), true)),
+        Arc::new(Field::new("entries", fields.data_type().clone(), true)),
         false,
     );
     let map = MapArray::new(

--- a/tests/it/arrow.rs
+++ b/tests/it/arrow.rs
@@ -142,11 +142,11 @@ fn make_struct() -> StructArray {
 
     let nulls = [true, true, false].into_iter().collect();
     StructArray::new(
-        DataType::Struct(vec![
+        DataType::Struct(Arc::new(vec![
             Field::new("a1", a1.data_type().clone(), true),
             Field::new("a2", a2.data_type().clone(), true),
             Field::new("a3", a3.data_type().clone(), true),
-        ]),
+        ])),
         vec![Box::new(a1), Box::new(a2), Box::new(a3)],
         Some(nulls),
     )
@@ -235,7 +235,7 @@ fn test_dictionary() {
     let dictionary = DictionaryArray::try_new(
         DataType::Dictionary(
             IntegerType::Int16,
-            Box::new(values.data_type().clone()),
+            std::sync::Arc::new(values.data_type().clone()),
             false,
         ),
         keys,
@@ -287,10 +287,10 @@ fn test_map() {
     );
     let values = PrimitiveArray::<i32>::from_iter([Some(1), None, Some(3), Some(1), None]);
     let fields = StructArray::new(
-        DataType::Struct(vec![
+        DataType::Struct(Arc::new(vec![
             Field::new("keys", DataType::Utf8, false), // Cannot be nullable
             Field::new("values", DataType::Int32, true),
-        ]),
+        ])),
         vec![Box::new(keys), Box::new(values)],
         None, // Cannot be nullable
     );
@@ -316,10 +316,10 @@ fn test_map() {
 
 #[test]
 fn test_dense_union() {
-    let fields = vec![
+    let fields = Arc::new(vec![
         Field::new("a1", DataType::Int32, true),
         Field::new("a2", DataType::Int64, true),
-    ];
+    ]);
 
     let a1 = PrimitiveArray::from_iter([Some(2), None]);
     let a2 = PrimitiveArray::from_iter([Some(2_i64), None, Some(3)]);
@@ -327,7 +327,7 @@ fn test_dense_union() {
     let types = vec![1, 0, 0, 1, 1];
     let offsets = vec![0, 0, 1, 1, 2];
     let union = UnionArray::new(
-        DataType::Union(fields.clone(), Some(vec![0, 1]), UnionMode::Dense),
+        DataType::Union(fields.clone(), Some(Arc::new(vec![0, 1])), UnionMode::Dense),
         types.into(),
         vec![Box::new(a1.clone()), Box::new(a2.clone())],
         Some(offsets.into()),
@@ -338,7 +338,7 @@ fn test_dense_union() {
     let types = vec![1, 4, 4, 1, 1];
     let offsets = vec![0, 0, 1, 1, 2];
     let union = UnionArray::new(
-        DataType::Union(fields, Some(vec![4, 1]), UnionMode::Dense),
+        DataType::Union(fields, Some(Arc::new(vec![4, 1])), UnionMode::Dense),
         types.into(),
         vec![Box::new(a1), Box::new(a2)],
         Some(offsets.into()),
@@ -349,17 +349,21 @@ fn test_dense_union() {
 
 #[test]
 fn test_sparse_union() {
-    let fields = vec![
+    let fields = Arc::new(vec![
         Field::new("a1", DataType::Int32, true),
         Field::new("a2", DataType::Int64, true),
-    ];
+    ]);
 
     let a1 = PrimitiveArray::from_iter([None, Some(2), None, None, None]);
     let a2 = PrimitiveArray::from_iter([Some(2_i64), None, None, None, Some(3)]);
 
     let types = vec![1, 0, 0, 1, 1];
     let union = UnionArray::new(
-        DataType::Union(fields.clone(), Some(vec![0, 1]), UnionMode::Sparse),
+        DataType::Union(
+            fields.clone(),
+            Some(Arc::new(vec![0, 1])),
+            UnionMode::Sparse,
+        ),
         types.into(),
         vec![Box::new(a1.clone()), Box::new(a2.clone())],
         None,
@@ -369,7 +373,7 @@ fn test_sparse_union() {
 
     let types = vec![1, 4, 4, 1, 1];
     let union = UnionArray::new(
-        DataType::Union(fields, Some(vec![4, 1]), UnionMode::Sparse),
+        DataType::Union(fields, Some(Arc::new(vec![4, 1])), UnionMode::Sparse),
         types.into(),
         vec![Box::new(a1), Box::new(a2)],
         None,

--- a/tests/it/arrow.rs
+++ b/tests/it/arrow.rs
@@ -92,7 +92,7 @@ fn test_primitive() {
     let array = PrimitiveArray::new(data_type, vec![1, 2, 3].into(), None);
     test_conversion(&array);
 
-    let data_type = DataType::Timestamp(TimeUnit::Second, Some("UTC".into()));
+    let data_type = DataType::Timestamp(TimeUnit::Second, Some(Arc::new("UTC".into())));
     let nulls = Bitmap::from_iter([true, true, false]);
     let array = PrimitiveArray::new(data_type, vec![1_i64, 24, 0].into(), Some(nulls));
     test_conversion(&array);
@@ -136,7 +136,7 @@ fn make_struct() -> StructArray {
     let a1 = BinaryArray::<i32>::from_iter([Some("s".as_bytes()), Some(b"sd\xFFfk\x23"), None]);
     let a2 = BinaryArray::<i64>::from_iter([Some("45848".as_bytes()), Some(b"\x03\xFF"), None]);
 
-    let data_type = DataType::Timestamp(TimeUnit::Millisecond, Some("UTC".into()));
+    let data_type = DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::new("UTC".into())));
     let nulls = Bitmap::from_iter([true, true, false]);
     let a3 = PrimitiveArray::new(data_type, vec![1_i64, 24, 0].into(), Some(nulls));
 

--- a/tests/it/compute/aggregate/memory.rs
+++ b/tests/it/compute/aggregate/memory.rs
@@ -25,7 +25,7 @@ fn utf8() {
 #[test]
 fn fixed_size_list() {
     let data_type =
-        DataType::FixedSizeList(Box::new(Field::new("elem", DataType::Float32, false)), 3);
+        DataType::FixedSizeList(std::sync::Arc::new(Field::new("elem", DataType::Float32, false)), 3);
     let values = Box::new(Float32Array::from_slice([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]));
     let a = FixedSizeListArray::new(data_type, values, None);
     assert_eq!(6 * std::mem::size_of::<f32>(), estimated_bytes_size(&a));

--- a/tests/it/compute/arithmetics/time.rs
+++ b/tests/it/compute/arithmetics/time.rs
@@ -8,7 +8,7 @@ use arrow2::types::months_days_ns;
 fn test_adding_timestamp() {
     let timestamp =
         PrimitiveArray::from([Some(100000i64), Some(200000i64), None, Some(300000i64)]).to(
-            DataType::Timestamp(TimeUnit::Second, Some("America/New_York".to_string())),
+            DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("America/New_york".to_string()))),
         );
 
     let duration = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)])
@@ -17,7 +17,7 @@ fn test_adding_timestamp() {
     let result = add_duration(&timestamp, &duration);
     let expected =
         PrimitiveArray::from([Some(100010i64), Some(200020i64), None, Some(300030i64)]).to(
-            DataType::Timestamp(TimeUnit::Second, Some("America/New_York".to_string())),
+            DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("America/New_york".to_string()))),
         );
 
     assert_eq!(result, expected);
@@ -27,7 +27,7 @@ fn test_adding_timestamp() {
     let result = add_duration_scalar(&timestamp, &duration);
     let expected =
         PrimitiveArray::from([Some(100010i64), Some(200010i64), None, Some(300010i64)]).to(
-            DataType::Timestamp(TimeUnit::Second, Some("America/New_York".to_string())),
+            DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("America/New_york".to_string()))),
         );
     assert_eq!(result, expected);
 }
@@ -36,11 +36,11 @@ fn test_adding_timestamp() {
 fn test_adding_duration_different_scale() {
     let timestamp =
         PrimitiveArray::from([Some(100000i64), Some(200000i64), None, Some(300000i64)]).to(
-            DataType::Timestamp(TimeUnit::Second, Some("America/New_York".to_string())),
+            DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("America/New_york".to_string()))),
         );
     let expected =
         PrimitiveArray::from([Some(100010i64), Some(200020i64), None, Some(300030i64)]).to(
-            DataType::Timestamp(TimeUnit::Second, Some("America/New_York".to_string())),
+            DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("America/New_york".to_string()))),
         );
 
     // Testing duration in milliseconds
@@ -69,20 +69,20 @@ fn test_adding_duration_different_scale() {
 #[test]
 fn test_adding_subtract_timestamps_scale() {
     let timestamp = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)]).to(
-        DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
+        DataType::Timestamp(TimeUnit::Millisecond, Some(std::sync::Arc::new("America/New_york".to_string()))),
     );
     let duration = PrimitiveArray::from([Some(1i64), Some(2i64), None, Some(3i64)])
         .to(DataType::Duration(TimeUnit::Second));
 
     let expected = PrimitiveArray::from([Some(1_010i64), Some(2_020i64), None, Some(3_030i64)]).to(
-        DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
+        DataType::Timestamp(TimeUnit::Millisecond, Some(std::sync::Arc::new("America/New_york".to_string()))),
     );
 
     let result = add_duration(&timestamp, &duration);
     assert_eq!(result, expected);
 
     let timestamp = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)]).to(
-        DataType::Timestamp(TimeUnit::Nanosecond, Some("America/New_York".to_string())),
+        DataType::Timestamp(TimeUnit::Nanosecond, Some(std::sync::Arc::new("America/New_york".to_string()))),
     );
     let duration = PrimitiveArray::from([Some(1i64), Some(2i64), None, Some(3i64)])
         .to(DataType::Duration(TimeUnit::Second));
@@ -95,7 +95,7 @@ fn test_adding_subtract_timestamps_scale() {
     ])
     .to(DataType::Timestamp(
         TimeUnit::Nanosecond,
-        Some("America/New_York".to_string()),
+        Some(std::sync::Arc::new("America/New_york".to_string())),
     ));
 
     let result = add_duration(&timestamp, &duration);
@@ -106,7 +106,7 @@ fn test_adding_subtract_timestamps_scale() {
 fn test_subtract_timestamp() {
     let timestamp =
         PrimitiveArray::from([Some(100000i64), Some(200000i64), None, Some(300000i64)]).to(
-            DataType::Timestamp(TimeUnit::Second, Some("America/New_York".to_string())),
+            DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("America/New_york".to_string()))),
         );
 
     let duration = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)])
@@ -115,7 +115,7 @@ fn test_subtract_timestamp() {
     let result = subtract_duration(&timestamp, &duration);
     let expected =
         PrimitiveArray::from([Some(99990i64), Some(199980i64), None, Some(299970i64)]).to(
-            DataType::Timestamp(TimeUnit::Second, Some("America/New_York".to_string())),
+            DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("America/New_york".to_string()))),
         );
 
     assert_eq!(result, expected);
@@ -125,11 +125,11 @@ fn test_subtract_timestamp() {
 fn test_subtracting_duration_different_scale() {
     let timestamp =
         PrimitiveArray::from([Some(100000i64), Some(200000i64), None, Some(300000i64)]).to(
-            DataType::Timestamp(TimeUnit::Second, Some("America/New_York".to_string())),
+            DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("America/New_york".to_string()))),
         );
     let expected =
         PrimitiveArray::from([Some(99990i64), Some(199980i64), None, Some(299970i64)]).to(
-            DataType::Timestamp(TimeUnit::Second, Some("America/New_York".to_string())),
+            DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("America/New_york".to_string()))),
         );
 
     // Testing duration in milliseconds
@@ -158,21 +158,21 @@ fn test_subtracting_duration_different_scale() {
 #[test]
 fn test_subtracting_subtract_timestamps_scale() {
     let timestamp = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)]).to(
-        DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
+        DataType::Timestamp(TimeUnit::Millisecond, Some(std::sync::Arc::new("America/New_york".to_string()))),
     );
     let duration = PrimitiveArray::from([Some(1i64), Some(2i64), None, Some(3i64)])
         .to(DataType::Duration(TimeUnit::Second));
 
     let expected =
         PrimitiveArray::from([Some(-990i64), Some(-1_980i64), None, Some(-2_970i64)]).to(
-            DataType::Timestamp(TimeUnit::Millisecond, Some("America/New_York".to_string())),
+            DataType::Timestamp(TimeUnit::Millisecond, Some(std::sync::Arc::new("America/New_york".to_string()))),
         );
 
     let result = subtract_duration(&timestamp, &duration);
     assert_eq!(result, expected);
 
     let timestamp = PrimitiveArray::from([Some(10i64), Some(20i64), None, Some(30i64)]).to(
-        DataType::Timestamp(TimeUnit::Nanosecond, Some("America/New_York".to_string())),
+        DataType::Timestamp(TimeUnit::Nanosecond, Some(std::sync::Arc::new("America/New_york".to_string()))),
     );
     let duration = PrimitiveArray::from([Some(1i64), Some(2i64), None, Some(3i64)])
         .to(DataType::Duration(TimeUnit::Second));
@@ -185,7 +185,7 @@ fn test_subtracting_subtract_timestamps_scale() {
     ])
     .to(DataType::Timestamp(
         TimeUnit::Nanosecond,
-        Some("America/New_York".to_string()),
+        Some(std::sync::Arc::new("America/New_york".to_string())),
     ));
 
     let result = subtract_duration(&timestamp, &duration);
@@ -342,7 +342,7 @@ fn test_add_interval() {
 fn test_add_interval_offset() {
     let timestamp = PrimitiveArray::from_slice([1i64]).to(DataType::Timestamp(
         TimeUnit::Second,
-        Some("+01:00".to_string()),
+        Some(std::sync::Arc::new("+01:00".to_string())),
     ));
 
     let interval = months_days_ns::new(0, 1, 0);
@@ -351,7 +351,7 @@ fn test_add_interval_offset() {
 
     let expected = PrimitiveArray::from_slice([1i64 + 24 * 60 * 60]).to(DataType::Timestamp(
         TimeUnit::Second,
-        Some("+01:00".to_string()),
+        Some(std::sync::Arc::new("+01:00".to_string())),
     ));
 
     let result = add_interval(&timestamp, &intervals).unwrap();
@@ -366,7 +366,7 @@ fn test_add_interval_offset() {
 fn test_add_interval_tz() {
     let timestamp = PrimitiveArray::from_slice([1i64]).to(DataType::Timestamp(
         TimeUnit::Second,
-        Some("GMT".to_string()),
+        Some(std::sync::Arc::new("GMT".to_string())),
     ));
 
     let interval = months_days_ns::new(0, 1, 0);
@@ -374,7 +374,7 @@ fn test_add_interval_tz() {
 
     let expected = PrimitiveArray::from_slice([1i64 + 24 * 60 * 60]).to(DataType::Timestamp(
         TimeUnit::Second,
-        Some("GMT".to_string()),
+        Some(std::sync::Arc::new("GMT".to_string())),
     ));
 
     let result = add_interval(&timestamp, &intervals).unwrap();

--- a/tests/it/compute/cast.rs
+++ b/tests/it/compute/cast.rs
@@ -125,7 +125,7 @@ fn i32_to_list_i32() {
     let array = Int32Array::from_slice([5, 6, 7, 8, 9]);
     let b = cast(
         &array,
-        &DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
+        &DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true))),
         CastOptions::default(),
     )
     .unwrap();
@@ -149,7 +149,7 @@ fn i32_to_list_i32_nullable() {
     let array = Int32Array::from(input);
     let b = cast(
         &array,
-        &DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
+        &DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true))),
         CastOptions::default(),
     )
     .unwrap();
@@ -173,7 +173,7 @@ fn i32_to_list_f64_nullable_sliced() {
     let array = array.sliced(2, 4);
     let b = cast(
         &array,
-        &DataType::List(Box::new(Field::new("item", DataType::Float64, true))),
+        &DataType::List(std::sync::Arc::new(Field::new("item", DataType::Float64, true))),
         CastOptions::default(),
     )
     .unwrap();
@@ -502,8 +502,8 @@ fn consistency() {
         Duration(TimeUnit::Millisecond),
         Duration(TimeUnit::Microsecond),
         Duration(TimeUnit::Nanosecond),
-        List(Box::new(Field::new("a", Utf8, true))),
-        LargeList(Box::new(Field::new("a", Utf8, true))),
+        List(std::sync::Arc::new(Field::new("a", Utf8, true))),
+        LargeList(std::sync::Arc::new(Field::new("a", Utf8, true))),
     ];
     for d1 in &datatypes {
         for d2 in &datatypes {

--- a/tests/it/compute/cast.rs
+++ b/tests/it/compute/cast.rs
@@ -689,7 +689,7 @@ fn utf8_to_dict() {
     let array = Utf8Array::<i32>::from([Some("one"), None, Some("three"), Some("one")]);
 
     // Cast to a dictionary (same value type, Utf8)
-    let cast_type = DataType::Dictionary(u8::KEY_TYPE, Box::new(DataType::Utf8), false);
+    let cast_type = DataType::Dictionary(u8::KEY_TYPE, Arc::new(DataType::Utf8), false);
     let result = cast(&array, &cast_type, CastOptions::default()).expect("cast failed");
 
     let mut expected = MutableDictionaryArray::<u8, MutableUtf8Array<i32>>::new();
@@ -720,7 +720,7 @@ fn i32_to_dict() {
     let array = Int32Array::from(&[Some(1), None, Some(3), Some(1)]);
 
     // Cast to a dictionary (same value type, Utf8)
-    let cast_type = DataType::Dictionary(u8::KEY_TYPE, Box::new(DataType::Int32), false);
+    let cast_type = DataType::Dictionary(u8::KEY_TYPE, Arc::new(DataType::Int32), false);
     let result = cast(&array, &cast_type, CastOptions::default()).expect("cast failed");
 
     let mut expected = MutableDictionaryArray::<u8, MutablePrimitiveArray<i32>>::new();
@@ -902,7 +902,7 @@ fn dict_keys() {
 
     let result = cast(
         &array,
-        &DataType::Dictionary(IntegerType::Int64, Box::new(DataType::Utf8), false),
+        &DataType::Dictionary(IntegerType::Int64, Arc::new(DataType::Utf8), false),
         CastOptions::default(),
     )
     .expect("cast failed");

--- a/tests/it/compute/cast.rs
+++ b/tests/it/compute/cast.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::array::*;
 use arrow2::compute::cast::{can_cast_types, cast, CastOptions};
 use arrow2::datatypes::*;
@@ -125,7 +127,11 @@ fn i32_to_list_i32() {
     let array = Int32Array::from_slice([5, 6, 7, 8, 9]);
     let b = cast(
         &array,
-        &DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true))),
+        &DataType::List(std::sync::Arc::new(Field::new(
+            "item",
+            DataType::Int32,
+            true,
+        ))),
         CastOptions::default(),
     )
     .unwrap();
@@ -149,7 +155,11 @@ fn i32_to_list_i32_nullable() {
     let array = Int32Array::from(input);
     let b = cast(
         &array,
-        &DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true))),
+        &DataType::List(std::sync::Arc::new(Field::new(
+            "item",
+            DataType::Int32,
+            true,
+        ))),
         CastOptions::default(),
     )
     .unwrap();
@@ -173,7 +183,11 @@ fn i32_to_list_f64_nullable_sliced() {
     let array = array.sliced(2, 4);
     let b = cast(
         &array,
-        &DataType::List(std::sync::Arc::new(Field::new("item", DataType::Float64, true))),
+        &DataType::List(std::sync::Arc::new(Field::new(
+            "item",
+            DataType::Float64,
+            true,
+        ))),
         CastOptions::default(),
     )
     .unwrap();
@@ -483,7 +497,10 @@ fn consistency() {
         Float64,
         Timestamp(TimeUnit::Second, None),
         Timestamp(TimeUnit::Millisecond, None),
-        Timestamp(TimeUnit::Millisecond, Some("+01:00".to_string())),
+        Timestamp(
+            TimeUnit::Millisecond,
+            Some(std::sync::Arc::new("+01:00".to_string())),
+        ),
         Timestamp(TimeUnit::Microsecond, None),
         Timestamp(TimeUnit::Nanosecond, None),
         Time64(TimeUnit::Microsecond),
@@ -622,7 +639,10 @@ fn int32_to_date32() {
 fn timestamp_to_date32() {
     test_primitive_to_primitive(
         &[864000000005i64, 1545696000001],
-        DataType::Timestamp(TimeUnit::Millisecond, Some(String::from("UTC"))),
+        DataType::Timestamp(
+            TimeUnit::Millisecond,
+            Some(std::sync::Arc::new("UTC".to_string())),
+        ),
         &[10000i32, 17890],
         DataType::Date32,
     );
@@ -632,7 +652,10 @@ fn timestamp_to_date32() {
 fn timestamp_to_date64() {
     test_primitive_to_primitive(
         &[864000000005i64, 1545696000001],
-        DataType::Timestamp(TimeUnit::Millisecond, Some(String::from("UTC"))),
+        DataType::Timestamp(
+            TimeUnit::Millisecond,
+            Some(std::sync::Arc::new("UTC".to_string())),
+        ),
         &[864000000005i64, 1545696000001i64],
         DataType::Date64,
     );
@@ -642,7 +665,10 @@ fn timestamp_to_date64() {
 fn timestamp_to_i64() {
     test_primitive_to_primitive(
         &[864000000005i64, 1545696000001],
-        DataType::Timestamp(TimeUnit::Millisecond, Some(String::from("UTC"))),
+        DataType::Timestamp(
+            TimeUnit::Millisecond,
+            Some(std::sync::Arc::new("UTC".to_string())),
+        ),
         &[864000000005i64, 1545696000001i64],
         DataType::Int64,
     );
@@ -759,7 +785,7 @@ fn list_to_from_fixed_size_list() {
 
 #[test]
 fn timestamp_with_tz_to_utf8() {
-    let tz = "-02:00".to_string();
+    let tz = Arc::new("-02:00".to_string());
     let expected =
         Utf8Array::<i32>::from_slice(["1996-12-19T16:39:57-02:00", "1996-12-19T17:39:57-02:00"]);
     let array = Int64Array::from_slice([851020797000000000, 851024397000000000])
@@ -771,7 +797,7 @@ fn timestamp_with_tz_to_utf8() {
 
 #[test]
 fn utf8_to_timestamp_with_tz() {
-    let tz = "-02:00".to_string();
+    let tz = Arc::new("-02:00".to_string());
     let array =
         Utf8Array::<i32>::from_slice(["1996-12-19T16:39:57-02:00", "1996-12-19T17:39:57-02:00"]);
     // the timezone is used to map the time to UTC.

--- a/tests/it/compute/comparison.rs
+++ b/tests/it/compute/comparison.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::array::*;
 use arrow2::bitmap::Bitmap;
 use arrow2::compute::comparison::{self, boolean::*, primitive, utf8};
@@ -42,7 +44,7 @@ fn consistency() {
         Duration(TimeUnit::Millisecond),
         Duration(TimeUnit::Microsecond),
         Duration(TimeUnit::Nanosecond),
-        Dictionary(IntegerType::Int32, Box::new(LargeBinary), false),
+        Dictionary(IntegerType::Int32, Arc::new(LargeBinary), false),
     ];
 
     // array <> array

--- a/tests/it/compute/filter.rs
+++ b/tests/it/compute/filter.rs
@@ -180,7 +180,7 @@ fn list_array() {
     let value_offsets = Buffer::from_slice_ref(&[0i64, 3, 6, 8, 8]);
 
     let list_data_type =
-        DataType::LargeList(Box::new(Field::new("item", DataType::Int32, false)));
+        DataType::LargeList(std::sync::Arc::new(Field::new("item", DataType::Int32, false)));
     let list_data = ArrayData::builder(list_data_type)
         .len(4)
         .add_buffer(value_offsets)
@@ -202,7 +202,7 @@ fn list_array() {
     let value_offsets = Buffer::from_slice_ref(&[0i64, 3, 3]);
 
     let list_data_type =
-        DataType::LargeList(Box::new(Field::new("item", DataType::Int32, false)));
+        DataType::LargeList(std::sync::Arc::new(Field::new("item", DataType::Int32, false)));
     let expected = ArrayData::builder(list_data_type)
         .len(2)
         .add_buffer(value_offsets)

--- a/tests/it/compute/sort/row/mod.rs
+++ b/tests/it/compute/sort/row/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::{
     array::{
         Array, BinaryArray, BooleanArray, DictionaryArray, Float32Array, Int128Array, Int16Array,
@@ -265,7 +267,7 @@ fn test_dictionary_nulls() {
     let values = Int32Array::from_iter([Some(1), Some(-1), None, Some(4), None]);
     let keys = Int32Array::from_iter([Some(0), Some(0), Some(1), Some(2), Some(4), None]);
 
-    let data_type = DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Int32), false);
+    let data_type = DataType::Dictionary(IntegerType::Int32, Arc::new(DataType::Int32), false);
     let data = DictionaryArray::try_from_keys(keys, values.to_boxed()).unwrap();
 
     let mut converter = RowConverter::new(vec![SortField::new(data_type)]);

--- a/tests/it/compute/take.rs
+++ b/tests/it/compute/take.rs
@@ -72,7 +72,7 @@ fn create_test_struct() -> StructArray {
         Field::new("b", DataType::Int32, true),
     ];
     StructArray::new(
-        DataType::Struct(fields),
+        DataType::Struct(std::sync::Arc::new(fields)),
         vec![boolean.boxed(), int.boxed()],
         validity,
     )

--- a/tests/it/compute/temporal.rs
+++ b/tests/it/compute/temporal.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::array::*;
 use arrow2::compute::temporal::*;
 use arrow2::datatypes::*;
@@ -198,7 +200,7 @@ fn test_data_tz() -> Vec<TestData> {
                 // Mon May 24 2021 17:25:30 GMT+0000
                 Int64Array::from(&[Some(1621877130000000), None]).to(DataType::Timestamp(
                     TimeUnit::Microsecond,
-                    Some("GMT".to_string()),
+                    Some(std::sync::Arc::new("GMT".to_string())),
                 )),
             ),
             year: Some(Int32Array::from(&[Some(2021), None])),
@@ -213,7 +215,10 @@ fn test_data_tz() -> Vec<TestData> {
         },
         TestData {
             input: Box::new(Int64Array::from(&[Some(1621877130000000), None]).to(
-                DataType::Timestamp(TimeUnit::Microsecond, Some("+01:00".to_string())),
+                DataType::Timestamp(
+                    TimeUnit::Microsecond,
+                    Some(std::sync::Arc::new("+01:00".to_string())),
+                ),
             )),
             year: Some(Int32Array::from(&[Some(2021), None])),
             month: Some(UInt32Array::from(&[Some(5), None])),
@@ -227,7 +232,10 @@ fn test_data_tz() -> Vec<TestData> {
         },
         TestData {
             input: Box::new(Int64Array::from(&[Some(1621877130000000), None]).to(
-                DataType::Timestamp(TimeUnit::Microsecond, Some("Europe/Lisbon".to_string())),
+                DataType::Timestamp(
+                    TimeUnit::Microsecond,
+                    Some(std::sync::Arc::new("Europe/Lisbon".to_string())),
+                ),
             )),
             year: Some(Int32Array::from(&[Some(2021), None])),
             month: Some(UInt32Array::from(&[Some(5), None])),
@@ -244,7 +252,7 @@ fn test_data_tz() -> Vec<TestData> {
                 // Sun Mar 29 2020 00:00:00 GMT+0000 (Western European Standard Time)
                 Int64Array::from(&[Some(1585440000), None]).to(DataType::Timestamp(
                     TimeUnit::Second,
-                    Some("Europe/Lisbon".to_string()),
+                    Some(std::sync::Arc::new("Europe/Lisbon".to_string())),
                 )),
             ),
             year: Some(Int32Array::from(&[Some(2020), None])),
@@ -262,7 +270,7 @@ fn test_data_tz() -> Vec<TestData> {
                 // Sun Mar 29 2020 02:00:00 GMT+0100 (Western European Summer Time)
                 Int64Array::from(&[Some(1585443600), None]).to(DataType::Timestamp(
                     TimeUnit::Second,
-                    Some("Europe/Lisbon".to_string()),
+                    Some(std::sync::Arc::new("Europe/Lisbon".to_string())),
                 )),
             ),
             year: Some(Int32Array::from(&[Some(2020), None])),
@@ -346,7 +354,7 @@ fn consistency_check<O: arrow2::types::NativeType>(
         Timestamp(TimeUnit::Millisecond, None),
         Timestamp(TimeUnit::Microsecond, None),
         Timestamp(TimeUnit::Nanosecond, None),
-        Timestamp(TimeUnit::Nanosecond, Some("+00:00".to_string())),
+        Timestamp(TimeUnit::Nanosecond, Some(Arc::new("+00:00".to_string()))),
         Time64(TimeUnit::Microsecond),
         Time64(TimeUnit::Nanosecond),
         Date32,

--- a/tests/it/ffi/data.rs
+++ b/tests/it/ffi/data.rs
@@ -291,7 +291,7 @@ fn list_list() -> Result<()> {
 
 #[test]
 fn struct_() -> Result<()> {
-    let data_type = DataType::Struct(vec![Field::new("a", DataType::Int32, true)]);
+    let data_type = DataType::Struct(Arc::new(vec![Field::new("a", DataType::Int32, true)]));
     let values = vec![Int32Array::from([Some(1), None, Some(3)]).boxed()];
     let validity = Bitmap::from([true, false, true]);
 
@@ -323,7 +323,7 @@ fn schema() -> Result<()> {
 
     let field = Field::new(
         "a",
-        DataType::Dictionary(u32::KEY_TYPE, Box::new(DataType::Utf8), false),
+        DataType::Dictionary(u32::KEY_TYPE, Arc::new(DataType::Utf8), false),
         true,
     );
     test_round_trip_schema(field)?;
@@ -341,8 +341,8 @@ fn extension() -> Result<()> {
         "a",
         DataType::Extension(
             "a".to_string(),
-            Box::new(DataType::Int32),
-            Some("bla".to_string()),
+            Arc::new(DataType::Int32),
+            Some("bla".to_string()).map(Arc::new),
         ),
         true,
     );
@@ -355,11 +355,11 @@ fn extension_children() -> Result<()> {
         "a",
         DataType::Extension(
             "b".to_string(),
-            Box::new(DataType::Struct(vec![Field::new(
+            Arc::new(DataType::Struct(Arc::new(vec![Field::new(
                 "c",
                 DataType::Int32,
                 true,
-            )])),
+            )]))),
             None,
         ),
         true,

--- a/tests/it/ffi/data.rs
+++ b/tests/it/ffi/data.rs
@@ -3,6 +3,7 @@ use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::{DataType, Field, TimeUnit};
 use arrow2::{error::Result, ffi};
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 fn _test_round_trip(array: Box<dyn Array>, expected: Box<dyn Array>) -> Result<()> {
     let field = Field::new("a", array.data_type().clone(), true);
@@ -93,7 +94,7 @@ fn decimal_nullable() -> Result<()> {
 fn timestamp_tz() -> Result<()> {
     let data = Int64Array::from(&vec![Some(2), None, None]).to(DataType::Timestamp(
         TimeUnit::Second,
-        Some("UTC".to_string()),
+        Some(Arc::new("UTC".to_string())),
     ));
     test_round_trip(data)
 }
@@ -256,7 +257,10 @@ fn fixed_size_list_sliced() -> Result<()> {
     let bitmap = Bitmap::from([true, false, false, true]).sliced(1, 3);
 
     let array = FixedSizeListArray::try_new(
-        DataType::FixedSizeList(std::sync::Arc::new(Field::new("a", DataType::Int32, true)), 2),
+        DataType::FixedSizeList(
+            std::sync::Arc::new(Field::new("a", DataType::Int32, true)),
+            2,
+        ),
         Box::new(PrimitiveArray::<i32>::from_vec(vec![1, 2, 3, 4, 5, 6])),
         Some(bitmap),
     )?;

--- a/tests/it/ffi/data.rs
+++ b/tests/it/ffi/data.rs
@@ -210,7 +210,7 @@ fn list_sliced() -> Result<()> {
     let bitmap = Bitmap::from([true, false, false, true]).sliced(1, 3);
 
     let array = ListArray::<i32>::try_new(
-        DataType::List(Box::new(Field::new("a", DataType::Int32, true))),
+        DataType::List(std::sync::Arc::new(Field::new("a", DataType::Int32, true))),
         vec![0, 1, 1, 2].try_into().unwrap(),
         Box::new(PrimitiveArray::<i32>::from_slice([1, 2])),
         Some(bitmap),
@@ -256,7 +256,7 @@ fn fixed_size_list_sliced() -> Result<()> {
     let bitmap = Bitmap::from([true, false, false, true]).sliced(1, 3);
 
     let array = FixedSizeListArray::try_new(
-        DataType::FixedSizeList(Box::new(Field::new("a", DataType::Int32, true)), 2),
+        DataType::FixedSizeList(std::sync::Arc::new(Field::new("a", DataType::Int32, true)), 2),
         Box::new(PrimitiveArray::<i32>::from_vec(vec![1, 2, 3, 4, 5, 6])),
         Some(bitmap),
     )?;
@@ -312,7 +312,7 @@ fn dict() -> Result<()> {
 fn schema() -> Result<()> {
     let field = Field::new(
         "a",
-        DataType::List(Box::new(Field::new("a", DataType::UInt32, true))),
+        DataType::List(std::sync::Arc::new(Field::new("a", DataType::UInt32, true))),
         true,
     );
     test_round_trip_schema(field)?;

--- a/tests/it/io/avro/read.rs
+++ b/tests/it/io/avro/read.rs
@@ -73,7 +73,7 @@ pub(super) fn schema() -> (AvroSchema, Schema) {
         Field::new("g", DataType::Utf8, true),
         Field::new(
             "h",
-            DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
+            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true))),
             false,
         ),
         Field::new(
@@ -331,7 +331,7 @@ fn schema_list() -> (AvroSchema, Schema) {
 
     let schema = Schema::from(vec![Field::new(
         "h",
-        DataType::List(Box::new(Field::new("item", DataType::Int32, false))),
+        DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, false))),
         false,
     )]);
 
@@ -343,7 +343,7 @@ pub(super) fn data_list() -> Chunk<Box<dyn Array>> {
 
     let mut array = MutableListArray::<i32, MutablePrimitiveArray<i32>>::new_from(
         Default::default(),
-        DataType::List(Box::new(Field::new("item", DataType::Int32, false))),
+        DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, false))),
         0,
     );
     array.try_extend(data).unwrap();

--- a/tests/it/io/avro/read.rs
+++ b/tests/it/io/avro/read.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::chunk::Chunk;
 use avro_rs::types::{Record, Value};
 use avro_rs::{Codec, Writer};
@@ -73,23 +75,27 @@ pub(super) fn schema() -> (AvroSchema, Schema) {
         Field::new("g", DataType::Utf8, true),
         Field::new(
             "h",
-            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true))),
+            DataType::List(std::sync::Arc::new(Field::new(
+                "item",
+                DataType::Int32,
+                true,
+            ))),
             false,
         ),
         Field::new(
             "i",
-            DataType::Struct(vec![Field::new("e", DataType::Float64, false)]),
+            DataType::Struct(Arc::new(vec![Field::new("e", DataType::Float64, false)])),
             false,
         ),
         Field::new(
             "enum",
-            DataType::Dictionary(i32::KEY_TYPE, Box::new(DataType::Utf8), false),
+            DataType::Dictionary(i32::KEY_TYPE, Arc::new(DataType::Utf8), false),
             false,
         ),
         Field::new("decimal", DataType::Decimal(18, 5), false),
         Field::new(
             "nullable_struct",
-            DataType::Struct(vec![Field::new("e", DataType::Float64, false)]),
+            DataType::Struct(Arc::new(vec![Field::new("e", DataType::Float64, false)])),
             true,
         ),
     ]);
@@ -117,7 +123,7 @@ pub(super) fn data() -> Chunk<Box<dyn Array>> {
         Utf8Array::<i32>::from([Some("foo"), None]).boxed(),
         array.into_box(),
         StructArray::new(
-            DataType::Struct(vec![Field::new("e", DataType::Float64, false)]),
+            DataType::Struct(Arc::new(vec![Field::new("e", DataType::Float64, false)])),
             vec![PrimitiveArray::<f64>::from_slice([1.0, 2.0]).boxed()],
             None,
         )
@@ -132,7 +138,7 @@ pub(super) fn data() -> Chunk<Box<dyn Array>> {
             .to(DataType::Decimal(18, 5))
             .boxed(),
         StructArray::new(
-            DataType::Struct(vec![Field::new("e", DataType::Float64, false)]),
+            DataType::Struct(Arc::new(vec![Field::new("e", DataType::Float64, false)])),
             vec![PrimitiveArray::<f64>::from_slice([1.0, 0.0]).boxed()],
             Some([true, false].into()),
         )
@@ -331,7 +337,11 @@ fn schema_list() -> (AvroSchema, Schema) {
 
     let schema = Schema::from(vec![Field::new(
         "h",
-        DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, false))),
+        DataType::List(std::sync::Arc::new(Field::new(
+            "item",
+            DataType::Int32,
+            false,
+        ))),
         false,
     )]);
 
@@ -343,7 +353,11 @@ pub(super) fn data_list() -> Chunk<Box<dyn Array>> {
 
     let mut array = MutableListArray::<i32, MutablePrimitiveArray<i32>>::new_from(
         Default::default(),
-        DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, false))),
+        DataType::List(std::sync::Arc::new(Field::new(
+            "item",
+            DataType::Int32,
+            false,
+        ))),
         0,
     );
     array.try_extend(data).unwrap();

--- a/tests/it/io/avro/write.rs
+++ b/tests/it/io/avro/write.rs
@@ -42,20 +42,20 @@ pub(super) fn schema() -> Schema {
         ),
         Field::new(
             "list",
-            DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
+            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true))),
             false,
         ),
         Field::new(
             "list nullable",
-            DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
+            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true))),
             true,
         ),
     ])
 }
 
 pub(super) fn data() -> Chunk<Box<dyn Array>> {
-    let list_dt = DataType::List(Box::new(Field::new("item", DataType::Int32, true)));
-    let list_dt1 = DataType::List(Box::new(Field::new("item", DataType::Int32, true)));
+    let list_dt = DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true)));
+    let list_dt1 = DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true)));
 
     let columns = vec![
         Box::new(Int64Array::from_slice([27, 47])) as Box<dyn Array>,

--- a/tests/it/io/avro/write.rs
+++ b/tests/it/io/avro/write.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::array::*;
 use arrow2::chunk::Chunk;
 use arrow2::datatypes::*;
@@ -42,20 +44,36 @@ pub(super) fn schema() -> Schema {
         ),
         Field::new(
             "list",
-            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true))),
+            DataType::List(std::sync::Arc::new(Field::new(
+                "item",
+                DataType::Int32,
+                true,
+            ))),
             false,
         ),
         Field::new(
             "list nullable",
-            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true))),
+            DataType::List(std::sync::Arc::new(Field::new(
+                "item",
+                DataType::Int32,
+                true,
+            ))),
             true,
         ),
     ])
 }
 
 pub(super) fn data() -> Chunk<Box<dyn Array>> {
-    let list_dt = DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true)));
-    let list_dt1 = DataType::List(std::sync::Arc::new(Field::new("item", DataType::Int32, true)));
+    let list_dt = DataType::List(std::sync::Arc::new(Field::new(
+        "item",
+        DataType::Int32,
+        true,
+    )));
+    let list_dt1 = DataType::List(std::sync::Arc::new(Field::new(
+        "item",
+        DataType::Int32,
+        true,
+    )));
 
     let columns = vec![
         Box::new(Int64Array::from_slice([27, 47])) as Box<dyn Array>,
@@ -242,28 +260,28 @@ fn struct_schema() -> Schema {
     Schema::from(vec![
         Field::new(
             "struct",
-            DataType::Struct(vec![
+            DataType::Struct(Arc::new(vec![
                 Field::new("item1", DataType::Int32, false),
                 Field::new("item2", DataType::Int32, true),
-            ]),
+            ])),
             false,
         ),
         Field::new(
             "struct nullable",
-            DataType::Struct(vec![
+            DataType::Struct(Arc::new(vec![
                 Field::new("item1", DataType::Int32, false),
                 Field::new("item2", DataType::Int32, true),
-            ]),
+            ])),
             true,
         ),
     ])
 }
 
 fn struct_data() -> Chunk<Box<dyn Array>> {
-    let struct_dt = DataType::Struct(vec![
+    let struct_dt = DataType::Struct(Arc::new(vec![
         Field::new("item1", DataType::Int32, false),
         Field::new("item2", DataType::Int32, true),
-    ]);
+    ]));
 
     Chunk::new(vec![
         Box::new(StructArray::new(

--- a/tests/it/io/csv/read.rs
+++ b/tests/it/io/csv/read.rs
@@ -426,7 +426,7 @@ fn deserialize_timestamp() -> Result<()> {
     let input = vec!["1996-12-19T16:34:57-02:00", "1996-12-19T16:34:58-02:00"];
     let input = input.join("\n");
 
-    let data_type = DataType::Timestamp(TimeUnit::Millisecond, Some("-01:00".to_string()));
+    let data_type = DataType::Timestamp(TimeUnit::Millisecond, Some(std::sync::Arc::new("-01:00".to_string())));
 
     let expected = Int64Array::from([Some(851020497000), Some(851020498000)]).to(data_type.clone());
 
@@ -455,6 +455,6 @@ proptest! {
     #[test]
     #[cfg_attr(miri, ignore)] // miri and proptest do not work well :(
     fn dates(v in "1996-12-19T16:3[0-9]:57-02:00") {
-        assert_eq!(infer(v.as_bytes()), DataType::Timestamp(TimeUnit::Millisecond, Some("-02:00".to_string())));
+        assert_eq!(infer(v.as_bytes()), DataType::Timestamp(TimeUnit::Millisecond, Some(std::sync::Arc::new("-02:00".to_string()))));
     }
 }

--- a/tests/it/io/csv/write.rs
+++ b/tests/it/io/csv/write.rs
@@ -226,7 +226,7 @@ fn data_array(column: &str) -> (Chunk<Box<dyn Array>>, Vec<&'static str>) {
             ])
             .to(DataType::Timestamp(
                 TimeUnit::Nanosecond,
-                Some("+01:00".to_string()),
+                Some(std::sync::Arc::new("+01:00".to_string())),
             ));
             (
                 array.boxed(),
@@ -243,7 +243,7 @@ fn data_array(column: &str) -> (Chunk<Box<dyn Array>>, Vec<&'static str>) {
             ])
             .to(DataType::Timestamp(
                 TimeUnit::Nanosecond,
-                Some("Europe/Lisbon".to_string()),
+                Some(std::sync::Arc::new("Europe/Lisbon".to_string())),
             ));
             (
                 array.boxed(),
@@ -344,7 +344,7 @@ fn write_tz_timezone_formatted_offset() -> Result<()> {
         PrimitiveArray::<i64>::from_slice([1_555_584_887_378_000_001, 1_555_555_555_555_000_001])
             .to(DataType::Timestamp(
                 TimeUnit::Nanosecond,
-                Some("+01:00".to_string()),
+                Some(std::sync::Arc::new("+01:00".to_string())),
             ));
 
     let columns = Chunk::new(vec![array.boxed()]);
@@ -369,7 +369,7 @@ fn write_tz_timezone_formatted_tz() -> Result<()> {
         PrimitiveArray::<i64>::from_slice([1_555_584_887_378_000_001, 1_555_555_555_555_000_001])
             .to(DataType::Timestamp(
                 TimeUnit::Nanosecond,
-                Some("Europe/Lisbon".to_string()),
+                Some(std::sync::Arc::new("Europe/Lisbon".to_string())),
             ));
 
     let columns = Chunk::new(vec![array.boxed()]);

--- a/tests/it/io/ipc/mmap.rs
+++ b/tests/it/io/ipc/mmap.rs
@@ -98,7 +98,11 @@ fn struct_() -> Result<()> {
     let array = PrimitiveArray::<i32>::from([None, None, None, Some(3), Some(4)]).boxed();
 
     let array = StructArray::new(
-        DataType::Struct(vec![Field::new("f1", array.data_type().clone(), true)]),
+        DataType::Struct(Arc::new(vec![Field::new(
+            "f1",
+            array.data_type().clone(),
+            true,
+        )])),
         vec![array],
         Some([true, true, false, true, false].into()),
     )

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -260,7 +260,7 @@ fn deserialize_timestamp_string_tz_s() -> Result<()> {
 
     let data_type = DataType::List(std::sync::Arc::new(Field::new(
         "item",
-        DataType::Timestamp(TimeUnit::Second, Some("+01:00".to_string())),
+        DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("+01:00".to_string()))),
         false,
     )));
 
@@ -268,7 +268,7 @@ fn deserialize_timestamp_string_tz_s() -> Result<()> {
 
     let expected = Int64Array::from([Some(1680870214)]).to(DataType::Timestamp(
         TimeUnit::Second,
-        Some("+01:00".to_string()),
+        Some(std::sync::Arc::new("+01:00".to_string())),
     ));
 
     assert_eq!(expected, result.as_ref());

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -170,7 +170,7 @@ fn deserialize_timestamp_string_ns() -> Result<()> {
 
     let json = json_deserializer::parse(data)?;
 
-    let data_type = DataType::List(Box::new(Field::new(
+    let data_type = DataType::List(std::sync::Arc::new(Field::new(
         "item",
         DataType::Timestamp(TimeUnit::Nanosecond, None),
         false,
@@ -192,7 +192,7 @@ fn deserialize_timestamp_string_us() -> Result<()> {
 
     let json = json_deserializer::parse(data)?;
 
-    let data_type = DataType::List(Box::new(Field::new(
+    let data_type = DataType::List(std::sync::Arc::new(Field::new(
         "item",
         DataType::Timestamp(TimeUnit::Microsecond, None),
         false,
@@ -214,7 +214,7 @@ fn deserialize_timestamp_string_ms() -> Result<()> {
 
     let json = json_deserializer::parse(data)?;
 
-    let data_type = DataType::List(Box::new(Field::new(
+    let data_type = DataType::List(std::sync::Arc::new(Field::new(
         "item",
         DataType::Timestamp(TimeUnit::Millisecond, None),
         false,
@@ -236,7 +236,7 @@ fn deserialize_timestamp_string_s() -> Result<()> {
 
     let json = json_deserializer::parse(data)?;
 
-    let data_type = DataType::List(Box::new(Field::new(
+    let data_type = DataType::List(std::sync::Arc::new(Field::new(
         "item",
         DataType::Timestamp(TimeUnit::Second, None),
         false,
@@ -258,7 +258,7 @@ fn deserialize_timestamp_string_tz_s() -> Result<()> {
 
     let json = json_deserializer::parse(data)?;
 
-    let data_type = DataType::List(Box::new(Field::new(
+    let data_type = DataType::List(std::sync::Arc::new(Field::new(
         "item",
         DataType::Timestamp(TimeUnit::Second, Some("+01:00".to_string())),
         false,
@@ -282,7 +282,7 @@ fn deserialize_timestamp_int_ns() -> Result<()> {
 
     let json = json_deserializer::parse(data)?;
 
-    let data_type = DataType::List(Box::new(Field::new(
+    let data_type = DataType::List(std::sync::Arc::new(Field::new(
         "item",
         DataType::Timestamp(TimeUnit::Nanosecond, None),
         false,

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::array::*;
 use arrow2::datatypes::*;
 use arrow2::error::Result;
@@ -24,7 +26,7 @@ fn read_json() -> Result<()> {
     let result = read::deserialize(&json, data_type)?;
 
     let expected = StructArray::new(
-        DataType::Struct(vec![Field::new("a", DataType::Int64, true)]),
+        DataType::Struct(Arc::new(vec![Field::new("a", DataType::Int64, true)])),
         vec![Box::new(Int64Array::from_slice([1, 2, 3])) as _],
         None,
     );
@@ -260,7 +262,10 @@ fn deserialize_timestamp_string_tz_s() -> Result<()> {
 
     let data_type = DataType::List(std::sync::Arc::new(Field::new(
         "item",
-        DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("+01:00".to_string()))),
+        DataType::Timestamp(
+            TimeUnit::Second,
+            Some(std::sync::Arc::new("+01:00".to_string())),
+        ),
         false,
     )));
 

--- a/tests/it/io/json/write.rs
+++ b/tests/it/io/json/write.rs
@@ -326,7 +326,7 @@ fn list_of_struct() -> Result<()> {
         Field::new("c11", DataType::Int32, false),
         Field::new("c12", DataType::Struct(inner.clone()), false),
     ];
-    let c1_datatype = DataType::List(Box::new(Field::new(
+    let c1_datatype = DataType::List(std::sync::Arc::new(Field::new(
         "s",
         DataType::Struct(fields.clone()),
         false,

--- a/tests/it/io/ndjson/mod.rs
+++ b/tests/it/io/ndjson/mod.rs
@@ -50,12 +50,12 @@ fn case_list() -> (String, Box<dyn Array>) {
         Field::new("a", DataType::Int64, true),
         Field::new(
             "b",
-            DataType::List(Box::new(Field::new("item", DataType::Float64, true))),
+            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Float64, true))),
             true,
         ),
         Field::new(
             "c",
-            DataType::List(Box::new(Field::new("item", DataType::Boolean, true))),
+            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Boolean, true))),
             true,
         ),
         Field::new("d", DataType::Utf8, true),
@@ -100,7 +100,7 @@ fn case_dict() -> (String, Box<dyn Array>) {
     "#
     .to_string();
 
-    let data_type = DataType::List(Box::new(Field::new(
+    let data_type = DataType::List(std::sync::Arc::new(Field::new(
         "item",
         DataType::Dictionary(u64::KEY_TYPE, Box::new(DataType::Utf8), false),
         true,
@@ -235,7 +235,7 @@ fn case_nested_list() -> (String, Box<dyn Array>) {
         DataType::Struct(vec![b_field.clone(), c_field.clone()]),
         true,
     );
-    let a_list_data_type = DataType::List(Box::new(a_struct_field));
+    let a_list_data_type = DataType::List(std::sync::Arc::new(a_struct_field));
     let a_field = Field::new("a", a_list_data_type.clone(), true);
 
     let data = r#"

--- a/tests/it/io/ndjson/mod.rs
+++ b/tests/it/io/ndjson/mod.rs
@@ -1,5 +1,7 @@
 mod read;
 
+use std::sync::Arc;
+
 use arrow2::array::*;
 use arrow2::bitmap::Bitmap;
 use arrow2::datatypes::*;
@@ -46,20 +48,28 @@ fn case_list() -> (String, Box<dyn Array>) {
             "#
     .to_string();
 
-    let data_type = DataType::Struct(vec![
+    let data_type = DataType::Struct(Arc::new(vec![
         Field::new("a", DataType::Int64, true),
         Field::new(
             "b",
-            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Float64, true))),
+            DataType::List(std::sync::Arc::new(Field::new(
+                "item",
+                DataType::Float64,
+                true,
+            ))),
             true,
         ),
         Field::new(
             "c",
-            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Boolean, true))),
+            DataType::List(std::sync::Arc::new(Field::new(
+                "item",
+                DataType::Boolean,
+                true,
+            ))),
             true,
         ),
         Field::new("d", DataType::Utf8, true),
-    ]);
+    ]));
 
     let a = Int64Array::from(&[Some(1), Some(-10), None]);
     let mut b = MutableListArray::<i32, MutablePrimitiveArray<f64>>::new();
@@ -102,7 +112,7 @@ fn case_dict() -> (String, Box<dyn Array>) {
 
     let data_type = DataType::List(std::sync::Arc::new(Field::new(
         "item",
-        DataType::Dictionary(u64::KEY_TYPE, Box::new(DataType::Utf8), false),
+        DataType::Dictionary(u64::KEY_TYPE, Arc::new(DataType::Utf8), false),
         true,
     )));
 
@@ -130,7 +140,12 @@ fn case_dict() -> (String, Box<dyn Array>) {
 
     (
         data,
-        StructArray::new(DataType::Struct(fields), vec![array.boxed()], None).boxed(),
+        StructArray::new(
+            DataType::Struct(std::sync::Arc::new(fields)),
+            vec![array.boxed()],
+            None,
+        )
+        .boxed(),
     )
 }
 
@@ -139,12 +154,12 @@ fn case_basics() -> (String, Box<dyn Array>) {
     {"a":-10, "b":-3.5, "c":true, "d":null}
     {"a":100000000, "b":0.6, "d":"text"}"#
         .to_string();
-    let data_type = DataType::Struct(vec![
+    let data_type = DataType::Struct(Arc::new(vec![
         Field::new("a", DataType::Int64, true),
         Field::new("b", DataType::Float64, true),
         Field::new("c", DataType::Boolean, true),
         Field::new("d", DataType::Utf8, true),
-    ]);
+    ]));
     let array = StructArray::new(
         data_type,
         vec![
@@ -163,13 +178,13 @@ fn case_projection() -> (String, Box<dyn Array>) {
     {"a":10, "b":-3.5, "c":true, "d":null, "e":"text"}
     {"a":100000000, "b":0.6, "d":"text"}"#
         .to_string();
-    let data_type = DataType::Struct(vec![
+    let data_type = DataType::Struct(Arc::new(vec![
         Field::new("a", DataType::UInt32, true),
         Field::new("b", DataType::Float32, true),
         Field::new("c", DataType::Boolean, true),
         // note how "d" is not here
         Field::new("e", DataType::Binary, true),
-    ]);
+    ]));
     let array = StructArray::new(
         data_type,
         vec![
@@ -191,27 +206,30 @@ fn case_struct() -> (String, Box<dyn Array>) {
         .to_string();
 
     let d_field = Field::new("d", DataType::Utf8, true);
-    let c_field = Field::new("c", DataType::Struct(vec![d_field.clone()]), true);
+    let c_field = Field::new("c", DataType::Struct(Arc::new(vec![d_field.clone()])), true);
     let a_field = Field::new(
         "a",
-        DataType::Struct(vec![
+        DataType::Struct(Arc::new(vec![
             Field::new("b", DataType::Boolean, true),
             c_field.clone(),
-        ]),
+        ])),
         true,
     );
-    let fields = vec![a_field];
+    let fields = Arc::new(vec![a_field]);
 
     // build expected output
     let d = Utf8Array::<i32>::from([Some("text"), None, Some("text"), None]);
     let c = StructArray::new(
-        DataType::Struct(vec![d_field]),
+        DataType::Struct(Arc::new(vec![d_field])),
         vec![d.boxed()],
         Some([true, false, true, true].into()),
     );
 
     let b = BooleanArray::from(vec![Some(true), Some(false), Some(true), None]);
-    let inner = DataType::Struct(vec![Field::new("b", DataType::Boolean, true), c_field]);
+    let inner = DataType::Struct(Arc::new(vec![
+        Field::new("b", DataType::Boolean, true),
+        c_field,
+    ]));
     let expected = StructArray::new(
         inner,
         vec![b.boxed(), c.boxed()],
@@ -228,11 +246,11 @@ fn case_struct() -> (String, Box<dyn Array>) {
 
 fn case_nested_list() -> (String, Box<dyn Array>) {
     let d_field = Field::new("d", DataType::Utf8, true);
-    let c_field = Field::new("c", DataType::Struct(vec![d_field.clone()]), true);
+    let c_field = Field::new("c", DataType::Struct(Arc::new(vec![d_field.clone()])), true);
     let b_field = Field::new("b", DataType::Boolean, true);
     let a_struct_field = Field::new(
         "a",
-        DataType::Struct(vec![b_field.clone(), c_field.clone()]),
+        DataType::Struct(Arc::new(vec![b_field.clone(), c_field.clone()])),
         true,
     );
     let a_list_data_type = DataType::List(std::sync::Arc::new(a_struct_field));
@@ -257,7 +275,7 @@ fn case_nested_list() -> (String, Box<dyn Array>) {
     ]);
 
     let c = StructArray::new(
-        DataType::Struct(vec![d_field]),
+        DataType::Struct(Arc::new(vec![d_field])),
         vec![d.boxed()],
         Some(Bitmap::from_u8_slice([0b11111011], 6)),
     );
@@ -271,7 +289,7 @@ fn case_nested_list() -> (String, Box<dyn Array>) {
         Some(true),
     ]);
     let a_struct = StructArray::new(
-        DataType::Struct(vec![b_field, c_field]),
+        DataType::Struct(Arc::new(vec![b_field, c_field])),
         vec![b.boxed(), c.boxed()],
         None,
     );
@@ -283,7 +301,7 @@ fn case_nested_list() -> (String, Box<dyn Array>) {
     );
 
     let array = StructArray::new(
-        DataType::Struct(vec![a_field]),
+        DataType::Struct(Arc::new(vec![a_field])),
         vec![expected.boxed()],
         None,
     )
@@ -316,7 +334,7 @@ fn infer_object() -> Result<()> {
     let utf8_fld = Field::new("utf8", DataType::Utf8, true);
     let bools_fld = Field::new("bools", DataType::Boolean, true);
 
-    let expected = DataType::Struct(vec![u64_fld, f64_fld, utf8_fld, bools_fld]);
+    let expected = DataType::Struct(Arc::new(vec![u64_fld, f64_fld, utf8_fld, bools_fld]));
     let actual = infer(data)?;
 
     assert_eq!(expected, actual);

--- a/tests/it/io/ndjson/read.rs
+++ b/tests/it/io/ndjson/read.rs
@@ -172,12 +172,12 @@ fn infer_schema_mixed_list() -> Result<()> {
         Field::new("a", DataType::Int64, true),
         Field::new(
             "b",
-            DataType::List(Box::new(Field::new("item", DataType::Float64, true))),
+            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Float64, true))),
             true,
         ),
         Field::new(
             "c",
-            DataType::List(Box::new(Field::new("item", DataType::Boolean, true))),
+            DataType::List(std::sync::Arc::new(Field::new("item", DataType::Boolean, true))),
             true,
         ),
         Field::new("d", DataType::Utf8, true),

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -586,7 +586,7 @@ pub fn pyarrow_nullable(column: &str) -> Box<dyn Array> {
             PrimitiveArray::<i64>::from(i64_values).to(DataType::Timestamp(TimeUnit::Second, None)),
         ),
         "timestamp_s_utc" => Box::new(PrimitiveArray::<i64>::from(i64_values).to(
-            DataType::Timestamp(TimeUnit::Second, Some("UTC".to_string())),
+            DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("UTC".to_string()))),
         )),
         _ => unreachable!(),
     }
@@ -739,11 +739,11 @@ pub fn pyarrow_nullable_statistics(column: &str) -> Statistics {
             null_count: UInt64Array::from([Some(3)]).boxed(),
             min_value: Box::new(Int64Array::from_slice([-256]).to(DataType::Timestamp(
                 TimeUnit::Second,
-                Some("UTC".to_string()),
+                Some(std::sync::Arc::new("UTC".to_string())),
             ))),
             max_value: Box::new(Int64Array::from_slice([9]).to(DataType::Timestamp(
                 TimeUnit::Second,
-                Some("UTC".to_string()),
+                Some(std::sync::Arc::new("UTC".to_string())),
             ))),
         },
         _ => unreachable!(),
@@ -1622,7 +1622,7 @@ fn generic_data() -> Result<(Schema, Chunk<Box<dyn Array>>)> {
     let values = PrimitiveArray::from_slice([1i64, 3])
         .to(DataType::Timestamp(
             TimeUnit::Millisecond,
-            Some("UTC".to_string()),
+            Some(std::sync::Arc::new("UTC".to_string())),
         ))
         .boxed();
     let array7 = DictionaryArray::try_from_keys(indices.clone(), values).unwrap();

--- a/tests/it/io/print.rs
+++ b/tests/it/io/print.rs
@@ -161,7 +161,7 @@ fn write_timestamp_second_with_tz() {
     ];
     check_datetime!(
         i64,
-        DataType::Timestamp(TimeUnit::Second, Some("UTC".to_string())),
+        DataType::Timestamp(TimeUnit::Second, Some(std::sync::Arc::new("UTC".to_string()))),
         11111111,
         expected
     );

--- a/tests/it/io/print.rs
+++ b/tests/it/io/print.rs
@@ -327,7 +327,7 @@ fn write_struct() -> Result<()> {
 
     let validity = Some(Bitmap::from(&[true, false, true]));
 
-    let array = StructArray::new(DataType::Struct(fields), values, validity);
+    let array = StructArray::new(DataType::Struct(std::sync::Arc::new(fields)), values, validity);
 
     let columns = Chunk::new(vec![&array as &dyn Array]);
 
@@ -356,7 +356,7 @@ fn write_union() -> Result<()> {
         Field::new("a", DataType::Int32, true),
         Field::new("b", DataType::Utf8, true),
     ];
-    let data_type = DataType::Union(fields, None, UnionMode::Sparse);
+    let data_type = DataType::Union(std::sync::Arc::new(fields), None, UnionMode::Sparse);
     let types = Buffer::from(vec![0, 0, 1]);
     let fields = vec![
         Int32Array::from(&[Some(1), None, Some(2)]).boxed(),

--- a/tests/it/scalar/fixed_size_list.rs
+++ b/tests/it/scalar/fixed_size_list.rs
@@ -7,7 +7,7 @@ use arrow2::{
 #[allow(clippy::eq_op)]
 #[test]
 fn equal() {
-    let dt = DataType::FixedSizeList(Box::new(Field::new("a", DataType::Boolean, true)), 2);
+    let dt = DataType::FixedSizeList(std::sync::Arc::new(Field::new("a", DataType::Boolean, true)), 2);
     let a = FixedSizeListScalar::new(
         dt.clone(),
         Some(BooleanArray::from_slice([true, false]).boxed()),
@@ -26,7 +26,7 @@ fn equal() {
 
 #[test]
 fn basics() {
-    let dt = DataType::FixedSizeList(Box::new(Field::new("a", DataType::Boolean, true)), 2);
+    let dt = DataType::FixedSizeList(std::sync::Arc::new(Field::new("a", DataType::Boolean, true)), 2);
     let a = FixedSizeListScalar::new(
         dt.clone(),
         Some(BooleanArray::from_slice([true, false]).boxed()),

--- a/tests/it/scalar/list.rs
+++ b/tests/it/scalar/list.rs
@@ -7,7 +7,7 @@ use arrow2::{
 #[allow(clippy::eq_op)]
 #[test]
 fn equal() {
-    let dt = DataType::List(Box::new(Field::new("a", DataType::Boolean, true)));
+    let dt = DataType::List(std::sync::Arc::new(Field::new("a", DataType::Boolean, true)));
     let a = ListScalar::<i32>::new(
         dt.clone(),
         Some(BooleanArray::from_slice([true, false]).boxed()),
@@ -23,7 +23,7 @@ fn equal() {
 
 #[test]
 fn basics() {
-    let dt = DataType::List(Box::new(Field::new("a", DataType::Boolean, true)));
+    let dt = DataType::List(std::sync::Arc::new(Field::new("a", DataType::Boolean, true)));
     let a = ListScalar::<i32>::new(
         dt.clone(),
         Some(BooleanArray::from_slice([true, false]).boxed()),

--- a/tests/it/scalar/map.rs
+++ b/tests/it/scalar/map.rs
@@ -30,7 +30,7 @@ fn equal() {
     )
     .unwrap();
 
-    let dt = DataType::Map(Box::new(Field::new("entries", kv_dt, true)), false);
+    let dt = DataType::Map(std::sync::Arc::new(Field::new("entries", kv_dt, true)), false);
     let a = MapScalar::new(dt.clone(), Some(Box::new(kv_array1)));
     let b = MapScalar::new(dt.clone(), None);
     assert_eq!(a, a);
@@ -57,7 +57,7 @@ fn basics() {
     )
     .unwrap();
 
-    let dt = DataType::Map(Box::new(Field::new("entries", kv_dt, true)), false);
+    let dt = DataType::Map(std::sync::Arc::new(Field::new("entries", kv_dt, true)), false);
     let a = MapScalar::new(dt.clone(), Some(Box::new(kv_array.clone())));
 
     assert_eq!(kv_array, a.values().as_ref());

--- a/tests/it/scalar/map.rs
+++ b/tests/it/scalar/map.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::{
     array::{BooleanArray, StructArray, Utf8Array},
     datatypes::{DataType, Field},
@@ -7,10 +9,10 @@ use arrow2::{
 #[allow(clippy::eq_op)]
 #[test]
 fn equal() {
-    let kv_dt = DataType::Struct(vec![
+    let kv_dt = DataType::Struct(Arc::new(vec![
         Field::new("key", DataType::Utf8, false),
         Field::new("value", DataType::Boolean, true),
-    ]);
+    ]));
     let kv_array1 = StructArray::try_new(
         kv_dt.clone(),
         vec![
@@ -30,7 +32,10 @@ fn equal() {
     )
     .unwrap();
 
-    let dt = DataType::Map(std::sync::Arc::new(Field::new("entries", kv_dt, true)), false);
+    let dt = DataType::Map(
+        std::sync::Arc::new(Field::new("entries", kv_dt, true)),
+        false,
+    );
     let a = MapScalar::new(dt.clone(), Some(Box::new(kv_array1)));
     let b = MapScalar::new(dt.clone(), None);
     assert_eq!(a, a);
@@ -43,10 +48,10 @@ fn equal() {
 
 #[test]
 fn basics() {
-    let kv_dt = DataType::Struct(vec![
+    let kv_dt = DataType::Struct(Arc::new(vec![
         Field::new("key", DataType::Utf8, false),
         Field::new("value", DataType::Boolean, true),
-    ]);
+    ]));
     let kv_array = StructArray::try_new(
         kv_dt.clone(),
         vec![
@@ -57,7 +62,10 @@ fn basics() {
     )
     .unwrap();
 
-    let dt = DataType::Map(std::sync::Arc::new(Field::new("entries", kv_dt, true)), false);
+    let dt = DataType::Map(
+        std::sync::Arc::new(Field::new("entries", kv_dt, true)),
+        false,
+    );
     let a = MapScalar::new(dt.clone(), Some(Box::new(kv_array.clone())));
 
     assert_eq!(kv_array, a.values().as_ref());

--- a/tests/it/scalar/struct_.rs
+++ b/tests/it/scalar/struct_.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use arrow2::{
     datatypes::{DataType, Field},
     scalar::{BooleanScalar, Scalar, StructScalar},
@@ -6,7 +8,7 @@ use arrow2::{
 #[allow(clippy::eq_op)]
 #[test]
 fn equal() {
-    let dt = DataType::Struct(vec![Field::new("a", DataType::Boolean, true)]);
+    let dt = DataType::Struct(Arc::new(vec![Field::new("a", DataType::Boolean, true)]));
     let a = StructScalar::new(
         dt.clone(),
         Some(vec![
@@ -29,7 +31,7 @@ fn equal() {
 
 #[test]
 fn basics() {
-    let dt = DataType::Struct(vec![Field::new("a", DataType::Boolean, true)]);
+    let dt = DataType::Struct(Arc::new(vec![Field::new("a", DataType::Boolean, true)]));
 
     let values = vec![Box::new(BooleanScalar::from(Some(true))) as Box<dyn Scalar>];
 

--- a/tests/it/temporal_conversions.rs
+++ b/tests/it/temporal_conversions.rs
@@ -2,6 +2,7 @@ use arrow2::array::*;
 use arrow2::datatypes::TimeUnit;
 use arrow2::temporal_conversions;
 use arrow2::types::months_days_ns;
+use std::sync::Arc;
 
 #[test]
 fn naive() {
@@ -125,7 +126,7 @@ fn naive_no_tz() {
 
 #[test]
 fn tz_aware() {
-    let tz = "-02:00".to_string();
+    let tz = Arc::new("-02:00".to_string());
     let expected =
         "Timestamp(Nanosecond, Some(\"-02:00\"))[1996-12-19 16:39:57 -02:00, 1996-12-19 17:39:57 -02:00, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S%.f%:z";
@@ -140,7 +141,7 @@ fn tz_aware() {
 
 #[test]
 fn tz_aware_no_timezone() {
-    let tz = "-02:00".to_string();
+    let tz = Arc::new("-02:00".to_string());
     let expected = "Timestamp(Nanosecond, Some(\"-02:00\"))[None, None, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S%.f";
     let array = Utf8Array::<i32>::from_slice([


### PR DESCRIPTION
Fixes #439

The entire PR pretty much comes down to this diff:
```diff
@@ -70,7 +111,7 @@ pub enum DataType {
     /// * An absolute time zone offset of the form +XX:XX or -XX:XX, such as +07:30
     /// When the timezone is not specified, the timestamp is considered to have no timezone
     /// and is represented _as is_
-    Timestamp(TimeUnit, Option<String>),
+    Timestamp(TimeUnit, Option<Arc<String>>),
     /// An [`i32`] representing the elapsed time since UNIX epoch (1970-01-01)
     /// in days.
     Date32,
@@ -100,16 +141,16 @@ pub enum DataType {
     /// A variable-length UTF-8 encoded string whose offsets are represented as [`i64`].
     LargeUtf8,
     /// A list of some logical data type whose offsets are represented as [`i32`].
-    List(Box<Field>),
+    List(Arc<Field>),
     /// A list of some logical data type with a fixed number of elements.
-    FixedSizeList(Box<Field>, usize),
+    FixedSizeList(Arc<Field>, usize),
     /// A list of some logical data type whose offsets are represented as [`i64`].
-    LargeList(Box<Field>),
+    LargeList(Arc<Field>),
     /// A nested [`DataType`] with a given number of [`Field`]s.
-    Struct(Vec<Field>),
+    Struct(Arc<Vec<Field>>),
     /// A nested datatype that can represent slots of differing types.
     /// Third argument represents mode
-    Union(Vec<Field>, Option<Vec<i32>>, UnionMode),
+    Union(Arc<Vec<Field>>, Option<Arc<Vec<i32>>>, UnionMode),
     /// A nested type that is represented as
     ///
     /// List<entries: Struct<key: K, value: V>>
@@ -135,7 +176,7 @@ pub enum DataType {
     /// The metadata is structured so that Arrow systems without special handling
     /// for Map can make Map an alias for List. The "layout" attribute for the Map
     /// field must have the same contents as a List.
-    Map(Box<Field>, bool),
+    Map(Arc<Field>, bool),
     /// A dictionary encoded array (`key_type`, `value_type`), where
     /// each array element is an index of `key_type` into an
     /// associated dictionary of `value_type`.
@@ -148,7 +189,7 @@ pub enum DataType {
     /// arrays or a limited set of primitive types as integers.
     ///
     /// The `bool` value indicates the `Dictionary` is sorted if set to `true`.
-    Dictionary(IntegerType, Box<DataType>, bool),
+    Dictionary(IntegerType, Arc<DataType>, bool),
     /// Decimal value with precision and scale
     /// precision is the number of digits in the number and
     /// scale is the number of decimal places.
@@ -157,12 +198,15 @@ pub enum DataType {
     /// Decimal backed by 256 bits
     Decimal256(usize, usize),
     /// Extension type.
-    Extension(String, Box<DataType>, Option<String>),
+    Extension(String, Arc<DataType>, Option<Arc<String>>),
 }
```
everything else is just a lot of grunt work and pain to accommodate for these new types.

As mentioned in https://github.com/jorgecarleitao/arrow2/issues/439#issuecomment-1506984699: I went for the path of least resistance, so this isn't optimal, but it is already quite the improvement.

I have branches ready for `arrow2_convert`, `polars` and `rerun`.
In Rerun, we've seen up to 50% reduced memory requirements in some use cases with this PR.