### PR TITLE
Add notice on mainenance bandwidth to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 [![](https://img.shields.io/crates/dv/arrow2.svg)](https://crates.io/crates/arrow2)
 [![](https://docs.rs/arrow2/badge.svg)](https://docs.rs/arrow2/)
 
+## Maintenance Status
+
+NOTE: as of May 2023, this crate has very limited maintenance capacity
+due to a lack of active maintainers. Thus it is unclear how quickly
+PRs will be reviewed, bugs fixed, or releases to crates.io
+made. Please see [arrow-rs](https://crates.io/crates/arrow) for a
+crate with more maintenance bandwidth and
+[#1429](https://github.com/jorgecarleitao/arrow2/issues/1429) for more
+details or to discuss the future this crate.
+
 A Rust crate to work with [Apache Arrow](https://arrow.apache.org/).
 The most feature-complete implementation of the Arrow format after the C++
 implementation.
@@ -50,7 +60,7 @@ for a detailed documentation of each of its APIs.
 * Extensive set of cargo feature flags to reduce compilation time and binary size
 * Fully-decoupled IO between CPU-bounded and IO-bounded tasks, allowing
   this crate to both be used in `async` contexts without blocking and leverage parallelism
-* Fastest known implementation of Avro and Parquet (e.g. faster than the official 
+* Fastest known implementation of Avro and Parquet (e.g. faster than the official
   C++ implementations)
 
 ## Safety and Security

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 
 ## Maintenance Status
 
-NOTE: as of May 2023, this crate has very limited maintenance capacity
-due to a lack of active maintainers. Thus it is unclear how quickly
-PRs will be reviewed, bugs fixed, or releases to crates.io
-made. Please see [arrow-rs](https://crates.io/crates/arrow) for a
+NOTE: as of May 2023, this crate has very limited maintenance
+capacity.  It may take significant time for PRs to be reviewed, bugs
+fixed, or releases made to crates.io.
+Please see [arrow-rs](https://crates.io/crates/arrow) for a
 crate with more maintenance bandwidth and
 [#1429](https://github.com/jorgecarleitao/arrow2/issues/1429) for more
 details or to discuss the future this crate.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Maintenance Status
 
 NOTE: as of May 2023, this crate is maintained by the
-[pol.rs](https://github.com/pola-rs/polars/) team.
+[pola.rs](https://github.com/pola-rs/polars/) team.
 Given limited maintenance
 capacity, it may take significant time for PRs to be reviewed, bugs
 fixed, or releases made to crates.io.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
 
 ## Maintenance Status
 
-NOTE: as of May 2023, this crate has very limited maintenance
-capacity.  It may take significant time for PRs to be reviewed, bugs
+NOTE: as of May 2023, this crate is maintained by the
+[pol.rs](https://github.com/pola-rs/polars/) team.
+Given limited maintenance
+capacity, it may take significant time for PRs to be reviewed, bugs
 fixed, or releases made to crates.io.
 Please see [arrow-rs](https://crates.io/crates/arrow) for a
 crate with more maintenance bandwidth and


### PR DESCRIPTION
Closes https://github.com/jorgecarleitao/arrow2/issues/1429

This PR clarifies for current and potential future users that the current maintenance bandwidth for this crate is very limited.  Related to @tustvold 's proposal on https://github.com/jorgecarleitao/arrow2/pull/1464

I also hope it might encourage other current users of arrow2 to offer to help maintain the crate if that is valuable to them.
