### PR TITLE
Implement into_inner for Utf8Array and BinaryArray for reusing Buffer allocations

### DIFF
--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -221,6 +221,17 @@ impl<O: Offset> BinaryArray<O> {
     impl_mut_validity!();
     impl_into_array!();
 
+    #[must_use]
+    pub fn into_inner(self) -> (DataType, OffsetsBuffer<O>, Buffer<u8>, Option<Bitmap>) {
+        let Self {
+            data_type,
+            offsets,
+            values,
+            validity,
+        } = self;
+        (data_type, offsets, values, validity)
+    }
+
     /// Try to convert this `BinaryArray` to a `MutableBinaryArray`
     #[must_use]
     pub fn into_mut(self) -> Either<Self, MutableBinaryArray<O>> {

--- a/src/array/binary/mod.rs
+++ b/src/array/binary/mod.rs
@@ -221,6 +221,7 @@ impl<O: Offset> BinaryArray<O> {
     impl_mut_validity!();
     impl_into_array!();
 
+    /// Returns its internal representation
     #[must_use]
     pub fn into_inner(self) -> (DataType, OffsetsBuffer<O>, Buffer<u8>, Option<Bitmap>) {
         let Self {

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -231,6 +231,16 @@ impl BooleanArray {
         self.values = values.into();
     }
 
+    #[must_use]
+    pub fn into_inner(self) -> (DataType, Bitmap, Option<Bitmap>) {
+        let Self {
+            data_type,
+            values,
+            validity,
+        } = self;
+        (data_type, values, validity)
+    }
+
     /// Try to convert this [`BooleanArray`] to a [`MutableBooleanArray`]
     pub fn into_mut(self) -> Either<Self, MutableBooleanArray> {
         use Either::*;

--- a/src/array/boolean/mod.rs
+++ b/src/array/boolean/mod.rs
@@ -231,16 +231,6 @@ impl BooleanArray {
         self.values = values.into();
     }
 
-    #[must_use]
-    pub fn into_inner(self) -> (DataType, Bitmap, Option<Bitmap>) {
-        let Self {
-            data_type,
-            values,
-            validity,
-        } = self;
-        (data_type, values, validity)
-    }
-
     /// Try to convert this [`BooleanArray`] to a [`MutableBooleanArray`]
     pub fn into_mut(self) -> Either<Self, MutableBooleanArray> {
         use Either::*;

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -240,6 +240,17 @@ impl<O: Offset> Utf8Array<O> {
     impl_mut_validity!();
     impl_into_array!();
 
+    #[must_use]
+    pub fn into_inner(self) -> (DataType, OffsetsBuffer<O>, Buffer<u8>, Option<Bitmap>) {
+        let Self {
+            data_type,
+            offsets,
+            values,
+            validity,
+        } = self;
+        (data_type, offsets, values, validity)
+    }
+
     /// Try to convert this `Utf8Array` to a `MutableUtf8Array`
     #[must_use]
     pub fn into_mut(self) -> Either<Self, MutableUtf8Array<O>> {

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -240,6 +240,7 @@ impl<O: Offset> Utf8Array<O> {
     impl_mut_validity!();
     impl_into_array!();
 
+    /// Returns its internal representation
     #[must_use]
     pub fn into_inner(self) -> (DataType, OffsetsBuffer<O>, Buffer<u8>, Option<Bitmap>) {
         let Self {


### PR DESCRIPTION
Many kernels operate directly on the underlying buffer, creating a new allocation for a new buffer with updated values, and re-use the other components of the array like the offsets, bitmap, etc.

In many cases, the the output of the kernel is transient, and the allocation for the buffer can be reused - as we run the kernel over a big set of arrays, we can reuse the same scratch buffer (similar to the scratch buffers used in the io modules).

Exposing `into_inner` allows applications to re-use the scratch allocation instead of calling out to the allocator for every array.

`PrimitiveArray`s and `BooleanArray`s already have an `into_inner` which deconstruct themselves into their constituent components - here we just bring Utf8Arrays and BinaryArrays in line with the other array types.
