### PR TITLE
Fix list array parsing in pandas record json

### DIFF
--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -625,14 +625,11 @@ fn allocate_array(f: &Field) -> Box<dyn MutableArray> {
             f.data_type().clone(),
             *size,
         )),
-        DataType::List(inner) => match inner.data_type() {
-            DataType::List(_) => Box::new(MutableListArray::<i32, _>::new_from(
-                allocate_array(inner),
-                inner.data_type().clone(),
-                0,
-            )),
-            _ => allocate_array(inner),
-        },
+        DataType::List(inner) => Box::new(MutableListArray::<i32, _>::new_from(
+            allocate_array(inner),
+            f.data_type().clone(),
+            0,
+        )),
         _ => todo!(),
     }
 }

--- a/src/io/json/read/infer_schema.rs
+++ b/src/io/json/read/infer_schema.rs
@@ -38,12 +38,7 @@ pub fn infer_records_schema(json: &Value) -> Result<Schema> {
 
                 Ok(Field {
                     name: name.clone(),
-                    data_type: DataType::List(Box::new(Field {
-                        name: format!("{name}-records"),
-                        data_type,
-                        is_nullable: true,
-                        metadata: Metadata::default(),
-                    })),
+                    data_type,
                     is_nullable: true,
                     metadata: Metadata::default(),
                 })


### PR DESCRIPTION
The double-list construction was a mistake that prevents parsing of several valid types of pandas record json constructs.

Fix that by removing the nested lists and add a test verifying that it works.