### PR TITLE
2nd (safe) rewrite of MutableDictionaryArray

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ hash_hasher = "^2.0.3"
 simdutf8 = "0.1.4"
 
 # A Rust port of SwissTable
-hashbrown = { version = "0.14", default-features = false, optional = true }
+hashbrown = { version = "0.14", default-features = false, features = ["ahash"] }
 
 # for timezone support
 chrono-tz = { version = "0.8", optional = true }
@@ -243,7 +243,7 @@ compute_merge_sort = ["itertools", "compute_sort"]
 compute_nullif = ["compute_comparison"]
 compute_partition = ["compute_sort"]
 compute_regex_match = ["regex"]
-compute_sort = ["compute_take", "hashbrown"]
+compute_sort = ["compute_take"]
 compute_substring = []
 compute_take = []
 compute_temporal = []

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -20,6 +20,7 @@ mod iterator;
 mod mutable;
 use crate::array::specification::check_indexes_unchecked;
 mod typed_iterator;
+mod value_map;
 
 use crate::array::dictionary::typed_iterator::{DictValue, DictionaryValuesIterTyped};
 pub use iterator::*;

--- a/src/array/dictionary/mod.rs
+++ b/src/array/dictionary/mod.rs
@@ -1,3 +1,4 @@
+use std::hash::Hash;
 use std::hint::unreachable_unchecked;
 
 use crate::{
@@ -34,7 +35,7 @@ use super::{new_null_array, specification::check_indexes};
 ///
 /// Any implementation of this trait must ensure that `always_fits_usize` only
 /// returns `true` if all values succeeds on `value::try_into::<usize>().unwrap()`.
-pub unsafe trait DictionaryKey: NativeType + TryInto<usize> + TryFrom<usize> {
+pub unsafe trait DictionaryKey: NativeType + TryInto<usize> + TryFrom<usize> + Hash {
     /// The corresponding [`IntegerType`] of this key
     const KEY_TYPE: IntegerType;
 

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -1,15 +1,15 @@
-use std::hash::{Hash, Hasher};
-use std::{collections::hash_map::DefaultHasher, sync::Arc};
+use std::hash::Hash;
+use std::sync::Arc;
 
-use hash_hasher::HashedMap;
-
+use crate::array::indexable::{AsIndexed, Indexable};
 use crate::{
     array::{primitive::MutablePrimitiveArray, Array, MutableArray, TryExtend, TryPush},
     bitmap::MutableBitmap,
     datatypes::DataType,
-    error::{Error, Result},
+    error::Result,
 };
 
+use super::value_map::ValueMap;
 use super::{DictionaryArray, DictionaryKey};
 
 /// A mutable, strong-typed version of [`DictionaryArray`].
@@ -30,37 +30,21 @@ use super::{DictionaryArray, DictionaryKey};
 #[derive(Debug)]
 pub struct MutableDictionaryArray<K: DictionaryKey, M: MutableArray> {
     data_type: DataType,
+    map: ValueMap<K, M>,
+    // invariant: `max(keys) < map.values().len()`
     keys: MutablePrimitiveArray<K>,
-    map: HashedMap<u64, K>,
-    // invariant: `keys.len() <= values.len()`
-    values: M,
 }
 
 impl<K: DictionaryKey, M: MutableArray> From<MutableDictionaryArray<K, M>> for DictionaryArray<K> {
-    fn from(mut other: MutableDictionaryArray<K, M>) -> Self {
+    fn from(other: MutableDictionaryArray<K, M>) -> Self {
         // Safety - the invariant of this struct ensures that this is up-held
         unsafe {
             DictionaryArray::<K>::try_new_unchecked(
                 other.data_type,
                 other.keys.into(),
-                other.values.as_box(),
+                other.map.into_boxed().as_box(),
             )
             .unwrap()
-        }
-    }
-}
-
-impl<K: DictionaryKey, M: MutableArray> From<M> for MutableDictionaryArray<K, M> {
-    fn from(values: M) -> Self {
-        Self {
-            data_type: DataType::Dictionary(
-                K::KEY_TYPE,
-                Box::new(values.data_type().clone()),
-                false,
-            ),
-            keys: MutablePrimitiveArray::<K>::new(),
-            map: HashedMap::default(),
-            values,
         }
     }
 }
@@ -68,17 +52,7 @@ impl<K: DictionaryKey, M: MutableArray> From<M> for MutableDictionaryArray<K, M>
 impl<K: DictionaryKey, M: MutableArray + Default> MutableDictionaryArray<K, M> {
     /// Creates an empty [`MutableDictionaryArray`].
     pub fn new() -> Self {
-        let values = M::default();
-        Self {
-            data_type: DataType::Dictionary(
-                K::KEY_TYPE,
-                Box::new(values.data_type().clone()),
-                false,
-            ),
-            keys: MutablePrimitiveArray::<K>::new(),
-            map: HashedMap::default(),
-            values,
-        }
+        Self::try_empty(M::default()).unwrap()
     }
 }
 
@@ -89,22 +63,34 @@ impl<K: DictionaryKey, M: MutableArray + Default> Default for MutableDictionaryA
 }
 
 impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
-    /// Returns whether the value should be pushed to the values or not
-    fn try_push_valid<T: Hash>(&mut self, value: &T) -> Result<bool> {
-        let mut hasher = DefaultHasher::new();
-        value.hash(&mut hasher);
-        let hash = hasher.finish();
-        match self.map.get(&hash) {
-            Some(key) => {
-                self.keys.push(Some(*key));
-                Ok(false)
-            }
-            None => {
-                let key = K::try_from(self.map.len()).map_err(|_| Error::Overflow)?;
-                self.map.insert(hash, key);
-                self.keys.push(Some(key));
-                Ok(true)
-            }
+    /// Creates an empty [`MutableDictionaryArray`] from a given empty values array.
+    /// # Errors
+    /// Errors if the array is non-empty.
+    pub fn try_empty(values: M) -> Result<Self> {
+        Ok(Self::from_value_map(ValueMap::<K, M>::try_empty(values)?))
+    }
+
+    /// Creates an empty [`MutableDictionaryArray`] preloaded with a given dictionary of values.
+    /// Indices associated with those values are automatically assigned based on the order of
+    /// the values.
+    /// # Errors
+    /// Errors if there's more values than the maximum value of `K`.
+    pub fn from_values(values: M) -> Result<Self>
+    where
+        M: Indexable,
+        M::Type: Eq + Hash,
+    {
+        Ok(Self::from_value_map(ValueMap::<K, M>::from_values(values)?))
+    }
+
+    fn from_value_map(value_map: ValueMap<K, M>) -> Self {
+        let keys = MutablePrimitiveArray::<K>::new();
+        let data_type =
+            DataType::Dictionary(K::KEY_TYPE, Box::new(value_map.data_type().clone()), false);
+        Self {
+            data_type,
+            map: value_map,
+            keys,
         }
     }
 
@@ -113,14 +99,9 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
         self.keys.push(None)
     }
 
-    /// returns a mutable reference to the inner values.
-    fn mut_values(&mut self) -> &mut M {
-        &mut self.values
-    }
-
     /// returns a reference to the inner values.
     pub fn values(&self) -> &M {
-        &self.values
+        self.map.values()
     }
 
     /// converts itself into [`Arc<dyn Array>`]
@@ -142,13 +123,8 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
 
     /// Shrinks the capacity of the [`MutableDictionaryArray`] to fit its current length.
     pub fn shrink_to_fit(&mut self) {
-        self.values.shrink_to_fit();
+        self.map.shrink_to_fit();
         self.keys.shrink_to_fit();
-    }
-
-    /// Returns the dictionary map
-    pub fn map(&self) -> &HashedMap<u64, K> {
-        &self.map
     }
 
     /// Returns the dictionary keys
@@ -160,7 +136,7 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
         DictionaryArray::<K>::try_new(
             self.data_type.clone(),
             std::mem::take(&mut self.keys).into(),
-            self.values.as_box(),
+            self.map.take_into(),
         )
         .unwrap()
     }
@@ -208,17 +184,20 @@ impl<K: DictionaryKey, M: 'static + MutableArray> MutableArray for MutableDictio
     }
 }
 
-impl<K, M, T: Hash> TryExtend<Option<T>> for MutableDictionaryArray<K, M>
+impl<K, M, T> TryExtend<Option<T>> for MutableDictionaryArray<K, M>
 where
     K: DictionaryKey,
-    M: MutableArray + TryExtend<Option<T>>,
+    M: MutableArray + Indexable + TryExtend<Option<T>>,
+    T: AsIndexed<M>,
+    M::Type: Eq + Hash,
 {
     fn try_extend<II: IntoIterator<Item = Option<T>>>(&mut self, iter: II) -> Result<()> {
         for value in iter {
             if let Some(value) = value {
-                if self.try_push_valid(&value)? {
-                    self.mut_values().try_extend(std::iter::once(Some(value)))?;
-                }
+                let key = self
+                    .map
+                    .try_push_valid(value, |arr, v| arr.try_extend(std::iter::once(Some(v))))?;
+                self.keys.try_push(Some(key))?;
             } else {
                 self.push_null();
             }
@@ -230,19 +209,19 @@ where
 impl<K, M, T> TryPush<Option<T>> for MutableDictionaryArray<K, M>
 where
     K: DictionaryKey,
-    M: MutableArray + TryPush<Option<T>>,
-    T: Hash,
+    M: MutableArray + Indexable + TryPush<Option<T>>,
+    T: AsIndexed<M>,
+    M::Type: Eq + Hash,
 {
     fn try_push(&mut self, item: Option<T>) -> Result<()> {
         if let Some(value) = item {
-            if self.try_push_valid(&value)? {
-                self.values.try_push(Some(value))
-            } else {
-                Ok(())
-            }
+            let key = self
+                .map
+                .try_push_valid(value, |arr, v| arr.try_push(Some(v)))?;
+            self.keys.try_push(Some(key))?;
         } else {
             self.push_null();
-            Ok(())
         }
+        Ok(())
     }
 }

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -42,7 +42,7 @@ impl<K: DictionaryKey, M: MutableArray> From<MutableDictionaryArray<K, M>> for D
             DictionaryArray::<K>::try_new_unchecked(
                 other.data_type,
                 other.keys.into(),
-                other.map.into_boxed().as_box(),
+                other.map.into_values().as_box(),
             )
             .unwrap()
         }
@@ -74,7 +74,7 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
     /// Indices associated with those values are automatically assigned based on the order of
     /// the values.
     /// # Errors
-    /// Errors if there's more values than the maximum value of `K`.
+    /// Errors if there's more values than the maximum value of `K` or if values are not unique.
     pub fn from_values(values: M) -> Result<Self>
     where
         M: Indexable,
@@ -92,6 +92,13 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
             map: value_map,
             keys,
         }
+    }
+
+    /// Creates an empty [`MutableDictionaryArray`] retaining the same dictionary as the current
+    /// mutable dictionary array, but with no data. This may come useful when serializing the
+    /// array into multiple chunks, where there's a requirement that the dictionary is the same.
+    pub fn into_empty(self) -> Self {
+        Self::from_value_map(self.map)
     }
 
     /// pushes a null value

--- a/src/array/dictionary/mutable.rs
+++ b/src/array/dictionary/mutable.rs
@@ -97,8 +97,17 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
     /// Creates an empty [`MutableDictionaryArray`] retaining the same dictionary as the current
     /// mutable dictionary array, but with no data. This may come useful when serializing the
     /// array into multiple chunks, where there's a requirement that the dictionary is the same.
+    /// No copying is performed, the value map is moved over to the new array.
     pub fn into_empty(self) -> Self {
         Self::from_value_map(self.map)
+    }
+
+    /// Same as `into_empty` but clones the inner value map instead of taking full ownership.
+    pub fn to_empty(&self) -> Self
+    where
+        M: Clone,
+    {
+        Self::from_value_map(self.map.clone())
     }
 
     /// pushes a null value

--- a/src/array/dictionary/value_map.rs
+++ b/src/array/dictionary/value_map.rs
@@ -1,0 +1,207 @@
+use std::borrow::Borrow;
+use std::fmt::{self, Debug};
+use std::hash::{Hash, Hasher};
+use std::pin::Pin;
+use std::ptr::NonNull;
+
+use hashbrown::{Equivalent, HashMap};
+
+use crate::array::Array;
+use crate::{
+    array::indexable::{AsIndexed, Indexable},
+    array::MutableArray,
+    datatypes::DataType,
+    error::{Error, Result},
+};
+
+use super::DictionaryKey;
+
+struct NonNullSend<M: ?Sized>(NonNull<M>);
+
+// safety: these pointers are for internal self-referential purposes to pinned array only
+unsafe impl<M> Send for NonNullSend<M> {}
+unsafe impl<M> Sync for NonNullSend<M> {}
+
+impl<M: ?Sized> From<&M> for NonNullSend<M> {
+    #[inline]
+    fn from(reference: &M) -> Self {
+        Self(NonNull::from(reference))
+    }
+}
+
+struct ValueRef<M> {
+    array: NonNullSend<M>,
+    index: usize,
+}
+
+impl<M> ValueRef<M> {
+    #[inline]
+    pub fn new(array: &Pin<Box<M>>, index: usize) -> Self {
+        Self {
+            array: NonNullSend::from(Pin::get_ref(array.as_ref())),
+            index,
+        }
+    }
+
+    #[inline]
+    pub fn get_array(&self) -> &M {
+        // safety: the invariant of the struct
+        unsafe { self.array.0.as_ref() }
+    }
+
+    #[inline]
+    pub unsafe fn get_unchecked(&self) -> M::Value<'_>
+    where
+        M: Indexable,
+    {
+        self.get_array().value_unchecked_at(self.index)
+    }
+
+    #[inline]
+    pub unsafe fn equals(&self, other: &M::Type) -> bool
+    where
+        M: Indexable,
+        M::Type: Eq,
+    {
+        self.get_unchecked().borrow() == other
+    }
+}
+
+impl<M: Indexable> PartialEq for ValueRef<M>
+where
+    M::Type: PartialEq,
+{
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        // safety: the way these value refs are constructed, they are always within bounds
+        unsafe {
+            self.get_unchecked()
+                .borrow()
+                .eq(other.get_unchecked().borrow())
+        }
+    }
+}
+
+impl<M: Indexable> Eq for ValueRef<M> where for<'a> M::Type: Eq {}
+
+impl<M: Indexable> Hash for ValueRef<M>
+where
+    M::Type: Hash,
+{
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // safety: the way these value refs are constructed, they are always within bounds
+        unsafe { self.get_unchecked().borrow().hash(state) }
+    }
+}
+
+// To avoid blanket implementation issues with `Equivalent` trait (we only use hashbrown
+// instead of the default HashMap to avoid blanket implementation problems with Borrow).
+#[derive(Hash)]
+struct Wrapped<'a, T: ?Sized>(&'a T);
+
+impl<'a, M: Indexable> Equivalent<ValueRef<M>> for Wrapped<'a, M::Type>
+where
+    M::Type: Eq,
+{
+    #[inline]
+    fn equivalent(&self, key: &ValueRef<M>) -> bool {
+        // safety: invariant of the struct
+        unsafe { key.equals(self.0) }
+    }
+}
+
+pub struct ValueMap<K: DictionaryKey, M: MutableArray> {
+    values: Pin<Box<M>>,
+    map: HashMap<ValueRef<M>, K>,
+}
+
+impl<K: DictionaryKey, M: MutableArray> ValueMap<K, M> {
+    pub fn try_empty(values: M) -> Result<Self> {
+        if !values.is_empty() {
+            return Err(Error::InvalidArgumentError(
+                "initializing value map with non-empty values array".into(),
+            ));
+        }
+        Ok(Self {
+            values: Box::pin(values),
+            map: HashMap::default(),
+        })
+    }
+
+    pub fn from_values(values: M) -> Result<Self>
+    where
+        M: Indexable,
+        M::Type: Eq + Hash,
+    {
+        let values = Box::pin(values);
+        let map = (0..values.len())
+            .map(|i| {
+                let key = K::try_from(i).map_err(|_| Error::Overflow)?;
+                Ok((ValueRef::new(&values, i), key))
+            })
+            .collect::<Result<_>>()?;
+        Ok(Self { values, map })
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        Pin::get_ref(self.values.as_ref()).data_type()
+    }
+
+    pub fn into_boxed(self) -> Box<M> {
+        // safety: we unpin the pointer but the value map is dropped along with all
+        // the value references that might refer to the pinned array
+        unsafe { Pin::into_inner_unchecked(self.values) }
+    }
+
+    pub fn take_into(&mut self) -> Box<dyn Array> {
+        // safety: we unpin the pointer but the value map is manually cleared
+        let arr = unsafe { self.values.as_mut().get_unchecked_mut().as_box() };
+        self.map.clear();
+        arr
+    }
+
+    #[inline]
+    pub fn values(&self) -> &M {
+        &self.values
+    }
+
+    /// Try to insert a value and return its index (it may or may not get inserted).
+    pub fn try_push_valid<V>(
+        &mut self,
+        value: V,
+        mut push: impl FnMut(&mut M, V) -> Result<()>,
+    ) -> Result<K>
+    where
+        M: Indexable,
+        V: AsIndexed<M>,
+        M::Type: Eq + Hash,
+    {
+        if let Some(&key) = self.map.get(&Wrapped(value.as_indexed())) {
+            return Ok(key);
+        }
+        let index = self.values.len();
+        let key = K::try_from(index).map_err(|_| Error::Overflow)?;
+        // safety: we don't move the data out of the mutable pinned reference
+        unsafe {
+            push(self.values.as_mut().get_unchecked_mut(), value)?;
+        }
+        debug_assert_eq!(self.values.len(), index + 1);
+        self.map.insert(ValueRef::new(&self.values, index), key);
+        debug_assert_eq!(self.values.len(), self.map.len());
+        Ok(key)
+    }
+
+    pub fn shrink_to_fit(&mut self) {
+        // safety: we don't move the data out of the mutable pinned reference
+        unsafe {
+            self.values.as_mut().get_unchecked_mut().shrink_to_fit();
+        }
+    }
+}
+
+impl<K: DictionaryKey, M: MutableArray> Debug for ValueMap<K, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Pin::get_ref(self.values.as_ref()).fmt(f)
+    }
+}

