### PR TITLE
MutableDictionaryArray rewrite: use values stored in the array instead of the hash->hash map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ hash_hasher = "^2.0.3"
 simdutf8 = "0.1.4"
 
 # A Rust port of SwissTable
-hashbrown = { version = "0.14", default-features = false, optional = true }
+hashbrown = { version = "0.14", default-features = false, features = ["ahash"] }
 
 # for timezone support
 chrono-tz = { version = "0.8", optional = true }
@@ -243,7 +243,7 @@ compute_merge_sort = ["itertools", "compute_sort"]
 compute_nullif = ["compute_comparison"]
 compute_partition = ["compute_sort"]
 compute_regex_match = ["regex"]
-compute_sort = ["compute_take", "hashbrown"]
+compute_sort = ["compute_take"]
 compute_substring = []
 compute_take = []
 compute_temporal = []

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -20,6 +20,7 @@ mod iterator;
 mod mutable;
 use crate::array::specification::check_indexes_unchecked;
 mod typed_iterator;
+mod value_map;
 
 use crate::array::dictionary::typed_iterator::{DictValue, DictionaryValuesIterTyped};
 pub use iterator::*;

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -67,15 +67,31 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
     /// # Errors
     /// Errors if the array is non-empty.
     pub fn try_empty(values: M) -> Result<Self> {
-        let value_map = ValueMap::<K, M>::try_empty(values)?;
+        Ok(Self::from_value_map(ValueMap::<K, M>::try_empty(values)?))
+    }
+
+    /// Creates an empty [`MutableDictionaryArray`] preloaded with a given dictionary of values.
+    /// Indices associated with those values are automatically assigned based on the order of
+    /// the values.
+    /// # Errors
+    /// Errors if there's more values than the maximum value of `K`.
+    pub fn from_values(values: M) -> Result<Self>
+    where
+        M: Indexable,
+        M::Type: Eq + Hash,
+    {
+        Ok(Self::from_value_map(ValueMap::<K, M>::from_values(values)?))
+    }
+
+    fn from_value_map(value_map: ValueMap<K, M>) -> Self {
         let keys = MutablePrimitiveArray::<K>::new();
         let data_type =
             DataType::Dictionary(K::KEY_TYPE, Box::new(value_map.data_type().clone()), false);
-        Ok(Self {
+        Self {
             data_type,
             map: value_map,
             keys,
-        })
+        }
     }
 
     /// pushes a null value

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -68,17 +68,7 @@ impl<K: DictionaryKey, M: MutableArray> From<M> for MutableDictionaryArray<K, M>
 impl<K: DictionaryKey, M: MutableArray + Default> MutableDictionaryArray<K, M> {
     /// Creates an empty [`MutableDictionaryArray`].
     pub fn new() -> Self {
-        let values = M::default();
-        Self {
-            data_type: DataType::Dictionary(
-                K::KEY_TYPE,
-                Box::new(values.data_type().clone()),
-                false,
-            ),
-            keys: MutablePrimitiveArray::<K>::new(),
-            map: HashedMap::default(),
-            values,
-        }
+        Self::from(M::default())
     }
 }
 

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -1,15 +1,15 @@
-use std::hash::{Hash, Hasher};
-use std::{collections::hash_map::DefaultHasher, sync::Arc};
+use std::hash::Hash;
+use std::sync::Arc;
 
-use hash_hasher::HashedMap;
-
+use crate::array::indexable::{AsIndexed, Indexable};
 use crate::{
     array::{primitive::MutablePrimitiveArray, Array, MutableArray, TryExtend, TryPush},
     bitmap::MutableBitmap,
     datatypes::DataType,
-    error::{Error, Result},
+    error::Result,
 };
 
+use super::value_map::ValueMap;
 use super::{DictionaryArray, DictionaryKey};
 
 /// A mutable, strong-typed version of [`DictionaryArray`].
