### PR TITLE
Adding new constructor for MutableListArray

### DIFF
--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -149,6 +149,7 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
         offsets: Offsets<O>,
         validity: Option<MutableBitmap>,
     ) -> Self {
+        assert_eq!(values.len(), offsets.last().to_usize());
         let data_type = values.data_type().clone();
         Self {
             data_type,

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -142,6 +142,22 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
         Self::new_from(values, data_type, capacity)
     }
 
+    /// Creates a new [`MutableListArray`] from a [`MutableArray`], [`Offsets`] and
+    /// [`MutableBitmap`].
+    pub fn new_from_mutable(
+        values: M,
+        offsets: Offsets<O>,
+        validity: Option<MutableBitmap>,
+    ) -> Self {
+        let data_type = values.data_type().clone();
+        Self {
+            data_type,
+            offsets,
+            values,
+            validity,
+        }
+    }
+
     #[inline]
     /// Needs to be called when a valid value was extended to this array.
     /// This is a relatively low level function, prefer `try_push` when you can.


### PR DESCRIPTION
This PR addresses #1502 by introducing a new constructor for `MutableListArray` that allows for building an object based on existing values from a `MutableArray`, `Offsets`, and `MutableBitmap`. I'm interested in feedback on this relative to the question posed in #1502, and happy to add tests if this seems like the right approach.