--- a/src/array/dictionary/value_map.rs
+++ b/src/array/dictionary/value_map.rs
@@ -15,6 +15,7 @@ use crate::{
 
 use super::DictionaryKey;
 
+#[derive(Clone)]
 pub struct ValueMap<K: DictionaryKey, M: MutableArray> {
     values: M,
     map: HashMap<K, ()>, // NB: *only* use insert_hashed_nocheck() and no other hashmap API

--- a/src/array/dictionary/value_map.rs
+++ b/src/array/dictionary/value_map.rs
@@ -1,10 +1,9 @@
 use std::borrow::Borrow;
 use std::fmt::{self, Debug};
-use std::hash::{Hash, Hasher};
-use std::pin::Pin;
-use std::ptr::NonNull;
+use std::hash::{BuildHasher, Hash, Hasher};
 
-use hashbrown::{Equivalent, HashMap};
+use hashbrown::hash_map::RawEntryMut;
+use hashbrown::HashMap;
 
 use crate::array::Array;
 use crate::{
@@ -16,104 +15,9 @@ use crate::{
 
 use super::DictionaryKey;
 
-struct NonNullSend<M: ?Sized>(NonNull<M>);
-
-// safety: these pointers are for internal self-referential purposes to pinned array only
-unsafe impl<M> Send for NonNullSend<M> {}
-unsafe impl<M> Sync for NonNullSend<M> {}
-
-impl<M: ?Sized> From<&M> for NonNullSend<M> {
-    #[inline]
-    fn from(reference: &M) -> Self {
-        Self(NonNull::from(reference))
-    }
-}
-
-struct ValueRef<M> {
-    array: NonNullSend<M>,
-    index: usize,
-}
-
-impl<M> ValueRef<M> {
-    #[inline]
-    pub fn new(array: &Pin<Box<M>>, index: usize) -> Self {
-        Self {
-            array: NonNullSend::from(Pin::get_ref(array.as_ref())),
-            index,
-        }
-    }
-
-    #[inline]
-    pub fn get_array(&self) -> &M {
-        // safety: the invariant of the struct
-        unsafe { self.array.0.as_ref() }
-    }
-
-    #[inline]
-    pub unsafe fn get_unchecked(&self) -> M::Value<'_>
-    where
-        M: Indexable,
-    {
-        self.get_array().value_unchecked_at(self.index)
-    }
-
-    #[inline]
-    pub unsafe fn equals(&self, other: &M::Type) -> bool
-    where
-        M: Indexable,
-        M::Type: Eq,
-    {
-        self.get_unchecked().borrow() == other
-    }
-}
-
-impl<M: Indexable> PartialEq for ValueRef<M>
-where
-    M::Type: PartialEq,
-{
-    #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        // safety: the way these value refs are constructed, they are always within bounds
-        unsafe {
-            self.get_unchecked()
-                .borrow()
-                .eq(other.get_unchecked().borrow())
-        }
-    }
-}
-
-impl<M: Indexable> Eq for ValueRef<M> where for<'a> M::Type: Eq {}
-
-impl<M: Indexable> Hash for ValueRef<M>
-where
-    M::Type: Hash,
-{
-    #[inline]
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        // safety: the way these value refs are constructed, they are always within bounds
-        unsafe { self.get_unchecked().borrow().hash(state) }
-    }
-}
-
-// To avoid blanket implementation issues with `Equivalent` trait (we only use hashbrown
-// instead of the default HashMap to avoid blanket implementation problems with Borrow).
-#[derive(Hash)]
-struct Wrapped<'a, T: ?Sized>(&'a T);
-
-impl<'a, M: Indexable> Equivalent<ValueRef<M>> for Wrapped<'a, M::Type>
-where
-    M::Type: Eq,
-{
-    #[inline]
-    fn equivalent(&self, key: &ValueRef<M>) -> bool {
-        // safety: invariant of the struct
-        unsafe { key.equals(self.0) }
-    }
-}
-
 pub struct ValueMap<K: DictionaryKey, M: MutableArray> {
-    values: Pin<Box<M>>,
-    map: HashMap<ValueRef<M>, K>,
+    values: M,
+    map: HashMap<usize, K>, // NB: *only* use insert_hashed_nocheck() and no other hashmap API
 }
 
 impl<K: DictionaryKey, M: MutableArray> ValueMap<K, M> {
@@ -124,7 +28,7 @@ impl<K: DictionaryKey, M: MutableArray> ValueMap<K, M> {
             ));
         }
         Ok(Self {
-            values: Box::pin(values),
+            values,
             map: HashMap::default(),
         })
     }