@@ -30,37 +30,21 @@ use super::{DictionaryArray, DictionaryKey};
 #[derive(Debug)]
 pub struct MutableDictionaryArray<K: DictionaryKey, M: MutableArray> {
     data_type: DataType,
+    map: ValueMap<K, M>,
+    // invariant: `max(keys) < map.values().len()`
     keys: MutablePrimitiveArray<K>,
-    map: HashedMap<u64, K>,
-    // invariant: `keys.len() <= values.len()`
-    values: M,
 }
 
 impl<K: DictionaryKey, M: MutableArray> From<MutableDictionaryArray<K, M>> for DictionaryArray<K> {
-    fn from(mut other: MutableDictionaryArray<K, M>) -> Self {
+    fn from(other: MutableDictionaryArray<K, M>) -> Self {
         // Safety - the invariant of this struct ensures that this is up-held
         unsafe {
             DictionaryArray::<K>::try_new_unchecked(
                 other.data_type,
                 other.keys.into(),
-                other.values.as_box(),
+                other.map.into_boxed().as_box(),
             )
             .unwrap()
-        }
-    }
-}
-
-impl<K: DictionaryKey, M: MutableArray> From<M> for MutableDictionaryArray<K, M> {
-    fn from(values: M) -> Self {
-        Self {
-            data_type: DataType::Dictionary(
-                K::KEY_TYPE,
-                Box::new(values.data_type().clone()),
-                false,
-            ),
-            keys: MutablePrimitiveArray::<K>::new(),
-            map: HashedMap::default(),
-            values,
         }
     }
 }
@@ -68,7 +52,7 @@ impl<K: DictionaryKey, M: MutableArray> From<M> for MutableDictionaryArray<K, M>
 impl<K: DictionaryKey, M: MutableArray + Default> MutableDictionaryArray<K, M> {
     /// Creates an empty [`MutableDictionaryArray`].
     pub fn new() -> Self {
-        Self::from(M::default())
+        Self::try_empty(M::default()).unwrap()
     }
 }
 
@@ -79,23 +63,19 @@ impl<K: DictionaryKey, M: MutableArray + Default> Default for MutableDictionaryA
 }
 
 impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
-    /// Returns whether the value should be pushed to the values or not
-    fn try_push_valid<T: Hash>(&mut self, value: &T) -> Result<bool> {
-        let mut hasher = DefaultHasher::new();
-        value.hash(&mut hasher);
-        let hash = hasher.finish();
-        match self.map.get(&hash) {
-            Some(key) => {
-                self.keys.push(Some(*key));
-                Ok(false)
-            }
-            None => {
-                let key = K::try_from(self.map.len()).map_err(|_| Error::Overflow)?;
-                self.map.insert(hash, key);
-                self.keys.push(Some(key));
-                Ok(true)
-            }
-        }
+    /// Creates an empty [`MutableDictionaryArray`] from a given empty values array.
+    /// # Errors
+    /// Errors if the array is non-empty.
+    pub fn try_empty(values: M) -> Result<Self> {
+        let value_map = ValueMap::<K, M>::try_empty(values)?;
+        let keys = MutablePrimitiveArray::<K>::new();
+        let data_type =
+            DataType::Dictionary(K::KEY_TYPE, Box::new(value_map.data_type().clone()), false);
+        Ok(Self {
+            data_type,
+            map: value_map,
+            keys,
+        })
     }
 
     /// pushes a null value
@@ -103,14 +83,9 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
         self.keys.push(None)
     }
 
-    /// returns a mutable reference to the inner values.
-    fn mut_values(&mut self) -> &mut M {
-        &mut self.values
-    }
-
     /// returns a reference to the inner values.
     pub fn values(&self) -> &M {
-        &self.values
+        self.map.values()
     }
 
     /// converts itself into [`Arc<dyn Array>`]
@@ -132,13 +107,8 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
 
     /// Shrinks the capacity of the [`MutableDictionaryArray`] to fit its current length.
     pub fn shrink_to_fit(&mut self) {
-        self.values.shrink_to_fit();
+        self.map.shrink_to_fit();
         self.keys.shrink_to_fit();
-    }
-
-    /// Returns the dictionary map
-    pub fn map(&self) -> &HashedMap<u64, K> {
-        &self.map
     }
 
     /// Returns the dictionary keys
@@ -150,7 +120,7 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
         DictionaryArray::<K>::try_new(
             self.data_type.clone(),
             std::mem::take(&mut self.keys).into(),
-            self.values.as_box(),
+            self.map.take_into(),
         )
         .unwrap()
     }
