### PR TITLE
Native hashed-hash for MutableDictionaryArray

### DIFF
--- a/tests/it/array/dictionary/mutable.rs
+++ b/tests/it/array/dictionary/mutable.rs
@@ -150,3 +150,20 @@ fn test_push_utf8_ex() {
 fn test_push_i64_ex() {
     test_push_ex::<MutablePrimitiveArray<i64>, _>(vec![10, 20, 30, 20], |i| 1000 + i as i64);
 }
+
+#[test]
+fn test_big_dict() {
+    let n = 10;
+    let strings = (0..10).map(|i| i.to_string()).collect::<Vec<_>>();
+    let mut arr = MutableDictionaryArray::<u8, MutableUtf8Array<i32>>::new();
+    for s in &strings {
+        arr.try_push(Some(s)).unwrap();
+    }
+    assert_eq!(arr.values().len(), n);
+    for _ in 0..10_000 {
+        for s in &strings {
+            arr.try_push(Some(s)).unwrap();
+        }
+    }
+    assert_eq!(arr.values().len(), n);
+}


### PR DESCRIPTION
Here's yet another refactor of mutable dictionary arrays... tested it on some arrays of 100+M size, this time it seems like it actually works correctly.

There's a somewhat flimsy part (or flimsy invariant rather) in assuming that hash of a u64 hash using `HashHasherNative` will be identical to the hash itself if it's built in an endian-dependent way. I've tested it on M1 (LE) and it's correct, I'm guessing it will be correct on BE as well.

// @ritchie46 

Fixes #1561 