@@ -134,29 +38,38 @@ impl<K: DictionaryKey, M: MutableArray> ValueMap<K, M> {
         M: Indexable,
         M::Type: Eq + Hash,
     {
-        let values = Box::pin(values);
-        let map = (0..values.len())
-            .map(|i| {
-                let key = K::try_from(i).map_err(|_| Error::Overflow)?;
-                Ok((ValueRef::new(&values, i), key))
-            })
-            .collect::<Result<_>>()?;
+        let mut map = HashMap::with_capacity(values.len());
+        for index in 0..values.len() {
+            let key = K::try_from(index).map_err(|_| Error::Overflow)?;
+            // safety: we only iterate within bounds
+            let value = unsafe { values.value_unchecked_at(index) };
+            let mut hasher = map.hasher().build_hasher();
+            value.borrow().hash(&mut hasher);
+            let hash = hasher.finish();
+            match map.raw_entry_mut().from_hash(hash, |_| true) {
+                RawEntryMut::Occupied(_) => {
+                    return Err(Error::InvalidArgumentError(
+                        "duplicate value in dictionary values array".into(),
+                    ))
+                }
+                RawEntryMut::Vacant(entry) => {
+                    entry.insert_hashed_nocheck(hash, index, key); // NB: don't use .insert() here!
+                }
+            }
+        }
         Ok(Self { values, map })
     }
 
     pub fn data_type(&self) -> &DataType {
-        Pin::get_ref(self.values.as_ref()).data_type()
+        self.values.data_type()
     }
 
-    pub fn into_boxed(self) -> Box<M> {
-        // safety: we unpin the pointer but the value map is dropped along with all
-        // the value references that might refer to the pinned array
-        unsafe { Pin::into_inner_unchecked(self.values) }
+    pub fn into_values(self) -> M {
+        self.values
     }
 
     pub fn take_into(&mut self) -> Box<dyn Array> {
-        // safety: we unpin the pointer but the value map is manually cleared
-        let arr = unsafe { self.values.as_mut().get_unchecked_mut().as_box() };
+        let arr = self.values.as_box();
         self.map.clear();
         arr
     }
@@ -177,31 +90,35 @@ impl<K: DictionaryKey, M: MutableArray> ValueMap<K, M> {
         V: AsIndexed<M>,
         M::Type: Eq + Hash,
     {
-        if let Some(&key) = self.map.get(&Wrapped(value.as_indexed())) {
-            return Ok(key);
-        }
-        let index = self.values.len();
-        let key = K::try_from(index).map_err(|_| Error::Overflow)?;
-        // safety: we don't move the data out of the mutable pinned reference
-        unsafe {
-            push(self.values.as_mut().get_unchecked_mut(), value)?;
-        }
-        debug_assert_eq!(self.values.len(), index + 1);
-        self.map.insert(ValueRef::new(&self.values, index), key);
-        debug_assert_eq!(self.values.len(), self.map.len());
-        Ok(key)
+        let mut hasher = self.map.hasher().build_hasher();
+        value.as_indexed().hash(&mut hasher);
+        let hash = hasher.finish();
+
+        Ok(
+            match self.map.raw_entry_mut().from_hash(hash, |index| {
+                // safety: invariant of the struct, it's always in bounds since we maintain it
+                let stored_value = unsafe { self.values.value_unchecked_at(*index) };
+                stored_value.borrow() == value.as_indexed()
+            }) {
+                RawEntryMut::Occupied(entry) => *entry.get(),
+                RawEntryMut::Vacant(entry) => {
+                    let index = self.values.len();
+                    let key = K::try_from(index).map_err(|_| Error::Overflow)?;
+                    entry.insert_hashed_nocheck(hash, index, key); // NB: don't use .insert() here!
+                    push(&mut self.values, value)?;
+                    key
+                }
+            },
+        )
     }
 
     pub fn shrink_to_fit(&mut self) {
-        // safety: we don't move the data out of the mutable pinned reference
-        unsafe {
-            self.values.as_mut().get_unchecked_mut().shrink_to_fit();
-        }
+        self.values.shrink_to_fit();
     }
 }
 
 impl<K: DictionaryKey, M: MutableArray> Debug for ValueMap<K, M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        Pin::get_ref(self.values.as_ref()).fmt(f)
+        self.values.fmt(f)
     }
 }