@@ -198,17 +168,20 @@ impl<K: DictionaryKey, M: 'static + MutableArray> MutableArray for MutableDictio
     }
 }
 
-impl<K, M, T: Hash> TryExtend<Option<T>> for MutableDictionaryArray<K, M>
+impl<K, M, T> TryExtend<Option<T>> for MutableDictionaryArray<K, M>
 where
     K: DictionaryKey,
-    M: MutableArray + TryExtend<Option<T>>,
+    M: MutableArray + Indexable + TryExtend<Option<T>>,
+    T: AsIndexed<M>,
+    M::Type: Eq + Hash,
 {
     fn try_extend<II: IntoIterator<Item = Option<T>>>(&mut self, iter: II) -> Result<()> {
         for value in iter {
             if let Some(value) = value {
-                if self.try_push_valid(&value)? {
-                    self.mut_values().try_extend(std::iter::once(Some(value)))?;
-                }
+                let key = self
+                    .map
+                    .try_push_valid(value, |arr, v| arr.try_extend(std::iter::once(Some(v))))?;
+                self.keys.try_push(Some(key))?;
             } else {
                 self.push_null();
             }
@@ -220,19 +193,19 @@ where
 impl<K, M, T> TryPush<Option<T>> for MutableDictionaryArray<K, M>
 where
     K: DictionaryKey,
-    M: MutableArray + TryPush<Option<T>>,
-    T: Hash,
+    M: MutableArray + Indexable + TryPush<Option<T>>,
+    T: AsIndexed<M>,
+    M::Type: Eq + Hash,
 {
     fn try_push(&mut self, item: Option<T>) -> Result<()> {
         if let Some(value) = item {
-            if self.try_push_valid(&value)? {
-                self.values.try_push(Some(value))
-            } else {
-                Ok(())
-            }
+            let key = self
+                .map
+                .try_push_valid(value, |arr, v| arr.try_push(Some(v)))?;
+            self.keys.try_push(Some(key))?;
         } else {
             self.push_null();
-            Ok(())
         }
+        Ok(())
     }
 }

--- a/src/array/dictionary/value_map.rs
+++ b/src/array/dictionary/value_map.rs
@@ -1,0 +1,192 @@
+use std::borrow::Borrow;
+use std::fmt::{self, Debug};
+use std::hash::{Hash, Hasher};
+use std::pin::Pin;
+use std::ptr::NonNull;
+
+use hashbrown::{Equivalent, HashMap};
+
+use crate::array::Array;
+use crate::{
+    array::indexable::{AsIndexed, Indexable},
+    array::MutableArray,
+    datatypes::DataType,
+    error::{Error, Result},
+};
+
+use super::DictionaryKey;
+
+struct NonNullSend<M: ?Sized>(NonNull<M>);
+
+// safety: these pointers are for internal self-referential purposes to pinned array only
+unsafe impl<M> Send for NonNullSend<M> {}
+unsafe impl<M> Sync for NonNullSend<M> {}
+
+impl<M: ?Sized> From<&M> for NonNullSend<M> {
+    #[inline]
+    fn from(reference: &M) -> Self {
+        Self(NonNull::from(reference))
+    }
+}
+
+struct ValueRef<M> {
+    array: NonNullSend<M>,
+    index: usize,
+}
+
+impl<M> ValueRef<M> {
+    #[inline]
+    pub fn new(array: &Pin<Box<M>>, index: usize) -> Self {
+        Self {
+            array: NonNullSend::from(Pin::get_ref(array.as_ref())),
+            index,
+        }
+    }
+
+    #[inline]
+    pub fn get_array(&self) -> &M {
+        // safety: the invariant of the struct
+        unsafe { self.array.0.as_ref() }
+    }
+
+    #[inline]
+    pub unsafe fn get_unchecked(&self) -> M::Value<'_>
+    where
+        M: Indexable,
+    {
+        self.get_array().value_unchecked_at(self.index)
+    }
+
+    #[inline]
+    pub unsafe fn equals(&self, other: &M::Type) -> bool
+    where
+        M: Indexable,
+        M::Type: Eq,
+    {
+        self.get_unchecked().borrow() == other
+    }
+}
+
+impl<M: Indexable> PartialEq for ValueRef<M>
+where
+    M::Type: PartialEq,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        // safety: the way these value refs are constructed, they are always within bounds
+        unsafe {
+            self.get_unchecked()
+                .borrow()
+                .eq(other.get_unchecked().borrow())
+        }
+    }
+}
+
+impl<M: Indexable> Eq for ValueRef<M> where for<'a> M::Type: Eq {}
+
+impl<M: Indexable> Hash for ValueRef<M>
+where
+    M::Type: Hash,
+{
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // safety: the way these value refs are constructed, they are always within bounds
+        unsafe { self.get_unchecked().borrow().hash(state) }
+    }
+}
+
+// To avoid blanket implementation issues with `Equivalent` trait (we only use hashbrown
+// instead of the default HashMap to avoid blanket implementation problems with Borrow).
+#[derive(Hash)]
+struct Wrapped<'a, T: ?Sized>(&'a T);
+
+impl<'a, M: Indexable> Equivalent<ValueRef<M>> for Wrapped<'a, M::Type>
+where
+    M::Type: Eq,
+{
+    #[inline]
+    fn equivalent(&self, key: &ValueRef<M>) -> bool {
+        // safety: invariant of the struct
+        unsafe { key.equals(self.0) }
+    }
+}
+
+pub struct ValueMap<K: DictionaryKey, M: MutableArray> {
+    values: Pin<Box<M>>,
+    map: HashMap<ValueRef<M>, K>,
+}
+
+impl<K: DictionaryKey, M: MutableArray> ValueMap<K, M> {
+    pub fn try_empty(values: M) -> Result<Self> {
+        if !values.is_empty() {
+            return Err(Error::InvalidArgumentError(
+                "initializing value map with non-empty values array".into(),
+            ));
+        }
+        Ok(Self {
+            values: Box::pin(values),
+            map: HashMap::default(),
+        })
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        Pin::get_ref(self.values.as_ref()).data_type()
+    }
+
+    pub fn into_boxed(self) -> Box<M> {
+        // safety: we unpin the pointer but the value map is dropped along with all
+        // the value references that might refer to the pinned array
+        unsafe { Pin::into_inner_unchecked(self.values) }
+    }
+
+    pub fn take_into(&mut self) -> Box<dyn Array> {
+        // safety: we unpin the pointer but the value map is manually cleared
+        let arr = unsafe { self.values.as_mut().get_unchecked_mut().as_box() };
+        self.map.clear();
+        arr
+    }
+
+    #[inline]
+    pub fn values(&self) -> &M {
+        &self.values
+    }
+
+    /// Try to insert a value and return its index (it may or may not get inserted).
+    pub fn try_push_valid<V>(
+        &mut self,
+        value: V,
+        mut push: impl FnMut(&mut M, V) -> Result<()>,
+    ) -> Result<K>
+    where
+        M: Indexable,
+        V: AsIndexed<M>,
+        M::Type: Eq + Hash,
+    {
+        if let Some(&key) = self.map.get(&Wrapped(value.as_indexed())) {
+            return Ok(key);
+        }
+        let index = self.values.len();
+        let key = K::try_from(index).map_err(|_| Error::Overflow)?;
+        // safety: we don't move the data out of the mutable pinned reference
+        unsafe {
+            push(self.values.as_mut().get_unchecked_mut(), value)?;
+        }
+        debug_assert_eq!(self.values.len(), index + 1);
+        self.map.insert(ValueRef::new(&self.values, index), key);
+        debug_assert_eq!(self.values.len(), self.map.len());
+        Ok(key)
+    }
+
+    pub fn shrink_to_fit(&mut self) {
+        // safety: we don't move the data out of the mutable pinned reference
+        unsafe {
+            self.values.as_mut().get_unchecked_mut().shrink_to_fit();
+        }
+    }
+}
+
+impl<K: DictionaryKey, M: MutableArray> Debug for ValueMap<K, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Pin::get_ref(self.values.as_ref()).fmt(f)
+    }
+}

