### PR TITLE
Added parquet deserialization of nested null types

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -728,7 +728,7 @@ pub use fixed_size_binary::{FixedSizeBinaryArray, MutableFixedSizeBinaryArray};
 pub use fixed_size_list::{FixedSizeListArray, MutableFixedSizeListArray};
 pub use list::{ListArray, ListValuesIter, MutableListArray};
 pub use map::MapArray;
-pub use null::NullArray;
+pub use null::{MutableNullArray, NullArray};
 pub use primitive::*;
 pub use struct_::{MutableStructArray, StructArray};
 pub use union::UnionArray;

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -1,5 +1,8 @@
 use crate::{bitmap::Bitmap, datatypes::DataType};
+use std::any::Any;
 
+use crate::array::MutableArray;
+use crate::bitmap::MutableBitmap;
 use crate::{
     array::{Array, FromFfi, ToFfi},
     datatypes::PhysicalType,
@@ -85,6 +88,44 @@ impl Array for NullArray {
 
     fn with_validity(&self, _: Option<Bitmap>) -> Box<dyn Array> {
         panic!("cannot set validity of a null array")
+    }
+}
+
+impl MutableArray for NullArray {
+    fn data_type(&self) -> &DataType {
+        &DataType::Null
+    }
+
+    fn len(&self) -> usize {
+        self.length
+    }
+
+    fn validity(&self) -> Option<&MutableBitmap> {
+        None
+    }
+
+    fn as_box(&mut self) -> Box<dyn Array> {
+        self.clone().boxed()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn push_null(&mut self) {
+        self.length += 1;
+    }
+
+    fn reserve(&mut self, _additional: usize) {
+        // no-op
+    }
+
+    fn shrink_to_fit(&mut self) {
+        // no-op
     }
 }
 

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -91,13 +91,37 @@ impl Array for NullArray {
     }
 }
 
-impl MutableArray for NullArray {
+#[derive(Debug)]
+/// A distinct type to disambiguate
+/// clashing methods
+pub struct MutableNullArray {
+    inner: NullArray,
+}
+
+impl MutableNullArray {
+    /// Returns a new [`MutableNullArray`].
+    /// # Panics
+    /// This function errors iff:
+    /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to [`crate::datatypes::PhysicalType::Null`].
+    pub fn new(data_type: DataType, length: usize) -> Self {
+        let inner = NullArray::try_new(data_type, length).unwrap();
+        Self { inner }
+    }
+}
+
+impl From<MutableNullArray> for NullArray {
+    fn from(value: MutableNullArray) -> Self {
+        value.inner
+    }
+}
+
+impl MutableArray for MutableNullArray {
     fn data_type(&self) -> &DataType {
         &DataType::Null
     }
 
     fn len(&self) -> usize {
-        self.length
+        self.inner.length
     }
 
     fn validity(&self) -> Option<&MutableBitmap> {
@@ -105,7 +129,7 @@ impl MutableArray for NullArray {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        self.clone().boxed()
+        self.inner.clone().boxed()
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -117,7 +141,7 @@ impl MutableArray for NullArray {
     }
 
     fn push_null(&mut self) {
-        self.length += 1;
+        self.inner.length += 1;
     }
 
     fn reserve(&mut self, _additional: usize) {

--- a/src/io/parquet/read/deserialize/nested.rs
+++ b/src/io/parquet/read/deserialize/nested.rs
@@ -52,6 +52,18 @@ where
     use crate::datatypes::PrimitiveType::*;
 
     Ok(match field.data_type().to_physical_type() {
+        Null => {
+            // physical type is i32
+            init.push(InitNested::Primitive(field.is_nullable));
+            types.pop();
+            primitive(null::NestedIter::new(
+                columns.pop().unwrap(),
+                init,
+                field.data_type().clone(),
+                num_rows,
+                chunk_size,
+            ))
+        }
         Boolean => {
             init.push(InitNested::Primitive(field.is_nullable));
             types.pop();

--- a/src/io/parquet/read/deserialize/null/mod.rs
+++ b/src/io/parquet/read/deserialize/null/mod.rs
@@ -1,8 +1,11 @@
+mod nested;
+
 use parquet2::page::Page;
 
 use crate::{array::NullArray, datatypes::DataType};
 
 use super::super::{ArrayIter, Pages};
+pub(super) use nested::NestedIter;
 
 /// Converts [`Pages`] to an [`ArrayIter`]
 pub fn iter_to_arrays<'a, I>(

--- a/src/io/parquet/read/deserialize/null/nested.rs
+++ b/src/io/parquet/read/deserialize/null/nested.rs
@@ -1,0 +1,124 @@
+use std::collections::VecDeque;
+
+use parquet2::page::{DataPage, DictPage};
+
+use crate::array::NullArray;
+use crate::io::parquet::read::deserialize::utils::DecodedState;
+use crate::{datatypes::DataType, error::Result};
+
+use super::super::nested_utils::*;
+use super::super::utils;
+use super::super::Pages;
+
+impl<'a> utils::PageState<'a> for () {
+    fn len(&self) -> usize {
+        0
+    }
+}
+
+#[derive(Debug)]
+struct NullDecoder {}
+
+impl DecodedState for usize {
+    fn len(&self) -> usize {
+        *self
+    }
+}
+
+impl<'a> NestedDecoder<'a> for NullDecoder {
+    type State = ();
+    type Dictionary = ();
+    type DecodedState = usize;
+
+    fn build_state(
+        &self,
+        _page: &'a DataPage,
+        _dict: Option<&'a Self::Dictionary>,
+    ) -> Result<Self::State> {
+        Ok(())
+    }
+
+    /// Initializes a new state
+    fn with_capacity(&self, _capacity: usize) -> Self::DecodedState {
+        0
+    }
+
+    fn push_valid(&self, _state: &mut Self::State, decoded: &mut Self::DecodedState) -> Result<()> {
+        *decoded += 1;
+        Ok(())
+    }
+
+    fn push_null(&self, decoded: &mut Self::DecodedState) {
+        let length = decoded;
+        *length += 1;
+    }
+
+    fn deserialize_dict(&self, _page: &DictPage) -> Self::Dictionary {
+        unreachable!()
+    }
+}
+
+/// An iterator adapter over [`Pages`] assumed to be encoded as null arrays
+#[derive(Debug)]
+pub struct NestedIter<I>
+where
+    I: Pages,
+{
+    iter: I,
+    init: Vec<InitNested>,
+    data_type: DataType,
+    items: VecDeque<(NestedState, usize)>,
+    remaining: usize,
+    chunk_size: Option<usize>,
+    decoder: NullDecoder,
+}
+
+impl<I> NestedIter<I>
+where
+    I: Pages,
+{
+    pub fn new(
+        iter: I,
+        init: Vec<InitNested>,
+        data_type: DataType,
+        num_rows: usize,
+        chunk_size: Option<usize>,
+    ) -> Self {
+        Self {
+            iter,
+            init,
+            data_type,
+            items: VecDeque::new(),
+            chunk_size,
+            remaining: num_rows,
+            decoder: NullDecoder {},
+        }
+    }
+}
+
+impl<I> Iterator for NestedIter<I>
+where
+    I: Pages,
+{
+    type Item = Result<(NestedState, NullArray)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let maybe_state = next(
+            &mut self.iter,
+            &mut self.items,
+            &mut None,
+            &mut self.remaining,
+            &self.init,
+            self.chunk_size,
+            &self.decoder,
+        );
+        match maybe_state {
+            utils::MaybeNext::Some(Ok((nested, state))) => {
+                Some(Ok((nested, NullArray::new(self.data_type.clone(), state))))
+            }
+            utils::MaybeNext::Some(Err(e)) => Some(Err(e)),
+            utils::MaybeNext::None => None,
+            utils::MaybeNext::More => self.next(),
+        }
+    }
+}

--- a/src/io/parquet/read/statistics/mod.rs
+++ b/src/io/parquet/read/statistics/mod.rs
@@ -26,6 +26,7 @@ mod dictionary;
 mod fixlen;
 mod list;
 mod map;
+mod null;
 mod primitive;
 mod struct_;
 mod utf8;
@@ -194,6 +195,7 @@ fn make_mutable(data_type: &DataType, capacity: usize) -> Result<Box<dyn Mutable
             data_type.clone(),
             capacity,
         )?),
+        PhysicalType::Null => Box::new(NullArray::new(DataType::Null, 0)) as Box<dyn MutableArray>,
         other => {
             return Err(Error::NotYetImplemented(format!(
                 "Deserializing parquet stats from {other:?} is still not implemented"
@@ -538,6 +540,7 @@ fn push(
         Utf8 => utf8::push::<i32>(from, min, max),
         LargeUtf8 => utf8::push::<i64>(from, min, max),
         FixedSizeBinary(_) => fixlen::push(from, min, max),
+        Null => null::push(min, max),
         other => todo!("{:?}", other),
     }
 }

--- a/src/io/parquet/read/statistics/mod.rs
+++ b/src/io/parquet/read/statistics/mod.rs
@@ -195,7 +195,9 @@ fn make_mutable(data_type: &DataType, capacity: usize) -> Result<Box<dyn Mutable
             data_type.clone(),
             capacity,
         )?),
-        PhysicalType::Null => Box::new(NullArray::new(DataType::Null, 0)) as Box<dyn MutableArray>,
+        PhysicalType::Null => {
+            Box::new(MutableNullArray::new(DataType::Null, 0)) as Box<dyn MutableArray>
+        }
         other => {
             return Err(Error::NotYetImplemented(format!(
                 "Deserializing parquet stats from {other:?} is still not implemented"

--- a/src/io/parquet/read/statistics/null.rs
+++ b/src/io/parquet/read/statistics/null.rs
@@ -1,0 +1,11 @@
+use crate::array::*;
+use crate::error::Result;
+
+pub(super) fn push(min: &mut dyn MutableArray, max: &mut dyn MutableArray) -> Result<()> {
+    let min = min.as_mut_any().downcast_mut::<NullArray>().unwrap();
+    let max = max.as_mut_any().downcast_mut::<NullArray>().unwrap();
+    min.push_null();
+    max.push_null();
+
+    Ok(())
+}

--- a/src/io/parquet/read/statistics/null.rs
+++ b/src/io/parquet/read/statistics/null.rs
@@ -2,8 +2,8 @@ use crate::array::*;
 use crate::error::Result;
 
 pub(super) fn push(min: &mut dyn MutableArray, max: &mut dyn MutableArray) -> Result<()> {
-    let min = min.as_mut_any().downcast_mut::<NullArray>().unwrap();
-    let max = max.as_mut_any().downcast_mut::<NullArray>().unwrap();
+    let min = min.as_mut_any().downcast_mut::<MutableNullArray>().unwrap();
+    let max = max.as_mut_any().downcast_mut::<MutableNullArray>().unwrap();
     min.push_null();
     max.push_null();
 


### PR DESCRIPTION
Nested nulls were not supported. They were written, but not read.

This adds support for that.