### PR TITLE
Improve bitmap slice unchecked

### DIFF
--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -172,9 +172,13 @@ impl Bitmap {
     /// The caller must ensure that `self.offset + offset + length <= self.len()`
     #[inline]
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
-        // first guard a no-op slice so that we don't do a bitcount
-        // if there isn't any data sliced
-        if !(offset == 0 && length == self.length) {
+        // we don't do a bitcount in the following cases:
+        // 1. if there isn't any data sliced.
+        // 2. if this [`Bitmap`] is all true or all false.
+        if !(offset == 0 && length == self.length
+            || self.unset_bits == 0
+            || self.unset_bits == self.length)
+        {
             // count the smallest chunk
             if length < self.length / 2 {
                 // count the null values in the slice
@@ -186,9 +190,9 @@ impl Bitmap {
                 let tail_count = count_zeros(&self.bytes, start_end, self.length - length - offset);
                 self.unset_bits -= head_count + tail_count;
             }
-            self.offset += offset;
-            self.length = length;
         }
+        self.offset += offset;
+        self.length = length;
     }
 
     /// Slices `self`, offsetting by `offset` and truncating up to `length` bits.

--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -172,8 +172,9 @@ impl Bitmap {
     /// The caller must ensure that `self.offset + offset + length <= self.len()`
     #[inline]
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
-        // first guard a no-op slice so that we don't do a bitcount
-        // if there isn't any data sliced
+        // we don't do a bitcount in the following cases:
+        // 1. if there isn't any data sliced.
+        // 2. if this [`Bitmap`] is all true or all false.
         if !(offset == 0 && length == self.length
             || self.unset_bits == 0
             || self.unset_bits == self.length)

--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -172,9 +172,8 @@ impl Bitmap {
     /// The caller must ensure that `self.offset + offset + length <= self.len()`
     #[inline]
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
-        // we don't do a bitcount in the following cases:
-        // 1. if there isn't any data sliced.
-        // 2. if this [`Bitmap`] is all true or all false.
+        // first guard a no-op slice so that we don't do a bitcount
+        // if there isn't any data sliced
         if !(offset == 0 && length == self.length
             || self.unset_bits == 0
             || self.unset_bits == self.length)

--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -174,7 +174,10 @@ impl Bitmap {
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
         // first guard a no-op slice so that we don't do a bitcount
         // if there isn't any data sliced
-        if !(offset == 0 && length == self.length) {
+        if !(offset == 0 && length == self.length
+            || self.unset_bits == 0
+            || self.unset_bits == self.length)
+        {
             // count the smallest chunk
             if length < self.length / 2 {
                 // count the null values in the slice
@@ -186,9 +189,9 @@ impl Bitmap {
                 let tail_count = count_zeros(&self.bytes, start_end, self.length - length - offset);
                 self.unset_bits -= head_count + tail_count;
             }
-            self.offset += offset;
-            self.length = length;
         }
+        self.offset += offset;
+        self.length = length;
     }
 
     /// Slices `self`, offsetting by `offset` and truncating up to `length` bits.

--- a/src/bitmap/immutable.rs
+++ b/src/bitmap/immutable.rs
@@ -174,10 +174,7 @@ impl Bitmap {
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
         // first guard a no-op slice so that we don't do a bitcount
         // if there isn't any data sliced
-        if !(offset == 0 && length == self.length
-            || self.unset_bits == 0
-            || self.unset_bits == self.length)
-        {
+        if !(offset == 0 && length == self.length) {
             // count the smallest chunk
             if length < self.length / 2 {
                 // count the null values in the slice
@@ -189,9 +186,9 @@ impl Bitmap {
                 let tail_count = count_zeros(&self.bytes, start_end, self.length - length - offset);
                 self.unset_bits -= head_count + tail_count;
             }
+            self.offset += offset;
+            self.length = length;
         }
-        self.offset += offset;
-        self.length = length;
     }
 
     /// Slices `self`, offsetting by `offset` and truncating up to `length` bits.


### PR DESCRIPTION
if a `Bitmap` is all true or all false, we don't do a bitcount in `slice_unchecked`.