### PR TITLE
fix oob if in .get

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -70,12 +70,21 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
 
     /// Returns whether slot `i` is null.
     /// # Panic
-    /// Panics iff `i >= self.len()` and validity is set.
+    /// Panics iff `i >= self.len()`
     #[inline]
     fn is_null(&self, i: usize) -> bool {
+        assert!(i < self.len());
+        unsafe { self.is_null_unchecked(i) }
+    }
+
+    /// Returns whether slot `i` is null.
+    /// # Safety
+    /// The caller must ensure `i < self.len()`
+    #[inline]
+    unsafe fn is_null_unchecked(&self, i: usize) -> bool {
         self.validity()
             .as_ref()
-            .map(|x| !x.get_bit(i))
+            .map(|x| !x.get_bit_unchecked(i))
             .unwrap_or(false)
     }
 

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -70,7 +70,7 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
 
     /// Returns whether slot `i` is null.
     /// # Panic
-    /// Panics iff `i >= self.len()`
+    /// Panics iff `i >= self.len()`.
     #[inline]
     fn is_null(&self, i: usize) -> bool {
         assert!(i < self.len());

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -70,7 +70,7 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
 
     /// Returns whether slot `i` is null.
     /// # Panic
-    /// Panics iff `i >= self.len()`.
+    /// Panics iff `i >= self.len()` and validity is set.
     #[inline]
     fn is_null(&self, i: usize) -> bool {
         self.validity()

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -203,7 +203,6 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// iff `i >= self.len()`
     #[inline]
     pub fn get(&self, i: usize) -> Option<T> {
-        assert!(i >= self.len());
         if !self.is_null(i) {
             // soundness: Array::is_null panics if i >= self.len
             unsafe { Some(self.value_unchecked(i)) }

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -203,6 +203,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// iff `i >= self.len()`
     #[inline]
     pub fn get(&self, i: usize) -> Option<T> {
+        assert!(i >= self.len());
         if !self.is_null(i) {
             // soundness: Array::is_null panics if i >= self.len
             unsafe { Some(self.value_unchecked(i)) }

--- a/src/io/ipc/read/file.rs
+++ b/src/io/ipc/read/file.rs
@@ -216,7 +216,7 @@ pub fn read_file_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetadata
     let start = reader.stream_position()?;
     reader.read_exact(&mut magic_buffer)?;
     if magic_buffer != ARROW_MAGIC_V2 {
-        if &magic_buffer[..4] == ARROW_MAGIC_V1 {
+        if magic_buffer[..4] == ARROW_MAGIC_V1 {
             return Err(Error::NotYetImplemented("feather v1 not supported".into()));
         }
         return Err(Error::from(OutOfSpecKind::InvalidHeader));


### PR DESCRIPTION
if the array doesn't have a validity `is_null` would not panic on OOB, leading to wrong assumptions in `get` that could lead to OOB.