### PR TITLE
Sampling tests for parquet round trips

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,14 @@ proptest = { version = "1", default_features = false, features = ["std"] }
 avro-rs = { version = "0.13", features = ["snappy"] }
 # use for flaky testing
 rand = "0.8"
+# use for generating and testing random data samples
+sample-arrow2 = "0.1"
+sample-std = "0.1"
+sample-test = "0.1"
+
+# ugly hack needed to match this library in sample_arrow2
+[patch.crates-io]
+arrow2 = { path = "." }
 
 [package.metadata.docs.rs]
 features = ["full"]
@@ -187,6 +195,9 @@ io_parquet_compression = [
     "io_parquet_lz4",
     "io_parquet_brotli"
 ]
+
+# sample testing of generated arrow data
+io_parquet_sample_test = ["io_parquet"]
 
 # compression backends
 io_parquet_zstd = ["parquet2/zstd"]

--- a/tests/it/io/parquet/mod.rs
+++ b/tests/it/io/parquet/mod.rs
@@ -21,6 +21,9 @@ mod read_indexes;
 mod write;
 mod write_async;
 
+#[cfg(feature = "io_parquet_sample_test")]
+mod sample_tests;
+
 type ArrayStats = (Box<dyn Array>, Statistics);
 
 fn new_struct(

--- a/tests/it/io/parquet/sample_tests.rs
+++ b/tests/it/io/parquet/sample_tests.rs
@@ -1,0 +1,119 @@
+use arrow2::io::parquet::write::*;
+use arrow2::{
+    chunk::Chunk,
+    datatypes::{Field, Metadata, Schema},
+    error::Result,
+    io::parquet::read as p_read,
+};
+use std::borrow::Borrow;
+use std::io::Cursor;
+
+use sample_arrow2::{
+    array::ArbitraryArray,
+    chunk::{ArbitraryChunk, ChainedChunk},
+    datatypes::{sample_flat, ArbitraryDataType},
+};
+use sample_std::{Chance, Random, Regex, Sample};
+use sample_test::sample_test;
+
+fn deep_chunk(depth: usize, len: usize) -> ArbitraryChunk<Regex, Chance> {
+    let names = Regex::new("[a-z]{4,8}");
+    let data_type = ArbitraryDataType {
+        struct_branch: 1..3,
+        names: names.clone(),
+        // TODO: this breaks the test
+        // nullable: Chance(0.5),
+        nullable: Chance(0.0),
+        flat: sample_flat,
+    }
+    .sample_depth(depth);
+
+    let array = ArbitraryArray {
+        names,
+        branch: 0..10,
+        len: len..(len + 1),
+        null: Chance(0.1),
+        // TODO: this breaks the test
+        // is_nullable: true,
+        is_nullable: false,
+    };
+
+    ArbitraryChunk {
+        // TODO: shrinking appears to be an issue with chunks this large. issues
+        // currently reproduce on the smaller sizes anyway.
+        // chunk_len: 10..1000,
+        chunk_len: 1..10,
+        array_count: 1..2,
+        data_type,
+        array,
+    }
+}
+
+#[sample_test]
+fn round_trip_sample(
+    #[sample(deep_chunk(5, 100).sample_one())] chained: ChainedChunk,
+) -> Result<()> {
+    sample_test::env_logger_init();
+    let chunks = vec![chained.value];
+    let name = Regex::new("[a-z]{4, 8}");
+    let mut g = Random::new();
+
+    // TODO: this probably belongs in a helper in sample-arrow2
+    let schema = Schema {
+        fields: chunks
+            .first()
+            .unwrap()
+            .iter()
+            .map(|arr| {
+                Field::new(
+                    name.generate(&mut g),
+                    arr.data_type().clone(),
+                    arr.validity().is_some(),
+                )
+            })
+            .collect(),
+        metadata: Metadata::default(),
+    };
+
+    let options = WriteOptions {
+        write_statistics: true,
+        compression: CompressionOptions::Uncompressed,
+        version: Version::V2,
+        data_pagesize_limit: None,
+    };
+
+    let encodings: Vec<_> = schema
+        .borrow()
+        .fields
+        .iter()
+        .map(|field| transverse(field.data_type(), |_| Encoding::Plain))
+        .collect();
+
+    let row_groups = RowGroupIterator::try_new(
+        chunks.clone().into_iter().map(Ok),
+        &schema,
+        options,
+        encodings,
+    )?;
+
+    let buffer = Cursor::new(vec![]);
+    let mut writer = FileWriter::try_new(buffer, schema, options)?;
+
+    for group in row_groups {
+        writer.write(group?)?;
+    }
+    writer.end(None)?;
+
+    let mut buffer = writer.into_inner();
+
+    let metadata = p_read::read_metadata(&mut buffer)?;
+    let schema = p_read::infer_schema(&metadata)?;
+
+    let mut reader = p_read::FileReader::new(buffer, metadata.row_groups, schema, None, None, None);
+
+    let result: Vec<_> = reader.collect::<Result<_>>()?;
+
+    assert_eq!(result, chunks);
+
+    Ok(())
+}


### PR DESCRIPTION
This uses [`sample-test`](https://docs.rs/sample-test/latest/sample_test/), and [`sample-arrow2`](https://github.com/WallarooLabs/sample-test/tree/main/sample-arrow2), which we built specifically for this purpose. See the [README](https://github.com/WallarooLabs/sample-test) for why we felt `quickcheck` and `proptest` were unsuitable.

I'm not sure if we'd rather have the libraries be optional `[dependencies]` instead of `[dev-dependencies]` (which cannot be optional). I figured this should be behind a feature flag though.

When run exhaustively (see the commented `TODO` lines), this appears to unearth more errors in the parquet IO code. Issues appear to trigger with nesting and nullable fields in combination. Some examples:

```
"assertion failed: `(left == right)`\n 
left: `[Chunk { arrays: [ListArray[[{wttdx: -3458878700, yjsyrg: [None]}]]] }]`,\n
right: `[Chunk { arrays: [ListArray[[{wttdx: -3458878700, yjsyrg: None}]]] }]`"
```

```
"assertion failed: `(left == right)`\n  
left: `[Chunk { arrays: [ListArray[[[None]]]] }]`,\n 
right: `[Chunk { arrays: [ListArray[[None]]] }]`"
```

My prior experience with the def/rep level encoder obviously leads me to suspect that code. I know it was recently rewritten, but it's a very complex subject and I'm not shocked that it may need more work.

Let me know how I can help assist. In particular, the shrinking behavior in `sample-arrow2` is suboptimal due to chained resampling and some implementation hacks that can probably be improved. I can definitely assist if you're playing around with this and are having trouble shrinking back to useful exemplars.

Setting the chunk length to a small value appears to be generating good counterexamples for now.