--- a/src/array/dictionary/value_map.rs
+++ b/src/array/dictionary/value_map.rs
@@ -129,6 +129,21 @@ impl<K: DictionaryKey, M: MutableArray> ValueMap<K, M> {
         })
     }
 
+    pub fn from_values(values: M) -> Result<Self>
+    where
+        M: Indexable,
+        M::Type: Eq + Hash,
+    {
+        let values = Box::pin(values);
+        let map = (0..values.len())
+            .map(|i| {
+                let key = K::try_from(i).map_err(|_| Error::Overflow)?;
+                Ok((ValueRef::new(&values, i), key))
+            })
+            .collect::<Result<_>>()?;
+        Ok(Self { values, map })
+    }
+
     pub fn data_type(&self) -> &DataType {
         Pin::get_ref(self.values.as_ref()).data_type()
     }

--- a/src/array/indexable.rs
+++ b/src/array/indexable.rs
@@ -1,0 +1,197 @@
+use std::borrow::Borrow;
+
+use crate::{
+    array::{
+        MutableArray, MutableBinaryArray, MutableBinaryValuesArray, MutableBooleanArray,
+        MutableFixedSizeBinaryArray, MutablePrimitiveArray, MutableUtf8Array,
+        MutableUtf8ValuesArray,
+    },
+    offset::Offset,
+    types::NativeType,
+};
+
+/// Trait for arrays that can be indexed directly to extract a value.
+pub trait Indexable {
+    /// The type of the element at index `i`; may be a reference type or a value type.
+    type Value<'a>: Borrow<Self::Type>
+    where
+        Self: 'a;
+
+    type Type: ?Sized;
+
+    /// Returns the element at index `i`.
+    /// # Panic
+    /// May panic if `i >= self.len()`.
+    fn value_at(&self, index: usize) -> Self::Value<'_>;
+
+    /// Returns the element at index `i`.
+    /// # Safety
+    /// Assumes that the `i < self.len`.
+    #[inline]
+    unsafe fn value_unchecked_at(&self, index: usize) -> Self::Value<'_> {
+        self.value_at(index)
+    }
+}
+
+pub trait AsIndexed<M: Indexable> {
+    fn as_indexed(&self) -> &M::Type;
+}
+
+impl Indexable for MutableBooleanArray {
+    type Value<'a> = bool;
+    type Type = bool;
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        self.values().get(i)
+    }
+}
+
+impl AsIndexed<MutableBooleanArray> for bool {
+    #[inline]
+    fn as_indexed(&self) -> &bool {
+        self
+    }
+}
+
+impl<O: Offset> Indexable for MutableBinaryArray<O> {
+    type Value<'a> = &'a [u8];
+    type Type = [u8];
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        // TODO: add .value() / .value_unchecked() to MutableBinaryArray?
+        assert!(i < self.len());
+        unsafe { self.value_unchecked_at(i) }
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        // TODO: add .value() / .value_unchecked() to MutableBinaryArray?
+        // soundness: the invariant of the function
+        let (start, end) = self.offsets().start_end_unchecked(i);
+        // soundness: the invariant of the struct
+        self.values().get_unchecked(start..end)
+    }
+}
+
+impl<O: Offset> AsIndexed<MutableBinaryArray<O>> for &[u8] {
+    #[inline]
+    fn as_indexed(&self) -> &[u8] {
+        self
+    }
+}
+
+impl<O: Offset> Indexable for MutableBinaryValuesArray<O> {
+    type Value<'a> = &'a [u8];
+    type Type = [u8];
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        self.value(i)
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        self.value_unchecked(i)
+    }
+}
+
+impl<O: Offset> AsIndexed<MutableBinaryValuesArray<O>> for &[u8] {
+    #[inline]
+    fn as_indexed(&self) -> &[u8] {
+        self
+    }
+}
+
+impl Indexable for MutableFixedSizeBinaryArray {
+    type Value<'a> = &'a [u8];
+    type Type = [u8];
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        self.value(i)
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        // soundness: the invariant of the struct
+        self.value_unchecked(i)
+    }
+}
+
+impl AsIndexed<MutableFixedSizeBinaryArray> for &[u8] {
+    #[inline]
+    fn as_indexed(&self) -> &[u8] {
+        self
+    }
+}
+
+// TODO: should NativeType derive from Hash?
+impl<T: NativeType> Indexable for MutablePrimitiveArray<T> {
+    type Value<'a> = T;
+    type Type = T;
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        assert!(i < self.len());
+        // TODO: add Length trait? (for both Array and MutableArray)
+        unsafe { self.value_unchecked_at(i) }
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        *self.values().get_unchecked(i)
+    }
+}
+
+impl<T: NativeType> AsIndexed<MutablePrimitiveArray<T>> for T {
+    #[inline]
+    fn as_indexed(&self) -> &T {
+        self
+    }
+}
+
+impl<O: Offset> Indexable for MutableUtf8Array<O> {
+    type Value<'a> = &'a str;
+    type Type = str;
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        self.value(i)
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        self.value_unchecked(i)
+    }
+}
+
+impl<O: Offset, V: AsRef<str>> AsIndexed<MutableUtf8Array<O>> for V {
+    #[inline]
+    fn as_indexed(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+impl<O: Offset> Indexable for MutableUtf8ValuesArray<O> {
+    type Value<'a> = &'a str;
+    type Type = str;
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        self.value(i)
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        self.value_unchecked(i)
+    }
+}
+
+impl<O: Offset, V: AsRef<str>> AsIndexed<MutableUtf8ValuesArray<O>> for V {
+    #[inline]
+    fn as_indexed(&self) -> &str {
+        self.as_ref()
+    }
+}

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -720,8 +720,10 @@ mod utf8;
 mod equal;
 mod ffi;
 mod fmt;
-pub mod growable;
+mod indexable;
 mod iterator;
+
+pub mod growable;
 pub mod ord;
 
 pub(crate) use iterator::ArrayAccessor;

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -306,9 +306,9 @@ pub fn primitive_to_dictionary<T: NativeType + Eq + Hash, K: DictionaryKey>(
     from: &PrimitiveArray<T>,
 ) -> Result<DictionaryArray<K>> {
     let iter = from.iter().map(|x| x.copied());
-    let mut array = MutableDictionaryArray::<K, _>::from(MutablePrimitiveArray::<T>::from(
+    let mut array = MutableDictionaryArray::<K, _>::try_empty(MutablePrimitiveArray::<T>::from(
         from.data_type().clone(),
-    ));
+    ))?;
     array.try_extend(iter)?;
 
     Ok(array.into())

--- a/tests/it/array/dictionary/mutable.rs
+++ b/tests/it/array/dictionary/mutable.rs
@@ -1,8 +1,5 @@
 use arrow2::array::*;
 use arrow2::error::Result;
-use hash_hasher::HashedMap;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 
 #[test]
 fn primitive() -> Result<()> {
@@ -61,16 +58,4 @@ fn push_utf8() {
     expected_keys.push(Some(0));
     expected_keys.push(Some(1));
     assert_eq!(*new.keys(), expected_keys);
-
-    let expected_map = ["A", "B", "C"]
-        .iter()
-        .enumerate()
-        .map(|(index, value)| {
-            let mut hasher = DefaultHasher::new();
-            value.hash(&mut hasher);
-            let hash = hasher.finish();
-            (hash, index as i32)
-        })
-        .collect::<HashedMap<_, _>>();
-    assert_eq!(*new.map(), expected_map);
 }


### PR DESCRIPTION
@ritchie46 @jorgecarleitao Here's one way to fix the incorrect current behaviour of `MutableDictionaryArray`: only rely on values actually stored in the values array and don't rely on hash-hash maps (due to potential hash collisions).

This is almost a rewrite of the whole thing, outer API aside, and gets pretty evil (self-referential) at the lower level, but I believe it's pretty sound.

There's probably bits and pieces that may need to be cleaned, types and methods to be renamed, potentially some docstrings added etc (comments welcome), but I figured I'd push the current version as soon as it's working so as to figure whether something like this would be acceptable.

Bench-wise, current main (10k dict insertions):

```
dict_utf8               time:   [239.70 µs 241.27 µs 242.78 µs]
dict_u64                time:   [123.60 µs 123.78 µs 123.98 µs]
```

This branch:

```
dict_utf8               time:   [151.54 µs 151.75 µs 151.97 µs]
                        change: [-37.274% -36.837% -36.411%] (p = 0.00 < 0.05)
dict_u64                time:   [42.466 µs 42.522 µs 42.581 µs]
                        change: [-65.705% -65.627% -65.547%] (p = 0.00 < 0.05)
```

Fixes #1485
Fixes #1554