### PR TITLE
Add support for casting ms and us timestamp 

### DIFF
--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -571,9 +571,17 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
                 to_type.clone(),
             )
             .boxed()),
-            Timestamp(TimeUnit::Nanosecond, None) => utf8_to_naive_timestamp_ns_dyn::<i32>(array),
+            Timestamp(TimeUnit::Nanosecond, None) => utf8_to_naive_timestamp_dyn::<i32>(array,TimeUnit::Nanosecond),
+            Timestamp(TimeUnit::Millisecond, None) => utf8_to_naive_timestamp_dyn::<i32>(array,TimeUnit::Millisecond),
+            Timestamp(TimeUnit::Microsecond, None) => utf8_to_naive_timestamp_dyn::<i32>(array,TimeUnit::Microsecond),
             Timestamp(TimeUnit::Nanosecond, Some(tz)) => {
-                utf8_to_timestamp_ns_dyn::<i32>(array, tz.clone())
+                utf8_to_timestamp_dyn::<i32>(array, tz.clone(), TimeUnit::Nanosecond)
+            },
+            Timestamp(TimeUnit::Millisecond, Some(tz)) => {
+                utf8_to_timestamp_dyn::<i32>(array, tz.clone(), TimeUnit::Millisecond)
+            },
+            Timestamp(TimeUnit::Microsecond, Some(tz)) => {
+                utf8_to_timestamp_dyn::<i32>(array, tz.clone(), TimeUnit::Microsecond)
             }
             _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {from_type:?} to {to_type:?} not supported",
@@ -598,10 +606,18 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
                 to_type.clone(),
             )
             .boxed()),
-            Timestamp(TimeUnit::Nanosecond, None) => utf8_to_naive_timestamp_ns_dyn::<i64>(array),
+            Timestamp(TimeUnit::Nanosecond, None) => utf8_to_naive_timestamp_dyn::<i64>(array,TimeUnit::Nanosecond),
+            Timestamp(TimeUnit::Millisecond, None) => utf8_to_naive_timestamp_dyn::<i64>(array,TimeUnit::Millisecond),
+            Timestamp(TimeUnit::Microsecond, None) => utf8_to_naive_timestamp_dyn::<i64>(array,TimeUnit::Microsecond),
             Timestamp(TimeUnit::Nanosecond, Some(tz)) => {
-                utf8_to_timestamp_ns_dyn::<i64>(array, tz.clone())
-            }
+                utf8_to_timestamp_dyn::<i64>(array, tz.clone(), TimeUnit::Nanosecond)
+            },
+            Timestamp(TimeUnit::Millisecond, Some(tz)) => {
+                utf8_to_timestamp_dyn::<i64>(array, tz.clone(), TimeUnit::Millisecond)
+            },
+            Timestamp(TimeUnit::Microsecond, Some(tz)) => {
+                utf8_to_timestamp_dyn::<i64>(array, tz.clone(), TimeUnit::Microsecond)
+            },
             _ => Err(Error::NotYetImplemented(format!(
                 "Casting from {from_type:?} to {to_type:?} not supported",
             ))),

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -6,11 +6,12 @@ use crate::{
     error::Result,
     offset::Offset,
     temporal_conversions::{
-        utf8_to_naive_timestamp_ns as utf8_to_naive_timestamp_ns_,
-        utf8_to_timestamp_ns as utf8_to_timestamp_ns_, EPOCH_DAYS_FROM_CE,
+        utf8_to_naive_timestamp as utf8_to_naive_timestamp_,
+        utf8_to_timestamp as utf8_to_timestamp_, EPOCH_DAYS_FROM_CE,
     },
     types::NativeType,
 };
+use crate::datatypes::TimeUnit;
 
 use super::CastOptions;
 
@@ -113,34 +114,36 @@ pub fn utf8_to_dictionary<O: Offset, K: DictionaryKey>(
     Ok(array.into())
 }
 
