### PR TITLE
Fix missing `UInt64` case for page filtering

### DIFF
--- a/src/io/parquet/read/indexes/mod.rs
+++ b/src/io/parquet/read/indexes/mod.rs
@@ -147,7 +147,8 @@ fn deserialize(
                 .unwrap();
             Ok(primitive::deserialize_i32(&index.indexes, data_type).into())
         }
-        PhysicalType::Primitive(PrimitiveType::Int64) => {
+        PhysicalType::Primitive(PrimitiveType::UInt64)
+        | PhysicalType::Primitive(PrimitiveType::Int64) => {
             let index = indexes.pop_front().unwrap();
             match index.physical_type() {
                 ParquetPhysicalType::Int64 => {


### PR DESCRIPTION
Previously when attempting to deserialize `UInt64` fields for page filtering, the `read_filtered_pages` function would incorrectly raise a `NotYetImplemented` error.

The cause was a missing match case for `PrimitiveType:UInt64`.

