### PR TITLE
Allows to use wrappers other than Box to build ArrowArrayStreamReader.

### DIFF
--- a/src/ffi/stream.rs
+++ b/src/ffi/stream.rs
@@ -1,5 +1,5 @@
-use std::ops::DerefMut;
 use std::ffi::{CStr, CString};
+use std::ops::DerefMut;
 
 use crate::{array::Array, datatypes::Field, error::Error};
 

--- a/src/ffi/stream.rs
+++ b/src/ffi/stream.rs
@@ -1,3 +1,4 @@
+use std::ops::DerefMut;
 use std::ffi::{CStr, CString};
 
 use crate::{array::Array, datatypes::Field, error::Error};
@@ -45,12 +46,12 @@ unsafe fn handle_error(iter: &mut ArrowArrayStream) -> Error {
 }
 
 /// Implements an iterator of [`Array`] consumed from the [C stream interface](https://arrow.apache.org/docs/format/CStreamInterface.html).
-pub struct ArrowArrayStreamReader {
-    iter: Box<ArrowArrayStream>,
+pub struct ArrowArrayStreamReader<Iter: DerefMut<Target = ArrowArrayStream>> {
+    iter: Iter,
     field: Field,
 }
 
-impl ArrowArrayStreamReader {
+impl<Iter: DerefMut<Target = ArrowArrayStream>> ArrowArrayStreamReader<Iter> {
     /// Returns a new [`ArrowArrayStreamReader`]
     /// # Error
     /// Errors iff the [`ArrowArrayStream`] is out of specification
@@ -60,7 +61,7 @@ impl ArrowArrayStreamReader {
     /// In particular:
     /// * The `ArrowArrayStream` fulfills the invariants of the C stream interface
     /// * The schema `get_schema` produces fulfills the C data interface
-    pub unsafe fn try_new(mut iter: Box<ArrowArrayStream>) -> Result<Self, Error> {
+    pub unsafe fn try_new(mut iter: Iter) -> Result<Self, Error> {
         if iter.get_next.is_none() {
             return Err(Error::OutOfSpec(
                 "The C stream MUST contain a non-null get_next".to_string(),


### PR DESCRIPTION
Before, only Box<ArrowArrayStream> was supported by ArrowArrayStreamReader.

This PR enables support for ArrowArrayStreams which are:
- stack-allocated rather than boxed (plain `ArrowArrayStream`);
- not owned (`&mut ArrowArrayStream`);
- wrapped in a `Box<ArrowArrayStream, CustomAllocator>`;
- wrapped in a Box-like type other than `std::alloc::Box`;
- wrapped in an `Arc<Mutex<>>`
- etc.

This is especially important when we receive a `*mut ArrowArrayStream` from C (or anywhere else outside of Rust) as it will need to be cleaned up in the correct way, so a normal `Box` does not cut it.