-pub(super) fn utf8_to_naive_timestamp_ns_dyn<O: Offset>(
-    from: &dyn Array,
+pub(super) fn utf8_to_naive_timestamp_dyn<O: Offset>(
+    from: &dyn Array,tu: TimeUnit
 ) -> Result<Box<dyn Array>> {
     let from = from.as_any().downcast_ref().unwrap();
-    Ok(Box::new(utf8_to_naive_timestamp_ns::<O>(from)))
+    Ok(Box::new(utf8_to_naive_timestamp::<O>(from,tu)))
 }
 
-/// [`crate::temporal_conversions::utf8_to_timestamp_ns`] applied for RFC3339 formatting
-pub fn utf8_to_naive_timestamp_ns<O: Offset>(from: &Utf8Array<O>) -> PrimitiveArray<i64> {
-    utf8_to_naive_timestamp_ns_(from, RFC3339)
+/// [`crate::temporal_conversions::utf8_to_timestamp`] applied for RFC3339 formatting
+pub fn utf8_to_naive_timestamp<O: Offset>(from: &Utf8Array<O>, tu: TimeUnit) -> PrimitiveArray<i64> {
+    utf8_to_naive_timestamp_(from, RFC3339,tu)
 }
 
-pub(super) fn utf8_to_timestamp_ns_dyn<O: Offset>(
+pub(super) fn utf8_to_timestamp_dyn<O: Offset>(
     from: &dyn Array,
     timezone: String,
+    timeunit: TimeUnit
 ) -> Result<Box<dyn Array>> {
     let from = from.as_any().downcast_ref().unwrap();
-    utf8_to_timestamp_ns::<O>(from, timezone)
+    utf8_to_timestamp::<O>(from, timezone, timeunit)
         .map(Box::new)
         .map(|x| x as Box<dyn Array>)
 }
 
-/// [`crate::temporal_conversions::utf8_to_timestamp_ns`] applied for RFC3339 formatting
-pub fn utf8_to_timestamp_ns<O: Offset>(
+/// [`crate::temporal_conversions::utf8_to_timestamp`] applied for RFC3339 formatting
+pub fn utf8_to_timestamp<O: Offset>(
     from: &Utf8Array<O>,
     timezone: String,
+    timeunit: TimeUnit
 ) -> Result<PrimitiveArray<i64>> {
-    utf8_to_timestamp_ns_(from, RFC3339, timezone)
+    utf8_to_timestamp_(from, RFC3339, timezone,timeunit)
 }
 
 /// Conversion of utf8

--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -332,17 +332,6 @@ pub fn parse_offset(offset: &str) -> Result<FixedOffset> {
 
 /// Parses `value` to `Option<i64>` consistent with the Arrow's definition of timestamp with timezone.
 /// `tz` must be built from `timezone` (either via [`parse_offset`] or `chrono-tz`).
-#[inline]
-pub fn utf8_to_timestamp_ns_scalar<T: chrono::TimeZone>(
-    value: &str,
-    fmt: &str,
-    tz: &T,
-) -> Option<i64> {
-    utf8_to_timestamp_scalar(value, fmt, tz, &TimeUnit::Nanosecond)
-}
-
-/// Parses `value` to `Option<i64>` consistent with the Arrow's definition of timestamp with timezone.
-/// `tz` must be built from `timezone` (either via [`parse_offset`] or `chrono-tz`).
 /// Returns in scale `tz` of `TimeUnit`.
 #[inline]
 pub fn utf8_to_timestamp_scalar<T: chrono::TimeZone>(
@@ -371,11 +360,6 @@ pub fn utf8_to_timestamp_scalar<T: chrono::TimeZone>(
     }
 }
 
-/// Parses `value` to `Option<i64>` consistent with the Arrow's definition of timestamp without timezone.
-#[inline]
-pub fn utf8_to_naive_timestamp_ns_scalar(value: &str, fmt: &str) -> Option<i64> {
-    utf8_to_naive_timestamp_scalar(value, fmt, &TimeUnit::Nanosecond)
-}
 
 /// Parses `value` to `Option<i64>` consistent with the Arrow's definition of timestamp without timezone.
 /// Returns in scale `tz` of `TimeUnit`.
@@ -395,18 +379,19 @@ pub fn utf8_to_naive_timestamp_scalar(value: &str, fmt: &str, tu: &TimeUnit) -> 
         .ok()
 }
 
-fn utf8_to_timestamp_ns_impl<O: Offset, T: chrono::TimeZone>(
+fn utf8_to_timestamp_impl<O: Offset, T: chrono::TimeZone>(
     array: &Utf8Array<O>,
     fmt: &str,
     timezone: String,
     tz: T,
+    tu: TimeUnit
 ) -> PrimitiveArray<i64> {
     let iter = array
         .iter()
-        .map(|x| x.and_then(|x| utf8_to_timestamp_ns_scalar(x, fmt, &tz)));
+        .map(|x| x.and_then(|x| utf8_to_timestamp_scalar(x, fmt, &tz,&tu)));
 
-    PrimitiveArray::from_trusted_len_iter(iter)
-        .to(DataType::Timestamp(TimeUnit::Nanosecond, Some(timezone)))
+    PrimitiveArray::from_trusted_len_iter(iter.clone())
+        .to(DataType::Timestamp(tu, Some(timezone)))
 }
 
 /// Parses `value` to a [`chrono_tz::Tz`] with the Arrow's definition of timestamp with a timezone.
@@ -423,16 +408,18 @@ pub fn parse_offset_tz(timezone: &str) -> Result<chrono_tz::Tz> {
 fn chrono_tz_utf_to_timestamp_ns<O: Offset>(
     array: &Utf8Array<O>,
     fmt: &str,
+    tu: TimeUnit,
     timezone: String,
 ) -> Result<PrimitiveArray<i64>> {
     let tz = parse_offset_tz(&timezone)?;
-    Ok(utf8_to_timestamp_ns_impl(array, fmt, timezone, tz))
+    Ok(utf8_to_timestamp_impl(array, fmt, timezone, tz, tu))
 }
 
 #[cfg(not(feature = "chrono-tz"))]
 fn chrono_tz_utf_to_timestamp_ns<O: Offset>(
     _: &Utf8Array<O>,
     _: &str,
+    _: TimeUnit,
     timezone: String,
 ) -> Result<PrimitiveArray<i64>> {
     Err(Error::InvalidArgumentError(format!(
@@ -443,22 +430,23 @@ fn chrono_tz_utf_to_timestamp_ns<O: Offset>(
 /// Parses a [`Utf8Array`] to a timeozone-aware timestamp, i.e. [`PrimitiveArray<i64>`] with type `Timestamp(Nanosecond, Some(timezone))`.
 /// # Implementation
 /// * parsed values with timezone other than `timezone` are converted to `timezone`.
-/// * parsed values without timezone are null. Use [`utf8_to_naive_timestamp_ns`] to parse naive timezones.
+/// * parsed values without timezone are null. Use [`utf8_to_naive_timestamp`] to parse naive timezones.
 /// * Null elements remain null; non-parsable elements are null.
 /// The feature `"chrono-tz"` enables IANA and zoneinfo formats for `timezone`.
 /// # Error
 /// This function errors iff `timezone` is not parsable to an offset.
-pub fn utf8_to_timestamp_ns<O: Offset>(
+pub fn utf8_to_timestamp<O: Offset>(
     array: &Utf8Array<O>,
     fmt: &str,
     timezone: String,
+    timeunit: TimeUnit
 ) -> Result<PrimitiveArray<i64>> {
     let tz = parse_offset(timezone.as_str());
 
     if let Ok(tz) = tz {
-        Ok(utf8_to_timestamp_ns_impl(array, fmt, timezone, tz))
+        Ok(utf8_to_timestamp_impl(array, fmt, timezone, tz, timeunit))
     } else {
-        chrono_tz_utf_to_timestamp_ns(array, fmt, timezone)
+        chrono_tz_utf_to_timestamp_ns(array, fmt, timeunit,timezone)
     }
 }
 
@@ -466,15 +454,16 @@ pub fn utf8_to_timestamp_ns<O: Offset>(
 /// [`PrimitiveArray<i64>`] with type `Timestamp(Nanosecond, None)`.
 /// Timezones are ignored.
 /// Null elements remain null; non-parsable elements are set to null.
-pub fn utf8_to_naive_timestamp_ns<O: Offset>(
+pub fn utf8_to_naive_timestamp<O: Offset>(
     array: &Utf8Array<O>,
     fmt: &str,
+    tu: TimeUnit
 ) -> PrimitiveArray<i64> {
     let iter = array
         .iter()
-        .map(|x| x.and_then(|x| utf8_to_naive_timestamp_ns_scalar(x, fmt)));
+        .map(|x| x.and_then(|x| utf8_to_naive_timestamp_scalar(x, fmt, &tu)));
 
-    PrimitiveArray::from_trusted_len_iter(iter).to(DataType::Timestamp(TimeUnit::Nanosecond, None))
+    PrimitiveArray::from_trusted_len_iter(iter).to(DataType::Timestamp(tu, None))
 }
 
 fn add_month(year: i32, month: u32, months: i32) -> chrono::NaiveDate {

--- a/tests/it/compute/cast.rs
+++ b/tests/it/compute/cast.rs
@@ -806,12 +806,49 @@ fn utf8_to_timestamp_with_tz() {
 }
 
 #[test]
-fn utf8_to_naive_timestamp() {
+fn utf8_to_naive_timestamp_ns() {
     let array =
         Utf8Array::<i32>::from_slice(["1996-12-19T16:39:57-02:00", "1996-12-19T17:39:57-02:00"]);
     // the timezone is disregarded from the string and we assume UTC
     let expected = Int64Array::from_slice([851013597000000000, 851017197000000000])
         .to(DataType::Timestamp(TimeUnit::Nanosecond, None));
+
+    let result = cast(&array, expected.data_type(), CastOptions::default()).expect("cast failed");
+    assert_eq!(expected, result.as_ref());
+}
+
+#[test]
+fn utf8_to_naive_timestamp_ms() {
+    let array =
+        Utf8Array::<i32>::from_slice(["1996-12-19T16:39:57-02:00", "1996-12-19T17:39:57-02:00"]);
+    // the timezone is disregarded from the string and we assume UTC
+    let expected = Int64Array::from_slice([851013597000, 851017197000])
+        .to(DataType::Timestamp(TimeUnit::Millisecond, None));
+
+    let result = cast(&array, expected.data_type(), CastOptions::default()).expect("cast failed");
+    assert_eq!(expected, result.as_ref());
+}
+
+#[test]
+fn utf8_to_naive_timestamp_us() {
+    let array =
+        Utf8Array::<i32>::from_slice(["1996-12-19T16:39:57-02:00", "1996-12-19T17:39:57-02:00"]);
+    // the timezone is disregarded from the string and we assume UTC
+    let expected = Int64Array::from_slice([851013597000000, 851017197000000])
+        .to(DataType::Timestamp(TimeUnit::Microsecond, None));
+
+    let result = cast(&array, expected.data_type(), CastOptions::default()).expect("cast failed");
+    assert_eq!(expected, result.as_ref());
+}
+
+#[test]
+fn utf8_to_timestamp_ms_with_tz() {
+    let tz = "-02:00".to_string();
+    let array =
+        Utf8Array::<i32>::from_slice(["1996-12-19T16:39:57-02:00", "1996-12-19T17:39:57-02:00"]);
+    // the timezone is used to map the time to UTC.
+    let expected = Int64Array::from_slice([851013597000, 851017197000])
+        .to(DataType::Timestamp(TimeUnit::Millisecond, Some(tz)));
 
     let result = cast(&array, expected.data_type(), CastOptions::default()).expect("cast failed");
     assert_eq!(expected, result.as_ref());

--- a/tests/it/compute/cast.rs
+++ b/tests/it/compute/cast.rs
@@ -793,7 +793,7 @@ fn timestamp_with_tz_to_utf8() {
 }
 
 #[test]
-fn utf8_to_timestamp_with_tz() {
+fn utf8_to_timestamp_ns_with_tz() {
     let tz = "-02:00".to_string();
     let array =
         Utf8Array::<i32>::from_slice(["1996-12-19T16:39:57-02:00", "1996-12-19T17:39:57-02:00"]);
@@ -847,8 +847,21 @@ fn utf8_to_timestamp_ms_with_tz() {
     let array =
         Utf8Array::<i32>::from_slice(["1996-12-19T16:39:57-02:00", "1996-12-19T17:39:57-02:00"]);
     // the timezone is used to map the time to UTC.
-    let expected = Int64Array::from_slice([851013597000, 851017197000])
+    let expected = Int64Array::from_slice([851020797000, 851024397000])
         .to(DataType::Timestamp(TimeUnit::Millisecond, Some(tz)));
+
+    let result = cast(&array, expected.data_type(), CastOptions::default()).expect("cast failed");
+    assert_eq!(expected, result.as_ref());
+}
+
+#[test]
+fn utf8_to_timestamp_us_with_tz() {
+    let tz = "-02:00".to_string();
+    let array =
+        Utf8Array::<i32>::from_slice(["1996-12-19T16:39:57-02:00", "1996-12-19T17:39:57-02:00"]);
+    // the timezone is used to map the time to UTC.
+    let expected = Int64Array::from_slice([851020797000000, 851024397000000])
+        .to(DataType::Timestamp(TimeUnit::Microsecond, Some(tz)));
 
     let result = cast(&array, expected.data_type(), CastOptions::default()).expect("cast failed");
     assert_eq!(expected, result.as_ref());

--- a/tests/it/temporal_conversions.rs
+++ b/tests/it/temporal_conversions.rs
@@ -14,7 +14,7 @@ fn naive() {
         "1996-12-19T13:39:57-03:00",
         "1996-12-19 13:39:57-03:00", // missing T
     ]);
-    let r = temporal_conversions::utf8_to_naive_timestamp_ns(&array, fmt);
+    let r = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
     assert_eq!(format!("{r:?}"), expected);
 
     let fmt = "%Y-%m-%dT%H:%M:%S"; // no tz info
@@ -23,7 +23,7 @@ fn naive() {
         "1996-12-19T13:39:57-03:00",
         "1996-12-19 13:39:57-03:00", // missing T
     ]);
-    let r = temporal_conversions::utf8_to_naive_timestamp_ns(&array, fmt);
+    let r = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
     assert_eq!(format!("{r:?}"), expected);
 }
 
@@ -120,7 +120,7 @@ fn naive_no_tz() {
         "1996-12-19T13:39:57",
         "1996-12-19 13:39:57", // missing T
     ]);
-    let r = temporal_conversions::utf8_to_naive_timestamp_ns(&array, fmt);
+    let r = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
     assert_eq!(format!("{r:?}"), expected);
 }
 
@@ -202,7 +202,8 @@ fn tz_aware() {
         "1996-12-19T16:39:57.0-03:00", // same time at a different TZ
         "1996-12-19 13:39:57.0-03:00",
     ]);
-    let r = temporal_conversions::utf8_to_timestamp_ns(&array, fmt, tz).unwrap();
+    let r = temporal_conversions::utf8_to_timestamp(&array, fmt, tz, TimeUnit::Nanosecond).unwrap();
+
     assert_eq!(format!("{r:?}"), expected);
 }
 
@@ -216,7 +217,7 @@ fn tz_aware_no_timezone() {
         "1996-12-19T17:39:57.0",
         "1996-12-19 13:39:57.0",
     ]);
-    let r = temporal_conversions::utf8_to_timestamp_ns(&array, fmt, tz).unwrap();
+    let r = temporal_conversions::utf8_to_timestamp(&array, fmt, tz, TimeUnit::Nanosecond).unwrap();
     assert_eq!(format!("{r:?}"), expected);
 }
 

--- a/tests/it/temporal_conversions.rs
+++ b/tests/it/temporal_conversions.rs
@@ -7,15 +7,21 @@ use chrono::NaiveDateTime;
 
 #[test]
 fn naive() {
-    let expected = "Timestamp(Nanosecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
+    let expected_ns = "Timestamp(Nanosecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
+    let expected_ms = "Timestamp(Millisecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
+    let expected_us = "Timestamp(Microsecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S:z";
     let array = Utf8Array::<i32>::from_slice([
         "1996-12-19T16:39:57-02:00",
         "1996-12-19T13:39:57-03:00",
         "1996-12-19 13:39:57-03:00", // missing T
     ]);
-    let r = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
-    assert_eq!(format!("{r:?}"), expected);
+    let r_ns = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
+    let r_ms = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Millisecond);
+    let r_us = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Microsecond);
+    assert_eq!(format!("{r_ns:?}"), expected_ns);
+    assert_eq!(format!("{r_ms:?}"), expected_ms);
+    assert_eq!(format!("{r_us:?}"), expected_us);
 
     let fmt = "%Y-%m-%dT%H:%M:%S"; // no tz info
     let array = Utf8Array::<i32>::from_slice([
@@ -23,8 +29,12 @@ fn naive() {
         "1996-12-19T13:39:57-03:00",
         "1996-12-19 13:39:57-03:00", // missing T
     ]);
-    let r = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
-    assert_eq!(format!("{r:?}"), expected);
+    let r_ns = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
+    let r_ms = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Millisecond);
+    let r_us = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Microsecond);
+    assert_eq!(format!("{r_ns:?}"), expected_ns);
+    assert_eq!(format!("{r_ms:?}"), expected_ms);
+    assert_eq!(format!("{r_us:?}"), expected_us);
 }
 
 #[test]
@@ -113,15 +123,21 @@ fn scalar_tz_aware_no_timezone() {
 
 #[test]
 fn naive_no_tz() {
-    let expected = "Timestamp(Nanosecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
+    let expected_ns = "Timestamp(Nanosecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
+    let expected_ms = "Timestamp(Millisecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
+    let expected_us = "Timestamp(Microsecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S"; // no tz info
     let array = Utf8Array::<i32>::from_slice([
         "1996-12-19T16:39:57",
         "1996-12-19T13:39:57",
         "1996-12-19 13:39:57", // missing T
     ]);
-    let r = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
-    assert_eq!(format!("{r:?}"), expected);
+    let r_ns = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
+    let r_ms = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Millisecond);
+    let r_us = temporal_conversions::utf8_to_naive_timestamp(&array, fmt, TimeUnit::Microsecond);
+    assert_eq!(format!("{r_ns:?}"), expected_ns);
+    assert_eq!(format!("{r_ms:?}"), expected_ms);
+    assert_eq!(format!("{r_us:?}"), expected_us);
 }
 
 #[test]
@@ -194,31 +210,46 @@ fn timestamp_to_negative_datetime() {
 #[test]
 fn tz_aware() {
     let tz = "-02:00".to_string();
-    let expected =
+    let expected_ns =
         "Timestamp(Nanosecond, Some(\"-02:00\"))[1996-12-19 16:39:57 -02:00, 1996-12-19 17:39:57 -02:00, None]";
+    let expected_ms =
+        "Timestamp(Millisecond, Some(\"-02:00\"))[1996-12-19 16:39:57 -02:00, 1996-12-19 17:39:57 -02:00, None]";
+    let expected_us =
+        "Timestamp(Microsecond, Some(\"-02:00\"))[1996-12-19 16:39:57 -02:00, 1996-12-19 17:39:57 -02:00, None]";
+
     let fmt = "%Y-%m-%dT%H:%M:%S%.f%:z";
     let array = Utf8Array::<i32>::from_slice([
-        "1996-12-19T16:39:57.0-02:00",
-        "1996-12-19T16:39:57.0-03:00", // same time at a different TZ
-        "1996-12-19 13:39:57.0-03:00",
+        "1996-12-19T16:39:57.000-02:00",
+        "1996-12-19T16:39:57.000-03:00", // same time at a different TZ
+        "1996-12-19 13:39:57.000-03:00",
     ]);
-    let r = temporal_conversions::utf8_to_timestamp(&array, fmt, tz, TimeUnit::Nanosecond).unwrap();
+    let r_ns = temporal_conversions::utf8_to_timestamp(&array, fmt, tz.clone(), TimeUnit::Nanosecond).unwrap();
+    let r_ms = temporal_conversions::utf8_to_timestamp(&array, fmt, tz.clone(), TimeUnit::Millisecond).unwrap();
+    let r_us = temporal_conversions::utf8_to_timestamp(&array, fmt, tz.clone(), TimeUnit::Microsecond).unwrap();
 
-    assert_eq!(format!("{r:?}"), expected);
+    assert_eq!(format!("{r_ns:?}"), expected_ns);
+    assert_eq!(format!("{r_ms:?}"), expected_ms);
+    assert_eq!(format!("{r_us:?}"), expected_us);
 }
 
 #[test]
 fn tz_aware_no_timezone() {
     let tz = "-02:00".to_string();
-    let expected = "Timestamp(Nanosecond, Some(\"-02:00\"))[None, None, None]";
+    let expected_ns = "Timestamp(Nanosecond, Some(\"-02:00\"))[None, None, None]";
+    let expected_ms = "Timestamp(Millisecond, Some(\"-02:00\"))[None, None, None]";
+    let expected_us = "Timestamp(Microsecond, Some(\"-02:00\"))[None, None, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S%.f";
     let array = Utf8Array::<i32>::from_slice([
         "1996-12-19T16:39:57.0",
         "1996-12-19T17:39:57.0",
         "1996-12-19 13:39:57.0",
     ]);
-    let r = temporal_conversions::utf8_to_timestamp(&array, fmt, tz, TimeUnit::Nanosecond).unwrap();
-    assert_eq!(format!("{r:?}"), expected);
+    let r_ns = temporal_conversions::utf8_to_timestamp(&array, fmt, tz.clone(), TimeUnit::Nanosecond).unwrap();
+    let r_ms = temporal_conversions::utf8_to_timestamp(&array, fmt, tz.clone(), TimeUnit::Millisecond).unwrap();
+    let r_us = temporal_conversions::utf8_to_timestamp(&array, fmt, tz.clone(), TimeUnit::Microsecond).unwrap();
+    assert_eq!(format!("{r_ns:?}"), expected_ns);
+    assert_eq!(format!("{r_ms:?}"), expected_ms);
+    assert_eq!(format!("{r_us:?}"), expected_us);
 }
 
 #[test]


### PR DESCRIPTION
This PR solves https://github.com/jorgecarleitao/arrow2/issues/1541 

This adds the minimal changes to support casting from a utf8 or largeutf8 to timestamp using ns, ms or us time units. 