### PR TITLE
Fixed timestamp to datetime conversion error

### DIFF
--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -120,13 +120,18 @@ pub fn timestamp_ms_to_datetime(v: i64) -> NaiveDateTime {
             (v % MILLISECONDS * MICROSECONDS) as u32,
         )
     } else {
-        // note: negative values require 'div_floor' rounding behaviour, which isn't
-        // yet stabilised (see - https://github.com/rust-lang/rust/issues/88581).
         let secs_rem = (v / MILLISECONDS, v % MILLISECONDS);
-        NaiveDateTime::from_timestamp_opt(
-            secs_rem.0 - (secs_rem.1 != 0) as i64,
-            (v % MILLISECONDS * MICROSECONDS).unsigned_abs() as u32,
-        )
+        if secs_rem.1 == 0 {
+            // whole/integer seconds; no adjustment required
+            NaiveDateTime::from_timestamp_opt(secs_rem.0, (v % MILLISECONDS * MICROSECONDS) as u32)
+        } else {
+            // negative values with fractional seconds require 'div_floor' rounding behaviour.
+            // (which isn't yet stabilised: https://github.com/rust-lang/rust/issues/88581)
+            NaiveDateTime::from_timestamp_opt(
+                secs_rem.0 - 1,
+                (NANOSECONDS + (v % MILLISECONDS * MICROSECONDS)) as u32,
+            )
+        }
     }
     .expect("invalid or out-of-range datetime")
 }
@@ -142,13 +147,18 @@ pub fn timestamp_us_to_datetime(v: i64) -> NaiveDateTime {
             (v % MICROSECONDS * MILLISECONDS) as u32,
         )
     } else {
-        // note: negative values require 'div_floor' rounding behaviour, which isn't
-        // yet stabilised (see - https://github.com/rust-lang/rust/issues/88581).
         let secs_rem = (v / MICROSECONDS, v % MICROSECONDS);
-        NaiveDateTime::from_timestamp_opt(
-            secs_rem.0 - (secs_rem.1 != 0) as i64,
-            (v % MICROSECONDS * MILLISECONDS).unsigned_abs() as u32,
-        )
+        if secs_rem.1 == 0 {
+            // whole/integer seconds; no adjustment required
+            NaiveDateTime::from_timestamp_opt(secs_rem.0, (v % MICROSECONDS * MILLISECONDS) as u32)
+        } else {
+            // negative values with fractional seconds require 'div_floor' rounding behaviour.
+            // (which isn't yet stabilised: https://github.com/rust-lang/rust/issues/88581)
+            NaiveDateTime::from_timestamp_opt(
+                secs_rem.0 - 1,
+                (NANOSECONDS + (v % MICROSECONDS * MILLISECONDS)) as u32,
+            )
+        }
     }
     .expect("invalid or out-of-range datetime")
 }
@@ -164,13 +174,18 @@ pub fn timestamp_ns_to_datetime(v: i64) -> NaiveDateTime {
             (v % NANOSECONDS) as u32,
         )
     } else {
-        // note: negative values require 'div_floor' rounding behaviour, which isn't
-        // yet stabilised (see - https://github.com/rust-lang/rust/issues/88581).
         let secs_rem = (v / NANOSECONDS, v % NANOSECONDS);
-        NaiveDateTime::from_timestamp_opt(
-            secs_rem.0 - (secs_rem.1 != 0) as i64,
-            (v % NANOSECONDS).unsigned_abs() as u32,
-        )
+        if secs_rem.1 == 0 {
+            // whole/integer seconds; no adjustment required
+            NaiveDateTime::from_timestamp_opt(secs_rem.0, (v % NANOSECONDS) as u32)
+        } else {
+            // negative values with fractional seconds require 'div_floor' rounding behaviour.
+            // (which isn't yet stabilised: https://github.com/rust-lang/rust/issues/88581)
+            NaiveDateTime::from_timestamp_opt(
+                secs_rem.0 - 1,
+                (NANOSECONDS + (v % NANOSECONDS)) as u32,
+            )
+        }
     }
     .expect("invalid or out-of-range datetime")
 }

--- a/tests/it/temporal_conversions.rs
+++ b/tests/it/temporal_conversions.rs
@@ -150,17 +150,17 @@ fn timestamp_to_datetime() {
     // negative milliseconds
     assert_eq!(
         temporal_conversions::timestamp_ms_to_datetime(ts / 1_000_000),
-        NaiveDateTime::parse_from_str("1969-07-05T01:02:03.987000000", fmt).unwrap()
+        NaiveDateTime::parse_from_str("1969-07-05T01:02:03.013000000", fmt).unwrap()
     );
     // negative microseconds
     assert_eq!(
         temporal_conversions::timestamp_us_to_datetime(ts / 1_000),
-        NaiveDateTime::parse_from_str("1969-07-05T01:02:03.987654000", fmt).unwrap()
+        NaiveDateTime::parse_from_str("1969-07-05T01:02:03.012346000", fmt).unwrap()
     );
     // negative nanoseconds
     assert_eq!(
         temporal_conversions::timestamp_ns_to_datetime(ts),
-        NaiveDateTime::parse_from_str("1969-07-05T01:02:03.987654321", fmt).unwrap()
+        NaiveDateTime::parse_from_str("1969-07-05T01:02:03.012345679", fmt).unwrap()
     );
 
     let fmt = "%Y-%m-%dT%H:%M:%S";


### PR DESCRIPTION
Third time's the charm 🙄 Fixes fractional second bug in [previous](https://github.com/jorgecarleitao/arrow2/pull/1467) PR(s), and fixes the unit test that let it slip through.