### PR TITLE
Fixed typo

### DIFF
--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -31,7 +31,7 @@ mod union;
 pub use union::UnionScalar;
 
 /// Trait object declaring an optional value with a [`DataType`].
-/// This strait is often used in APIs that accept multiple scalar types.
+/// This trait is often used in APIs that accept multiple scalar types.
 pub trait Scalar: std::fmt::Debug + Send + Sync + dyn_clone::DynClone + 'static {
     /// convert itself to
     fn as_any(&self) -> &dyn Any;


### PR DESCRIPTION
Typo -- `strait` instead of `trait`