### PR TITLE
Parse PrimitiveLogicalType::Unknown as Arrow Null DataType

### DIFF
--- a/src/io/parquet/read/schema/convert.rs
+++ b/src/io/parquet/read/schema/convert.rs
@@ -170,6 +170,12 @@ fn from_fixed_len_byte_array(
 
 /// Maps a [`PhysicalType`] with optional metadata to a [`DataType`]
 fn to_primitive_type_inner(primitive_type: &PrimitiveType) -> DataType {
+    // Unknown type refers to values that should always be treated as Null
+    // See: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#unknown-always-null
+    if matches!(primitive_type.logical_type, Some(PrimitiveLogicalType::Unknown)) {
+        return DataType::Null;
+    }
+
     match primitive_type.physical_type {
         PhysicalType::Boolean => DataType::Boolean,
         PhysicalType::Int32 => {


### PR DESCRIPTION
This PR adds logic to parse any Parquet fields with `Unknown` LogicalType as the Arrow `Null` DataType.