--- a/src/array/indexable.rs
+++ b/src/array/indexable.rs
@@ -1,0 +1,197 @@
+use std::borrow::Borrow;
+
+use crate::{
+    array::{
+        MutableArray, MutableBinaryArray, MutableBinaryValuesArray, MutableBooleanArray,
+        MutableFixedSizeBinaryArray, MutablePrimitiveArray, MutableUtf8Array,
+        MutableUtf8ValuesArray,
+    },
+    offset::Offset,
+    types::NativeType,
+};
+
+/// Trait for arrays that can be indexed directly to extract a value.
+pub trait Indexable {
+    /// The type of the element at index `i`; may be a reference type or a value type.
+    type Value<'a>: Borrow<Self::Type>
+    where
+        Self: 'a;
+
+    type Type: ?Sized;
+
+    /// Returns the element at index `i`.
+    /// # Panic
+    /// May panic if `i >= self.len()`.
+    fn value_at(&self, index: usize) -> Self::Value<'_>;
+
+    /// Returns the element at index `i`.
+    /// # Safety
+    /// Assumes that the `i < self.len`.
+    #[inline]
+    unsafe fn value_unchecked_at(&self, index: usize) -> Self::Value<'_> {
+        self.value_at(index)
+    }
+}
+
+pub trait AsIndexed<M: Indexable> {
+    fn as_indexed(&self) -> &M::Type;
+}
+
+impl Indexable for MutableBooleanArray {
+    type Value<'a> = bool;
+    type Type = bool;
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        self.values().get(i)
+    }
+}
+
+impl AsIndexed<MutableBooleanArray> for bool {
+    #[inline]
+    fn as_indexed(&self) -> &bool {
+        self
+    }
+}
+
+impl<O: Offset> Indexable for MutableBinaryArray<O> {
+    type Value<'a> = &'a [u8];
+    type Type = [u8];
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        // TODO: add .value() / .value_unchecked() to MutableBinaryArray?
+        assert!(i < self.len());
+        unsafe { self.value_unchecked_at(i) }
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        // TODO: add .value() / .value_unchecked() to MutableBinaryArray?
+        // soundness: the invariant of the function
+        let (start, end) = self.offsets().start_end_unchecked(i);
+        // soundness: the invariant of the struct
+        self.values().get_unchecked(start..end)
+    }
+}
+
+impl<O: Offset> AsIndexed<MutableBinaryArray<O>> for &[u8] {
+    #[inline]
+    fn as_indexed(&self) -> &[u8] {
+        self
+    }
+}
+
+impl<O: Offset> Indexable for MutableBinaryValuesArray<O> {
+    type Value<'a> = &'a [u8];
+    type Type = [u8];
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        self.value(i)
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        self.value_unchecked(i)
+    }
+}
+
+impl<O: Offset> AsIndexed<MutableBinaryValuesArray<O>> for &[u8] {
+    #[inline]
+    fn as_indexed(&self) -> &[u8] {
+        self
+    }
+}
+
+impl Indexable for MutableFixedSizeBinaryArray {
+    type Value<'a> = &'a [u8];
+    type Type = [u8];
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        self.value(i)
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        // soundness: the invariant of the struct
+        self.value_unchecked(i)
+    }
+}
+
+impl AsIndexed<MutableFixedSizeBinaryArray> for &[u8] {
+    #[inline]
+    fn as_indexed(&self) -> &[u8] {
+        self
+    }
+}
+
+// TODO: should NativeType derive from Hash?
+impl<T: NativeType> Indexable for MutablePrimitiveArray<T> {
+    type Value<'a> = T;
+    type Type = T;
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        assert!(i < self.len());
+        // TODO: add Length trait? (for both Array and MutableArray)
+        unsafe { self.value_unchecked_at(i) }
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        *self.values().get_unchecked(i)
+    }
+}
+
+impl<T: NativeType> AsIndexed<MutablePrimitiveArray<T>> for T {
+    #[inline]
+    fn as_indexed(&self) -> &T {
+        self
+    }
+}
+
+impl<O: Offset> Indexable for MutableUtf8Array<O> {
+    type Value<'a> = &'a str;
+    type Type = str;
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        self.value(i)
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        self.value_unchecked(i)
+    }
+}
+
+impl<O: Offset, V: AsRef<str>> AsIndexed<MutableUtf8Array<O>> for V {
+    #[inline]
+    fn as_indexed(&self) -> &str {
+        self.as_ref()
+    }
+}
+
+impl<O: Offset> Indexable for MutableUtf8ValuesArray<O> {
+    type Value<'a> = &'a str;
+    type Type = str;
+
+    #[inline]
+    fn value_at(&self, i: usize) -> Self::Value<'_> {
+        self.value(i)
+    }
+
+    #[inline]
+    unsafe fn value_unchecked_at(&self, i: usize) -> Self::Value<'_> {
+        self.value_unchecked(i)
+    }
+}
+
+impl<O: Offset, V: AsRef<str>> AsIndexed<MutableUtf8ValuesArray<O>> for V {
+    #[inline]
+    fn as_indexed(&self) -> &str {
+        self.as_ref()
+    }
+}

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -720,7 +720,8 @@ mod utf8;
 mod equal;
 mod ffi;
 mod fmt;
