### PR TITLE
Fixed struct FFI for sliced pyarrow

### DIFF
--- a/src/array/struct_/ffi.rs
+++ b/src/array/struct_/ffi.rs
@@ -30,11 +30,38 @@ impl<A: ffi::ArrowArrayRef> FromFfi<A> for StructArray {
         let data_type = array.data_type().clone();
         let fields = Self::get_fields(&data_type);
 
+        let arrow_array = array.array();
         let validity = unsafe { array.validity() }?;
+        let len = arrow_array.len();
+        let offset = arrow_array.offset();
         let values = (0..fields.len())
             .map(|index| {
                 let child = array.child(index)?;
-                ffi::try_from(child)
+                ffi::try_from(child).map(|arr| {
+                    // there is a discrepancy with how arrow2 exports sliced
+                    // struct array and how pyarrow does it.
+                    // # Pyarrow
+                    // ## struct array len 3
+                    //  * slice 1 by with len 2
+                    //      offset on struct array: 1
+                    //      length on struct array: 2
+                    //      offset on value array: 0
+                    //      length on value array: 3
+                    // # Arrow2
+                    // ## struct array len 3
+                    //  * slice 1 by with len 2
+                    //      offset on struct array: 0
+                    //      length on struct array: 3
+                    //      offset on value array: 1
+                    //      length on value array: 2
+                    //
+                    // this branch will ensure both can round trip
+                    if arr.len() >= (len + offset) {
+                        arr.sliced(offset, len)
+                    } else {
+                        arr
+                    }
+                })
             })
             .collect::<Result<Vec<Box<dyn Array>>>>()?;
 

--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -182,19 +182,23 @@ impl Bitmap {
     /// The caller must ensure that `self.offset + offset + length <= self.len()`
     #[inline]
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
-        // count the smallest chunk
-        if length < self.length / 2 {
-            // count the null values in the slice
-            self.unset_bits = count_zeros(&self.bytes, self.offset + offset, length);
-        } else {
-            // subtract the null count of the chunks we slice off
-            let start_end = self.offset + offset + length;
-            let head_count = count_zeros(&self.bytes, self.offset, offset);
-            let tail_count = count_zeros(&self.bytes, start_end, self.length - length - offset);
-            self.unset_bits -= head_count + tail_count;
+        // first guard a no-op slice so that we don't do a bitcount
+        // if there isn't any data sliced
+        if !(offset == 0 && length == self.length) {
+            // count the smallest chunk
+            if length < self.length / 2 {
+                // count the null values in the slice
+                self.unset_bits = count_zeros(&self.bytes, self.offset + offset, length);
+            } else {
+                // subtract the null count of the chunks we slice off
+                let start_end = self.offset + offset + length;
+                let head_count = count_zeros(&self.bytes, self.offset, offset);
+                let tail_count = count_zeros(&self.bytes, start_end, self.length - length - offset);
+                self.unset_bits -= head_count + tail_count;
+            }
+            self.offset += offset;
+            self.length = length;
         }
-        self.offset += offset;
-        self.length = length;
     }
 
     /// Slices `self`, offsetting by `offset` and truncating up to `length` bits.


### PR DESCRIPTION
Fix ffi for sliced struct arrays coming from pyarrow. 