### PR TITLE
defer null_count compute

### DIFF
--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -1,5 +1,4 @@
 //! Contains functionality to load an ArrayData from the C Data Interface
-use std::ptr::null;
 use std::sync::Arc;
 
 use crate::bitmap::utils::count_zeros;


### PR DESCRIPTION
fixes an edge case introduced in #1506. Only on arrays we know the `null_count` and don't have to recompute it.