### PR TITLE
Fixing dtype for MutableListArray

### DIFF
--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -149,6 +149,7 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
         offsets: Offsets<O>,
         validity: Option<MutableBitmap>,
     ) -> Self {
+        assert_eq!(values.len(), offsets.last().to_usize());
         let data_type = values.data_type().clone();
         Self {
             data_type,

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -142,6 +142,22 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
         Self::new_from(values, data_type, capacity)
     }
 
+    /// Creates a new [`MutableListArray`] from a [`MutableArray`], [`Offsets`] and
+    /// [`MutableBitmap`].
+    pub fn new_from_mutable(
+        values: M,
+        offsets: Offsets<O>,
+        validity: Option<MutableBitmap>,
+    ) -> Self {
+        let data_type = values.data_type().clone();
+        Self {
+            data_type,
+            offsets,
+            values,
+            validity,
+        }
+    }
+
     #[inline]
     /// Needs to be called when a valid value was extended to this array.
     /// This is a relatively low level function, prefer `try_push` when you can.

--- a/src/array/list/mutable.rs
+++ b/src/array/list/mutable.rs
@@ -150,7 +150,7 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
         validity: Option<MutableBitmap>,
     ) -> Self {
         assert_eq!(values.len(), offsets.last().to_usize());
-        let data_type = values.data_type().clone();
+        let data_type = ListArray::<O>::default_datatype(values.data_type().clone());
         Self {
             data_type,
             offsets,


### PR DESCRIPTION
In #1503, the dtype was incorrectly taken for the inner array, instead of the dtype for the overall List. This PR fixes that line.