### PR TITLE
Add datetime with timezone support to Json serializer

### DIFF
--- a/src/io/json/write/serialize.rs
+++ b/src/io/json/write/serialize.rs
@@ -11,8 +11,9 @@ use crate::offset::Offset;
 use crate::temporal_conversions::parse_offset_tz;
 use crate::temporal_conversions::{
     date32_to_date, date64_to_date, duration_ms_to_duration, duration_ns_to_duration,
-    duration_s_to_duration, duration_us_to_duration, timestamp_ms_to_datetime,
-    timestamp_ns_to_datetime, timestamp_s_to_datetime, timestamp_us_to_datetime,
+    duration_s_to_duration, duration_us_to_duration, parse_offset, timestamp_ms_to_datetime,
+    timestamp_ns_to_datetime, timestamp_s_to_datetime, timestamp_to_datetime,
+    timestamp_us_to_datetime,
 };
 use crate::util::lexical_to_bytes_mut;
 use crate::{array::*, datatypes::DataType, types::NativeType};

--- a/tests/it/io/json/write.rs
+++ b/tests/it/io/json/write.rs
@@ -413,3 +413,58 @@ fn write_timestamp() -> Result<()> {
 
     test!(array, expected)
 }
+
+#[test]
+fn write_timestamp_with_tz_secs() -> Result<()> {
+    let array = PrimitiveArray::new(
+        DataType::Timestamp(TimeUnit::Second, Some("UTC".to_owned())),
+        vec![10i64, 1 << 32, 1 << 33].into(),
+        None,
+    );
+
+    let expected =
+        r#"["1970-01-01T00:00:10+00:00","2106-02-07T06:28:16+00:00","2242-03-16T12:56:32+00:00"]"#;
+    test!(array, expected)
+}
+
+#[test]
+fn write_timestamp_with_tz_micros() -> Result<()> {
+    let array = PrimitiveArray::new(
+        DataType::Timestamp(TimeUnit::Microsecond, Some("+02:00".to_owned())),
+        vec![
+            10i64 * 1_000_000,
+            (1 << 32) * 1_000_000,
+            (1 << 33) * 1_000_000,
+            1_234_567_890_123_450,
+            1_234_567_890_120_000,
+        ]
+        .into(),
+        None,
+    );
+    // Note, default chrono DateTime string conversion strips off milli/micro/nanoseconds parts
+    // if they are zero
+    let expected = r#"["1970-01-01T02:00:10+02:00","2106-02-07T08:28:16+02:00","2242-03-16T14:56:32+02:00","2009-02-14T01:31:30.123450+02:00","2009-02-14T01:31:30.120+02:00"]"#;
+
+    test!(array, expected)
+}
+#[cfg(feature = "chrono-tz")]
+#[test]
+fn write_timestamp_with_chrono_tz_millis() -> Result<()> {
+    let array = PrimitiveArray::new(
+        DataType::Timestamp(TimeUnit::Millisecond, Some("Europe/Oslo".to_owned())),
+        vec![
+            10i64 * 1_000,
+            (1 << 32) * 1_000,
+            (1 << 33) * 1_000,
+            1_234_567_890_123,
+            1_239_874_560_120,
+        ]
+        .into(),
+        None,
+    );
+    // Note, default chrono DateTime string conversion strips off milli/micro/nanoseconds parts
+    // if they are zero
+    let expected = r#"["1970-01-01T01:00:10+01:00","2106-02-07T07:28:16+01:00","2242-03-16T13:56:32+01:00","2009-02-14T00:31:30.123+01:00","2009-04-16T11:36:00.120+02:00"]"#;
+
+    test!(array, expected)
+}


### PR DESCRIPTION
Hello,
We were trying to serialize data to Json via polars, but was hit with the missing support for DateTime types with timezone
support. I'm not too well versed in Rust, but I made an attempt at adding support for it.

It's inspired by how the CSV serializer does this. The Json serializer doesn't propagate errors back in `new_serializer()` as the CSV serializer does, I havn't attempted rewriting the interface, so this panics if invalid timezones are encontered. It should still be an improvement over the `todo!("still have to implement timezone")` in `src/io/json/write/serialize.rs`

`DateTime` serializing is done differently from serializing `NaiveDateTime`, which uses a space instead of a T as the date and time separator.
However the default chrono `to_string` on timezone aware `DateTIme` produces a space before the tz offset (e.g. 1996-12-19 16:39:57 +08:00) which Javascript engines won't parse as a Date(), so the RFC3339 format is used instead. `chrono-tz` timezones are also serialized with a fixed timezone offset format [+-hh:mm] so Javascrpt engines can make use of it.

I do have some future plans as well, including adding a options for custom time format string as is done in the CSV parser, some knobs to tune how `NaiveDateTime` is serialized, but this is perhaps a start.

