### PR TITLE
Added PushUnchecked trait

### DIFF
--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::array::PushUnchecked;
 use crate::{
     array::{
         physical_binary::extend_validity, Array, MutableArray, TryExtend, TryExtendFromSelf,
@@ -102,6 +103,15 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
             validity.push(true)
         }
         Ok(())
+    }
+
+    #[inline]
+    /// Needs to be called when a valid value was extended to this array.
+    /// This is a relatively low level function, prefer `try_push` when you can.
+    pub fn push_valid(&mut self) {
+        if let Some(validity) = &mut self.validity {
+            validity.push(true)
+        }
     }
 
     #[inline]
@@ -218,6 +228,22 @@ where
             self.push_null();
         }
         Ok(())
+    }
+}
+
+impl<M, I, T> PushUnchecked<Option<I>> for MutableFixedSizeListArray<M>
+where
+    M: MutableArray + Extend<Option<T>>,
+    I: IntoIterator<Item = Option<T>>,
+{
+    #[inline]
+    unsafe fn push_unchecked(&mut self, item: Option<I>) {
+        if let Some(items) = item {
+            self.values.extend(items);
+            self.push_valid();
+        } else {
+            self.push_null();
+        }
     }
 }
 

--- a/src/array/fixed_size_list/mutable.rs
+++ b/src/array/fixed_size_list/mutable.rs
@@ -236,6 +236,9 @@ where
     M: MutableArray + Extend<Option<T>>,
     I: IntoIterator<Item = Option<T>>,
 {
+    /// # Safety
+    /// The caller must ensure that the `I` iterates exactly over `size`
+    /// items, where `size` is the fixed size width.
     #[inline]
     unsafe fn push_unchecked(&mut self, item: Option<I>) {
         if let Some(items) = item {

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -754,6 +754,9 @@ pub trait TryPush<A> {
 /// A trait describing the ability of a struct to receive new items.
 pub trait PushUnchecked<A> {
     /// Push a new element that holds the invariants of the struct.
+    /// # Safety
+    /// The items must uphold the invariants of the struct
+    /// Read the specific implementation of the trait to understand what these are.
     unsafe fn push_unchecked(&mut self, item: A);
 }
 

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -751,6 +751,12 @@ pub trait TryPush<A> {
     fn try_push(&mut self, item: A) -> Result<()>;
 }
 
+/// A trait describing the ability of a struct to receive new items.
+pub trait PushUnchecked<A> {
+    /// Push a new element that holds the invariants of the struct.
+    unsafe fn push_unchecked(&mut self, item: A);
+}
+
 /// A trait describing the ability of a struct to extend from a reference of itself.
 /// Specialization of [`TryExtend`].
 pub trait TryExtendFromSelf {


### PR DESCRIPTION
This allows callers who build from trusted sources to elide the very expensive modulo check.