### PR TITLE
feat: expose `non_null_sum`

### DIFF
--- a/src/compute/aggregate/sum.rs
+++ b/src/compute/aggregate/sum.rs
@@ -21,7 +21,8 @@ pub trait Sum<T> {
 }
 
 #[multiversion(targets = "simd")]
-pub fn nonnull_sum_slice<T>(values: &[T]) -> T
+/// Compute the sum of a slice
+pub fn sum_slice<T>(values: &[T]) -> T
 where
     T: NativeType + Simd + Add<Output = T> + std::iter::Sum<T>,
     T::Simd: Sum<T> + Add<Output = T::Simd>,
@@ -97,7 +98,7 @@ where
     }
 
     match array.validity() {
-        None => Some(nonnull_sum_slice(array.values())),
+        None => Some(sum_slice(array.values())),
         Some(bitmap) => Some(null_sum(array.values(), bitmap)),
     }
 }

--- a/src/compute/aggregate/sum.rs
+++ b/src/compute/aggregate/sum.rs
@@ -21,7 +21,7 @@ pub trait Sum<T> {
 }
 
 #[multiversion(targets = "simd")]
-fn nonnull_sum<T>(values: &[T]) -> T
+pub fn nonnull_sum_slice<T>(values: &[T]) -> T
 where
     T: NativeType + Simd + Add<Output = T> + std::iter::Sum<T>,
     T::Simd: Sum<T> + Add<Output = T::Simd>,
@@ -97,7 +97,7 @@ where
     }
 
     match array.validity() {
-        None => Some(nonnull_sum(array.values())),
+        None => Some(nonnull_sum_slice(array.values())),
         Some(bitmap) => Some(null_sum(array.values(), bitmap)),
     }
 }


### PR DESCRIPTION
This simd sum kernel is compiled for slices. If I want to make use of it, I currently need to allocate a primitive array, which is wasteful. This allows users to use that kernel on slices directly.