### PR TITLE
Relax the checks for the presence of ArrowSchema.name as this field is optional

### DIFF
--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -154,15 +154,18 @@ impl ArrowSchema {
     }
 
     /// returns the name of this schema.
+    ///
+    /// Since this field is optional, `""` is returned if it is not set (as per the spec).
     pub(crate) fn name(&self) -> &str {
-        assert!(!self.name.is_null());
+        if self.name.is_null() {
+            return ""
+        }
         // safe because the lifetime of `self.name` equals `self`
         unsafe { CStr::from_ptr(self.name) }.to_str().unwrap()
     }
 
     pub(crate) fn child(&self, index: usize) -> &'static Self {
         assert!(index < self.n_children as usize);
-        assert!(!self.name.is_null());
         unsafe { self.children.add(index).as_ref().unwrap().as_ref().unwrap() }
     }
 

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -158,7 +158,7 @@ impl ArrowSchema {
     /// Since this field is optional, `""` is returned if it is not set (as per the spec).
     pub(crate) fn name(&self) -> &str {
         if self.name.is_null() {
-            return ""
+            return "";
         }
         // safe because the lifetime of `self.name` equals `self`
         unsafe { CStr::from_ptr(self.name) }.to_str().unwrap()


### PR DESCRIPTION
As per the spec, the [ArrowSchema.name](https://arrow.apache.org/docs/format/CDataInterface.html#c.ArrowSchema.name) field is optional.
SQLite is an example of a producer which does not set this field.

This PR removes the checks on this field, returning an empty string if the field is NULL for backwards compatibility.