### PR TITLE
Added try_new for mutable data types

### DIFF
--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -100,6 +100,16 @@ pub struct MutableNullArray {
 
 impl MutableNullArray {
     /// Returns a new [`MutableNullArray`].
+    /// # Errors
+    /// This function errors iff:
+    /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to [`crate::datatypes::PhysicalType::Null`].
+    pub fn try_new(data_type: DataType, length: usize) -> Result<Self, Error> {
+        Ok(Self {
+            inner: NullArray::try_new(data_type, length)?,
+        })
+    }
+
+    /// Returns a new [`MutableNullArray`].
     /// # Panics
     /// This function errors iff:
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to [`crate::datatypes::PhysicalType::Null`].

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -93,6 +93,20 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     pub fn apply_values<F: Fn(&mut [T])>(&mut self, f: F) {
         f(&mut self.values);
     }
+
+    /// The number of null slots on this [`Array`].
+    /// # Implementation
+    /// This is `O(1)` since the number of null elements is pre-computed.
+    #[inline]
+    pub fn null_count(&self) -> usize {
+        if self.data_type() == &DataType::Null {
+            return self.len();
+        };
+        self.validity()
+            .as_ref()
+            .map(|x| x.unset_bits())
+            .unwrap_or(0)
+    }
 }
 
 impl<T: NativeType> Default for MutablePrimitiveArray<T> {


### PR DESCRIPTION
This PR is made to have consistent in try_new() constructors that accept DataType in a similar way, for all mutable array types