### PR TITLE
Dont use offset as timezone

### DIFF
--- a/src/io/parquet/read/schema/convert.rs
+++ b/src/io/parquet/read/schema/convert.rs
@@ -79,7 +79,7 @@ fn from_int64(
             let timezone = if is_adjusted_to_utc {
                 // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
                 // A TIMESTAMP with isAdjustedToUTC=true is defined as [...] elapsed since the Unix epoch
-                Some("+00:00".to_string())
+                Some("UTC".to_string())
             } else {
                 // PARQUET:
                 // https://github.com/apache/parquet-format/blob/master/LogicalTypes.md
@@ -867,7 +867,7 @@ mod tests {
             ),
             Field::new(
                 "ts_nano",
-                DataType::Timestamp(TimeUnit::Nanosecond, Some("+00:00".to_string())),
+                DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".to_string())),
                 false,
             ),
         ];

--- a/tests/it/compute/temporal.rs
+++ b/tests/it/compute/temporal.rs
@@ -346,7 +346,7 @@ fn consistency_check<O: arrow2::types::NativeType>(
         Timestamp(TimeUnit::Millisecond, None),
         Timestamp(TimeUnit::Microsecond, None),
         Timestamp(TimeUnit::Nanosecond, None),
-        Timestamp(TimeUnit::Nanosecond, Some("+00:00".to_string())),
+        Timestamp(TimeUnit::Nanosecond, Some("UTC".to_string())),
         Time64(TimeUnit::Microsecond),
         Time64(TimeUnit::Nanosecond),
         Date32,


### PR DESCRIPTION
this came up here https://github.com/pola-rs/polars/issues/9586#issuecomment-1609854914

Any chance "UTC" could be used as the time zone, instead of "+00:00"? The latter isn't in the IANA timezone database and can't be parsed by `chrono-tz`