### PR TITLE
Fix `any`/`all` for Kleene logic

### DIFF
--- a/src/compute/boolean.rs
+++ b/src/compute/boolean.rs
@@ -230,7 +230,24 @@ pub fn or_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray {
     }
 }
 
-/// Returns whether any of the values in the array is `true`
+/// Returns whether any of the values in the array are `true`.
+///
+/// Null values are treated as `false`.
+///
+/// # Example
+///
+/// ```
+/// use arrow2::array::BooleanArray;
+/// use arrow2::compute::boolean::any;
+///
+/// let a = BooleanArray::from(&[Some(true), Some(false)]);
+/// let b = BooleanArray::from(&[Some(false), Some(false)]);
+/// let c = BooleanArray::from(&[None, Some(false)]);
+///
+/// assert_eq!(any(&a), true);
+/// assert_eq!(any(&b), false);
+/// assert_eq!(any(&c), false);
+/// ```
 pub fn any(array: &BooleanArray) -> bool {
     if array.is_empty() {
         false
@@ -242,7 +259,24 @@ pub fn any(array: &BooleanArray) -> bool {
     }
 }
 
-/// Check if all of the values in the array are `true`
+/// Returns whether all values in the array are `true`.
+///
+/// Null values are treated as `false`.
+///
+/// # Example
+///
+/// ```
+/// use arrow2::array::BooleanArray;
+/// use arrow2::compute::boolean::all;
+///
+/// let a = BooleanArray::from(&[Some(true), Some(true)]);
+/// let b = BooleanArray::from(&[Some(false), Some(true)]);
+/// let c = BooleanArray::from(&[None, Some(true)]);
+///
+/// assert_eq!(all(&a), true);
+/// assert_eq!(all(&b), false);
+/// assert_eq!(all(&c), false);
+/// ```
 pub fn all(array: &BooleanArray) -> bool {
     if array.is_empty() {
         true

--- a/src/compute/boolean.rs
+++ b/src/compute/boolean.rs
@@ -232,7 +232,7 @@ pub fn or_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray {
 
 /// Returns whether any of the values in the array are `true`.
 ///
-/// Null values are treated as `false`.
+/// Null values are ignored.
 ///
 /// # Example
 ///
@@ -261,7 +261,7 @@ pub fn any(array: &BooleanArray) -> bool {
 
 /// Returns whether all values in the array are `true`.
 ///
-/// Null values are treated as `false`.
+/// Null values are ignored.
 ///
 /// # Example
 ///
@@ -275,13 +275,13 @@ pub fn any(array: &BooleanArray) -> bool {
 ///
 /// assert_eq!(all(&a), true);
 /// assert_eq!(all(&b), false);
-/// assert_eq!(all(&c), false);
+/// assert_eq!(all(&c), true);
 /// ```
 pub fn all(array: &BooleanArray) -> bool {
     if array.is_empty() {
         true
     } else if array.null_count() > 0 {
-        false
+        !array.into_iter().any(|v| v == Some(false))
     } else {
         let vals = array.values();
         vals.unset_bits() == 0

--- a/src/compute/boolean.rs
+++ b/src/compute/boolean.rs
@@ -251,7 +251,7 @@ pub fn or_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray {
 pub fn any(array: &BooleanArray) -> bool {
     if array.is_empty() {
         false
-    } else if array.validity().is_some() {
+    } else if array.null_count() > 0 {
         array.into_iter().any(|v| v == Some(true))
     } else {
         let vals = array.values();

--- a/src/compute/boolean_kleene.rs
+++ b/src/compute/boolean_kleene.rs
@@ -234,26 +234,70 @@ pub fn and_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray 
     }
 }
 
-/// Returns whether any of the values in the array is `true`
-pub fn any(array: &BooleanArray) -> bool {
+/// Returns whether any of the values in the array are `true`.
+///
+/// The output is unknown (`None`) if the array contains any null values and
+/// no `true` values.
+///
+/// # Example
+///
+/// ```
+/// use arrow2::array::BooleanArray;
+/// use arrow2::compute::boolean_kleene::any;
+///
+/// let a = BooleanArray::from(&[Some(true), Some(false)]);
+/// let b = BooleanArray::from(&[Some(false), Some(false)]);
+/// let c = BooleanArray::from(&[None, Some(false)]);
+///
+/// assert_eq!(any(&a), Some(true));
+/// assert_eq!(any(&b), Some(false));
+/// assert_eq!(any(&c), None);
+/// ```
+pub fn any(array: &BooleanArray) -> Option<bool> {
     if array.is_empty() {
-        false
+        Some(false)
     } else if array.validity().is_some() {
-        array.into_iter().any(|v| v == Some(true))
+        if array.into_iter().any(|v| v == Some(true)) {
+            Some(true)
+        } else {
+            None
+        }
     } else {
         let vals = array.values();
-        vals.unset_bits() != vals.len()
+        Some(vals.unset_bits() != vals.len())
     }
 }
 
-/// Returns whether all values in the array are `true`
-pub fn all(array: &BooleanArray) -> bool {
+/// Returns whether all values in the array are `true`.
+///
+/// The output is unknown (`None`) if the array contains any null values and
+/// no `false` values.
+///
+/// # Example
+///
+/// ```
+/// use arrow2::array::BooleanArray;
+/// use arrow2::compute::boolean_kleene::all;
+///
+/// let a = BooleanArray::from(&[Some(true), Some(true)]);
+/// let b = BooleanArray::from(&[Some(false), Some(true)]);
+/// let c = BooleanArray::from(&[None, Some(true)]);
+///
+/// assert_eq!(all(&a), Some(true));
+/// assert_eq!(all(&b), Some(false));
+/// assert_eq!(all(&c), None);
+/// ```
+pub fn all(array: &BooleanArray) -> Option<bool> {
     if array.is_empty() {
-        true
-    } else if array.null_count() > 0 {
-        false
+        Some(true)
+    } else if array.validity().is_some() {
+        if array.into_iter().any(|v| v == Some(false)) {
+            Some(false)
+        } else {
+            None
+        }
     } else {
         let vals = array.values();
-        vals.unset_bits() == 0
+        Some(vals.unset_bits() == 0)
     }
 }

--- a/src/compute/boolean_kleene.rs
+++ b/src/compute/boolean_kleene.rs
@@ -256,7 +256,7 @@ pub fn and_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray 
 pub fn any(array: &BooleanArray) -> Option<bool> {
     if array.is_empty() {
         Some(false)
-    } else if array.validity().is_some() {
+    } else if array.null_count() > 0 {
         if array.into_iter().any(|v| v == Some(true)) {
             Some(true)
         } else {
@@ -290,7 +290,7 @@ pub fn any(array: &BooleanArray) -> Option<bool> {
 pub fn all(array: &BooleanArray) -> Option<bool> {
     if array.is_empty() {
         Some(true)
-    } else if array.validity().is_some() {
+    } else if array.null_count() > 0 {
         if array.into_iter().any(|v| v == Some(false)) {
             Some(false)
         } else {

--- a/tests/it/compute/boolean.rs
+++ b/tests/it/compute/boolean.rs
@@ -429,21 +429,24 @@ fn test_any_all() {
     assert!(!any(&array));
     assert!(!all(&array));
     let array = BooleanArray::from(&[None, Some(true), Some(true)]);
-    assert!(!all(&array));
     assert!(any(&array));
+    assert!(all(&array));
     let array = BooleanArray::from_iter(std::iter::repeat(false).take(10).map(Some));
     assert!(!any(&array));
     assert!(!all(&array));
     let array = BooleanArray::from_iter(std::iter::repeat(true).take(10).map(Some));
+    assert!(any(&array));
     assert!(all(&array));
-    assert!(any(&array));
     let array = BooleanArray::from_iter([true, false, true, true].map(Some));
-    assert!(!all(&array));
     assert!(any(&array));
+    assert!(!all(&array));
     let array = BooleanArray::from(&[Some(true)]);
     assert!(any(&array));
     assert!(all(&array));
     let array = BooleanArray::from(&[Some(false)]);
     assert!(!any(&array));
     assert!(!all(&array));
+    let array = BooleanArray::from(&[]);
+    assert!(!any(&array));
+    assert!(all(&array));
 }

--- a/tests/it/compute/boolean_kleene.rs
+++ b/tests/it/compute/boolean_kleene.rs
@@ -218,6 +218,6 @@ fn array_or_none() {
 #[test]
 fn array_empty() {
     let array = BooleanArray::from(&[]);
-    assert!(!any(&array));
-    assert!(all(&array));
+    assert_eq!(any(&array), Some(false));
+    assert_eq!(all(&array), Some(true));
 }


### PR DESCRIPTION
#### Changes

* `any` and `all` in the `boolean_kleene` module now return an `Option<bool>`. _(The versions in the `boolean` module are untouched.)_
* Added doctests for both.