### PR TITLE
Pandas record support for utf8 and bool arrays

### DIFF
--- a/src/io/json/read/deserialize.rs
+++ b/src/io/json/read/deserialize.rs
@@ -620,6 +620,9 @@ fn allocate_array(f: &Field) -> Box<dyn MutableArray> {
         DataType::Float16 => Box::new(MutablePrimitiveArray::<f16>::new()),
         DataType::Float32 => Box::new(MutablePrimitiveArray::<f32>::new()),
         DataType::Float64 => Box::new(MutablePrimitiveArray::<f64>::new()),
+        DataType::Boolean => Box::new(MutableBooleanArray::new()),
+        DataType::Utf8 => Box::new(MutableUtf8Array::<i32>::new()),
+        DataType::LargeUtf8 => Box::new(MutableUtf8Array::<i64>::new()),
         DataType::FixedSizeList(inner, size) => Box::new(MutableFixedSizeListArray::<_>::new_from(
             allocate_array(inner),
             f.data_type().clone(),

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -108,8 +108,8 @@ fn read_json_records() -> Result<()> {
     let c_iter = c_iter.into_iter().map(Some);
     let mut c = MutableListArray::<i32, MutableUtf8Array<i32>>::new_with_field(
         MutableUtf8Array::<i32>::new(),
-        "c",
-        false,
+        "item",
+        true,
     );
 
     c.try_extend(c_iter).unwrap();
@@ -123,8 +123,8 @@ fn read_json_records() -> Result<()> {
     let d_iter = d_iter.into_iter().map(Some);
     let mut d = MutableListArray::<i32, MutableBooleanArray>::new_with_field(
         MutableBooleanArray::new(),
-        "d",
-        false,
+        "item",
+        true,
     );
 
     d.try_extend(d_iter).unwrap();

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -100,10 +100,7 @@ fn read_json_records() -> Result<()> {
     b.try_extend(b_iter).unwrap();
     let b_expected: ListArray<i32> = b.into();
 
-    let c_iter = vec![
-        vec![Some("test")],
-        vec![Some("string")],
-    ];
+    let c_iter = vec![vec![Some("test")], vec![Some("string")]];
 
     let c_iter = c_iter.into_iter().map(Some);
     let mut c = MutableListArray::<i32, MutableUtf8Array<i32>>::new_with_field(
@@ -115,10 +112,7 @@ fn read_json_records() -> Result<()> {
     c.try_extend(c_iter).unwrap();
     let c_expected: ListArray<i32> = c.into();
 
-    let d_iter = vec![
-        vec![Some(true)],
-        vec![Some(false)],
-    ];
+    let d_iter = vec![vec![Some(true)], vec![Some(false)]];
 
     let d_iter = d_iter.into_iter().map(Some);
     let mut d = MutableListArray::<i32, MutableBooleanArray>::new_with_field(
@@ -129,7 +123,6 @@ fn read_json_records() -> Result<()> {
 
     d.try_extend(d_iter).unwrap();
     let d_expected: ListArray<i32> = d.into();
-
 
     let json = json_deserializer::parse(data)?;
 

--- a/tests/it/io/json/read.rs
+++ b/tests/it/io/json/read.rs
@@ -43,7 +43,9 @@ fn read_json_records() -> Result<()> {
                 [2, 3],
                 [4, 5, 6]
             ],
-            "b": [1, 2, 3]
+            "b": [1, 2, 3],
+            "c": ["test"],
+            "d": [true]
         },
         {
             "a": [
@@ -53,7 +55,9 @@ fn read_json_records() -> Result<()> {
             ]
         },
         {
-            "b": [7, 8, 9]
+            "b": [7, 8, 9],
+            "c": ["string"],
+            "d": [false]
         }
     ]"#;
 
@@ -96,6 +100,37 @@ fn read_json_records() -> Result<()> {
     b.try_extend(b_iter).unwrap();
     let b_expected: ListArray<i32> = b.into();
 
+    let c_iter = vec![
+        vec![Some("test")],
+        vec![Some("string")],
+    ];
+
+    let c_iter = c_iter.into_iter().map(Some);
+    let mut c = MutableListArray::<i32, MutableUtf8Array<i32>>::new_with_field(
+        MutableUtf8Array::<i32>::new(),
+        "c",
+        false,
+    );
+
+    c.try_extend(c_iter).unwrap();
+    let c_expected: ListArray<i32> = c.into();
+
+    let d_iter = vec![
+        vec![Some(true)],
+        vec![Some(false)],
+    ];
+
+    let d_iter = d_iter.into_iter().map(Some);
+    let mut d = MutableListArray::<i32, MutableBooleanArray>::new_with_field(
+        MutableBooleanArray::new(),
+        "d",
+        false,
+    );
+
+    d.try_extend(d_iter).unwrap();
+    let d_expected: ListArray<i32> = d.into();
+
+
     let json = json_deserializer::parse(data)?;
 
     let schema = read::infer_records_schema(&json)?;
@@ -106,6 +141,10 @@ fn read_json_records() -> Result<()> {
             (&a_expected, arr.as_ref())
         } else if f.name == "b" {
             (&b_expected, arr.as_ref())
+        } else if f.name == "c" {
+            (&c_expected, arr.as_ref())
+        } else if f.name == "d" {
+            (&d_expected, arr.as_ref())
         } else {
             panic!("unexpected field found: {}", f.name);
         };


### PR DESCRIPTION
Pretty straightforward, these were an oversight when this was originally implemented.