### PR TITLE
ArrowArrayStreamReader::try_new(): Safeguard against released streams

### DIFF
--- a/src/ffi/stream.rs
+++ b/src/ffi/stream.rs
@@ -53,7 +53,8 @@ pub struct ArrowArrayStreamReader {
 impl ArrowArrayStreamReader {
     /// Returns a new [`ArrowArrayStreamReader`]
     /// # Error
-    /// Errors iff the [`ArrowArrayStream`] is out of specification
+    /// Errors iff the [`ArrowArrayStream`] is out of specification,
+    /// or was already released prior to calling this function.
     /// # Safety
     /// This method is intrinsically `unsafe` since it assumes that the `ArrowArrayStream`
     /// contains a valid Arrow C stream interface.
@@ -61,6 +62,12 @@ impl ArrowArrayStreamReader {
     /// * The `ArrowArrayStream` fulfills the invariants of the C stream interface
     /// * The schema `get_schema` produces fulfills the C data interface
     pub unsafe fn try_new(mut iter: Box<ArrowArrayStream>) -> Result<Self, Error> {
+        if iter.release.is_none() {
+            return Err(Error::InvalidArgumentError(
+                "The C stream was already released".to_string(),
+            ));
+        };
+
         if iter.get_next.is_none() {
             return Err(Error::OutOfSpec(
                 "The C stream MUST contain a non-null get_next".to_string(),

--- a/tests/it/ffi/stream.rs
+++ b/tests/it/ffi/stream.rs
@@ -1,6 +1,6 @@
 use arrow2::array::*;
 use arrow2::datatypes::Field;
-use arrow2::{error::Result, ffi};
+use arrow2::{error::Error, error::Result, ffi};
 
 fn _test_round_trip(arrays: Vec<Box<dyn Array>>) -> Result<()> {
     let field = Field::new("a", arrays[0].data_type().clone(), true);
@@ -29,4 +29,15 @@ fn round_trip() -> Result<()> {
     let array: Box<dyn Array> = Box::new(array);
 
     _test_round_trip(vec![array.clone(), array.clone(), array])
+}
+
+#[test]
+fn stream_reader_try_new_invalid_argument_error_on_released_stream() {
+    let released_stream = Box::new(ffi::ArrowArrayStream::empty());
+    let reader = unsafe { ffi::ArrowArrayStreamReader::try_new(released_stream) };
+    // poor man's assert_matches:
+    match reader {
+        Err(Error::OutOfSpec(_)) => {}
+        _ => panic!("ArrowArrayStreamReader::try_new did not return an InvalidArgumentError"),
+    }
 }

--- a/tests/it/ffi/stream.rs
+++ b/tests/it/ffi/stream.rs
@@ -37,7 +37,7 @@ fn stream_reader_try_new_invalid_argument_error_on_released_stream() {
     let reader = unsafe { ffi::ArrowArrayStreamReader::try_new(released_stream) };
     // poor man's assert_matches:
     match reader {
-        Err(Error::OutOfSpec(_)) => {}
+        Err(Error::InvalidArgumentError(_)) => {}
         _ => panic!("ArrowArrayStreamReader::try_new did not return an InvalidArgumentError"),
     }
 }


### PR DESCRIPTION
Before, passing an already-released stream to `ArrowArrayStreamReader::try_new()` would result in a call to `.get_schema()` (and later on when the reader is used possibly to `.get_next()`), which goes against the spec, as [those callbacks should not be called on released streams](https://arrow.apache.org/docs/format/CStreamInterface.html#the-arrowarraystream-structure).

This PR adds an extra check to the start of `try_new()` to safeguard against already-released streams.