### PR TITLE
Add a "contains" fast-path to `like_utf8_scalar`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ odbc-api = { version = "0.36", optional = true }
 ahash = "0.8"
 
 # For `LIKE` matching "contains" fast-path 
-memchr = { version = "2.6.4", optional = true }
+memchr = { version = "2.6", optional = true }
 
 # Support conversion to/from arrow-rs
 arrow-buffer = { version = ">=40", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,9 @@ odbc-api = { version = "0.36", optional = true }
 # Faster hashing
 ahash = "0.8"
 
+# For `LIKE` matching "contains" fast-path 
+memchr = { version = "2.6.4", optional = true }
+
 # Support conversion to/from arrow-rs
 arrow-buffer = { version = ">=40", optional = true }
 arrow-schema = { version = ">=40", optional = true }
@@ -237,7 +240,7 @@ compute_filter = []
 compute_hash = ["multiversion"]
 compute_if_then_else = []
 compute_length = []
-compute_like = ["regex", "regex-syntax"]
+compute_like = ["regex", "regex-syntax", "dep:memchr"]
 compute_limit = []
 compute_merge_sort = ["itertools", "compute_sort"]
 compute_nullif = ["compute_comparison"]
@@ -394,3 +397,8 @@ harness = false
 [[bench]]
 name = "assign_ops"
 harness = false
+
+[[bench]]
+name = "like_kernels"
+harness = false
+

--- a/benches/like_kernels.rs
+++ b/benches/like_kernels.rs
@@ -1,0 +1,22 @@
+use arrow2::util::bench_util::create_string_array;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use arrow2::array::*;
+use arrow2::compute::like::like_utf8_scalar;
+
+fn bench_like(array: &Utf8Array<i32>, pattern: &str) {
+    criterion::black_box(like_utf8_scalar(array, pattern).unwrap());
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    for size_log2 in 16..21_u32 {
+        let size = size_log2.pow(2) as usize;
+        let array = create_string_array::<i32>(100, size, 0.0, 0);
+        c.bench_function(&format!("LIKE length = 2^{}", size_log2), |b| {
+            b.iter(|| bench_like(&array, "%abba%"))
+        });
+    }
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/src/compute/like.rs
+++ b/src/compute/like.rs
@@ -159,7 +159,10 @@ fn a_like_utf8_scalar<O: Offset, F: Fn(bool) -> bool>(
     {
         let needle = &rhs[1..rhs.len() - 1];
         let finder = memchr::memmem::Finder::new(needle);
-        Bitmap::from_trusted_len_iter(lhs.values_iter().map(|x| op(finder.find(x.as_bytes()).is_some())))
+        Bitmap::from_trusted_len_iter(
+            lhs.values_iter()
+                .map(|x| op(finder.find(x.as_bytes()).is_some())),
+        )
     } else {
         let re_pattern = replace_pattern(rhs);
         let re = Regex::new(&format!("^{re_pattern}$")).map_err(|e| {

--- a/src/compute/like.rs
+++ b/src/compute/like.rs
@@ -152,6 +152,14 @@ fn a_like_utf8_scalar<O: Offset, F: Fn(bool) -> bool>(
         // fast path, can use ends_with
         let ends_with = &rhs[1..];
         Bitmap::from_trusted_len_iter(lhs.values_iter().map(|x| op(x.ends_with(ends_with))))
+    } else if rhs.starts_with('%')
+        && rhs.ends_with('%')
+        && !rhs.ends_with("\\%")
+        && !rhs[1..rhs.len() - 1].contains(is_like_pattern)
+    {
+        let needle = &rhs[1..rhs.len() - 1];
+        let finder = memchr::memmem::Finder::new(needle);
+        Bitmap::from_trusted_len_iter(lhs.values_iter().map(|x| op(finder.find(x.as_bytes()).is_some())))
     } else {
         let re_pattern = replace_pattern(rhs);
         let re = Regex::new(&format!("^{re_pattern}$")).map_err(|e| {

--- a/tests/it/compute/like.rs
+++ b/tests/it/compute/like.rs
@@ -58,6 +58,10 @@ fn test_like_utf8_scalar() -> Result<()> {
     let result = like_utf8_scalar(&array, "A\\_row").unwrap();
     assert_eq!(result, BooleanArray::from_slice([true, false]));
 
+    let array = Utf8Array::<i32>::from_slice(["Arrow", "Arrow", "row your", "boat"]);
+    let result = like_utf8_scalar(&array, "%row%").unwrap();
+    assert_eq!(result, BooleanArray::from_slice([true, true, true, false]));
+
     Ok(())
 }
 


### PR DESCRIPTION
This PR uses `memchr` to add a fast path to `like_utf8_scalar` for when the pattern can be processed as a "contains" query. For example, if the pattern is `%ABBA%`, then we can check to see if each string contains `ABBA` instead of building a regular expression.

To measure the performance improvement from this fast path, I added a benchmark. Here are the results on my machine:

| Length |   regex   |   memchr  |
|--------|-----------|-----------|
| 2^16   |  63.5 µs  |  0.88 µs  |
| 2^17   |  68.1 µs  |  1.04 µs  |
| 2^18   |  72.4 µs  |  1.05 µs  |
| 2^19   |  76.7 µs  |  1.11 µs  |
| 2^20   |  81.3 µs  |  1.13 µs  |

Since `memchr` does the state-of-the-art SIMD tricks (as far as I know), this technique should even be faster for "contains" queries than the glob-matching suggestion in #1295 .