### PR TITLE
 Move parquet async functionality behind feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ odbc-api = { version = "0.36", optional = true }
 # Faster hashing
 ahash = "0.8"
 
-# For `LIKE` matching "contains" fast-path 
+# For `LIKE` matching "contains" fast-path
 memchr = { version = "2.6", optional = true }
 
 # Support conversion to/from arrow-rs
@@ -117,7 +117,6 @@ getrandom = { version = "0.2", features = ["js"] }
 version = "0.17"
 optional = true
 default_features = false
-features = ["async"]
 
 [dev-dependencies]
 criterion = "0.4"
@@ -160,7 +159,7 @@ full = [
     "io_ipc_compression",
     "io_json_integration",
     "io_print",
-    "io_parquet",
+    "io_parquet_async",
     "io_parquet_compression",
     "io_avro",
     "io_orc",
@@ -189,7 +188,8 @@ io_ipc_compression = ["lz4", "zstd"]
 io_flight = ["io_ipc", "arrow-format/flight-data"]
 
 # base64 + io_ipc because arrow schemas are stored as base64-encoded ipc format.
-io_parquet = ["parquet2", "io_ipc", "base64", "futures", "streaming-iterator", "fallible-streaming-iterator"]
+io_parquet = ["parquet2", "io_ipc", "base64", "streaming-iterator", "fallible-streaming-iterator"]
+io_parquet_async = ["futures", "io_parquet", "parquet2/async"]
 
 io_parquet_compression = [
     "io_parquet_zstd",
@@ -200,7 +200,7 @@ io_parquet_compression = [
 ]
 
 # sample testing of generated arrow data
-io_parquet_sample_test = ["io_parquet"]
+io_parquet_sample_test = ["io_parquet_async"]
 
 # compression backends
 io_parquet_zstd = ["parquet2/zstd"]

--- a/src/io/parquet/read/mod.rs
+++ b/src/io/parquet/read/mod.rs
@@ -10,19 +10,22 @@ pub mod statistics;
 
 use std::io::{Read, Seek};
 
+#[cfg(feature = "io_parquet_async")]
 use futures::{AsyncRead, AsyncSeek};
 
 // re-exports of parquet2's relevant APIs
+#[cfg(feature = "io_parquet_async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io_parquet_async")))]
+pub use parquet2::read::{get_page_stream, read_metadata_async as _read_metadata_async};
 pub use parquet2::{
     error::Error as ParquetError,
     fallible_streaming_iterator,
     metadata::{ColumnChunkMetaData, ColumnDescriptor, RowGroupMetaData},
     page::{CompressedDataPage, DataPageHeader, Page},
     read::{
-        decompress, get_column_iterator, get_page_stream,
-        read_columns_indexes as _read_columns_indexes, read_metadata as _read_metadata,
-        read_metadata_async as _read_metadata_async, read_pages_locations, BasicDecompressor,
-        Decompressor, MutStreamingIterator, PageFilter, PageReader, ReadColumnIterator, State,
+        decompress, get_column_iterator, read_columns_indexes as _read_columns_indexes,
+        read_metadata as _read_metadata, read_pages_locations, BasicDecompressor, Decompressor,
+        MutStreamingIterator, PageFilter, PageReader, ReadColumnIterator, State,
     },
     schema::types::{
         GroupLogicalType, ParquetType, PhysicalType, PrimitiveConvertedType, PrimitiveLogicalType,
@@ -60,6 +63,8 @@ pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
 }
 
 /// Reads parquets' metadata asynchronously.
+#[cfg(feature = "io_parquet_async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io_parquet_async")))]
 pub async fn read_metadata_async<R: AsyncRead + AsyncSeek + Send + Unpin>(
     reader: &mut R,
 ) -> Result<FileMetaData> {

--- a/src/io/parquet/read/row_group.rs
+++ b/src/io/parquet/read/row_group.rs
@@ -1,5 +1,6 @@
 use std::io::{Read, Seek};
 
+#[cfg(feature = "io_parquet_async")]
 use futures::{
     future::{try_join_all, BoxFuture},
     AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt,
@@ -138,6 +139,7 @@ where
     Ok((meta, chunk))
 }
 
+#[cfg(feature = "io_parquet_async")]
 async fn _read_single_column_async<'b, R, F>(
     reader_factory: F,
     meta: &ColumnChunkMetaData,
@@ -163,6 +165,8 @@ where
 ///
 /// It does so asynchronously via a single `join_all` over all the necessary columns for
 /// `field_name`.
+#[cfg(feature = "io_parquet_async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io_parquet_async")))]
 pub async fn read_columns_async<
     'a,
     'b,
@@ -303,6 +307,8 @@ pub fn read_columns_many<'a, R: Read + Seek>(
 /// This operation is IO-bounded `O(C)` where C is the number of columns in the row group -
 /// it reads all the columns to memory from the row group associated to the requested fields.
 /// It does so asynchronously via `join_all`
+#[cfg(feature = "io_parquet_async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io_parquet_async")))]
 pub async fn read_columns_many_async<
     'a,
     'b,

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -22,6 +22,7 @@ mod pages;
 mod primitive;
 mod row_group;
 mod schema;
+#[cfg(feature = "io_parquet_async")]
 mod sink;
 mod utf8;
 mod utils;
@@ -68,6 +69,8 @@ use crate::compute::aggregate::estimated_bytes_size;
 pub use file::FileWriter;
 pub use row_group::{row_group_iter, RowGroupIterator};
 pub use schema::to_parquet_type;
+#[cfg(feature = "io_parquet_async")]
+#[cfg_attr(docsrs, doc(cfg(feature = "io_parquet_async")))]
 pub use sink::FileSink;
 
 pub use pages::array_to_columns;


### PR DESCRIPTION
Addresses #1296 with a new `io_parquet_async` feature flag.

Since this is a breaking change for anyone using the async functions through the `io_parquet` flag, let me know if you want me to bump the version or just add `io_parquet_async` as a dependency of `io_parquet` (are circular feature dependencies allowed?).

`cargo check` output:
```
$ cargo clean
$ cargo check -F io_parquet
   Compiling proc-macro2 v1.0.69
   Compiling unicode-ident v1.0.12
   Compiling libc v0.2.149
   Compiling semver v1.0.20
   Compiling version_check v0.9.4
   Compiling autocfg v1.1.0
    Checking cfg-if v1.0.0
   Compiling serde v1.0.189
    Checking zerocopy v0.7.15
    Checking array-init-cursor v0.2.0
    Checking fallible-streaming-iterator v0.1.9
    Checking once_cell v1.18.0
    Checking streaming-decompression v0.1.2
   Compiling ahash v0.8.6
    Checking planus v0.3.1
    Checking parquet-format-safe v0.2.4
   Compiling num-traits v0.2.17
   Compiling seq-macro v0.3.5
    Checking base64 v0.21.5
    Checking simdutf8 v0.1.4
    Checking foreign_vec v0.1.0
    Checking streaming-iterator v0.1.9
    Checking either v1.9.0
    Checking hash_hasher v2.0.3
   Compiling quote v1.0.33
    Checking parquet2 v0.17.2
    Checking dyn-clone v1.0.14
   Compiling rustc_version v0.4.0
    Checking ethnum v1.4.0
   Compiling syn v2.0.38
    Checking getrandom v0.2.10
   Compiling arrow2 v0.17.4 (/Users/blevin/dev/lib/arrow2)
    Checking hashbrown v0.14.2
    Checking chrono v0.4.31
   Compiling serde_derive v1.0.189
   Compiling bytemuck_derive v1.5.0
    Checking bytemuck v1.14.0
    Checking arrow-format v0.8.1
    Finished dev [unoptimized + debuginfo] target(s) in 7.99s
$ cargo check -F io_parquet_async
   Compiling futures-core v0.3.28
   Compiling futures-channel v0.3.28
   Compiling futures-task v0.3.28
    Checking pin-project-lite v0.2.13
    Checking futures-sink v0.3.28
   Compiling slab v0.4.9
   Compiling futures-util v0.3.28
   Compiling syn v2.0.38
    Checking pin-utils v0.1.0
    Checking futures-io v0.3.28
    Checking memchr v2.6.4
   Compiling async-trait v0.1.74
   Compiling arrow2 v0.17.4 (/Users/blevin/dev/lib/arrow2)
   Compiling futures-macro v0.3.28
   Compiling async-stream-impl v0.3.5
   Compiling serde_derive v1.0.189
   Compiling bytemuck_derive v1.5.0
    Checking async-stream v0.3.5
    Checking bytemuck v1.14.0
    Checking serde v1.0.189
    Checking futures-executor v0.3.28
    Checking futures v0.3.28
    Checking parquet-format-safe v0.2.4
    Checking arrow-format v0.8.1
    Checking parquet2 v0.17.2
    Finished dev [unoptimized + debuginfo] target(s) in 8.41s
```