-mod indexable;
+#[doc(hidden)]
+pub mod indexable;
 mod iterator;
 
 pub mod growable;

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -720,8 +720,10 @@ mod utf8;
 mod equal;
 mod ffi;
 mod fmt;
-pub mod growable;
+mod indexable;
 mod iterator;
+
+pub mod growable;
 pub mod ord;
 
 pub(crate) use iterator::ArrayAccessor;

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -306,9 +306,9 @@ pub fn primitive_to_dictionary<T: NativeType + Eq + Hash, K: DictionaryKey>(
     from: &PrimitiveArray<T>,
 ) -> Result<DictionaryArray<K>> {
     let iter = from.iter().map(|x| x.copied());
-    let mut array = MutableDictionaryArray::<K, _>::from(MutablePrimitiveArray::<T>::from(
+    let mut array = MutableDictionaryArray::<K, _>::try_empty(MutablePrimitiveArray::<T>::from(
         from.data_type().clone(),
-    ));
+    ))?;
     array.try_extend(iter)?;
 
     Ok(array.into())

--- a/tests/it/array/dictionary/mutable.rs
+++ b/tests/it/array/dictionary/mutable.rs
@@ -1,8 +1,5 @@
 use arrow2::array::*;
 use arrow2::error::Result;
-use hash_hasher::HashedMap;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 
 #[test]
 fn primitive() -> Result<()> {
@@ -61,16 +58,4 @@ fn push_utf8() {
     expected_keys.push(Some(0));
     expected_keys.push(Some(1));
     assert_eq!(*new.keys(), expected_keys);
-
-    let expected_map = ["A", "B", "C"]
-        .iter()
-        .enumerate()
-        .map(|(index, value)| {
-            let mut hasher = DefaultHasher::new();
-            value.hash(&mut hasher);
-            let hash = hasher.finish();
-            (hash, index as i32)
-        })
-        .collect::<HashedMap<_, _>>();
-    assert_eq!(*new.map(), expected_map);
 }

--- a/tests/it/array/dictionary/mutable.rs
+++ b/tests/it/array/dictionary/mutable.rs
@@ -1,3 +1,9 @@
+use std::borrow::Borrow;
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use arrow2::array::indexable::{AsIndexed, Indexable};
 use arrow2::array::*;
 use arrow2::error::Result;
 
@@ -58,4 +64,89 @@ fn push_utf8() {
     expected_keys.push(Some(0));
     expected_keys.push(Some(1));
     assert_eq!(*new.keys(), expected_keys);
+}
+
+#[test]
+fn into_empty() {
+    let mut new: MutableDictionaryArray<i32, MutableUtf8Array<i32>> = MutableDictionaryArray::new();
+    for value in [Some("A"), Some("B"), None, Some("C"), Some("A"), Some("B")] {
+        new.try_push(value).unwrap();
+    }
+    let values = new.values().clone();
+    let empty = new.into_empty();
+    assert_eq!(empty.values(), &values);
+    assert!(empty.is_empty());
+}
+
+#[test]
+fn from_values() {
+    let mut new: MutableDictionaryArray<i32, MutableUtf8Array<i32>> = MutableDictionaryArray::new();
+    for value in [Some("A"), Some("B"), None, Some("C"), Some("A"), Some("B")] {
+        new.try_push(value).unwrap();
+    }
+    let mut values = new.values().clone();
+    let empty = MutableDictionaryArray::<i32, _>::from_values(values.clone()).unwrap();
+    assert_eq!(empty.values(), &values);
+    assert!(empty.is_empty());
+    values.push(Some("A"));
+    assert!(MutableDictionaryArray::<i32, _>::from_values(values).is_err());
+}
+
+#[test]
+fn try_empty() {
+    let mut values = MutableUtf8Array::<i32>::new();
+    MutableDictionaryArray::<i32, _>::try_empty(values.clone()).unwrap();
+    values.push(Some("A"));
+    assert!(MutableDictionaryArray::<i32, _>::try_empty(values.clone()).is_err());
+}
+
+fn test_push_ex<M, T>(values: Vec<T>, gen: impl Fn(usize) -> T)
+where
+    M: MutableArray + Indexable + TryPush<Option<T>> + TryExtend<Option<T>> + Default + 'static,
+    M::Type: Eq + Hash + Debug,
+    T: AsIndexed<M> + Default + Clone + Eq + Hash,
+{
+    for is_extend in [false, true] {
+        let mut set = HashSet::new();
+        let mut arr = MutableDictionaryArray::<u8, M>::new();
+        macro_rules! push {
+            ($v:expr) => {
+                if is_extend {
+                    arr.try_extend(std::iter::once($v))
+                } else {
+                    arr.try_push($v)
+                }
+            };
+        }
+        arr.push_null();
+        push!(None).unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr.values().len(), 0);
+        for (i, v) in values.iter().cloned().enumerate() {
+            push!(Some(v.clone())).unwrap();
+            let is_dup = !set.insert(v.clone());
+            if !is_dup {
+                assert_eq!(arr.values().value_at(i).borrow(), v.as_indexed());
+                assert_eq!(arr.keys().value_at(arr.keys().len() - 1), i as u8);
+            }
+            assert_eq!(arr.values().len(), set.len());
+            assert_eq!(arr.len(), 3 + i);
+        }
+        for i in 0..256 - set.len() {
+            push!(Some(gen(i))).unwrap();
+        }
+        assert!(push!(Some(gen(256))).is_err());
+    }
+}
+
+#[test]
+fn test_push_utf8_ex() {
+    test_push_ex::<MutableUtf8Array<i32>, _>(vec!["a".into(), "b".into(), "a".into()], |i| {
+        i.to_string()
+    })
+}
+
+#[test]
+fn test_push_i64_ex() {
+    test_push_ex::<MutablePrimitiveArray<i64>, _>(vec![10, 20, 30, 20], |i| 1000 + i as i64);
 }


### PR DESCRIPTION
As suggested by @ritchie46, using hashbrown's raw-entry API (flipped `<K, usize>` to `<usize, K>` though).

Need to be very careful to _not_ use any default map API though since it will break map consistency (like .insert(), .collect(), etc).

Benchmarks are roughly the same as in #1555, not slower, not faster; miri should be happy though.