### PR TITLE
fix: fix deserialization of parquets with large string list columns causing stack overflow

### DIFF
--- a/src/io/parquet/read/deserialize/binary/nested.rs
+++ b/src/io/parquet/read/deserialize/binary/nested.rs
@@ -170,22 +170,26 @@ impl<O: Offset, I: Pages> Iterator for NestedIter<O, I> {
     type Item = Result<(NestedState, Box<dyn Array>)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let maybe_state = next(
-            &mut self.iter,
-            &mut self.items,
-            &mut self.dict,
-            &mut self.remaining,
-            &self.init,
-            self.chunk_size,
-            &BinaryDecoder::<O>::default(),
-        );
-        match maybe_state {
-            MaybeNext::Some(Ok((nested, decoded))) => {
-                Some(finish(&self.data_type, decoded.0, decoded.1).map(|array| (nested, array)))
+        loop {
+            let maybe_state = next(
+                &mut self.iter,
+                &mut self.items,
+                &mut self.dict,
+                &mut self.remaining,
+                &self.init,
+                self.chunk_size,
+                &BinaryDecoder::<O>::default(),
+            );
+            match maybe_state {
+                MaybeNext::Some(Ok((nested, decoded))) => {
+                    return Some(
+                        finish(&self.data_type, decoded.0, decoded.1).map(|array| (nested, array)),
+                    )
+                },
+                MaybeNext::Some(Err(e)) => return Some(Err(e)),
+                MaybeNext::None => return None,
+                MaybeNext::More => continue, // Using continue in a loop instead of calling next helps prevent stack overflow.
             }
-            MaybeNext::Some(Err(e)) => Some(Err(e)),
-            MaybeNext::None => None,
-            MaybeNext::More => self.next(),
         }
     }
 }

--- a/src/io/parquet/read/deserialize/binary/nested.rs
+++ b/src/io/parquet/read/deserialize/binary/nested.rs
@@ -185,7 +185,7 @@ impl<O: Offset, I: Pages> Iterator for NestedIter<O, I> {
                     return Some(
                         finish(&self.data_type, decoded.0, decoded.1).map(|array| (nested, array)),
                     )
-                },
+                }
                 MaybeNext::Some(Err(e)) => return Some(Err(e)),
                 MaybeNext::None => return None,
                 MaybeNext::More => continue, // Using continue in a loop instead of calling next helps prevent stack overflow.


### PR DESCRIPTION
This mirrors a fix I did within polars: https://github.com/pola-rs/polars/pull/11471