### PR TITLE
Rebase to polars-arrow for BinaryView/StringView support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ num-traits = "0.2"
 dyn-clone = "1"
 bytemuck = { version = "1", features = ["derive"] }
 chrono = { version = "0.4.31", default_features = false, features = ["std"] }
+atoi_simd = "0.15.5"
+itoa = "1.0.6"
+ryu = "1.0.13"
+fast-float = { version = "0.2" }
 
 # for decimal i256
 ethnum = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,7 +184,7 @@ io_json_write = ["streaming-iterator", "fallible-streaming-iterator", "lexical-c
 io_ipc = ["arrow-format"]
 io_ipc_write_async = ["io_ipc", "futures"]
 io_ipc_read_async = ["io_ipc", "futures", "async-stream"]
-io_ipc_compression = ["lz4", "zstd"]
+io_ipc_compression = ["lz4", "zstd", "io_ipc"]
 io_flight = ["io_ipc", "arrow-format/flight-data"]
 
 # base64 + io_ipc because arrow schemas are stored as base64-encoded ipc format.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ indexmap = { version = "^1.6", optional = true }
 # used to print columns in a nice columnar format
 comfy-table = { version = "6.0", optional = true, default-features = false }
 
-arrow-format = { version = "0.8", optional = true, features = ["ipc"] }
+arrow-format = { package = "polars-arrow-format", version = "0.1.0", optional = true, features = ["ipc"] }
 
 hex = { version = "^0.4", optional = true }
 

--- a/examples/ipc_file_mmap.rs
+++ b/examples/ipc_file_mmap.rs
@@ -29,7 +29,7 @@ fn write(
     let options = arrow2::io::ipc::write::WriteOptions { compression };
     let mut writer = arrow2::io::ipc::write::FileWriter::try_new(
         result,
-        schema.clone(),
+        schema.clone().into(),
         ipc_fields.clone(),
         options,
     )?;

--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -62,6 +62,6 @@ impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryArray<O> {
         // assumption that data from FFI is well constructed
         let offsets = unsafe { OffsetsBuffer::new_unchecked(offsets) };
 
-        Ok(Self::new(data_type, offsets, values, validity))
+        Self::try_new(data_type, offsets, values, validity)
     }
 }

--- a/src/array/binary/ffi.rs
+++ b/src/array/binary/ffi.rs
@@ -13,8 +13,8 @@ unsafe impl<O: Offset> ToFfi for BinaryArray<O> {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            Some(self.offsets.buffer().as_ptr().cast::<u8>()),
-            Some(self.values.as_ptr().cast::<u8>()),
+            Some(self.offsets.buffer().storage_ptr().cast::<u8>()),
+            Some(self.values.storage_ptr().cast::<u8>()),
         ]
     }
 

--- a/src/array/binview/ffi.rs
+++ b/src/array/binview/ffi.rs
@@ -67,6 +67,11 @@ impl<T: ViewType + ?Sized, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryViewArray
             buffers.push(values);
         }
 
-        Self::try_new(data_type, views, Arc::from(buffers), validity)
+        Ok(Self::new_unchecked(
+            data_type,
+            views,
+            Arc::from(buffers),
+            validity,
+        ))
     }
 }

--- a/src/array/binview/ffi.rs
+++ b/src/array/binview/ffi.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+
+use polars_error::PolarsResult;
+
+use super::BinaryViewArrayGeneric;
+use crate::array::binview::ViewType;
+use crate::array::{FromFfi, ToFfi};
+use crate::bitmap::align;
+use crate::ffi;
+
+unsafe impl<T: ViewType + ?Sized> ToFfi for BinaryViewArrayGeneric<T> {
+    fn buffers(&self) -> Vec<Option<*const u8>> {
+        let mut buffers = Vec::with_capacity(self.buffers.len() + 2);
+        buffers.push(self.validity.as_ref().map(|x| x.as_ptr()));
+        buffers.push(Some(self.views.as_ptr().cast::<u8>()));
+        buffers.extend(self.buffers.iter().map(|b| Some(b.as_ptr())));
+        buffers
+    }
+
+    fn offset(&self) -> Option<usize> {
+        let offset = self.views.offset();
+        if let Some(bitmap) = self.validity.as_ref() {
+            if bitmap.offset() == offset {
+                Some(offset)
+            } else {
+                None
+            }
+        } else {
+            Some(offset)
+        }
+    }
+
+    fn to_ffi_aligned(&self) -> Self {
+        let offset = self.views.offset();
+
+        let validity = self.validity.as_ref().map(|bitmap| {
+            if bitmap.offset() == offset {
+                bitmap.clone()
+            } else {
+                align(bitmap, offset)
+            }
+        });
+
+        Self {
+            data_type: self.data_type.clone(),
+            validity,
+            views: self.views.clone(),
+            buffers: self.buffers.clone(),
+            raw_buffers: self.raw_buffers.clone(),
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl<T: ViewType + ?Sized, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryViewArrayGeneric<T> {
+    unsafe fn try_from_ffi(array: A) -> PolarsResult<Self> {
+        let data_type = array.data_type().clone();
+
+        let validity = unsafe { array.validity() }?;
+        let views = unsafe { array.buffer::<u128>(1) }?;
+
+        let n = array.n_buffers() - 2;
+        let mut buffers = Vec::with_capacity(n);
+
+        for i in 2..n + 2 {
+            let values = unsafe { array.buffer::<u8>(i) }?;
+            buffers.push(values);
+        }
+
+        Self::try_new(data_type, views, Arc::from(buffers), validity)
+    }
+}

--- a/src/array/binview/ffi.rs
+++ b/src/array/binview/ffi.rs
@@ -62,18 +62,37 @@ impl<T: ViewType + ?Sized, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryViewArray
         let validity = unsafe { array.validity() }?;
         let views = unsafe { array.buffer::<u128>(1) }?;
 
-        let n = array.n_buffers() - 2;
-        let mut buffers = Vec::with_capacity(n);
+        // 2 - validity + views
+        let n_buffers = array.n_buffers();
+        let mut remaining_buffers = n_buffers - 2;
+        if remaining_buffers <= 1 {
+            return Ok(Self::new_unchecked_unknown_md(
+                data_type,
+                views,
+                Arc::from([]),
+                validity,
+            ));
+        }
 
-        for i in 2..n + 2 {
-            let values = unsafe { array.buffer::<u8>(i) }?;
-            buffers.push(values);
+        let n_variadic_buffers = remaining_buffers - 1;
+        let variadic_buffer_offset = n_buffers - 1;
+
+        let variadic_buffer_sizes =
+            array.buffer_known_len::<i64>(variadic_buffer_offset, n_variadic_buffers)?;
+        remaining_buffers -= 1;
+
+        let mut variadic_buffers = Vec::with_capacity(remaining_buffers);
+
+        let offset = 2;
+        for (i, &size) in (offset..remaining_buffers + offset).zip(variadic_buffer_sizes.iter()) {
+            let values = unsafe { array.buffer_known_len::<u8>(i, size as usize) }?;
+            variadic_buffers.push(values);
         }
 
         Ok(Self::new_unchecked_unknown_md(
             data_type,
             views,
-            Arc::from(buffers),
+            Arc::from(variadic_buffers),
             validity,
         ))
     }

--- a/src/array/binview/ffi.rs
+++ b/src/array/binview/ffi.rs
@@ -48,6 +48,8 @@ unsafe impl<T: ViewType + ?Sized> ToFfi for BinaryViewArrayGeneric<T> {
             buffers: self.buffers.clone(),
             raw_buffers: self.raw_buffers.clone(),
             phantom: Default::default(),
+            total_bytes_len: self.total_bytes_len,
+            total_buffer_len: self.total_buffer_len,
         }
     }
 }
@@ -67,7 +69,7 @@ impl<T: ViewType + ?Sized, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryViewArray
             buffers.push(values);
         }
 
-        Ok(Self::new_unchecked(
+        Ok(Self::new_unchecked_unknown_md(
             data_type,
             views,
             Arc::from(buffers),

--- a/src/array/binview/ffi.rs
+++ b/src/array/binview/ffi.rs
@@ -12,8 +12,8 @@ unsafe impl<T: ViewType + ?Sized> ToFfi for BinaryViewArrayGeneric<T> {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         let mut buffers = Vec::with_capacity(self.buffers.len() + 2);
         buffers.push(self.validity.as_ref().map(|x| x.as_ptr()));
-        buffers.push(Some(self.views.as_ptr().cast::<u8>()));
-        buffers.extend(self.buffers.iter().map(|b| Some(b.as_ptr())));
+        buffers.push(Some(self.views.storage_ptr().cast::<u8>()));
+        buffers.extend(self.buffers.iter().map(|b| Some(b.storage_ptr())));
         buffers
     }
 

--- a/src/array/binview/ffi.rs
+++ b/src/array/binview/ffi.rs
@@ -71,6 +71,7 @@ impl<T: ViewType + ?Sized, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryViewArray
                 views,
                 Arc::from([]),
                 validity,
+                None,
             ));
         }
 
@@ -94,6 +95,7 @@ impl<T: ViewType + ?Sized, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryViewArray
             views,
             Arc::from(variadic_buffers),
             validity,
+            None,
         ))
     }
 }

--- a/src/array/binview/ffi.rs
+++ b/src/array/binview/ffi.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use polars_error::PolarsResult;
@@ -48,7 +49,7 @@ unsafe impl<T: ViewType + ?Sized> ToFfi for BinaryViewArrayGeneric<T> {
             buffers: self.buffers.clone(),
             raw_buffers: self.raw_buffers.clone(),
             phantom: Default::default(),
-            total_bytes_len: self.total_bytes_len,
+            total_bytes_len: AtomicU64::new(self.total_bytes_len.load(Ordering::Relaxed)),
             total_buffer_len: self.total_buffer_len,
         }
     }

--- a/src/array/binview/ffi.rs
+++ b/src/array/binview/ffi.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use super::BinaryViewArrayGeneric;
 
 use crate::error::Result;
-use crate::array::binview::ViewType;
+use crate::array::binview::{View, ViewType};
 use crate::array::{FromFfi, ToFfi};
 use crate::bitmap::align;
 use crate::ffi;
@@ -60,7 +60,7 @@ impl<T: ViewType + ?Sized, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryViewArray
         let data_type = array.data_type().clone();
 
         let validity = unsafe { array.validity() }?;
-        let views = unsafe { array.buffer::<u128>(1) }?;
+        let views = unsafe { array.buffer::<View>(1) }?;
 
         // 2 - validity + views
         let n_buffers = array.n_buffers();

--- a/src/array/binview/ffi.rs
+++ b/src/array/binview/ffi.rs
@@ -1,9 +1,9 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use polars_error::PolarsResult;
-
 use super::BinaryViewArrayGeneric;
+
+use crate::error::Result;
 use crate::array::binview::ViewType;
 use crate::array::{FromFfi, ToFfi};
 use crate::bitmap::align;
@@ -56,7 +56,7 @@ unsafe impl<T: ViewType + ?Sized> ToFfi for BinaryViewArrayGeneric<T> {
 }
 
 impl<T: ViewType + ?Sized, A: ffi::ArrowArrayRef> FromFfi<A> for BinaryViewArrayGeneric<T> {
-    unsafe fn try_from_ffi(array: A) -> PolarsResult<Self> {
+    unsafe fn try_from_ffi(array: A) -> Result<Self> {
         let data_type = array.data_type().clone();
 
         let validity = unsafe { array.validity() }?;

--- a/src/array/binview/fmt.rs
+++ b/src/array/binview/fmt.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Formatter, Result, Write};
 use super::super::fmt::write_vec;
 use super::BinaryViewArrayGeneric;
 use crate::array::binview::ViewType;
-use crate::array::Array;
+use crate::array::{Array, BinaryViewArray, Utf8ViewArray};
 
 pub fn write_value<'a, T: ViewType + ?Sized, W: Write>(
     array: &'a BinaryViewArrayGeneric<T>,
@@ -19,19 +19,18 @@ where
     write_vec(f, writer, None, bytes.len(), "None", false)
 }
 
-impl<T: ViewType + ?Sized> Debug for BinaryViewArrayGeneric<T>
-where
-    for<'a> &'a T: Debug,
-{
+impl Debug for BinaryViewArray {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let writer = |f: &mut Formatter, index| write_value(self, index, f);
+        write!(f, "BinaryViewArray")?;
+        write_vec(f, writer, self.validity(), self.len(), "None", false)
+    }
+}
 
-        let head = if T::IS_UTF8 {
-            "Utf8ViewArray"
-        } else {
-            "BinaryViewArray"
-        };
-        write!(f, "{head}")?;
+impl Debug for Utf8ViewArray {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let writer = |f: &mut Formatter, index| write!(f, "{}", self.value(index));
+        write!(f, "Utf8ViewArray")?;
         write_vec(f, writer, self.validity(), self.len(), "None", false)
     }
 }

--- a/src/array/binview/fmt.rs
+++ b/src/array/binview/fmt.rs
@@ -1,0 +1,37 @@
+use std::fmt::{Debug, Formatter, Result, Write};
+
+use super::super::fmt::write_vec;
+use super::BinaryViewArrayGeneric;
+use crate::array::binview::ViewType;
+use crate::array::Array;
+
+pub fn write_value<'a, T: ViewType + ?Sized, W: Write>(
+    array: &'a BinaryViewArrayGeneric<T>,
+    index: usize,
+    f: &mut W,
+) -> Result
+where
+    &'a T: Debug,
+{
+    let bytes = array.value(index).to_bytes();
+    let writer = |f: &mut W, index| write!(f, "{}", bytes[index]);
+
+    write_vec(f, writer, None, bytes.len(), "None", false)
+}
+
+impl<T: ViewType + ?Sized> Debug for BinaryViewArrayGeneric<T>
+where
+    for<'a> &'a T: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let writer = |f: &mut Formatter, index| write_value(self, index, f);
+
+        let head = if T::IS_UTF8 {
+            "Utf8ViewArray"
+        } else {
+            "BinaryViewArray"
+        };
+        write!(f, "{head}")?;
+        write_vec(f, writer, self.validity(), self.len(), "None", false)
+    }
+}

--- a/src/array/binview/iterator.rs
+++ b/src/array/binview/iterator.rs
@@ -1,0 +1,30 @@
+use super::BinaryViewArrayGeneric;
+use crate::array::binview::ViewType;
+use crate::array::{ArrayAccessor, ArrayValuesIter};
+use crate::bitmap::utils::{BitmapIter, ZipValidity};
+
+unsafe impl<'a, T: ViewType + ?Sized> ArrayAccessor<'a> for BinaryViewArrayGeneric<T> {
+    type Item = &'a T;
+
+    #[inline]
+    unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
+        self.value_unchecked(index)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.views.len()
+    }
+}
+
+/// Iterator of values of an [`BinaryArray`].
+pub type BinaryViewValueIter<'a, T> = ArrayValuesIter<'a, BinaryViewArrayGeneric<T>>;
+
+impl<'a, T: ViewType + ?Sized> IntoIterator for &'a BinaryViewArrayGeneric<T> {
+    type Item = Option<&'a T>;
+    type IntoIter = ZipValidity<&'a T, BinaryViewValueIter<'a, T>, BitmapIter<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}

--- a/src/array/binview/iterator.rs
+++ b/src/array/binview/iterator.rs
@@ -1,6 +1,6 @@
 use super::BinaryViewArrayGeneric;
 use crate::array::binview::ViewType;
-use crate::array::{ArrayAccessor, ArrayValuesIter};
+use crate::array::{ArrayAccessor, ArrayValuesIter, MutableBinaryViewArray};
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 
 unsafe impl<'a, T: ViewType + ?Sized> ArrayAccessor<'a> for BinaryViewArrayGeneric<T> {
@@ -28,3 +28,20 @@ impl<'a, T: ViewType + ?Sized> IntoIterator for &'a BinaryViewArrayGeneric<T> {
         self.iter()
     }
 }
+
+unsafe impl<'a, T: ViewType + ?Sized> ArrayAccessor<'a> for MutableBinaryViewArray<T> {
+    type Item = &'a T;
+
+    #[inline]
+    unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
+        self.value_unchecked(index)
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.views().len()
+    }
+}
+
+/// Iterator of values of an [`MutableBinaryViewArray`].
+pub type MutableBinaryViewValueIter<'a, T> = ArrayValuesIter<'a, MutableBinaryViewArray<T>>;

--- a/src/array/binview/mod.rs
+++ b/src/array/binview/mod.rs
@@ -1,0 +1,304 @@
+//! See thread: https://lists.apache.org/thread/w88tpz76ox8h3rxkjl4so6rg3f1rv7wt
+mod ffi;
+pub(super) mod fmt;
+mod iterator;
+mod mutable;
+mod view;
+
+use std::any::Any;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use polars_error::*;
+
+use crate::array::Array;
+use crate::bitmap::Bitmap;
+use crate::buffer::Buffer;
+use crate::datatypes::ArrowDataType;
+
+mod private {
+    pub trait Sealed: Send + Sync {}
+
+    impl Sealed for str {}
+    impl Sealed for [u8] {}
+}
+use private::Sealed;
+
+use crate::array::binview::iterator::BinaryViewValueIter;
+use crate::array::binview::view::{validate_binary_view, validate_utf8_view};
+use crate::array::iterator::NonNullValuesIter;
+use crate::bitmap::utils::{BitmapIter, ZipValidity};
+
+pub type BinaryViewArray = BinaryViewArrayGeneric<[u8]>;
+pub type Utf8ViewArray = BinaryViewArrayGeneric<str>;
+
+pub trait ViewType: Sealed + 'static + PartialEq {
+    const IS_UTF8: bool;
+    const DATA_TYPE: ArrowDataType;
+    type Owned: Debug + Clone + Sync + Send + AsRef<Self>;
+
+    /// # Safety
+    /// The caller must ensure `index < self.len()`.
+    unsafe fn from_bytes_unchecked(slice: &[u8]) -> &Self;
+
+    fn to_bytes(&self) -> &[u8];
+
+    #[allow(clippy::wrong_self_convention)]
+    fn into_owned(&self) -> Self::Owned;
+}
+
+impl ViewType for str {
+    const IS_UTF8: bool = true;
+    const DATA_TYPE: ArrowDataType = ArrowDataType::Utf8View;
+    type Owned = String;
+
+    #[inline(always)]
+    unsafe fn from_bytes_unchecked(slice: &[u8]) -> &Self {
+        std::str::from_utf8_unchecked(slice)
+    }
+
+    #[inline(always)]
+    fn to_bytes(&self) -> &[u8] {
+        self.as_bytes()
+    }
+
+    fn into_owned(&self) -> Self::Owned {
+        self.to_string()
+    }
+}
+
+impl ViewType for [u8] {
+    const IS_UTF8: bool = false;
+    const DATA_TYPE: ArrowDataType = ArrowDataType::BinaryView;
+    type Owned = Vec<u8>;
+
+    #[inline(always)]
+    unsafe fn from_bytes_unchecked(slice: &[u8]) -> &Self {
+        slice
+    }
+
+    #[inline(always)]
+    fn to_bytes(&self) -> &[u8] {
+        self
+    }
+
+    fn into_owned(&self) -> Self::Owned {
+        self.to_vec()
+    }
+}
+
+pub struct BinaryViewArrayGeneric<T: ViewType + ?Sized> {
+    data_type: ArrowDataType,
+    views: Buffer<u128>,
+    buffers: Arc<[Buffer<u8>]>,
+    // Raw buffer access. (pointer, len).
+    raw_buffers: Arc<[(*const u8, usize)]>,
+    validity: Option<Bitmap>,
+    phantom: PhantomData<T>,
+}
+
+impl<T: ViewType + ?Sized> Clone for BinaryViewArrayGeneric<T> {
+    fn clone(&self) -> Self {
+        Self {
+            data_type: self.data_type.clone(),
+            views: self.views.clone(),
+            buffers: self.buffers.clone(),
+            raw_buffers: self.raw_buffers.clone(),
+            validity: self.validity.clone(),
+            phantom: Default::default(),
+        }
+    }
+}
+
+unsafe impl<T: ViewType + ?Sized> Send for BinaryViewArrayGeneric<T> {}
+unsafe impl<T: ViewType + ?Sized> Sync for BinaryViewArrayGeneric<T> {}
+
+fn buffers_into_raw<T>(buffers: &[Buffer<T>]) -> Arc<[(*const T, usize)]> {
+    buffers
+        .iter()
+        .map(|buf| (buf.as_ptr(), buf.len()))
+        .collect()
+}
+
+impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
+    /// # Safety
+    /// The caller must ensure
+    /// - the data is valid utf8 (if required)
+    /// - The offsets match the buffers.
+    pub unsafe fn new_unchecked(
+        data_type: ArrowDataType,
+        views: Buffer<u128>,
+        buffers: Arc<[Buffer<u8>]>,
+        validity: Option<Bitmap>,
+    ) -> Self {
+        let raw_buffers = buffers_into_raw(&buffers);
+        Self {
+            data_type,
+            views,
+            buffers,
+            raw_buffers,
+            validity,
+            phantom: Default::default(),
+        }
+    }
+
+    pub fn data_buffers(&self) -> &[Buffer<u8>] {
+        self.buffers.as_ref()
+    }
+
+    pub fn views(&self) -> &Buffer<u128> {
+        &self.views
+    }
+
+    pub fn try_new(
+        data_type: ArrowDataType,
+        views: Buffer<u128>,
+        buffers: Arc<[Buffer<u8>]>,
+        validity: Option<Bitmap>,
+    ) -> PolarsResult<Self> {
+        if T::IS_UTF8 {
+            validate_utf8_view(views.as_ref(), buffers.as_ref())?;
+        } else {
+            validate_binary_view(views.as_ref(), buffers.as_ref())?;
+        }
+
+        if let Some(validity) = &validity {
+            polars_ensure!(validity.len()== views.len(), ComputeError: "validity mask length must match the number of values" )
+        }
+
+        let raw_buffers = buffers_into_raw(&buffers);
+        Ok(Self {
+            data_type,
+            views,
+            buffers,
+            raw_buffers,
+            validity,
+            phantom: Default::default(),
+        })
+    }
+
+    /// Creates an empty [`BinaryViewArrayGeneric`], i.e. whose `.len` is zero.
+    #[inline]
+    pub fn new_empty(data_type: ArrowDataType) -> Self {
+        unsafe { Self::new_unchecked(data_type, Buffer::new(), Arc::from([]), None) }
+    }
+
+    /// Returns a new null [`BinaryViewArrayGeneric`] of `length`.
+    #[inline]
+    pub fn new_null(data_type: ArrowDataType, length: usize) -> Self {
+        let validity = Some(Bitmap::new_zeroed(length));
+        unsafe { Self::new_unchecked(data_type, Buffer::zeroed(length), Arc::from([]), validity) }
+    }
+
+    /// Returns the element at index `i`
+    /// # Panics
+    /// iff `i >= self.len()`
+    #[inline]
+    pub fn value(&self, i: usize) -> &T {
+        assert!(i < self.len());
+        unsafe { self.value_unchecked(i) }
+    }
+
+    /// Returns the element at index `i`
+    /// # Safety
+    /// Assumes that the `i < self.len`.
+    #[inline]
+    pub unsafe fn value_unchecked(&self, i: usize) -> &T {
+        let v = *self.views.get_unchecked(i);
+        let len = v as u32;
+
+        // view layout:
+        // length: 4 bytes
+        // prefix: 4 bytes
+        // buffer_index: 4 bytes
+        // offset: 4 bytes
+
+        // inlined layout:
+        // length: 4 bytes
+        // data: 12 bytes
+
+        let bytes = if len <= 12 {
+            let ptr = self.views.as_ptr() as *const u8;
+            std::slice::from_raw_parts(ptr.add(i * 16 + 4), len as usize)
+        } else {
+            let buffer_idx = (v >> 64) as u32;
+            let offset = (v >> 96) as u32;
+            let (data_ptr, data_len) = *self.raw_buffers.get_unchecked(buffer_idx as usize);
+            let data = std::slice::from_raw_parts(data_ptr, data_len);
+            let offset = offset as usize;
+            data.get_unchecked(offset..offset + len as usize)
+        };
+        T::from_bytes_unchecked(bytes)
+    }
+
+    /// Returns an iterator of `Option<&T>` over every element of this array.
+    pub fn iter(&self) -> ZipValidity<&T, BinaryViewValueIter<T>, BitmapIter> {
+        ZipValidity::new_with_validity(self.values_iter(), self.validity.as_ref())
+    }
+
+    /// Returns an iterator of `&[u8]` over every element of this array, ignoring the validity
+    pub fn values_iter(&self) -> BinaryViewValueIter<T> {
+        BinaryViewValueIter::new(self)
+    }
+
+    /// Returns an iterator of the non-null values.
+    #[inline]
+    pub fn non_null_values_iter(&self) -> NonNullValuesIter<'_, BinaryViewArrayGeneric<T>> {
+        NonNullValuesIter::new(self, self.validity())
+    }
+
+    impl_sliced!();
+    impl_mut_validity!();
+    impl_into_array!();
+}
+
+impl<T: ViewType + ?Sized> Array for BinaryViewArrayGeneric<T> {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn len(&self) -> usize {
+        self.views.len()
+    }
+
+    fn data_type(&self) -> &ArrowDataType {
+        &self.data_type
+    }
+
+    fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
+    }
+
+    fn slice(&mut self, offset: usize, length: usize) {
+        assert!(
+            offset + length <= self.len(),
+            "the offset of the new Buffer cannot exceed the existing length"
+        );
+        unsafe { self.slice_unchecked(offset, length) }
+        todo!()
+    }
+
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        self.validity = self
+            .validity
+            .take()
+            .map(|bitmap| bitmap.sliced_unchecked(offset, length))
+            .filter(|bitmap| bitmap.unset_bits() > 0);
+        self.views.slice_unchecked(offset, length);
+    }
+
+    fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {
+        let mut new = self.clone();
+        new.validity = validity;
+        Box::new(new)
+    }
+
+    fn to_boxed(&self) -> Box<dyn Array> {
+        Box::new(self.clone())
+    }
+}

--- a/src/array/binview/mod.rs
+++ b/src/array/binview/mod.rs
@@ -26,6 +26,7 @@ mod private {
 use private::Sealed;
 
 use crate::array::binview::iterator::BinaryViewValueIter;
+use crate::array::binview::mutable::MutableBinaryViewArray;
 use crate::array::binview::view::{validate_binary_view, validate_utf8_view};
 use crate::array::iterator::NonNullValuesIter;
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
@@ -147,6 +148,10 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
         self.buffers.as_ref()
     }
 
+    pub fn variadic_buffer_lengths(&self) -> Vec<i64> {
+        self.buffers.iter().map(|buf| buf.len() as i64).collect()
+    }
+
     pub fn views(&self) -> &Buffer<u128> {
         &self.views
     }
@@ -251,6 +256,12 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
     impl_sliced!();
     impl_mut_validity!();
     impl_into_array!();
+
+    pub fn from<S: AsRef<T>, P: AsRef<[Option<S>]>>(slice: P) -> Self {
+        let mutable =
+            MutableBinaryViewArray::from_iter(slice.as_ref().iter().map(|opt_v| opt_v.as_ref()));
+        mutable.into()
+    }
 }
 
 impl<T: ViewType + ?Sized> Array for BinaryViewArrayGeneric<T> {

--- a/src/array/binview/mod.rs
+++ b/src/array/binview/mod.rs
@@ -8,6 +8,7 @@ mod view;
 use std::any::Any;
 use std::fmt::Debug;
 use std::marker::PhantomData;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use crate::array::Array;
@@ -113,7 +114,7 @@ pub struct BinaryViewArrayGeneric<T: ViewType + ?Sized> {
     validity: Option<Bitmap>,
     phantom: PhantomData<T>,
     /// Total bytes length if we would concatenate them all.
-    total_bytes_len: usize,
+    total_bytes_len: AtomicU64,
     /// Total bytes in the buffer (excluding remaining capacity)
     total_buffer_len: usize,
 }
@@ -133,7 +134,7 @@ impl<T: ViewType + ?Sized> Clone for BinaryViewArrayGeneric<T> {
             raw_buffers: self.raw_buffers.clone(),
             validity: self.validity.clone(),
             phantom: Default::default(),
-            total_bytes_len: self.total_bytes_len,
+            total_bytes_len: AtomicU64::new(self.total_bytes_len.load(Ordering::Relaxed)),
             total_buffer_len: self.total_buffer_len,
         }
     }
@@ -148,6 +149,7 @@ fn buffers_into_raw<T>(buffers: &[Buffer<T>]) -> Arc<[(*const T, usize)]> {
         .map(|buf| (buf.storage_ptr(), buf.len()))
         .collect()
 }
+const UNKNOWN_LEN: u64 = u64::MAX;
 
 impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
     /// # Safety
@@ -170,7 +172,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
             raw_buffers,
             validity,
             phantom: Default::default(),
-            total_bytes_len,
+            total_bytes_len: AtomicU64::new(total_bytes_len as u64),
             total_buffer_len,
         }
     }
@@ -327,7 +329,14 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
 
     /// Get the total length of bytes that it would take to concatenate all binary/str values in this array.
     pub fn total_bytes_len(&self) -> usize {
-        self.total_bytes_len
+        let total = self.total_bytes_len.load(Ordering::Relaxed);
+        if total == UNKNOWN_LEN {
+            let total = self.len_iter().map(|v| v as usize).sum::<usize>();
+            self.total_bytes_len.store(total as u64, Ordering::Relaxed);
+            total
+        } else {
+            total as usize
+        }
     }
 
     /// Get the length of bytes that are stored in the variadic buffers.
@@ -358,8 +367,9 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
         if self.total_buffer_len == 0 {
             return self;
         }
+        let total_bytes_len = self.total_bytes_len.load(Ordering::Relaxed) as usize;
         // Subtract the maximum amount of inlined strings.
-        let min_in_buffer = self.total_bytes_len.saturating_sub(self.len() * 12);
+        let min_in_buffer = total_bytes_len.saturating_sub(self.len() * 12);
         let frac = (min_in_buffer as f64) / ((self.total_buffer_len() + 1) as f64);
 
         if frac < 0.25 {
@@ -391,7 +401,7 @@ impl BinaryViewArray {
             self.views.clone(),
             self.buffers.clone(),
             self.validity.clone(),
-            self.total_bytes_len,
+            self.total_bytes_len.load(Ordering::Relaxed) as usize,
             self.total_buffer_len,
         )
     }
@@ -406,7 +416,7 @@ impl Utf8ViewArray {
                 self.views.clone(),
                 self.buffers.clone(),
                 self.validity.clone(),
-                self.total_bytes_len,
+                self.total_bytes_len.load(Ordering::Relaxed) as usize,
                 self.total_buffer_len,
             )
         }
@@ -451,7 +461,7 @@ impl<T: ViewType + ?Sized> Array for BinaryViewArrayGeneric<T> {
             .map(|bitmap| bitmap.sliced_unchecked(offset, length))
             .filter(|bitmap| bitmap.unset_bits() > 0);
         self.views.slice_unchecked(offset, length);
-        self.total_bytes_len = self.len_iter().map(|v| v as usize).sum::<usize>();
+        self.total_bytes_len.store(UNKNOWN_LEN, Ordering::Relaxed)
     }
 
     fn with_validity(&self, validity: Option<Bitmap>) -> Box<dyn Array> {

--- a/src/array/binview/mod.rs
+++ b/src/array/binview/mod.rs
@@ -222,8 +222,14 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
             validate_binary_view(views.as_ref(), buffers.as_ref())?;
         }
 
-        if let Some(validity) = &validity {
-            polars_ensure!(validity.len()== views.len(), ComputeError: "validity mask length must match the number of values" )
+
+        if validity
+            .as_ref()
+            .map_or(false, |validity| validity.len() == views.len())
+        {
+            return Err(Error::oos(
+                "validity mask length must match the number of values",
+            ));
         }
 
         unsafe {

--- a/src/array/binview/mod.rs
+++ b/src/array/binview/mod.rs
@@ -392,7 +392,8 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
 impl BinaryViewArray {
     /// Validate the underlying bytes on UTF-8.
     pub fn validate_utf8(&self) -> Result<()> {
-        validate_utf8_only(&self.views, &self.buffers)
+        // SAFETY: views are correct
+        unsafe { validate_utf8_only(&self.views, &self.buffers) }
     }
 
     /// Convert [`BinaryViewArray`] to [`Utf8ViewArray`].

--- a/src/array/binview/mod.rs
+++ b/src/array/binview/mod.rs
@@ -370,6 +370,10 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
         mutable.freeze().with_validity(self.validity)
     }
 
+    pub fn is_sliced(&self) -> bool {
+        self.views.as_ptr() != self.views.storage_ptr()
+    }
+
     pub fn maybe_gc(self) -> Self {
         const GC_MINIMUM_SAVINGS: usize = 16 * 1024; // At least 16 KiB.
 

--- a/src/array/binview/mod.rs
+++ b/src/array/binview/mod.rs
@@ -303,6 +303,11 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
     pub fn total_buffer_len(&self) -> usize {
         self.total_buffer_len
     }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.views.len()
+    }
 }
 
 impl BinaryViewArray {
@@ -358,8 +363,9 @@ impl<T: ViewType + ?Sized> Array for BinaryViewArrayGeneric<T> {
         self
     }
 
+    #[inline(always)]
     fn len(&self) -> usize {
-        self.views.len()
+        BinaryViewArrayGeneric::len(self)
     }
 
     fn data_type(&self) -> &DataType {

--- a/src/array/binview/mod.rs
+++ b/src/array/binview/mod.rs
@@ -124,7 +124,7 @@ unsafe impl<T: ViewType + ?Sized> Sync for BinaryViewArrayGeneric<T> {}
 fn buffers_into_raw<T>(buffers: &[Buffer<T>]) -> Arc<[(*const T, usize)]> {
     buffers
         .iter()
-        .map(|buf| (buf.as_ptr(), buf.len()))
+        .map(|buf| (buf.storage_ptr(), buf.len()))
         .collect()
 }
 
@@ -260,7 +260,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
         // data: 12 bytes
 
         let bytes = if len <= 12 {
-            let ptr = self.views.as_ptr() as *const u8;
+            let ptr = self.views.storage_ptr() as *const u8;
             std::slice::from_raw_parts(ptr.add(i * 16 + 4), len as usize)
         } else {
             let buffer_idx = (v >> 64) as u32;

--- a/src/array/binview/mod.rs
+++ b/src/array/binview/mod.rs
@@ -364,18 +364,28 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
     }
 
     pub fn maybe_gc(self) -> Self {
-        if self.total_buffer_len == 0 {
+        const GC_MINIMUM_SAVINGS: usize = 16 * 1024; // At least 16 KiB.
+
+        if self.total_buffer_len <= GC_MINIMUM_SAVINGS {
             return self;
         }
-        let total_bytes_len = self.total_bytes_len.load(Ordering::Relaxed) as usize;
-        // Subtract the maximum amount of inlined strings.
-        let min_in_buffer = total_bytes_len.saturating_sub(self.len() * 12);
-        let frac = (min_in_buffer as f64) / ((self.total_buffer_len() + 1) as f64);
 
-        if frac < 0.25 {
-            return self.gc();
+        // Subtract the maximum amount of inlined strings to get a lower bound
+        // on the number of buffer bytes needed (assuming no dedup).
+        let total_bytes_len = self.total_bytes_len.load(Ordering::Relaxed) as usize;
+        let buffer_req_lower_bound = total_bytes_len.saturating_sub(self.len() * 12);
+
+        let lower_bound_mem_usage_post_gc = self.len() * 16 + buffer_req_lower_bound;
+        let cur_mem_usage = self.len() * 16 + self.total_buffer_len();
+        let savings_upper_bound = cur_mem_usage.saturating_sub(lower_bound_mem_usage_post_gc);
+
+        if savings_upper_bound >= GC_MINIMUM_SAVINGS
+            && cur_mem_usage >= 4 * lower_bound_mem_usage_post_gc
+        {
+            self.gc()
+        } else {
+            self
         }
-        self
     }
 }
 

--- a/src/array/binview/mod.rs
+++ b/src/array/binview/mod.rs
@@ -393,6 +393,21 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
             self
         }
     }
+
+    pub fn make_mut(self) -> MutableBinaryViewArray<T> {
+        let views = self.views.make_mut();
+        let completed_buffers = self.buffers.to_vec();
+        let validity = self.validity.map(|bitmap| bitmap.make_mut());
+        MutableBinaryViewArray {
+            views,
+            completed_buffers,
+            in_progress_buffer: vec![],
+            validity,
+            phantom: Default::default(),
+            total_bytes_len: self.total_bytes_len.load(Ordering::Relaxed) as usize,
+            total_buffer_len: self.total_buffer_len,
+        }
+    }
 }
 
 impl BinaryViewArray {

--- a/src/array/binview/mod.rs
+++ b/src/array/binview/mod.rs
@@ -185,9 +185,11 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
         views: Buffer<u128>,
         buffers: Arc<[Buffer<u8>]>,
         validity: Option<Bitmap>,
+        total_buffer_len: Option<usize>,
     ) -> Self {
-        let total_bytes_len = views.iter().map(|v| (*v as u32) as usize).sum();
-        let total_buffer_len = buffers.iter().map(|b| b.len()).sum();
+        let total_bytes_len = UNKNOWN_LEN as usize;
+        let total_buffer_len =
+            total_buffer_len.unwrap_or_else(|| buffers.iter().map(|b| b.len()).sum());
         Self::new_unchecked(
             data_type,
             views,
@@ -234,7 +236,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
 
         unsafe {
             Ok(Self::new_unchecked_unknown_md(
-                data_type, views, buffers, validity,
+                data_type, views, buffers, validity, None,
             ))
         }
     }
@@ -378,7 +380,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
 
         // Subtract the maximum amount of inlined strings to get a lower bound
         // on the number of buffer bytes needed (assuming no dedup).
-        let total_bytes_len = self.total_bytes_len.load(Ordering::Relaxed) as usize;
+        let total_bytes_len = self.total_bytes_len();
         let buffer_req_lower_bound = total_bytes_len.saturating_sub(self.len() * 12);
 
         let lower_bound_mem_usage_post_gc = self.len() * 16 + buffer_req_lower_bound;

--- a/src/array/binview/mutable.rs
+++ b/src/array/binview/mutable.rs
@@ -165,6 +165,10 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
         mutable.extend_values(iterator);
         mutable
     }
+
+    pub fn from<S: AsRef<T>, P: AsRef<[Option<S>]>>(slice: P) -> Self {
+        Self::from_iter(slice.as_ref().iter().map(|opt_v| opt_v.as_ref()))
+    }
 }
 
 impl<T: ViewType + ?Sized, P: AsRef<T>> Extend<Option<P>> for MutableBinaryViewArray<T> {

--- a/src/array/binview/mutable.rs
+++ b/src/array/binview/mutable.rs
@@ -1,0 +1,182 @@
+use std::sync::Arc;
+
+use polars_utils::slice::GetSaferUnchecked;
+
+use crate::array::binview::{BinaryViewArrayGeneric, ViewType};
+use crate::bitmap::MutableBitmap;
+use crate::buffer::Buffer;
+
+const DEFAULT_BLOCK_SIZE: usize = 8 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct MutableBinaryViewArray<T: ViewType + ?Sized> {
+    views: Vec<u128>,
+    completed_buffers: Vec<Buffer<u8>>,
+    in_progress_buffer: Vec<u8>,
+    validity: Option<MutableBitmap>,
+    phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: ViewType + ?Sized> Default for MutableBinaryViewArray<T> {
+    fn default() -> Self {
+        Self::with_capacity(0)
+    }
+}
+
+impl<T: ViewType + ?Sized> From<MutableBinaryViewArray<T>> for BinaryViewArrayGeneric<T> {
+    fn from(mut value: MutableBinaryViewArray<T>) -> Self {
+        value
+            .completed_buffers
+            .push(std::mem::take(&mut value.in_progress_buffer).into());
+
+        unsafe {
+            Self::new_unchecked(
+                T::DATA_TYPE,
+                value.views.into(),
+                Arc::from(value.completed_buffers),
+                value.validity.map(|b| b.into()),
+            )
+        }
+    }
+}
+
+impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            views: Vec::with_capacity(capacity),
+            completed_buffers: vec![],
+            in_progress_buffer: vec![],
+            validity: None,
+            phantom: Default::default(),
+        }
+    }
+
+    /// Reserves `additional` elements and `additional_buffer` on the buffer.
+    pub fn reserve(&mut self, additional: usize) {
+        self.views.reserve(additional);
+    }
+
+    pub fn len(&self) -> usize {
+        self.views.len()
+    }
+
+    fn init_validity(&mut self) {
+        let mut validity = MutableBitmap::with_capacity(self.views.capacity());
+        validity.extend_constant(self.len(), true);
+        validity.set(self.len() - 1, false);
+        self.validity = Some(validity);
+    }
+
+    pub fn push_value<V: AsRef<T>>(&mut self, value: V) {
+        if let Some(validity) = &mut self.validity {
+            validity.push(true)
+        }
+
+        let value = value.as_ref();
+        let bytes = value.to_bytes();
+        let len: u32 = bytes.len().try_into().unwrap();
+        let mut payload = [0; 16];
+        payload[0..4].copy_from_slice(&len.to_le_bytes());
+
+        if len <= 12 {
+            payload[4..4 + bytes.len()].copy_from_slice(bytes);
+        } else {
+            let required_cap = self.in_progress_buffer.len() + bytes.len();
+            if self.in_progress_buffer.capacity() < required_cap {
+                let new_capacity = (self.in_progress_buffer.capacity() * 2)
+                    .clamp(DEFAULT_BLOCK_SIZE, 16 * 1024 * 1024)
+                    .max(bytes.len());
+                let in_progress = Vec::with_capacity(new_capacity);
+                let flushed = std::mem::replace(&mut self.in_progress_buffer, in_progress);
+                if !flushed.is_empty() {
+                    self.completed_buffers.push(flushed.into())
+                }
+            }
+            let offset = self.in_progress_buffer.len() as u32;
+            self.in_progress_buffer.extend_from_slice(bytes);
+
+            unsafe { payload[4..8].copy_from_slice(bytes.get_unchecked_release(0..4)) };
+            let buffer_idx: u32 = self.completed_buffers.len().try_into().unwrap();
+            payload[8..12].copy_from_slice(&buffer_idx.to_le_bytes());
+            payload[12..16].copy_from_slice(&offset.to_le_bytes());
+        }
+        let value = u128::from_le_bytes(payload);
+        self.views.push(value);
+    }
+
+    pub fn push<V: AsRef<T>>(&mut self, value: Option<V>) {
+        if let Some(value) = value {
+            self.push_value(value)
+        } else {
+            self.views.push(0);
+            match &mut self.validity {
+                Some(validity) => validity.push(false),
+                None => self.init_validity(),
+            }
+        }
+    }
+
+    impl_mutable_array_mut_validity!();
+
+    #[inline]
+    pub fn extend_values<I, P>(&mut self, iterator: I)
+    where
+        I: Iterator<Item = P>,
+        P: AsRef<T>,
+    {
+        self.reserve(iterator.size_hint().0);
+        for v in iterator {
+            self.push_value(v)
+        }
+    }
+
+    #[inline]
+    pub fn extend<I, P>(&mut self, iterator: I)
+    where
+        I: Iterator<Item = Option<P>>,
+        P: AsRef<T>,
+    {
+        self.reserve(iterator.size_hint().0);
+        for p in iterator {
+            self.push(p)
+        }
+    }
+
+    pub fn from_iter<I, P>(iterator: I) -> Self
+    where
+        I: Iterator<Item = Option<P>>,
+        P: AsRef<T>,
+    {
+        let mut mutable = Self::with_capacity(iterator.size_hint().0);
+        mutable.extend(iterator);
+        mutable
+    }
+
+    pub fn from_values_iter<I, P>(iterator: I) -> Self
+    where
+        I: Iterator<Item = P>,
+        P: AsRef<T>,
+    {
+        let mut mutable = Self::with_capacity(iterator.size_hint().0);
+        mutable.extend_values(iterator);
+        mutable
+    }
+}
+
+impl<T: ViewType + ?Sized, P: AsRef<T>> Extend<Option<P>> for MutableBinaryViewArray<T> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = Option<P>>>(&mut self, iter: I) {
+        Self::extend(self, iter.into_iter())
+    }
+}
+
+impl<T: ViewType + ?Sized, P: AsRef<T>> FromIterator<Option<P>> for MutableBinaryViewArray<T> {
+    #[inline]
+    fn from_iter<I: IntoIterator<Item = Option<P>>>(iter: I) -> Self {
+        Self::from_iter(iter.into_iter())
+    }
+}

--- a/src/array/binview/mutable.rs
+++ b/src/array/binview/mutable.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
+use crate::array::binview::iterator::MutableBinaryViewValueIter;
 use crate::array::binview::view::validate_utf8_only;
 use crate::array::binview::{BinaryViewArrayGeneric, ViewType};
 use crate::array::{Array, MutableArray};
@@ -14,15 +15,15 @@ use crate::trusted_len::TrustedLen;
 const DEFAULT_BLOCK_SIZE: usize = 8 * 1024;
 
 pub struct MutableBinaryViewArray<T: ViewType + ?Sized> {
-    views: Vec<u128>,
-    completed_buffers: Vec<Buffer<u8>>,
-    in_progress_buffer: Vec<u8>,
-    validity: Option<MutableBitmap>,
-    phantom: std::marker::PhantomData<T>,
+    pub(super) views: Vec<u128>,
+    pub(super) completed_buffers: Vec<Buffer<u8>>,
+    pub(super) in_progress_buffer: Vec<u8>,
+    pub(super) validity: Option<MutableBitmap>,
+    pub(super) phantom: std::marker::PhantomData<T>,
     /// Total bytes length if we would concatenate them all.
-    total_bytes_len: usize,
+    pub(super) total_bytes_len: usize,
     /// Total bytes in the buffer (excluding remaining capacity)
-    total_buffer_len: usize,
+    pub(super) total_buffer_len: usize,
 }
 
 impl<T: ViewType + ?Sized> Clone for MutableBinaryViewArray<T> {
@@ -84,8 +85,14 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
         }
     }
 
-    pub fn views(&mut self) -> &mut Vec<u128> {
+    #[inline]
+    pub fn views_mut(&mut self) -> &mut Vec<u128> {
         &mut self.views
+    }
+
+    #[inline]
+    pub fn views(&self) -> &[u128] {
+        &self.views
     }
 
     pub fn validity(&mut self) -> Option<&mut MutableBitmap> {
@@ -308,6 +315,47 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
     #[inline]
     pub fn freeze(self) -> BinaryViewArrayGeneric<T> {
         self.into()
+    }
+
+    /// Returns the element at index `i`
+    /// # Safety
+    /// Assumes that the `i < self.len`.
+    #[inline]
+    pub unsafe fn value_unchecked(&self, i: usize) -> &T {
+        let v = *self.views.get_unchecked(i);
+        let len = v as u32;
+
+        // view layout:
+        // length: 4 bytes
+        // prefix: 4 bytes
+        // buffer_index: 4 bytes
+        // offset: 4 bytes
+
+        // inlined layout:
+        // length: 4 bytes
+        // data: 12 bytes
+        let bytes = if len <= 12 {
+            let ptr = self.views.as_ptr() as *const u8;
+            std::slice::from_raw_parts(ptr.add(i * 16 + 4), len as usize)
+        } else {
+            let buffer_idx = ((v >> 64) as u32) as usize;
+            let offset = (v >> 96) as u32;
+
+            let data = if buffer_idx == self.completed_buffers.len() {
+                self.in_progress_buffer.as_slice()
+            } else {
+                self.completed_buffers.get_unchecked_release(buffer_idx)
+            };
+
+            let offset = offset as usize;
+            data.get_unchecked(offset..offset + len as usize)
+        };
+        T::from_bytes_unchecked(bytes)
+    }
+
+    /// Returns an iterator of `&[u8]` over every element of this array, ignoring the validity
+    pub fn values_iter(&self) -> MutableBinaryViewValueIter<T> {
+        MutableBinaryViewValueIter::new(self)
     }
 }
 

--- a/src/array/binview/mutable.rs
+++ b/src/array/binview/mutable.rs
@@ -313,7 +313,9 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
 
 impl MutableBinaryViewArray<[u8]> {
     pub fn validate_utf8(&mut self) -> Result<()> {
-        validate_utf8_only(&self.views, &self.completed_buffers)
+        self.finish_in_progress();
+        // views are correct
+        unsafe { validate_utf8_only(&self.views, &self.completed_buffers) }
     }
 }
 

--- a/src/array/binview/mutable.rs
+++ b/src/array/binview/mutable.rs
@@ -5,17 +5,18 @@ use std::sync::Arc;
 use crate::array::binview::iterator::MutableBinaryViewValueIter;
 use crate::array::binview::view::validate_utf8_only;
 use crate::array::binview::{BinaryViewArrayGeneric, ViewType};
-use crate::array::{Array, MutableArray};
+use crate::array::{Array, MutableArray, View};
 use crate::bitmap::MutableBitmap;
 use crate::buffer::Buffer;
 use crate::error::Result;
 use crate::datatypes::DataType;
 use crate::trusted_len::TrustedLen;
+use crate::types::NativeType;
 
 const DEFAULT_BLOCK_SIZE: usize = 8 * 1024;
 
 pub struct MutableBinaryViewArray<T: ViewType + ?Sized> {
-    pub(super) views: Vec<u128>,
+    pub(super) views: Vec<View>,
     pub(super) completed_buffers: Vec<Buffer<u8>>,
     pub(super) in_progress_buffer: Vec<u8>,
     pub(super) validity: Option<MutableBitmap>,
@@ -86,12 +87,12 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
     }
 
     #[inline]
-    pub fn views_mut(&mut self) -> &mut Vec<u128> {
+    pub fn views_mut(&mut self) -> &mut Vec<View> {
         &mut self.views
     }
 
     #[inline]
-    pub fn views(&self) -> &[u128] {
+    pub fn views(&self) -> &[View] {
         &self.views
     }
 
@@ -127,20 +128,18 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
     /// - caller must allocate enough capacity
     /// - caller must ensure the view and buffers match.
     #[inline]
-    pub unsafe fn push_view(&mut self, v: u128, buffers: &[(*const u8, usize)]) {
-        let len = v as u32;
+    pub unsafe fn push_view(&mut self, v: View, buffers: &[(*const u8, usize)]) {
+        let len = v.length;
         self.total_bytes_len += len as usize;
         if len <= 12 {
             debug_assert!(self.views.capacity() > self.views.len());
             self.views.push(v)
         } else {
             self.total_buffer_len += len as usize;
-            let buffer_idx = (v >> 64) as u32;
-            let offset = (v >> 96) as u32;
-            let (data_ptr, data_len) = *buffers.get_unchecked(buffer_idx as usize);
+            let (data_ptr, data_len) = *buffers.get_unchecked_release(v.buffer_idx as usize);
             let data = std::slice::from_raw_parts(data_ptr, data_len);
-            let offset = offset as usize;
-            let bytes = data.get_unchecked(offset..offset + len as usize);
+            let offset = v.offset as usize;
+            let bytes = data.get_unchecked_release(offset..offset + len as usize);
             let t = T::from_bytes_unchecked(bytes);
             self.push_value_ignore_validity(t)
         }
@@ -177,7 +176,7 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
             payload[8..12].copy_from_slice(&buffer_idx.to_le_bytes());
             payload[12..16].copy_from_slice(&offset.to_le_bytes());
         }
-        let value = u128::from_le_bytes(payload);
+        let value = View::from_le_bytes(payload);
         self.views.push(value);
     }
 
@@ -197,7 +196,7 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
     }
 
     pub fn push_null(&mut self) {
-        self.views.push(0);
+        self.views.push(View::default());
         match &mut self.validity {
             Some(validity) => validity.push(false),
             None => self.init_validity(true),
@@ -208,7 +207,8 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
         if self.validity.is_none() && additional > 0 {
             self.init_validity(false);
         }
-        self.views.extend(std::iter::repeat(0).take(additional));
+        self.views
+            .extend(std::iter::repeat(View::default()).take(additional));
         if let Some(validity) = &mut self.validity {
             validity.extend_constant(additional, false);
         }
@@ -231,7 +231,7 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
                 self.push_value_ignore_validity(v);
                 self.views.pop().unwrap()
             })
-            .unwrap_or(0);
+            .unwrap_or_default();
         self.views
             .extend(std::iter::repeat(view_value).take(additional));
     }
@@ -323,7 +323,7 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
     #[inline]
     pub unsafe fn value_unchecked(&self, i: usize) -> &T {
         let v = *self.views.get_unchecked(i);
-        let len = v as u32;
+        let len = v.length;
 
         // view layout:
         // length: 4 bytes
@@ -338,8 +338,8 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
             let ptr = self.views.as_ptr() as *const u8;
             std::slice::from_raw_parts(ptr.add(i * 16 + 4), len as usize)
         } else {
-            let buffer_idx = ((v >> 64) as u32) as usize;
-            let offset = (v >> 96) as u32;
+            let buffer_idx = v.buffer_idx as usize;
+            let offset = v.offset;
 
             let data = if buffer_idx == self.completed_buffers.len() {
                 self.in_progress_buffer.as_slice()

--- a/src/array/binview/mutable.rs
+++ b/src/array/binview/mutable.rs
@@ -133,7 +133,7 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
             let (data_ptr, data_len) = *buffers.get_unchecked(buffer_idx as usize);
             let data = std::slice::from_raw_parts(data_ptr, data_len);
             let offset = offset as usize;
-            let bytes = data.get_unchecked(offset..offset + len as usize);
+            let bytes = data.get_unchecked_release(offset..offset + len as usize);
             let t = T::from_bytes_unchecked(bytes);
             self.push_value_ignore_validity(t)
         }

--- a/src/array/binview/mutable.rs
+++ b/src/array/binview/mutable.rs
@@ -133,7 +133,7 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
             let (data_ptr, data_len) = *buffers.get_unchecked(buffer_idx as usize);
             let data = std::slice::from_raw_parts(data_ptr, data_len);
             let offset = offset as usize;
-            let bytes = data.get_unchecked_release(offset..offset + len as usize);
+            let bytes = data.get_unchecked(offset..offset + len as usize);
             let t = T::from_bytes_unchecked(bytes);
             self.push_value_ignore_validity(t)
         }
@@ -165,7 +165,7 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
             let offset = self.in_progress_buffer.len() as u32;
             self.in_progress_buffer.extend_from_slice(bytes);
 
-            unsafe { payload[4..8].copy_from_slice(bytes.get_unchecked_release(0..4)) };
+            unsafe { payload[4..8].copy_from_slice(bytes.get_unchecked(0..4)) };
             let buffer_idx: u32 = self.completed_buffers.len().try_into().unwrap();
             payload[8..12].copy_from_slice(&buffer_idx.to_le_bytes());
             payload[12..16].copy_from_slice(&offset.to_le_bytes());

--- a/src/array/binview/mutable.rs
+++ b/src/array/binview/mutable.rs
@@ -136,10 +136,10 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
             self.views.push(v)
         } else {
             self.total_buffer_len += len as usize;
-            let (data_ptr, data_len) = *buffers.get_unchecked_release(v.buffer_idx as usize);
+            let (data_ptr, data_len) = *buffers.get_unchecked(v.buffer_idx as usize);
             let data = std::slice::from_raw_parts(data_ptr, data_len);
             let offset = v.offset as usize;
-            let bytes = data.get_unchecked_release(offset..offset + len as usize);
+            let bytes = data.get_unchecked(offset..offset + len as usize);
             let t = T::from_bytes_unchecked(bytes);
             self.push_value_ignore_validity(t)
         }
@@ -344,7 +344,7 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
             let data = if buffer_idx == self.completed_buffers.len() {
                 self.in_progress_buffer.as_slice()
             } else {
-                self.completed_buffers.get_unchecked_release(buffer_idx)
+                self.completed_buffers.get_unchecked(buffer_idx)
             };
 
             let offset = offset as usize;

--- a/src/array/binview/mutable.rs
+++ b/src/array/binview/mutable.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use polars_utils::slice::GetSaferUnchecked;
-
+use crate::array::binview::view::validate_utf8_only_view;
 use crate::array::binview::{BinaryViewArrayGeneric, ViewType};
 use crate::bitmap::MutableBitmap;
 use crate::buffer::Buffer;
+use crate::error::Result;
 
 const DEFAULT_BLOCK_SIZE: usize = 8 * 1024;
 
@@ -15,6 +15,10 @@ pub struct MutableBinaryViewArray<T: ViewType + ?Sized> {
     in_progress_buffer: Vec<u8>,
     validity: Option<MutableBitmap>,
     phantom: std::marker::PhantomData<T>,
+    /// Total bytes length if we would concatenate them all.
+    total_bytes_len: usize,
+    /// Total bytes in the buffer (excluding remaining capacity)
+    total_buffer_len: usize,
 }
 
 impl<T: ViewType + ?Sized> Default for MutableBinaryViewArray<T> {
@@ -25,16 +29,15 @@ impl<T: ViewType + ?Sized> Default for MutableBinaryViewArray<T> {
 
 impl<T: ViewType + ?Sized> From<MutableBinaryViewArray<T>> for BinaryViewArrayGeneric<T> {
     fn from(mut value: MutableBinaryViewArray<T>) -> Self {
-        value
-            .completed_buffers
-            .push(std::mem::take(&mut value.in_progress_buffer).into());
-
+        value.finish_in_progress();
         unsafe {
             Self::new_unchecked(
                 T::DATA_TYPE,
                 value.views.into(),
                 Arc::from(value.completed_buffers),
                 value.validity.map(|b| b.into()),
+                value.total_bytes_len,
+                value.total_buffer_len,
             )
         }
     }
@@ -52,7 +55,17 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
             in_progress_buffer: vec![],
             validity: None,
             phantom: Default::default(),
+            total_buffer_len: 0,
+            total_bytes_len: 0,
         }
+    }
+
+    pub fn views(&mut self) -> &mut Vec<u128> {
+        &mut self.views
+    }
+
+    pub fn validity(&mut self) -> Option<&mut MutableBitmap> {
+        self.validity.as_mut()
     }
 
     /// Reserves `additional` elements and `additional_buffer` on the buffer.
@@ -71,13 +84,10 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
         self.validity = Some(validity);
     }
 
-    pub fn push_value<V: AsRef<T>>(&mut self, value: V) {
-        if let Some(validity) = &mut self.validity {
-            validity.push(true)
-        }
-
+    pub fn push_value_ignore_validity<V: AsRef<T>>(&mut self, value: V) {
         let value = value.as_ref();
         let bytes = value.to_bytes();
+        self.total_bytes_len += bytes.len();
         let len: u32 = bytes.len().try_into().unwrap();
         let mut payload = [0; 16];
         payload[0..4].copy_from_slice(&len.to_le_bytes());
@@ -85,6 +95,7 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
         if len <= 12 {
             payload[4..4 + bytes.len()].copy_from_slice(bytes);
         } else {
+            self.total_buffer_len += bytes.len();
             let required_cap = self.in_progress_buffer.len() + bytes.len();
             if self.in_progress_buffer.capacity() < required_cap {
                 let new_capacity = (self.in_progress_buffer.capacity() * 2)
@@ -108,15 +119,26 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
         self.views.push(value);
     }
 
+    pub fn push_value<V: AsRef<T>>(&mut self, value: V) {
+        if let Some(validity) = &mut self.validity {
+            validity.push(true)
+        }
+        self.push_value_ignore_validity(value)
+    }
+
     pub fn push<V: AsRef<T>>(&mut self, value: Option<V>) {
         if let Some(value) = value {
             self.push_value(value)
         } else {
-            self.views.push(0);
-            match &mut self.validity {
-                Some(validity) => validity.push(false),
-                None => self.init_validity(),
-            }
+            self.push_null()
+        }
+    }
+
+    pub fn push_null(&mut self) {
+        self.views.push(0);
+        match &mut self.validity {
+            Some(validity) => validity.push(false),
+            None => self.init_validity(),
         }
     }
 
@@ -146,7 +168,7 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
         }
     }
 
-    pub fn from_iter<I, P>(iterator: I) -> Self
+    pub fn from_iterator<I, P>(iterator: I) -> Self
     where
         I: Iterator<Item = Option<P>>,
         P: AsRef<T>,
@@ -167,7 +189,20 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
     }
 
     pub fn from<S: AsRef<T>, P: AsRef<[Option<S>]>>(slice: P) -> Self {
-        Self::from_iter(slice.as_ref().iter().map(|opt_v| opt_v.as_ref()))
+        Self::from_iterator(slice.as_ref().iter().map(|opt_v| opt_v.as_ref()))
+    }
+
+    fn finish_in_progress(&mut self) {
+        if !self.in_progress_buffer.is_empty() {
+            self.completed_buffers
+                .push(std::mem::take(&mut self.in_progress_buffer).into());
+        }
+    }
+}
+
+impl MutableBinaryViewArray<[u8]> {
+    pub fn validate_utf8(&mut self) -> Result<()> {
+        validate_utf8_only_view(&self.views, &self.completed_buffers)
     }
 }
 
@@ -181,6 +216,6 @@ impl<T: ViewType + ?Sized, P: AsRef<T>> Extend<Option<P>> for MutableBinaryViewA
 impl<T: ViewType + ?Sized, P: AsRef<T>> FromIterator<Option<P>> for MutableBinaryViewArray<T> {
     #[inline]
     fn from_iter<I: IntoIterator<Item = Option<P>>>(iter: I) -> Self {
-        Self::from_iter(iter.into_iter())
+        Self::from_iterator(iter.into_iter())
     }
 }

--- a/src/array/binview/mutable.rs
+++ b/src/array/binview/mutable.rs
@@ -1,14 +1,18 @@
+use std::any::Any;
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use crate::array::binview::view::validate_utf8_only_view;
+use crate::array::binview::view::validate_utf8_only;
 use crate::array::binview::{BinaryViewArrayGeneric, ViewType};
+use crate::array::{Array, MutableArray};
 use crate::bitmap::MutableBitmap;
 use crate::buffer::Buffer;
 use crate::error::Result;
+use crate::datatypes::DataType;
+use crate::trusted_len::TrustedLen;
 
 const DEFAULT_BLOCK_SIZE: usize = 8 * 1024;
 
-#[derive(Debug, Clone)]
 pub struct MutableBinaryViewArray<T: ViewType + ?Sized> {
     views: Vec<u128>,
     completed_buffers: Vec<Buffer<u8>>,
@@ -19,6 +23,26 @@ pub struct MutableBinaryViewArray<T: ViewType + ?Sized> {
     total_bytes_len: usize,
     /// Total bytes in the buffer (excluding remaining capacity)
     total_buffer_len: usize,
+}
+
+impl<T: ViewType + ?Sized> Clone for MutableBinaryViewArray<T> {
+    fn clone(&self) -> Self {
+        Self {
+            views: self.views.clone(),
+            completed_buffers: self.completed_buffers.clone(),
+            in_progress_buffer: self.in_progress_buffer.clone(),
+            validity: self.validity.clone(),
+            phantom: Default::default(),
+            total_bytes_len: self.total_bytes_len,
+            total_buffer_len: self.total_buffer_len,
+        }
+    }
+}
+
+impl<T: ViewType + ?Sized> Debug for MutableBinaryViewArray<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "mutable-binview{:?}", T::DATA_TYPE)
+    }
 }
 
 impl<T: ViewType + ?Sized> Default for MutableBinaryViewArray<T> {
@@ -73,15 +97,46 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
         self.views.reserve(additional);
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         self.views.len()
     }
 
-    fn init_validity(&mut self) {
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.views.capacity()
+    }
+
+    fn init_validity(&mut self, unset_last: bool) {
         let mut validity = MutableBitmap::with_capacity(self.views.capacity());
         validity.extend_constant(self.len(), true);
-        validity.set(self.len() - 1, false);
+        if unset_last {
+            validity.set(self.len() - 1, false);
+        }
         self.validity = Some(validity);
+    }
+
+    /// # Safety
+    /// - caller must allocate enough capacity
+    /// - caller must ensure the view and buffers match.
+    #[inline]
+    pub unsafe fn push_view(&mut self, v: u128, buffers: &[(*const u8, usize)]) {
+        let len = v as u32;
+        self.total_bytes_len += len as usize;
+        if len <= 12 {
+            debug_assert!(self.views.capacity() > self.views.len());
+            self.views.push(v)
+        } else {
+            self.total_buffer_len += len as usize;
+            let buffer_idx = (v >> 64) as u32;
+            let offset = (v >> 96) as u32;
+            let (data_ptr, data_len) = *buffers.get_unchecked(buffer_idx as usize);
+            let data = std::slice::from_raw_parts(data_ptr, data_len);
+            let offset = offset as usize;
+            let bytes = data.get_unchecked(offset..offset + len as usize);
+            let t = T::from_bytes_unchecked(bytes);
+            self.push_value_ignore_validity(t)
+        }
     }
 
     pub fn push_value_ignore_validity<V: AsRef<T>>(&mut self, value: V) {
@@ -138,8 +193,40 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
         self.views.push(0);
         match &mut self.validity {
             Some(validity) => validity.push(false),
-            None => self.init_validity(),
+            None => self.init_validity(true),
         }
+    }
+
+    pub fn extend_null(&mut self, additional: usize) {
+        if self.validity.is_none() && additional > 0 {
+            self.init_validity(false);
+        }
+        self.views.extend(std::iter::repeat(0).take(additional));
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
+    }
+
+    pub fn extend_constant<V: AsRef<T>>(&mut self, additional: usize, value: Option<V>) {
+        if value.is_none() && self.validity.is_none() {
+            self.init_validity(false);
+        }
+
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, value.is_some())
+        }
+
+        // Push and pop to get the properly encoded value.
+        // For long string this leads to a dictionary encoding,
+        // as we push the string only once in the buffers
+        let view_value = value
+            .map(|v| {
+                self.push_value_ignore_validity(v);
+                self.views.pop().unwrap()
+            })
+            .unwrap_or(0);
+        self.views
+            .extend(std::iter::repeat(view_value).take(additional));
     }
 
     impl_mutable_array_mut_validity!();
@@ -157,6 +244,15 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
     }
 
     #[inline]
+    pub fn extend_trusted_len_values<I, P>(&mut self, iterator: I)
+    where
+        I: TrustedLen<Item = P>,
+        P: AsRef<T>,
+    {
+        self.extend_values(iterator)
+    }
+
+    #[inline]
     pub fn extend<I, P>(&mut self, iterator: I)
     where
         I: Iterator<Item = Option<P>>,
@@ -168,6 +264,16 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
         }
     }
 
+    #[inline]
+    pub fn extend_trusted_len<I, P>(&mut self, iterator: I)
+    where
+        I: TrustedLen<Item = Option<P>>,
+        P: AsRef<T>,
+    {
+        self.extend(iterator)
+    }
+
+    #[inline]
     pub fn from_iterator<I, P>(iterator: I) -> Self
     where
         I: Iterator<Item = Option<P>>,
@@ -198,11 +304,16 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
                 .push(std::mem::take(&mut self.in_progress_buffer).into());
         }
     }
+
+    #[inline]
+    pub fn freeze(self) -> BinaryViewArrayGeneric<T> {
+        self.into()
+    }
 }
 
 impl MutableBinaryViewArray<[u8]> {
     pub fn validate_utf8(&mut self) -> Result<()> {
-        validate_utf8_only_view(&self.views, &self.completed_buffers)
+        validate_utf8_only(&self.views, &self.completed_buffers)
     }
 }
 
@@ -217,5 +328,45 @@ impl<T: ViewType + ?Sized, P: AsRef<T>> FromIterator<Option<P>> for MutableBinar
     #[inline]
     fn from_iter<I: IntoIterator<Item = Option<P>>>(iter: I) -> Self {
         Self::from_iterator(iter.into_iter())
+    }
+}
+
+impl<T: ViewType + ?Sized> MutableArray for MutableBinaryViewArray<T> {
+    fn data_type(&self) -> &DataType {
+        T::dtype()
+    }
+
+    fn len(&self) -> usize {
+        MutableBinaryViewArray::len(self)
+    }
+
+    fn validity(&self) -> Option<&MutableBitmap> {
+        self.validity.as_ref()
+    }
+
+    fn as_box(&mut self) -> Box<dyn Array> {
+        let mutable = std::mem::take(self);
+        let arr: BinaryViewArrayGeneric<T> = mutable.into();
+        arr.boxed()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn push_null(&mut self) {
+        MutableBinaryViewArray::push_null(self)
+    }
+
+    fn reserve(&mut self, additional: usize) {
+        MutableBinaryViewArray::reserve(self, additional)
+    }
+
+    fn shrink_to_fit(&mut self) {
+        self.views.shrink_to_fit()
     }
 }

--- a/src/array/binview/view.rs
+++ b/src/array/binview/view.rs
@@ -1,0 +1,81 @@
+use polars_error::*;
+
+use crate::buffer::Buffer;
+
+pub struct View {
+    /// The length of the string/bytes.
+    pub length: u32,
+    /// First 4 bytes of string/bytes data.
+    pub prefix: u32,
+    /// The buffer index.
+    pub buffer_idx: u32,
+    /// The offset into the buffer.
+    pub offset: u32,
+}
+
+impl From<u128> for View {
+    #[inline]
+    fn from(value: u128) -> Self {
+        Self {
+            length: value as u32,
+            prefix: (value >> 64) as u32,
+            buffer_idx: (value >> 64) as u32,
+            offset: (value >> 96) as u32,
+        }
+    }
+}
+
+impl From<View> for u128 {
+    #[inline]
+    fn from(value: View) -> Self {
+        value.length as u128
+            | ((value.prefix as u128) << 32)
+            | ((value.buffer_idx as u128) << 64)
+            | ((value.offset as u128) << 96)
+    }
+}
+
+fn validate_view<F>(views: &[u128], buffers: &[Buffer<u8>], validate_bytes: F) -> PolarsResult<()>
+where
+    F: Fn(&[u8]) -> PolarsResult<()>,
+{
+    for view in views {
+        let len = *view as u32;
+        if len <= 12 {
+            if len < 12 && view >> (32 + len * 8) != 0 {
+                polars_bail!(ComputeError: "view contained non-zero padding in prefix");
+            }
+
+            validate_bytes(&view.to_le_bytes()[4..4 + len as usize])?;
+        } else {
+            let view = View::from(*view);
+
+            let data = buffers.get(view.buffer_idx as usize).ok_or_else(|| {
+                polars_err!(OutOfBounds: "view index out of bounds\n\nGot: {} buffers and index: {}", buffers.len(), view.buffer_idx)
+            })?;
+
+            let start = view.offset as usize;
+            let end = start + len as usize;
+            let b = data
+                .as_slice()
+                .get(start..end)
+                .ok_or_else(|| polars_err!(OutOfBounds: "buffer slice out of bounds"))?;
+
+            polars_ensure!(b.starts_with(&view.prefix.to_le_bytes()), ComputeError: "prefix does not match string data");
+            validate_bytes(b)?;
+        };
+    }
+
+    Ok(())
+}
+
+pub(super) fn validate_binary_view(views: &[u128], buffers: &[Buffer<u8>]) -> PolarsResult<()> {
+    validate_view(views, buffers, |_| Ok(()))
+}
+
+pub(super) fn validate_utf8_view(views: &[u128], buffers: &[Buffer<u8>]) -> PolarsResult<()> {
+    validate_view(views, buffers, |b| match simdutf8::basic::from_utf8(b) {
+        Ok(_) => Ok(()),
+        Err(_) => Err(polars_err!(ComputeError: "invalid utf8")),
+    })
+}

--- a/src/array/binview/view.rs
+++ b/src/array/binview/view.rs
@@ -1,7 +1,17 @@
 use crate::buffer::Buffer;
 use crate::error::{Error, Result};
+use std::cmp::Ordering;
+use std::fmt::{Display, Formatter};
+use std::ops::Add;
 
-#[derive(Debug)]
+use bytemuck::{Pod, Zeroable};
+
+use crate::datatypes::PrimitiveType;
+use crate::types::NativeType;
+
+// We use this instead of u128 because we want alignment of <= 8 bytes.
+#[derive(Debug, Copy, Clone, Default)]
+#[repr(C)]
 pub struct View {
     /// The length of the string/bytes.
     pub length: u32,
@@ -13,36 +23,94 @@ pub struct View {
     pub offset: u32,
 }
 
+impl View {
+    #[inline(always)]
+    pub fn as_u128(self) -> u128 {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl Display for View {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+unsafe impl Zeroable for View {}
+
+unsafe impl Pod for View {}
+
+impl Add<Self> for View {
+    type Output = View;
+
+    fn add(self, _rhs: Self) -> Self::Output {
+        unimplemented!()
+    }
+}
+
+impl num_traits::Zero for View {
+    fn zero() -> Self {
+        Default::default()
+    }
+
+    fn is_zero(&self) -> bool {
+        *self == Self::zero()
+    }
+}
+
+impl PartialEq for View {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_u128() == other.as_u128()
+    }
+}
+
+impl NativeType for View {
+    const PRIMITIVE: PrimitiveType = PrimitiveType::UInt128;
+    type Bytes = [u8; 16];
+
+    #[inline]
+    fn to_le_bytes(&self) -> Self::Bytes {
+        self.as_u128().to_le_bytes()
+    }
+
+    #[inline]
+    fn to_be_bytes(&self) -> Self::Bytes {
+        self.as_u128().to_be_bytes()
+    }
+
+    #[inline]
+    fn from_le_bytes(bytes: Self::Bytes) -> Self {
+        Self::from(u128::from_le_bytes(bytes))
+    }
+
+    #[inline]
+    fn from_be_bytes(bytes: Self::Bytes) -> Self {
+        Self::from(u128::from_be_bytes(bytes))
+    }
+}
+
 impl From<u128> for View {
     #[inline]
     fn from(value: u128) -> Self {
-        Self {
-            length: value as u32,
-            prefix: (value >> 32) as u32,
-            buffer_idx: (value >> 64) as u32,
-            offset: (value >> 96) as u32,
-        }
+        unsafe { std::mem::transmute(value) }
     }
 }
 
 impl From<View> for u128 {
     #[inline]
     fn from(value: View) -> Self {
-        value.length as u128
-            | ((value.prefix as u128) << 32)
-            | ((value.buffer_idx as u128) << 64)
-            | ((value.offset as u128) << 96)
+        value.as_u128()
     }
 }
 
-fn validate_view<F>(views: &[u128], buffers: &[Buffer<u8>], validate_bytes: F) -> Result<()>
+fn validate_view<F>(views: &[View], buffers: &[Buffer<u8>], validate_bytes: F) -> Result<()>
 where
     F: Fn(&[u8]) -> Result<()>,
 {
     for view in views {
-        let len = *view as u32;
+        let len = view.length;
         if len <= 12 {
-            if len < 12 && view >> (32 + len * 8) != 0 {
+            if len < 12 && view.as_u128() >> (32 + len * 8) != 0 {
                 return Err(Error::InvalidArgumentError(format!(
                     "View contained non-zero padding for string of length {len}",
                 )));
@@ -50,8 +118,6 @@ where
 
             validate_bytes(&view.to_le_bytes()[4..4 + len as usize])?;
         } else {
-            let view = View::from(*view);
-
             let data = buffers.get(view.buffer_idx as usize).ok_or_else(|| {
                 Error::InvalidArgumentError(format!(
                     "Invalid buffer index: got index {} but only has {} buffers",
@@ -85,7 +151,7 @@ where
     Ok(())
 }
 
-pub(super) fn validate_binary_view(views: &[u128], buffers: &[Buffer<u8>]) -> Result<()> {
+pub(super) fn validate_binary_view(views: &[View], buffers: &[Buffer<u8>]) -> Result<()> {
     validate_view(views, buffers, |_| Ok(()))
 }
 
@@ -98,21 +164,26 @@ fn validate_utf8(b: &[u8]) -> Result<()> {
     }
 }
 
-pub(super) fn validate_utf8_view(views: &[u128], buffers: &[Buffer<u8>]) -> Result<()> {
+pub(super) fn validate_utf8_view(views: &[View], buffers: &[Buffer<u8>]) -> Result<()> {
     validate_view(views, buffers, validate_utf8)
 }
 
-pub(super) fn validate_utf8_only(views: &[u128], buffers: &[Buffer<u8>]) -> Result<()> {
+/// # Safety
+/// The views and buffers must uphold the invariants of BinaryView otherwise we will go OOB.
+pub(super) unsafe fn validate_utf8_only(
+    views: &[View],
+    buffers: &[Buffer<u8>],
+) -> Result<()> {
     for view in views {
-        let len = *view as u32;
+        let len = view.length;
         if len <= 12 {
             validate_utf8(
                 view.to_le_bytes()
                     .get_unchecked_release(4..4 + len as usize),
             )?;
         } else {
-            let buffer_idx = (*view >> 64) as u32;
-            let offset = (*view >> 96) as u32;
+            let buffer_idx = view.buffer_idx;
+            let offset = view.offset;
             let data = buffers.get_unchecked_release(buffer_idx as usize);
 
             let start = offset as usize;

--- a/src/array/binview/view.rs
+++ b/src/array/binview/view.rs
@@ -1,6 +1,7 @@
 use crate::buffer::Buffer;
 use crate::error::{Error, Result};
 
+#[derive(Debug)]
 pub struct View {
     /// The length of the string/bytes.
     pub length: u32,
@@ -17,7 +18,7 @@ impl From<u128> for View {
     fn from(value: u128) -> Self {
         Self {
             length: value as u32,
-            prefix: (value >> 64) as u32,
+            prefix: (value >> 32) as u32,
             buffer_idx: (value >> 64) as u32,
             offset: (value >> 96) as u32,
         }
@@ -85,7 +86,7 @@ pub(super) fn validate_utf8_view(views: &[u128], buffers: &[Buffer<u8>]) -> Resu
     validate_view(views, buffers, validate_utf8)
 }
 
-pub(super) fn validate_utf8_only_view(views: &[u128], buffers: &[Buffer<u8>]) -> Result<()> {
+pub(super) fn validate_utf8_only(views: &[u128], buffers: &[Buffer<u8>]) -> Result<()> {
     for view in views {
         let len = *view as u32;
         if len <= 12 {

--- a/src/array/binview/view.rs
+++ b/src/array/binview/view.rs
@@ -1,6 +1,5 @@
 use crate::buffer::Buffer;
 use crate::error::{Error, Result};
-use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::ops::Add;
 
@@ -179,16 +178,16 @@ pub(super) unsafe fn validate_utf8_only(
         if len <= 12 {
             validate_utf8(
                 view.to_le_bytes()
-                    .get_unchecked_release(4..4 + len as usize),
+                    .get_unchecked(4..4 + len as usize),
             )?;
         } else {
             let buffer_idx = view.buffer_idx;
             let offset = view.offset;
-            let data = buffers.get_unchecked_release(buffer_idx as usize);
+            let data = buffers.get_unchecked(buffer_idx as usize);
 
             let start = offset as usize;
             let end = start + len as usize;
-            let b = &data.as_slice().get_unchecked_release(start..end);
+            let b = &data.as_slice().get_unchecked(start..end);
             validate_utf8(b)?;
         };
     }

--- a/src/array/binview/view.rs
+++ b/src/array/binview/view.rs
@@ -90,14 +90,18 @@ pub(super) fn validate_utf8_only(views: &[u128], buffers: &[Buffer<u8>]) -> Resu
     for view in views {
         let len = *view as u32;
         if len <= 12 {
-            validate_utf8(&view.to_le_bytes()[4..4 + len as usize])?;
+            validate_utf8(
+                view.to_le_bytes()
+                    .get_unchecked_release(4..4 + len as usize),
+            )?;
         } else {
-            let view = View::from(*view);
-            let data = &buffers[view.buffer_idx as usize];
+            let buffer_idx = (*view >> 64) as u32;
+            let offset = (*view >> 96) as u32;
+            let data = buffers.get_unchecked_release(buffer_idx as usize);
 
-            let start = view.offset as usize;
+            let start = offset as usize;
             let end = start + len as usize;
-            let b = &data.as_slice()[start..end];
+            let b = &data.as_slice().get_unchecked_release(start..end);
             validate_utf8(b)?;
         };
     }

--- a/src/array/binview/view.rs
+++ b/src/array/binview/view.rs
@@ -1,6 +1,5 @@
-use polars_error::*;
-
 use crate::buffer::Buffer;
+use crate::error::{Error, Result};
 
 pub struct View {
     /// The length of the string/bytes.
@@ -73,9 +72,34 @@ pub(super) fn validate_binary_view(views: &[u128], buffers: &[Buffer<u8>]) -> Po
     validate_view(views, buffers, |_| Ok(()))
 }
 
-pub(super) fn validate_utf8_view(views: &[u128], buffers: &[Buffer<u8>]) -> PolarsResult<()> {
-    validate_view(views, buffers, |b| match simdutf8::basic::from_utf8(b) {
+fn validate_utf8(b: &[u8]) -> Result<()> {
+    match simdutf8::basic::from_utf8(b) {
         Ok(_) => Ok(()),
-        Err(_) => Err(polars_err!(ComputeError: "invalid utf8")),
-    })
+        Err(e) => Err(Error::InvalidArgumentError(format!(
+            "Encountered non-UTF-8 data {e}"
+        )))
+    }
+}
+
+pub(super) fn validate_utf8_view(views: &[u128], buffers: &[Buffer<u8>]) -> Result<()> {
+    validate_view(views, buffers, validate_utf8)
+}
+
+pub(super) fn validate_utf8_only_view(views: &[u128], buffers: &[Buffer<u8>]) -> Result<()> {
+    for view in views {
+        let len = *view as u32;
+        if len <= 12 {
+            validate_utf8(&view.to_le_bytes()[4..4 + len as usize])?;
+        } else {
+            let view = View::from(*view);
+            let data = &buffers[view.buffer_idx as usize];
+
+            let start = view.offset as usize;
+            let end = start + len as usize;
+            let b = &data.as_slice()[start..end];
+            validate_utf8(b)?;
+        };
+    }
+
+    Ok(())
 }

--- a/src/array/equal/binary_view.rs
+++ b/src/array/equal/binary_view.rs
@@ -1,0 +1,9 @@
+use crate::array::binview::{BinaryViewArrayGeneric, ViewType};
+use crate::array::Array;
+
+pub(super) fn equal<T: ViewType + ?Sized>(
+    lhs: &BinaryViewArrayGeneric<T>,
+    rhs: &BinaryViewArrayGeneric<T>,
+) -> bool {
+    lhs.data_type() == rhs.data_type() && lhs.len() == rhs.len() && lhs.iter().eq(rhs.iter())
+}

--- a/src/array/equal/mod.rs
+++ b/src/array/equal/mod.rs
@@ -4,6 +4,7 @@ use crate::types::NativeType;
 use super::*;
 
 mod binary;
+mod binary_view;
 mod boolean;
 mod dictionary;
 mod fixed_size_binary;
@@ -283,6 +284,16 @@ pub fn equal(lhs: &dyn Array, rhs: &dyn Array) -> bool {
             let lhs = lhs.as_any().downcast_ref().unwrap();
             let rhs = rhs.as_any().downcast_ref().unwrap();
             map::equal(lhs, rhs)
-        }
+        },
+        BinaryView => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            binary_view::equal::<[u8]>(lhs, rhs)
+        },
+        Utf8View => {
+            let lhs = lhs.as_any().downcast_ref().unwrap();
+            let rhs = rhs.as_any().downcast_ref().unwrap();
+            binary_view::equal::<str>(lhs, rhs)
+        },
     }
 }

--- a/src/array/ffi.rs
+++ b/src/array/ffi.rs
@@ -71,6 +71,8 @@ pub fn offset_buffers_children_dictionary(array: &dyn Array) -> BuffersChildren 
         Struct => ffi_dyn!(array, StructArray),
         Union => ffi_dyn!(array, UnionArray),
         Map => ffi_dyn!(array, MapArray),
+        BinaryView => ffi_dyn!(array, BinaryViewArray),
+        Utf8View => ffi_dyn!(array, Utf8ViewArray),
         Dictionary(key_type) => {
             match_integer_type!(key_type, |$T| {
                 let array = array.as_any().downcast_ref::<DictionaryArray<$T>>().unwrap();

--- a/src/array/fixed_size_binary/ffi.rs
+++ b/src/array/fixed_size_binary/ffi.rs
@@ -11,7 +11,7 @@ unsafe impl ToFfi for FixedSizeBinaryArray {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            Some(self.values.as_ptr().cast::<u8>()),
+            Some(self.values.storage_ptr().cast::<u8>()),
         ]
     }
 

--- a/src/array/fmt.rs
+++ b/src/array/fmt.rs
@@ -91,6 +91,20 @@ pub fn get_value_display<'a, F: Write + 'a>(
         Map => Box::new(move |f, index| {
             super::map::fmt::write_value(array.as_any().downcast_ref().unwrap(), index, null, f)
         }),
+        BinaryView => Box::new(move |f, index| {
+            super::binview::fmt::write_value::<[u8], _>(
+                array.as_any().downcast_ref().unwrap(),
+                index,
+                f,
+            )
+        }),
+        Utf8View => Box::new(move |f, index| {
+            super::binview::fmt::write_value::<str, _>(
+                array.as_any().downcast_ref().unwrap(),
+                index,
+                f,
+            )
+        }),
         Dictionary(key_type) => match_integer_type!(key_type, |$T| {
             Box::new(move |f, index| {
                 super::dictionary::fmt::write_value::<$T,_>(array.as_any().downcast_ref().unwrap(), index, null, f)

--- a/src/array/growable/binary.rs
+++ b/src/array/growable/binary.rs
@@ -8,18 +8,18 @@ use crate::{
 };
 
 use super::{
-    utils::{build_extend_null_bits, extend_offset_values, ExtendNullBits},
+    utils::extend_offset_values,
     Growable,
 };
+use crate::array::growable::utils::{extend_validity, prepare_validity};
 
 /// Concrete [`Growable`] for the [`BinaryArray`].
 pub struct GrowableBinary<'a, O: Offset> {
     arrays: Vec<&'a BinaryArray<O>>,
     data_type: DataType,
-    validity: MutableBitmap,
+    validity: Option<MutableBitmap>,
     values: Vec<u8>,
     offsets: Offsets<O>,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a, O: Offset> GrowableBinary<'a, O> {
@@ -35,18 +35,12 @@ impl<'a, O: Offset> GrowableBinary<'a, O> {
             use_validity = true;
         };
 
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(*array, use_validity))
-            .collect();
-
         Self {
             arrays,
             data_type,
             values: Vec::with_capacity(0),
             offsets: Offsets::with_capacity(capacity),
-            validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
         }
     }
 
@@ -56,15 +50,20 @@ impl<'a, O: Offset> GrowableBinary<'a, O> {
         let offsets = std::mem::take(&mut self.offsets);
         let values = std::mem::take(&mut self.values);
 
-        BinaryArray::<O>::new(data_type, offsets.into(), values.into(), validity.into())
+        BinaryArray::<O>::new(
+            data_type,
+            offsets.into(),
+            values.into(),
+            validity.map(|v| v.into()),
+        )
     }
 }
 
 impl<'a, O: Offset> Growable<'a> for GrowableBinary<'a, O> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.validity, start, len);
-
         let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
+
         let offsets = array.offsets();
         let values = array.values();
 
@@ -78,7 +77,9 @@ impl<'a, O: Offset> Growable<'a> for GrowableBinary<'a, O> {
 
     fn extend_validity(&mut self, additional: usize) {
         self.offsets.extend_constant(additional);
-        self.validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]
@@ -101,7 +102,7 @@ impl<'a, O: Offset> From<GrowableBinary<'a, O>> for BinaryArray<O> {
             val.data_type,
             val.offsets.into(),
             val.values.into(),
-            val.validity.into(),
+            val.validity.map(|v| v.into()),
         )
     }
 }

--- a/src/array/growable/binview.rs
+++ b/src/array/growable/binview.rs
@@ -114,6 +114,28 @@ impl<'a, T: ViewType + ?Sized> GrowableBinaryViewArray<'a, T> {
                 }
             }));
     }
+
+    #[inline]
+    pub(crate) unsafe fn extend_unchecked_no_buffers(
+        &mut self,
+        index: usize,
+        start: usize,
+        len: usize,
+    ) {
+        let array = *self.arrays.get_unchecked(index);
+
+        extend_validity(&mut self.validity, array, start, len);
+
+        let range = start..start + len;
+
+        self.views
+            .extend(array.views().get_unchecked(range).iter().map(|view| {
+                let len = (*view as u32) as usize;
+                self.total_bytes_len += len;
+
+                *view
+            }))
+    }
 }
 
 impl<'a, T: ViewType + ?Sized> Growable<'a> for GrowableBinaryViewArray<'a, T> {

--- a/src/array/growable/binview.rs
+++ b/src/array/growable/binview.rs
@@ -15,6 +15,7 @@ pub struct GrowableBinaryViewArray<'a, T: ViewType + ?Sized> {
     validity: Option<MutableBitmap>,
     views: Vec<u128>,
     buffers: Vec<Buffer<u8>>,
+    buffers_offsets: Vec<u32>,
     total_bytes_len: usize,
     total_buffer_len: usize,
 }
@@ -36,9 +37,24 @@ impl<'a, T: ViewType + ?Sized> GrowableBinaryViewArray<'a, T> {
             use_validity = true;
         };
 
-        let n_buffers = arrays
+        let mut cum_sum = 0;
+        let cum_offset = arrays
             .iter()
-            .map(|binview| binview.data_buffers().len())
+            .map(|binview| {
+                let out = cum_sum;
+                cum_sum += binview.data_buffers().len() as u32;
+                out
+            })
+            .collect::<Vec<_>>();
+
+        let buffers = arrays
+            .iter()
+            .flat_map(|array| array.data_buffers().as_ref())
+            .cloned()
+            .collect::<Vec<_>>();
+        let total_buffer_len = arrays
+            .iter()
+            .map(|arr| arr.data_buffers().len())
             .sum::<usize>();
 
         Self {
@@ -46,9 +62,10 @@ impl<'a, T: ViewType + ?Sized> GrowableBinaryViewArray<'a, T> {
             data_type,
             validity: prepare_validity(use_validity, capacity),
             views: Vec::with_capacity(capacity),
-            buffers: Vec::with_capacity(n_buffers),
+            buffers,
+            buffers_offsets: cum_offset,
             total_bytes_len: 0,
-            total_buffer_len: 0,
+            total_buffer_len,
         }
     }
 
@@ -65,33 +82,39 @@ impl<'a, T: ViewType + ?Sized> GrowableBinaryViewArray<'a, T> {
                 self.total_bytes_len,
                 self.total_buffer_len,
             )
+            .maybe_gc()
         }
+    }
+
+    /// # Safety
+    /// doesn't check bounds
+    pub unsafe fn extend_unchecked(&mut self, index: usize, start: usize, len: usize) {
+        let array = *self.arrays.get_unchecked(index);
+
+        extend_validity(&mut self.validity, array, start, len);
+
+        let range = start..start + len;
+
+        self.views
+            .extend(array.views().get_unchecked(range).iter().map(|&view| {
+                let len = (view as u32) as usize;
+                self.total_bytes_len += len;
+
+                if len > 12 {
+                    let buffer_offset = *self.buffers_offsets.get_unchecked(index);
+                    let mask = (u32::MAX as u128) << 64;
+                    (view & !mask) | ((buffer_offset as u128) << 64)
+                } else {
+                    view
+                }
+            }));
     }
 }
 
 impl<'a, T: ViewType + ?Sized> Growable<'a> for GrowableBinaryViewArray<'a, T> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        let array = self.arrays[index];
-        extend_validity(&mut self.validity, array, start, len);
-
-        let buffer_offset: u32 = self.buffers.len().try_into().expect("unsupported");
-        let buffer_offset = (buffer_offset as u128) << 64;
-
-        let range = start..start + len;
-        let buffers_range = &array.data_buffers()[range.clone()];
-        self.buffers.extend_from_slice(buffers_range);
-
-        for b in buffers_range {
-            self.total_buffer_len += b.len();
-        }
-
-        self.views.extend(array.views()[range].iter().map(|&view| {
-            self.total_bytes_len += (view as u32) as usize;
-
-            // If null the buffer index is ignored because the length is 0,
-            // so we can just do this
-            view + buffer_offset
-        }));
+        assert!(index < self.arrays.len());
+        unsafe { self.extend_unchecked(index, start, len) }
     }
 
     fn extend_validity(&mut self, additional: usize) {
@@ -126,6 +149,7 @@ impl<'a, T: ViewType + ?Sized> From<GrowableBinaryViewArray<'a, T>> for BinaryVi
                 val.total_bytes_len,
                 val.total_buffer_len,
             )
+            .maybe_gc()
         }
     }
 }

--- a/src/array/growable/binview.rs
+++ b/src/array/growable/binview.rs
@@ -1,0 +1,116 @@
+use std::sync::Arc;
+
+use super::Growable;
+use crate::array::binview::{BinaryViewArrayGeneric, ViewType};
+use crate::array::growable::utils::{extend_validity, prepare_validity};
+use crate::array::Array;
+use crate::bitmap::MutableBitmap;
+use crate::buffer::Buffer;
+use crate::datatypes::ArrowDataType;
+
+/// Concrete [`Growable`] for the [`BinaryArray`].
+pub struct GrowableBinaryViewArray<'a, T: ViewType + ?Sized> {
+    arrays: Vec<&'a BinaryViewArrayGeneric<T>>,
+    data_type: ArrowDataType,
+    validity: Option<MutableBitmap>,
+    views: Vec<u128>,
+    buffers: Vec<Buffer<u8>>,
+}
+
+impl<'a, T: ViewType + ?Sized> GrowableBinaryViewArray<'a, T> {
+    /// Creates a new [`GrowableBinaryViewArray`] bound to `arrays` with a pre-allocated `capacity`.
+    /// # Panics
+    /// If `arrays` is empty.
+    pub fn new(
+        arrays: Vec<&'a BinaryViewArrayGeneric<T>>,
+        mut use_validity: bool,
+        capacity: usize,
+    ) -> Self {
+        let data_type = arrays[0].data_type().clone();
+
+        // if any of the arrays has nulls, insertions from any array requires setting bits
+        // as there is at least one array with nulls.
+        if !use_validity & arrays.iter().any(|array| array.null_count() > 0) {
+            use_validity = true;
+        };
+
+        let n_buffers = arrays
+            .iter()
+            .map(|binview| binview.data_buffers().len())
+            .sum::<usize>();
+
+        Self {
+            arrays,
+            data_type,
+            validity: prepare_validity(use_validity, capacity),
+            views: Vec::with_capacity(capacity),
+            buffers: Vec::with_capacity(n_buffers),
+        }
+    }
+
+    fn to(&mut self) -> BinaryViewArrayGeneric<T> {
+        let views = std::mem::take(&mut self.views);
+        let buffers = std::mem::take(&mut self.buffers);
+        let validity = self.validity.take();
+        unsafe {
+            BinaryViewArrayGeneric::<T>::new_unchecked(
+                self.data_type.clone(),
+                views.into(),
+                Arc::from(buffers),
+                validity.map(|v| v.into()),
+            )
+        }
+    }
+}
+
+impl<'a, T: ViewType + ?Sized> Growable<'a> for GrowableBinaryViewArray<'a, T> {
+    fn extend(&mut self, index: usize, start: usize, len: usize) {
+        let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
+
+        let buffer_offset: u32 = self.buffers.len().try_into().expect("unsupported");
+        let buffer_offset = (buffer_offset as u128) << 64;
+
+        let range = start..start + len;
+        self.buffers
+            .extend_from_slice(&array.data_buffers()[range.clone()]);
+        self.views.extend(array.views()[range].iter().map(|&view| {
+            // If null the buffer index is ignored because the length is 0,
+            // so we can just do this
+            view + buffer_offset
+        }));
+    }
+
+    fn extend_validity(&mut self, additional: usize) {
+        self.views.extend(std::iter::repeat(0).take(additional));
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
+    }
+
+    #[inline]
+    fn len(&self) -> usize {
+        self.views.len()
+    }
+
+    fn as_arc(&mut self) -> Arc<dyn Array> {
+        self.to().arced()
+    }
+
+    fn as_box(&mut self) -> Box<dyn Array> {
+        self.to().boxed()
+    }
+}
+
+impl<'a, T: ViewType + ?Sized> From<GrowableBinaryViewArray<'a, T>> for BinaryViewArrayGeneric<T> {
+    fn from(val: GrowableBinaryViewArray<'a, T>) -> Self {
+        unsafe {
+            BinaryViewArrayGeneric::<T>::new_unchecked(
+                val.data_type,
+                val.views.into(),
+                Arc::from(val.buffers),
+                val.validity.map(|v| v.into()),
+            )
+        }
+    }
+}

--- a/src/array/growable/binview.rs
+++ b/src/array/growable/binview.rs
@@ -15,7 +15,7 @@ pub struct GrowableBinaryViewArray<'a, T: ViewType + ?Sized> {
     validity: Option<MutableBitmap>,
     views: Vec<u128>,
     buffers: Vec<Buffer<u8>>,
-    buffers_offsets: Vec<u32>,
+    buffers_idx_offsets: Vec<u32>,
     total_bytes_len: usize,
     total_buffer_len: usize,
 }
@@ -63,7 +63,7 @@ impl<'a, T: ViewType + ?Sized> GrowableBinaryViewArray<'a, T> {
             validity: prepare_validity(use_validity, capacity),
             views: Vec::with_capacity(capacity),
             buffers,
-            buffers_offsets: cum_offset,
+            buffers_idx_offsets: cum_offset,
             total_bytes_len: 0,
             total_buffer_len,
         }
@@ -101,9 +101,14 @@ impl<'a, T: ViewType + ?Sized> GrowableBinaryViewArray<'a, T> {
                 self.total_bytes_len += len;
 
                 if len > 12 {
-                    let buffer_offset = *self.buffers_offsets.get_unchecked(index);
+                    // Take the buffer index of the View.
+                    let current_buffer_idx = (view >> 64) as u32;
+                    // And add the offset of the buffers.
+                    let buffer_idx =
+                        *self.buffers_idx_offsets.get_unchecked(index) + current_buffer_idx;
+                    // Mask out the old buffer-idx and OR in the new.
                     let mask = (u32::MAX as u128) << 64;
-                    (view & !mask) | ((buffer_offset as u128) << 64)
+                    (view & !mask) | ((buffer_idx as u128) << 64)
                 } else {
                     view
                 }

--- a/src/array/growable/binview.rs
+++ b/src/array/growable/binview.rs
@@ -6,12 +6,12 @@ use crate::array::growable::utils::{extend_validity, prepare_validity};
 use crate::array::Array;
 use crate::bitmap::MutableBitmap;
 use crate::buffer::Buffer;
-use crate::datatypes::ArrowDataType;
+use crate::datatypes::DataType;
 
 /// Concrete [`Growable`] for the [`BinaryArray`].
 pub struct GrowableBinaryViewArray<'a, T: ViewType + ?Sized> {
     arrays: Vec<&'a BinaryViewArrayGeneric<T>>,
-    data_type: ArrowDataType,
+    data_type: DataType,
     validity: Option<MutableBitmap>,
     views: Vec<u128>,
     buffers: Vec<Buffer<u8>>,

--- a/src/array/growable/binview.rs
+++ b/src/array/growable/binview.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::Growable;
-use crate::array::binview::{BinaryViewArrayGeneric, ViewType};
+use crate::array::binview::{BinaryViewArrayGeneric, View, ViewType};
 use crate::array::growable::utils::{extend_validity, prepare_validity};
 use crate::array::Array;
 use crate::bitmap::MutableBitmap;
@@ -13,7 +13,7 @@ pub struct GrowableBinaryViewArray<'a, T: ViewType + ?Sized> {
     arrays: Vec<&'a BinaryViewArrayGeneric<T>>,
     data_type: DataType,
     validity: Option<MutableBitmap>,
-    views: Vec<u128>,
+    views: Vec<View>,
     buffers: Vec<Buffer<u8>>,
     buffers_idx_offsets: Vec<u32>,
     total_bytes_len: usize,
@@ -96,22 +96,16 @@ impl<'a, T: ViewType + ?Sized> GrowableBinaryViewArray<'a, T> {
         let range = start..start + len;
 
         self.views
-            .extend(array.views().get_unchecked(range).iter().map(|&view| {
-                let len = (view as u32) as usize;
+            .extend(array.views().get_unchecked(range).iter().map(|view| {
+                let mut view = *view;
+                let len = view.length as usize;
                 self.total_bytes_len += len;
 
                 if len > 12 {
-                    // Take the buffer index of the View.
-                    let current_buffer_idx = (view >> 64) as u32;
-                    // And add the offset of the buffers.
-                    let buffer_idx =
-                        *self.buffers_idx_offsets.get_unchecked(index) + current_buffer_idx;
-                    // Mask out the old buffer-idx and OR in the new.
-                    let mask = (u32::MAX as u128) << 64;
-                    (view & !mask) | ((buffer_idx as u128) << 64)
-                } else {
-                    view
+                    let buffer_idx = *self.buffers_idx_offsets.get_unchecked(index);
+                    view.buffer_idx += buffer_idx;
                 }
+                view
             }));
     }
 
@@ -130,7 +124,7 @@ impl<'a, T: ViewType + ?Sized> GrowableBinaryViewArray<'a, T> {
 
         self.views
             .extend(array.views().get_unchecked(range).iter().map(|view| {
-                let len = (*view as u32) as usize;
+                let len = view.length as usize;
                 self.total_bytes_len += len;
 
                 *view
@@ -145,7 +139,8 @@ impl<'a, T: ViewType + ?Sized> Growable<'a> for GrowableBinaryViewArray<'a, T> {
     }
 
     fn extend_validity(&mut self, additional: usize) {
-        self.views.extend(std::iter::repeat(0).take(additional));
+        self.views
+            .extend(std::iter::repeat(View::default()).take(additional));
         if let Some(validity) = &mut self.validity {
             validity.extend_constant(additional, false);
         }

--- a/src/array/growable/boolean.rs
+++ b/src/array/growable/boolean.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 use super::{
-    utils::{build_extend_null_bits, ExtendNullBits},
+    utils::{extend_validity, prepare_validity},
     Growable,
 };
 
@@ -15,9 +15,8 @@ use super::{
 pub struct GrowableBoolean<'a> {
     arrays: Vec<&'a BooleanArray>,
     data_type: DataType,
-    validity: MutableBitmap,
+    validity: Option<MutableBitmap>,
     values: MutableBitmap,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a> GrowableBoolean<'a> {
@@ -33,33 +32,31 @@ impl<'a> GrowableBoolean<'a> {
             use_validity = true;
         };
 
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(*array, use_validity))
-            .collect();
-
         Self {
             arrays,
             data_type,
             values: MutableBitmap::with_capacity(capacity),
-            validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
         }
     }
 
     fn to(&mut self) -> BooleanArray {
-        let validity = std::mem::take(&mut self.validity);
+        let validity = self.validity.take();
         let values = std::mem::take(&mut self.values);
 
-        BooleanArray::new(self.data_type.clone(), values.into(), validity.into())
+        BooleanArray::new(
+            self.data_type.clone(),
+            values.into(),
+            validity.map(|v| v.into()),
+        )
     }
 }
 
 impl<'a> Growable<'a> for GrowableBoolean<'a> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.validity, start, len);
-
         let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
+
         let values = array.values();
 
         let (slice, offset, _) = values.as_slice();
@@ -72,7 +69,9 @@ impl<'a> Growable<'a> for GrowableBoolean<'a> {
 
     fn extend_validity(&mut self, additional: usize) {
         self.values.extend_constant(additional, false);
-        self.validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]
@@ -91,6 +90,10 @@ impl<'a> Growable<'a> for GrowableBoolean<'a> {
 
 impl<'a> From<GrowableBoolean<'a>> for BooleanArray {
     fn from(val: GrowableBoolean<'a>) -> Self {
-        BooleanArray::new(val.data_type, val.values.into(), val.validity.into())
+        BooleanArray::new(
+            val.data_type,
+            val.values.into(),
+            val.validity.map(|v| v.into()),
+        )
     }
 }

--- a/src/array/growable/dictionary.rs
+++ b/src/array/growable/dictionary.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::{
     make_growable,
-    utils::{build_extend_null_bits, ExtendNullBits},
+    utils::{extend_validity, prepare_validity},
     Growable,
 };
 
@@ -18,12 +18,11 @@ use super::{
 /// the values of each [`DictionaryArray`] one after the other.
 pub struct GrowableDictionary<'a, K: DictionaryKey> {
     data_type: DataType,
-    keys_values: Vec<&'a [K]>,
+    keys: Vec<&'a PrimitiveArray<K>>,
     key_values: Vec<K>,
-    key_validity: MutableBitmap,
+    validity: Option<MutableBitmap>,
     offsets: Vec<usize>,
     values: Box<dyn Array>,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 fn concatenate_values<K: DictionaryKey>(
@@ -55,16 +54,6 @@ impl<'a, T: DictionaryKey> GrowableDictionary<'a, T> {
         };
 
         let arrays_keys = arrays.iter().map(|array| array.keys()).collect::<Vec<_>>();
-        let keys_values = arrays_keys
-            .iter()
-            .map(|array| array.values().as_slice())
-            .collect::<Vec<_>>();
-
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(array.keys(), use_validity))
-            .collect();
-
         let arrays_values = arrays
             .iter()
             .map(|array| array.values().as_ref())
@@ -76,24 +65,26 @@ impl<'a, T: DictionaryKey> GrowableDictionary<'a, T> {
             data_type,
             offsets,
             values,
-            keys_values,
+            keys: arrays_keys,
             key_values: Vec::with_capacity(capacity),
-            key_validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
         }
     }
 
     #[inline]
     fn to(&mut self) -> DictionaryArray<T> {
-        let validity = std::mem::take(&mut self.key_validity);
+        let validity = self.validity.take();
         let key_values = std::mem::take(&mut self.key_values);
 
         #[cfg(debug_assertions)]
         {
             crate::array::specification::check_indexes(&key_values, self.values.len()).unwrap();
         }
-        let keys =
-            PrimitiveArray::<T>::new(T::PRIMITIVE.into(), key_values.into(), validity.into());
+        let keys = PrimitiveArray::<T>::new(
+            T::PRIMITIVE.into(),
+            key_values.into(),
+            validity.map(|v| v.into()),
+        );
 
         // Safety - the invariant of this struct ensures that this is up-held
         unsafe {
@@ -110,9 +101,10 @@ impl<'a, T: DictionaryKey> GrowableDictionary<'a, T> {
 impl<'a, T: DictionaryKey> Growable<'a> for GrowableDictionary<'a, T> {
     #[inline]
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.key_validity, start, len);
+        let keys_array = self.keys[index];
+        extend_validity(&mut self.validity, keys_array, start, len);
 
-        let values = &self.keys_values[index][start..start + len];
+        let values = &keys_array.values()[start..start + len];
         let offset = self.offsets[index];
         self.key_values.extend(
             values
@@ -141,7 +133,9 @@ impl<'a, T: DictionaryKey> Growable<'a> for GrowableDictionary<'a, T> {
     fn extend_validity(&mut self, additional: usize) {
         self.key_values
             .resize(self.key_values.len() + additional, T::default());
-        self.key_validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]

--- a/src/array/growable/fixed_binary.rs
+++ b/src/array/growable/fixed_binary.rs
@@ -6,16 +6,15 @@ use crate::{
 };
 
 use super::{
-    utils::{build_extend_null_bits, ExtendNullBits},
+    utils::{extend_validity, prepare_validity},
     Growable,
 };
 
 /// Concrete [`Growable`] for the [`FixedSizeBinaryArray`].
 pub struct GrowableFixedSizeBinary<'a> {
     arrays: Vec<&'a FixedSizeBinaryArray>,
-    validity: MutableBitmap,
+    validity: Option<MutableBitmap>,
     values: Vec<u8>,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
     size: usize, // just a cache
 }
 
@@ -34,17 +33,11 @@ impl<'a> GrowableFixedSizeBinary<'a> {
             use_validity = true;
         };
 
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(*array, use_validity))
-            .collect();
-
         let size = FixedSizeBinaryArray::get_size(arrays[0].data_type());
         Self {
             arrays,
             values: Vec::with_capacity(0),
-            validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
             size,
         }
     }
@@ -56,16 +49,16 @@ impl<'a> GrowableFixedSizeBinary<'a> {
         FixedSizeBinaryArray::new(
             self.arrays[0].data_type().clone(),
             values.into(),
-            validity.into(),
+            validity.map(|v| v.into()),
         )
     }
 }
 
 impl<'a> Growable<'a> for GrowableFixedSizeBinary<'a> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.validity, start, len);
-
         let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
+
         let values = array.values();
 
         self.values
@@ -75,7 +68,9 @@ impl<'a> Growable<'a> for GrowableFixedSizeBinary<'a> {
     fn extend_validity(&mut self, additional: usize) {
         self.values
             .extend_from_slice(&vec![0; self.size * additional]);
-        self.validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]
@@ -97,7 +92,7 @@ impl<'a> From<GrowableFixedSizeBinary<'a>> for FixedSizeBinaryArray {
         FixedSizeBinaryArray::new(
             val.arrays[0].data_type().clone(),
             val.values.into(),
-            val.validity.into(),
+            val.validity.map(|v| v.into()),
         )
     }
 }

--- a/src/array/growable/fixed_size_list.rs
+++ b/src/array/growable/fixed_size_list.rs
@@ -8,16 +8,15 @@ use crate::{
 
 use super::{
     make_growable,
-    utils::{build_extend_null_bits, ExtendNullBits},
+    utils::{extend_validity, prepare_validity},
     Growable,
 };
 
 /// Concrete [`Growable`] for the [`FixedSizeListArray`].
 pub struct GrowableFixedSizeList<'a> {
     arrays: Vec<&'a FixedSizeListArray>,
-    validity: MutableBitmap,
+    validity: Option<MutableBitmap>,
     values: Box<dyn Growable<'a> + 'a>,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
     size: usize,
 }
 
@@ -45,11 +44,6 @@ impl<'a> GrowableFixedSizeList<'a> {
                 unreachable!("`GrowableFixedSizeList` expects `DataType::FixedSizeList`")
             };
 
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(*array, use_validity))
-            .collect();
-
         let inner = arrays
             .iter()
             .map(|array| array.values().as_ref())
@@ -59,8 +53,7 @@ impl<'a> GrowableFixedSizeList<'a> {
         Self {
             arrays,
             values,
-            validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
             size,
         }
     }
@@ -69,20 +62,28 @@ impl<'a> GrowableFixedSizeList<'a> {
         let validity = std::mem::take(&mut self.validity);
         let values = self.values.as_box();
 
-        FixedSizeListArray::new(self.arrays[0].data_type().clone(), values, validity.into())
+        FixedSizeListArray::new(
+            self.arrays[0].data_type().clone(),
+            values,
+            validity.map(|v| v.into()),
+        )
     }
 }
 
 impl<'a> Growable<'a> for GrowableFixedSizeList<'a> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.validity, start, len);
+        let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
+
         self.values
             .extend(index, start * self.size, len * self.size);
     }
 
     fn extend_validity(&mut self, additional: usize) {
         self.values.extend_validity(additional * self.size);
-        self.validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]
@@ -107,7 +108,7 @@ impl<'a> From<GrowableFixedSizeList<'a>> for FixedSizeListArray {
         Self::new(
             val.arrays[0].data_type().clone(),
             values,
-            val.validity.into(),
+            val.validity.map(|v| v.into()),
         )
     }
 }

--- a/src/array/growable/list.rs
+++ b/src/array/growable/list.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::{
     make_growable,
-    utils::{build_extend_null_bits, ExtendNullBits},
+    utils::{extend_validity, prepare_validity},
     Growable,
 };
 
@@ -35,10 +35,9 @@ fn extend_offset_values<O: Offset>(
 /// Concrete [`Growable`] for the [`ListArray`].
 pub struct GrowableList<'a, O: Offset> {
     arrays: Vec<&'a ListArray<O>>,
-    validity: MutableBitmap,
+    validity: Option<MutableBitmap>,
     values: Box<dyn Growable<'a> + 'a>,
     offsets: Offsets<O>,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a, O: Offset> GrowableList<'a, O> {
@@ -52,11 +51,6 @@ impl<'a, O: Offset> GrowableList<'a, O> {
             use_validity = true;
         };
 
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(*array, use_validity))
-            .collect();
-
         let inner = arrays
             .iter()
             .map(|array| array.values().as_ref())
@@ -67,8 +61,7 @@ impl<'a, O: Offset> GrowableList<'a, O> {
             arrays,
             offsets: Offsets::with_capacity(capacity),
             values,
-            validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
         }
     }
 
@@ -81,20 +74,23 @@ impl<'a, O: Offset> GrowableList<'a, O> {
             self.arrays[0].data_type().clone(),
             offsets.into(),
             values,
-            validity.into(),
+            validity.map(|v| v.into()),
         )
     }
 }
 
 impl<'a, O: Offset> Growable<'a> for GrowableList<'a, O> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.validity, start, len);
+        let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
         extend_offset_values::<O>(self, index, start, len);
     }
 
     fn extend_validity(&mut self, additional: usize) {
         self.offsets.extend_constant(additional);
-        self.validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]

--- a/src/array/growable/map.rs
+++ b/src/array/growable/map.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use super::{
     make_growable,
-    utils::{build_extend_null_bits, ExtendNullBits},
+    utils::{extend_validity, prepare_validity},
     Growable,
 };
 
@@ -30,10 +30,9 @@ fn extend_offset_values(growable: &mut GrowableMap<'_>, index: usize, start: usi
 /// Concrete [`Growable`] for the [`MapArray`].
 pub struct GrowableMap<'a> {
     arrays: Vec<&'a MapArray>,
-    validity: MutableBitmap,
+    validity: Option<MutableBitmap>,
     values: Box<dyn Growable<'a> + 'a>,
     offsets: Offsets<i32>,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a> GrowableMap<'a> {
@@ -47,11 +46,6 @@ impl<'a> GrowableMap<'a> {
             use_validity = true;
         };
 
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(*array, use_validity))
-            .collect();
-
         let inner = arrays
             .iter()
             .map(|array| array.field().as_ref())
@@ -62,8 +56,7 @@ impl<'a> GrowableMap<'a> {
             arrays,
             offsets: Offsets::with_capacity(capacity),
             values,
-            validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
         }
     }
 
@@ -76,20 +69,23 @@ impl<'a> GrowableMap<'a> {
             self.arrays[0].data_type().clone(),
             offsets.into(),
             values,
-            validity.into(),
+            validity.map(|v| v.into()),
         )
     }
 }
 
 impl<'a> Growable<'a> for GrowableMap<'a> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.validity, start, len);
+        let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
         extend_offset_values(self, index, start, len);
     }
 
     fn extend_validity(&mut self, additional: usize) {
         self.offsets.extend_constant(additional);
-        self.validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]

--- a/src/array/growable/mod.rs
+++ b/src/array/growable/mod.rs
@@ -31,6 +31,7 @@ mod dictionary;
 pub use dictionary::GrowableDictionary;
 
 mod binview;
+pub use binview::GrowableBinaryViewArray;
 mod utils;
 
 /// Describes a struct that can be extended from slices of other pre-existing [`Array`]s.

--- a/src/array/growable/mod.rs
+++ b/src/array/growable/mod.rs
@@ -30,6 +30,7 @@ pub use utf8::GrowableUtf8;
 mod dictionary;
 pub use dictionary::GrowableDictionary;
 
+mod binview;
 mod utils;
 
 /// Describes a struct that can be extended from slices of other pre-existing [`Array`]s.
@@ -118,14 +119,22 @@ pub fn make_growable<'a>(
             use_validity,
             capacity
         ),
-        Union => {
-            let arrays = arrays
-                .iter()
-                .map(|array| array.as_any().downcast_ref().unwrap())
-                .collect::<Vec<_>>();
-            Box::new(union::GrowableUnion::new(arrays, capacity))
-        }
-        Map => dyn_growable!(map::GrowableMap, arrays, use_validity, capacity),
+        BinaryView => {
+            dyn_growable!(
+                binview::GrowableBinaryViewArray::<[u8]>,
+                arrays,
+                use_validity,
+                capacity
+            )
+        },
+        Utf8View => {
+            dyn_growable!(
+                binview::GrowableBinaryViewArray::<str>,
+                arrays,
+                use_validity,
+                capacity
+            )
+        },
         Dictionary(key_type) => {
             match_integer_type!(key_type, |$T| {
                 let arrays = arrays
@@ -143,6 +152,14 @@ pub fn make_growable<'a>(
                     capacity,
                 ))
             })
-        }
+        },
+        Map => dyn_growable!(map::GrowableMap, arrays, use_validity, capacity),
+        Union => {
+            let arrays = arrays
+                .iter()
+                .map(|array| array.as_any().downcast_ref().unwrap())
+                .collect::<Vec<_>>();
+            Box::new(union::GrowableUnion::new(arrays, capacity))
+        },
     }
 }

--- a/src/array/growable/primitive.rs
+++ b/src/array/growable/primitive.rs
@@ -8,17 +8,16 @@ use crate::{
 };
 
 use super::{
-    utils::{build_extend_null_bits, ExtendNullBits},
+    utils::{extend_validity, prepare_validity},
     Growable,
 };
 
 /// Concrete [`Growable`] for the [`PrimitiveArray`].
 pub struct GrowablePrimitive<'a, T: NativeType> {
     data_type: DataType,
-    arrays: Vec<&'a [T]>,
-    validity: MutableBitmap,
+    arrays: Vec<&'a PrimitiveArray<T>>,
+    validity: Option<MutableBitmap>,
     values: Vec<T>,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a, T: NativeType> GrowablePrimitive<'a, T> {
@@ -38,22 +37,11 @@ impl<'a, T: NativeType> GrowablePrimitive<'a, T> {
 
         let data_type = arrays[0].data_type().clone();
 
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(*array, use_validity))
-            .collect();
-
-        let arrays = arrays
-            .iter()
-            .map(|array| array.values().as_slice())
-            .collect::<Vec<_>>();
-
         Self {
             data_type,
             arrays,
             values: Vec::with_capacity(capacity),
-            validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
         }
     }
 
@@ -62,16 +50,21 @@ impl<'a, T: NativeType> GrowablePrimitive<'a, T> {
         let validity = std::mem::take(&mut self.validity);
         let values = std::mem::take(&mut self.values);
 
-        PrimitiveArray::<T>::new(self.data_type.clone(), values.into(), validity.into())
+        PrimitiveArray::<T>::new(
+            self.data_type.clone(),
+            values.into(),
+            validity.map(|v| v.into()),
+        )
     }
 }
 
 impl<'a, T: NativeType> Growable<'a> for GrowablePrimitive<'a, T> {
     #[inline]
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.validity, start, len);
+        let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
 
-        let values = self.arrays[index];
+        let values = array.values().as_slice();
         self.values.extend_from_slice(&values[start..start + len]);
     }
 
@@ -79,7 +72,9 @@ impl<'a, T: NativeType> Growable<'a> for GrowablePrimitive<'a, T> {
     fn extend_validity(&mut self, additional: usize) {
         self.values
             .resize(self.values.len() + additional, T::default());
-        self.validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]
@@ -101,6 +96,10 @@ impl<'a, T: NativeType> Growable<'a> for GrowablePrimitive<'a, T> {
 impl<'a, T: NativeType> From<GrowablePrimitive<'a, T>> for PrimitiveArray<T> {
     #[inline]
     fn from(val: GrowablePrimitive<'a, T>) -> Self {
-        PrimitiveArray::<T>::new(val.data_type, val.values.into(), val.validity.into())
+        PrimitiveArray::<T>::new(
+            val.data_type,
+            val.values.into(),
+            val.validity.map(|v| v.into()),
+        )
     }
 }

--- a/src/array/growable/utf8.rs
+++ b/src/array/growable/utf8.rs
@@ -7,17 +7,16 @@ use crate::{
 };
 
 use super::{
-    utils::{build_extend_null_bits, extend_offset_values, ExtendNullBits},
+    utils::{extend_validity, prepare_validity, extend_offset_values},
     Growable,
 };
 
 /// Concrete [`Growable`] for the [`Utf8Array`].
 pub struct GrowableUtf8<'a, O: Offset> {
     arrays: Vec<&'a Utf8Array<O>>,
-    validity: MutableBitmap,
+    validity: Option<MutableBitmap>,
     values: Vec<u8>,
     offsets: Offsets<O>,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a, O: Offset> GrowableUtf8<'a, O> {
@@ -31,17 +30,11 @@ impl<'a, O: Offset> GrowableUtf8<'a, O> {
             use_validity = true;
         };
 
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(*array, use_validity))
-            .collect();
-
         Self {
             arrays: arrays.to_vec(),
             values: Vec::with_capacity(0),
             offsets: Offsets::with_capacity(capacity),
-            validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
         }
     }
 
@@ -60,7 +53,7 @@ impl<'a, O: Offset> GrowableUtf8<'a, O> {
                 self.arrays[0].data_type().clone(),
                 offsets.into(),
                 values.into(),
-                validity.into(),
+                validity.map(|v| v.into()),
             )
             .unwrap()
         }
@@ -69,9 +62,9 @@ impl<'a, O: Offset> GrowableUtf8<'a, O> {
 
 impl<'a, O: Offset> Growable<'a> for GrowableUtf8<'a, O> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.validity, start, len);
-
         let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
+
         let offsets = array.offsets();
         let values = array.values();
 
@@ -85,7 +78,9 @@ impl<'a, O: Offset> Growable<'a> for GrowableUtf8<'a, O> {
 
     fn extend_validity(&mut self, additional: usize) {
         self.offsets.extend_constant(additional);
-        self.validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]

--- a/src/array/growable/utils.rs
+++ b/src/array/growable/utils.rs
@@ -1,28 +1,5 @@
 use crate::{array::Array, bitmap::MutableBitmap, offset::Offset};
 
-// function used to extend nulls from arrays. This function's lifetime is bound to the array
-// because it reads nulls from it.
-pub(super) type ExtendNullBits<'a> = Box<dyn Fn(&mut MutableBitmap, usize, usize) + 'a>;
-
-pub(super) fn build_extend_null_bits(array: &dyn Array, use_validity: bool) -> ExtendNullBits {
-    if let Some(bitmap) = array.validity() {
-        Box::new(move |validity, start, len| {
-            debug_assert!(start + len <= bitmap.len());
-            let (slice, offset, _) = bitmap.as_slice();
-            // safety: invariant offset + length <= slice.len()
-            unsafe {
-                validity.extend_from_slice_unchecked(slice, start + offset, len);
-            }
-        })
-    } else if use_validity {
-        Box::new(|validity, _, len| {
-            validity.extend_constant(len, true);
-        })
-    } else {
-        Box::new(|_, _, _| {})
-    }
-}
-
 #[inline]
 pub(super) fn extend_offset_values<O: Offset>(
     buffer: &mut Vec<u8>,
@@ -35,4 +12,33 @@ pub(super) fn extend_offset_values<O: Offset>(
     let end_values = offsets[start + len].to_usize();
     let new_values = &values[start_values..end_values];
     buffer.extend_from_slice(new_values);
+}
+
+pub(super) fn prepare_validity(use_validity: bool, capacity: usize) -> Option<MutableBitmap> {
+    if use_validity {
+        Some(MutableBitmap::with_capacity(capacity))
+    } else {
+        None
+    }
+}
+
+pub(super) fn extend_validity(
+    mutable_validity: &mut Option<MutableBitmap>,
+    array: &dyn Array,
+    start: usize,
+    len: usize,
+) {
+    if let Some(mutable_validity) = mutable_validity {
+        match array.validity() {
+            None => mutable_validity.extend_constant(len, true),
+            Some(validity) => {
+                debug_assert!(start + len <= validity.len());
+                let (slice, offset, _) = validity.as_slice();
+                // safety: invariant offset + length <= slice.len()
+                unsafe {
+                    mutable_validity.extend_from_slice_unchecked(slice, start + offset, len);
+                }
+            },
+        }
+    }
 }

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -9,7 +9,7 @@ unsafe impl<O: Offset> ToFfi for ListArray<O> {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            Some(self.offsets.buffer().as_ptr().cast::<u8>()),
+            Some(self.offsets.buffer().storage_ptr().cast::<u8>()),
         ]
     }
 

--- a/src/array/list/ffi.rs
+++ b/src/array/list/ffi.rs
@@ -61,6 +61,6 @@ impl<O: Offset, A: ffi::ArrowArrayRef> FromFfi<A> for ListArray<O> {
         // assumption that data from FFI is well constructed
         let offsets = unsafe { OffsetsBuffer::new_unchecked(offsets) };
 
-        Ok(Self::new(data_type, offsets, values, validity))
+        Self::try_new(data_type, offsets, values, validity)
     }
 }

--- a/src/array/map/ffi.rs
+++ b/src/array/map/ffi.rs
@@ -7,7 +7,7 @@ unsafe impl ToFfi for MapArray {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            Some(self.offsets.buffer().as_ptr().cast::<u8>()),
+            Some(self.offsets.buffer().storage_ptr().cast::<u8>()),
         ]
     }
 

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -749,7 +749,7 @@ pub use fmt::{get_display, get_value_display};
 pub use binary::{BinaryArray, BinaryValueIter, MutableBinaryArray, MutableBinaryValuesArray};
 pub use binview::{
     BinaryViewArray, BinaryViewArrayGeneric, MutableBinaryViewArray, MutablePlBinary,
-    MutablePlString, Utf8ViewArray, ViewType,
+    MutablePlString, Utf8ViewArray, View, ViewType,
 };
 pub use boolean::{BooleanArray, MutableBooleanArray};
 pub use dictionary::{DictionaryArray, DictionaryKey, MutableDictionaryArray};

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -320,6 +320,8 @@ impl std::fmt::Debug for dyn Array + '_ {
             Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
                 fmt_dyn!(self, PrimitiveArray<$T>, f)
             }),
+            BinaryView => fmt_dyn!(self, Utf8ViewArray, f),
+            Utf8View => fmt_dyn!(self, BinaryViewArray, f),
             Binary => fmt_dyn!(self, BinaryArray<i32>, f),
             LargeBinary => fmt_dyn!(self, BinaryArray<i64>, f),
             FixedSizeBinary => fmt_dyn!(self, FixedSizeBinaryArray, f),
@@ -360,6 +362,8 @@ pub fn new_empty_array(data_type: DataType) -> Box<dyn Array> {
         Struct => Box::new(StructArray::new_empty(data_type)),
         Union => Box::new(UnionArray::new_empty(data_type)),
         Map => Box::new(MapArray::new_empty(data_type)),
+        Utf8View => Box::new(Utf8ViewArray::new_empty(data_type)),
+        BinaryView => Box::new(BinaryViewArray::new_empty(data_type)),
         Dictionary(key_type) => {
             match_integer_type!(key_type, |$T| {
                 Box::new(DictionaryArray::<$T>::new_empty(data_type))
@@ -390,6 +394,8 @@ pub fn new_null_array(data_type: DataType, length: usize) -> Box<dyn Array> {
         Struct => Box::new(StructArray::new_null(data_type, length)),
         Union => Box::new(UnionArray::new_null(data_type, length)),
         Map => Box::new(MapArray::new_null(data_type, length)),
+        BinaryView => Box::new(BinaryViewArray::new_null(data_type, length)),
+        Utf8View => Box::new(Utf8ViewArray::new_null(data_type, length)),
         Dictionary(key_type) => {
             match_integer_type!(key_type, |$T| {
                 Box::new(DictionaryArray::<$T>::new_null(data_type, length))
@@ -472,6 +478,7 @@ pub fn to_data(array: &dyn Array) -> arrow_data::ArrayData {
             })
         }
         Map => to_data_dyn!(array, MapArray),
+        BinaryView | Utf8View => todo!(),
     }
 }
 
@@ -502,6 +509,7 @@ pub fn from_data(data: &arrow_data::ArrayData) -> Box<dyn Array> {
             })
         }
         Map => Box::new(MapArray::from_data(data)),
+        BinaryView | Utf8View => todo!(),
     }
 }
 
@@ -687,6 +695,8 @@ pub fn clone(array: &dyn Array) -> Box<dyn Array> {
         Struct => clone_dyn!(array, StructArray),
         Union => clone_dyn!(array, UnionArray),
         Map => clone_dyn!(array, MapArray),
+        BinaryView => clone_dyn!(array, BinaryViewArray),
+        Utf8View => clone_dyn!(array, Utf8ViewArray),
         Dictionary(key_type) => {
             match_integer_type!(key_type, |$T| {
                 clone_dyn!(array, DictionaryArray::<$T>)
@@ -724,6 +734,7 @@ mod fmt;
 pub mod indexable;
 mod iterator;
 
+mod binview;
 pub mod growable;
 pub mod ord;
 
@@ -734,6 +745,7 @@ pub use equal::equal;
 pub use fmt::{get_display, get_value_display};
 
 pub use binary::{BinaryArray, BinaryValueIter, MutableBinaryArray, MutableBinaryValuesArray};
+pub use binview::{BinaryViewArray, BinaryViewArrayGeneric, Utf8ViewArray, ViewType};
 pub use boolean::{BooleanArray, MutableBooleanArray};
 pub use dictionary::{DictionaryArray, DictionaryKey, MutableDictionaryArray};
 pub use fixed_size_binary::{FixedSizeBinaryArray, MutableFixedSizeBinaryArray};

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -308,6 +308,8 @@ macro_rules! with_match_primitive_type {(
         Float16 => __with_ty__! { f16 },
         Float32 => __with_ty__! { f32 },
         Float64 => __with_ty__! { f64 },
+        _ => panic!("operator does not support primitive `{:?}`",
+            $key_type)
     }
 })}
 

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -320,8 +320,8 @@ impl std::fmt::Debug for dyn Array + '_ {
             Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
                 fmt_dyn!(self, PrimitiveArray<$T>, f)
             }),
-            BinaryView => fmt_dyn!(self, Utf8ViewArray, f),
-            Utf8View => fmt_dyn!(self, BinaryViewArray, f),
+            BinaryView => fmt_dyn!(self, BinaryViewArray, f),
+            Utf8View => fmt_dyn!(self, Utf8ViewArray, f),
             Binary => fmt_dyn!(self, BinaryArray<i32>, f),
             LargeBinary => fmt_dyn!(self, BinaryArray<i64>, f),
             FixedSizeBinary => fmt_dyn!(self, FixedSizeBinaryArray, f),
@@ -745,7 +745,9 @@ pub use equal::equal;
 pub use fmt::{get_display, get_value_display};
 
 pub use binary::{BinaryArray, BinaryValueIter, MutableBinaryArray, MutableBinaryValuesArray};
-pub use binview::{BinaryViewArray, BinaryViewArrayGeneric, Utf8ViewArray, ViewType};
+pub use binview::{
+    BinaryViewArray, BinaryViewArrayGeneric, MutableBinaryViewArray, Utf8ViewArray, ViewType,
+};
 pub use boolean::{BooleanArray, MutableBooleanArray};
 pub use dictionary::{DictionaryArray, DictionaryKey, MutableDictionaryArray};
 pub use fixed_size_binary::{FixedSizeBinaryArray, MutableFixedSizeBinaryArray};

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -746,7 +746,8 @@ pub use fmt::{get_display, get_value_display};
 
 pub use binary::{BinaryArray, BinaryValueIter, MutableBinaryArray, MutableBinaryValuesArray};
 pub use binview::{
-    BinaryViewArray, BinaryViewArrayGeneric, MutableBinaryViewArray, Utf8ViewArray, ViewType,
+    BinaryViewArray, BinaryViewArrayGeneric, MutableBinaryViewArray, MutablePlBinary,
+    MutablePlString, Utf8ViewArray, ViewType,
 };
 pub use boolean::{BooleanArray, MutableBooleanArray};
 pub use dictionary::{DictionaryArray, DictionaryKey, MutableDictionaryArray};

--- a/src/array/primitive/ffi.rs
+++ b/src/array/primitive/ffi.rs
@@ -13,7 +13,7 @@ unsafe impl<T: NativeType> ToFfi for PrimitiveArray<T> {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            Some(self.values.as_ptr().cast::<u8>()),
+            Some(self.values.storage_ptr().cast::<u8>()),
         ]
     }
 

--- a/src/array/primitive/mod.rs
+++ b/src/array/primitive/mod.rs
@@ -96,6 +96,20 @@ impl<T: NativeType> PrimitiveArray<T> {
         })
     }
 
+    /// # Safety
+    /// Doesn't check invariants
+    pub unsafe fn new_unchecked(
+        data_type: DataType,
+        values: Buffer<T>,
+        validity: Option<Bitmap>,
+    ) -> Self {
+        Self {
+            data_type,
+            values,
+            validity,
+        }
+    }
+
     /// Returns a new [`PrimitiveArray`] with a different logical type.
     ///
     /// This function is useful to assign a different [`DataType`] to the array.

--- a/src/array/primitive/mutable.rs
+++ b/src/array/primitive/mutable.rs
@@ -286,6 +286,10 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     pub fn capacity(&self) -> usize {
         self.values.capacity()
     }
+
+    pub fn freeze(self) -> PrimitiveArray<T> {
+        self.into()
+    }
 }
 
 /// Accessors

--- a/src/array/union/ffi.rs
+++ b/src/array/union/ffi.rs
@@ -7,11 +7,11 @@ unsafe impl ToFfi for UnionArray {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         if let Some(offsets) = &self.offsets {
             vec![
-                Some(self.types.as_ptr().cast::<u8>()),
-                Some(offsets.as_ptr().cast::<u8>()),
+                Some(self.types.storage_ptr().cast::<u8>()),
+                Some(offsets.storage_ptr().cast::<u8>()),
             ]
         } else {
-            vec![Some(self.types.as_ptr().cast::<u8>())]
+            vec![Some(self.types.storage_ptr().cast::<u8>())]
         }
     }
 

--- a/src/array/utf8/ffi.rs
+++ b/src/array/utf8/ffi.rs
@@ -12,8 +12,8 @@ unsafe impl<O: Offset> ToFfi for Utf8Array<O> {
     fn buffers(&self) -> Vec<Option<*const u8>> {
         vec![
             self.validity.as_ref().map(|x| x.as_ptr()),
-            Some(self.offsets.buffer().as_ptr().cast::<u8>()),
-            Some(self.values.as_ptr().cast::<u8>()),
+            Some(self.offsets.buffer().storage_ptr().cast::<u8>()),
+            Some(self.values.storage_ptr().cast::<u8>()),
         ]
     }
 

--- a/src/array/utf8/mod.rs
+++ b/src/array/utf8/mod.rs
@@ -12,10 +12,7 @@ use crate::{
 
 use either::Either;
 
-use super::{
-    specification::{try_check_offsets_bounds, try_check_utf8},
-    Array, GenericBinaryArray,
-};
+use super::{specification::{try_check_offsets_bounds, try_check_utf8}, Array, GenericBinaryArray, BinaryArray};
 
 #[cfg(feature = "arrow")]
 mod data;
@@ -511,6 +508,18 @@ impl<O: Offset> Utf8Array<O> {
     pub fn apply_validity<F: FnOnce(Bitmap) -> Bitmap>(&mut self, f: F) {
         if let Some(validity) = std::mem::take(&mut self.validity) {
             self.set_validity(Some(f(validity)))
+        }
+    }
+
+    // Convert this [`Utf8Array`] to a [`BinaryArray`].
+    pub fn to_binary(&self) -> BinaryArray<O> {
+        unsafe {
+            BinaryArray::new(
+                BinaryArray::<O>::default_data_type(),
+                self.offsets.clone(),
+                self.values.clone(),
+                self.validity.clone(),
+            )
         }
     }
 }

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -334,6 +334,10 @@ impl MutableBitmap {
     pub(crate) fn bitchunks_exact_mut<T: BitChunk>(&mut self) -> BitChunksExactMut<T> {
         BitChunksExactMut::new(&mut self.buffer, self.length)
     }
+
+    pub fn freeze(self) -> Bitmap {
+        self.into()
+    }
 }
 
 impl From<MutableBitmap> for Bitmap {

--- a/src/bitmap/mutable.rs
+++ b/src/bitmap/mutable.rs
@@ -2,7 +2,7 @@ use std::hint::unreachable_unchecked;
 use std::iter::FromIterator;
 use std::sync::Arc;
 
-use crate::bitmap::utils::{merge_reversed, set_bit_unchecked};
+use crate::bitmap::utils::{get_bit_unchecked, merge_reversed, set_bit_unchecked};
 use crate::error::Error;
 use crate::trusted_len::TrustedLen;
 
@@ -115,7 +115,7 @@ impl MutableBitmap {
         if self.length % 8 == 0 {
             self.buffer.push(0);
         }
-        let byte = self.buffer.as_mut_slice().last_mut().unwrap();
+        let byte = unsafe { self.buffer.as_mut_slice().last_mut().unwrap_unchecked() };
         *byte = set(*byte, self.length % 8, value);
         self.length += 1;
     }
@@ -129,7 +129,7 @@ impl MutableBitmap {
         }
 
         self.length -= 1;
-        let value = self.get(self.length);
+        let value = unsafe { self.get_unchecked(self.length) };
         if self.length % 8 == 0 {
             self.buffer.pop();
         }
@@ -142,6 +142,15 @@ impl MutableBitmap {
     #[inline]
     pub fn get(&self, index: usize) -> bool {
         get_bit(&self.buffer, index)
+    }
+
+    /// Returns whether the position `index` is set.
+    ///
+    /// # Safety
+    /// The caller must ensure `index < self.len()`.
+    #[inline]
+    pub unsafe fn get_unchecked(&self, index: usize) -> bool {
+        get_bit_unchecked(&self.buffer, index)
     }
 
     /// Sets the position `index` to `value`

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -241,6 +241,15 @@ impl<T> Buffer<T> {
     }
 }
 
+impl<T: Clone> Buffer<T> {
+    pub fn make_mut(self) -> Vec<T> {
+        match self.into_mut() {
+            Either::Right(v) => v,
+            Either::Left(same) => same.as_slice().to_vec(),
+        }
+    }
+}
+
 impl<T: Zero + Copy> Buffer<T> {
     pub fn zeroed(len: usize) -> Self {
         vec![T::zero(); len].into()

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -3,8 +3,8 @@ use std::{iter::FromIterator, ops::Deref, sync::Arc, usize};
 use either::Either;
 use num_traits::Zero;
 
-use super::Bytes;
-use super::IntoIter;
+use super::{Bytes, IntoIter};
+use crate::array::ArrayAccessor;
 
 /// [`Buffer`] is a contiguous memory region that can be shared across
 /// thread boundaries.
@@ -329,5 +329,17 @@ impl<T: crate::types::NativeType> From<Buffer<T>> for arrow_buffer::Buffer {
             value.offset * std::mem::size_of::<T>(),
             value.length * std::mem::size_of::<T>(),
         )
+    }
+}
+
+unsafe impl<'a, T: 'a> ArrayAccessor<'a> for Buffer<T> {
+    type Item = &'a T;
+
+    unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
+        self.as_slice().get_unchecked(index)
+    }
+
+    fn len(&self) -> usize {
+        Buffer::len(self)
     }
 }

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -37,16 +37,18 @@ use crate::array::ArrayAccessor;
 /// ```
 #[derive(Clone)]
 pub struct Buffer<T> {
-    /// the internal byte buffer.
-    data: Arc<Bytes<T>>,
+    /// The internal byte buffer.
+    storage: Arc<Bytes<T>>,
 
-    /// The offset into the buffer.
-    offset: usize,
+    /// A pointer into the buffer where our data starts.
+    ptr: *const T,
 
-    // the length of the buffer. Given a region `data` of N bytes, [offset..offset+length] is visible
-    // to this buffer.
+    // The length of the buffer.
     length: usize,
 }
+
+unsafe impl<T: Sync> Sync for Buffer<T> {}
+unsafe impl<T: Send> Send for Buffer<T> {}
 
 impl<T: PartialEq> PartialEq for Buffer<T> {
     #[inline]
@@ -77,10 +79,11 @@ impl<T> Buffer<T> {
 
     /// Auxiliary method to create a new Buffer
     pub(crate) fn from_bytes(bytes: Bytes<T>) -> Self {
+        let ptr = bytes.as_ptr();
         let length = bytes.len();
         Buffer {
-            data: Arc::new(bytes),
-            offset: 0,
+            storage: Arc::new(bytes),
+            ptr,
             length,
         }
     }
@@ -94,14 +97,14 @@ impl<T> Buffer<T> {
     /// Returns whether the buffer is empty.
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.length == 0
     }
 
     /// Returns whether underlying data is sliced.
     /// If sliced the [`Buffer`] is backed by
     /// more data than the length of `Self`.
     pub fn is_sliced(&self) -> bool {
-        self.data.len() != self.length
+        self.storage.len() != self.length
     }
 
     /// Returns the byte slice stored in this buffer
@@ -109,11 +112,8 @@ impl<T> Buffer<T> {
     pub fn as_slice(&self) -> &[T] {
         // Safety:
         // invariant of this struct `offset + length <= data.len()`
-        debug_assert!(self.offset + self.length <= self.data.len());
-        unsafe {
-            self.data
-                .get_unchecked(self.offset..self.offset + self.length)
-        }
+        debug_assert!(self.offset() + self.length <= self.storage.len());
+        unsafe { std::slice::from_raw_parts(self.ptr, self.length) }
     }
 
     /// Returns the byte slice stored in this buffer
@@ -124,7 +124,7 @@ impl<T> Buffer<T> {
         // Safety:
         // invariant of this function
         debug_assert!(index < self.length);
-        unsafe { self.data.get_unchecked(self.offset + index) }
+        unsafe { &*self.ptr.add(index) }
     }
 
     /// Returns a new [`Buffer`] that is a slice of this buffer starting at `offset`.
@@ -170,20 +170,24 @@ impl<T> Buffer<T> {
     /// The caller must ensure `offset + length <= self.len()`
     #[inline]
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
-        self.offset += offset;
+        self.ptr = self.ptr.add(offset);
         self.length = length;
     }
 
-    /// Returns a pointer to the start of this buffer.
+    /// Returns a pointer to the start of the storage underlying this buffer.
     #[inline]
-    pub(crate) fn as_ptr(&self) -> *const T {
-        self.data.deref().as_ptr()
+    pub(crate) fn storage_ptr(&self) -> *const T {
+        self.storage.as_ptr()
     }
 
-    /// Returns the offset of this buffer.
+    /// Returns the start offset of this buffer within the underlying storage.
     #[inline]
     pub fn offset(&self) -> usize {
-        self.offset
+        unsafe {
+            let ret = self.ptr.offset_from(self.storage.as_ptr()) as usize;
+            debug_assert!(ret <= self.storage.len());
+            ret
+        }
     }
 
     /// # Safety
@@ -197,10 +201,14 @@ impl<T> Buffer<T> {
     ///
     /// This operation returns [`Either::Right`] iff this [`Buffer`]:
     /// * has not been cloned (i.e. [`Arc`]`::get_mut` yields [`Some`])
-    /// * has not been imported from the c data interface (FFI)
+    /// * has not been imported from the C data interface (FFI)
     #[inline]
     pub fn into_mut(mut self) -> Either<Self, Vec<T>> {
-        match Arc::get_mut(&mut self.data)
+        // We lose information if the data is sliced.
+        if self.is_sliced() {
+            return Either::Left(self);
+        }
+        match Arc::get_mut(&mut self.storage)
             .and_then(|b| b.get_vec())
             .map(std::mem::take)
         {
@@ -209,65 +217,27 @@ impl<T> Buffer<T> {
         }
     }
 
-    /// Returns a mutable reference to its underlying `Vec`, if possible.
-    /// Note that only `[self.offset(), self.offset() + self.len()[` in this vector is visible
-    /// by this buffer.
-    ///
-    /// This operation returns [`Some`] iff this [`Buffer`]:
-    /// * has not been cloned (i.e. [`Arc`]`::get_mut` yields [`Some`])
-    /// * has not been imported from the c data interface (FFI)
-    /// # Safety
-    /// The caller must ensure that the vector in the mutable reference keeps a length of at least `self.offset() + self.len() - 1`.
-    #[inline]
-    pub unsafe fn get_mut(&mut self) -> Option<&mut Vec<T>> {
-        Arc::get_mut(&mut self.data).and_then(|b| b.get_vec())
-    }
-
     /// Returns a mutable reference to its slice, if possible.
     ///
     /// This operation returns [`Some`] iff this [`Buffer`]:
     /// * has not been cloned (i.e. [`Arc`]`::get_mut` yields [`Some`])
-    /// * has not been imported from the c data interface (FFI)
+    /// * has not been imported from the C data interface (FFI)
     #[inline]
     pub fn get_mut_slice(&mut self) -> Option<&mut [T]> {
-        Arc::get_mut(&mut self.data)
-            .and_then(|b| b.get_vec())
-            // Safety: the invariant of this struct
-            .map(|x| unsafe { x.get_unchecked_mut(self.offset..self.offset + self.length) })
+        let offset = self.offset();
+        let unique = Arc::get_mut(&mut self.storage)?;
+        let vec = unique.get_vec()?;
+        Some(unsafe { vec.get_unchecked_mut(offset..offset + self.length) })
     }
 
     /// Get the strong count of underlying `Arc` data buffer.
     pub fn shared_count_strong(&self) -> usize {
-        Arc::strong_count(&self.data)
+        Arc::strong_count(&self.storage)
     }
 
     /// Get the weak count of underlying `Arc` data buffer.
     pub fn shared_count_weak(&self) -> usize {
-        Arc::weak_count(&self.data)
-    }
-
-    /// Returns its internal representation
-    #[must_use]
-    pub fn into_inner(self) -> (Arc<Bytes<T>>, usize, usize) {
-        let Self {
-            data,
-            offset,
-            length,
-        } = self;
-        (data, offset, length)
-    }
-
-    /// Creates a `[Bitmap]` from its internal representation.
-    /// This is the inverted from `[Bitmap::into_inner]`
-    ///
-    /// # Safety
-    /// Callers must ensure all invariants of this struct are upheld.
-    pub unsafe fn from_inner_unchecked(data: Arc<Bytes<T>>, offset: usize, length: usize) -> Self {
-        Self {
-            data,
-            offset,
-            length,
-        }
+        Arc::weak_count(&self.storage)
     }
 }
 
@@ -281,10 +251,12 @@ impl<T> From<Vec<T>> for Buffer<T> {
     #[inline]
     fn from(p: Vec<T>) -> Self {
         let bytes: Bytes<T> = p.into();
+        let ptr = bytes.as_ptr();
+        let length = bytes.len();
         Self {
-            offset: 0,
-            length: bytes.len(),
-            data: Arc::new(bytes),
+            storage: Arc::new(bytes),
+            ptr,
+            length,
         }
     }
 }
@@ -325,8 +297,9 @@ impl<T: crate::types::NativeType> From<arrow_buffer::Buffer> for Buffer<T> {
 #[cfg(feature = "arrow")]
 impl<T: crate::types::NativeType> From<Buffer<T>> for arrow_buffer::Buffer {
     fn from(value: Buffer<T>) -> Self {
-        crate::buffer::to_buffer(value.data).slice_with_length(
-            value.offset * std::mem::size_of::<T>(),
+        let offset = value.offset();
+        crate::buffer::to_buffer(value.storage).slice_with_length(
+            offset * std::mem::size_of::<T>(),
             value.length * std::mem::size_of::<T>(),
         )
     }
@@ -336,7 +309,7 @@ unsafe impl<'a, T: 'a> ArrayAccessor<'a> for Buffer<T> {
     type Item = &'a T;
 
     unsafe fn value_unchecked(&'a self, index: usize) -> Self::Item {
-        self.as_slice().get_unchecked(index)
+        unsafe { &*self.ptr.add(index) }
     }
 
     fn len(&self) -> usize {

--- a/src/buffer/immutable.rs
+++ b/src/buffer/immutable.rs
@@ -1,6 +1,7 @@
 use std::{iter::FromIterator, ops::Deref, sync::Arc, usize};
 
 use either::Either;
+use num_traits::Zero;
 
 use super::Bytes;
 use super::IntoIter;
@@ -267,6 +268,12 @@ impl<T> Buffer<T> {
             offset,
             length,
         }
+    }
+}
+
+impl<T: Zero + Copy> Buffer<T> {
+    pub fn zeroed(len: usize) -> Self {
+        vec![T::zero(); len].into()
     }
 }
 

--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -7,6 +7,9 @@ use crate::ffi::InternalArrowArray;
 use std::ops::Deref;
 
 pub(crate) enum BytesAllocator {
+    // Dead code lint is a false positive.
+    // remove once fixed in rustc
+    #[allow(dead_code)]
     InternalArrowArray(InternalArrowArray),
 
     #[cfg(feature = "arrow")]

--- a/src/compute/aggregate/memory.rs
+++ b/src/compute/aggregate/memory.rs
@@ -22,6 +22,12 @@ macro_rules! dyn_binary {
     }};
 }
 
+fn binview_size<T: ViewType + ?Sized>(array: &BinaryViewArrayGeneric<T>) -> usize {
+    array.views().len() * std::mem::size_of::<u128>()
+        + array.data_buffers().iter().map(|b| b.len()).sum::<usize>()
+        + validity_size(array.validity())
+}
+
 /// Returns the total (heap) allocated size of the array in bytes.
 /// # Implementation
 /// This estimation is the sum of the size of its buffers, validity, including nested arrays.
@@ -109,6 +115,8 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
                 .unwrap();
             estimated_bytes_size(array.keys()) + estimated_bytes_size(array.values().as_ref())
         }),
+        Utf8View => binview_size::<str>(array.as_any().downcast_ref().unwrap()),
+        BinaryView => binview_size::<[u8]>(array.as_any().downcast_ref().unwrap()),
         Map => {
             let array = array.as_any().downcast_ref::<MapArray>().unwrap();
             let offsets = array.offsets().len_proxy() * std::mem::size_of::<i32>();

--- a/src/compute/arithmetics/basic/mod.rs
+++ b/src/compute/arithmetics/basic/mod.rs
@@ -39,6 +39,7 @@ impl NativeArithmetics for i8 {}
 impl NativeArithmetics for i16 {}
 impl NativeArithmetics for i32 {}
 impl NativeArithmetics for i64 {}
+impl NativeArithmetics for i128 {}
 impl NativeArithmetics for f32 {}
 impl NativeArithmetics for f64 {}
 

--- a/src/compute/arithmetics/decimal/add.rs
+++ b/src/compute/arithmetics/decimal/add.rs
@@ -2,7 +2,6 @@
 use crate::{
     array::PrimitiveArray,
     compute::{
-        arithmetics::{ArrayAdd, ArrayCheckedAdd, ArraySaturatingAdd},
         arity::{binary, binary_checked},
         utils::{check_same_len, combine_validities},
     },
@@ -132,27 +131,6 @@ pub fn checked_add(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Pr
     };
 
     binary_checked(lhs, rhs, lhs.data_type().clone(), op)
-}
-
-// Implementation of ArrayAdd trait for PrimitiveArrays
-impl ArrayAdd<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn add(&self, rhs: &PrimitiveArray<i128>) -> Self {
-        add(self, rhs)
-    }
-}
-
-// Implementation of ArrayCheckedAdd trait for PrimitiveArrays
-impl ArrayCheckedAdd<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn checked_add(&self, rhs: &PrimitiveArray<i128>) -> Self {
-        checked_add(self, rhs)
-    }
-}
-
-// Implementation of ArraySaturatingAdd trait for PrimitiveArrays
-impl ArraySaturatingAdd<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn saturating_add(&self, rhs: &PrimitiveArray<i128>) -> Self {
-        saturating_add(self, rhs)
-    }
 }
 
 /// Adaptive addition of two decimal primitive arrays with different precision

--- a/src/compute/arithmetics/decimal/div.rs
+++ b/src/compute/arithmetics/decimal/div.rs
@@ -4,7 +4,6 @@
 use crate::{
     array::PrimitiveArray,
     compute::{
-        arithmetics::{ArrayCheckedDiv, ArrayDiv},
         arity::{binary, binary_checked, unary},
         utils::{check_same_len, combine_validities},
     },
@@ -197,20 +196,6 @@ pub fn checked_div(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Pr
     };
 
     binary_checked(lhs, rhs, lhs.data_type().clone(), op)
-}
-
-// Implementation of ArrayDiv trait for PrimitiveArrays
-impl ArrayDiv<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn div(&self, rhs: &PrimitiveArray<i128>) -> Self {
-        div(self, rhs)
-    }
-}
-
-// Implementation of ArrayCheckedDiv trait for PrimitiveArrays
-impl ArrayCheckedDiv<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn checked_div(&self, rhs: &PrimitiveArray<i128>) -> Self {
-        checked_div(self, rhs)
-    }
 }
 
 /// Adaptive division of two decimal primitive arrays with different precision

--- a/src/compute/arithmetics/decimal/mul.rs
+++ b/src/compute/arithmetics/decimal/mul.rs
@@ -4,7 +4,6 @@
 use crate::{
     array::PrimitiveArray,
     compute::{
-        arithmetics::{ArrayCheckedMul, ArrayMul, ArraySaturatingMul},
         arity::{binary, binary_checked, unary},
         utils::{check_same_len, combine_validities},
     },
@@ -202,27 +201,6 @@ pub fn checked_mul(lhs: &PrimitiveArray<i128>, rhs: &PrimitiveArray<i128>) -> Pr
     };
 
     binary_checked(lhs, rhs, lhs.data_type().clone(), op)
-}
-
-// Implementation of ArrayMul trait for PrimitiveArrays
-impl ArrayMul<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn mul(&self, rhs: &PrimitiveArray<i128>) -> Self {
-        mul(self, rhs)
-    }
-}
-
-// Implementation of ArrayCheckedMul trait for PrimitiveArrays
-impl ArrayCheckedMul<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn checked_mul(&self, rhs: &PrimitiveArray<i128>) -> Self {
-        checked_mul(self, rhs)
-    }
-}
-
-// Implementation of ArraySaturatingMul trait for PrimitiveArrays
-impl ArraySaturatingMul<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn saturating_mul(&self, rhs: &PrimitiveArray<i128>) -> Self {
-        saturating_mul(self, rhs)
-    }
 }
 
 /// Adaptive multiplication of two decimal primitive arrays with different

--- a/src/compute/arithmetics/decimal/sub.rs
+++ b/src/compute/arithmetics/decimal/sub.rs
@@ -3,7 +3,6 @@
 use crate::{
     array::PrimitiveArray,
     compute::{
-        arithmetics::{ArrayCheckedSub, ArraySaturatingSub, ArraySub},
         arity::{binary, binary_checked},
         utils::{check_same_len, combine_validities},
     },
@@ -97,26 +96,6 @@ pub fn saturating_sub(
     binary(lhs, rhs, lhs.data_type().clone(), op)
 }
 
-// Implementation of ArraySub trait for PrimitiveArrays
-impl ArraySub<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn sub(&self, rhs: &PrimitiveArray<i128>) -> Self {
-        sub(self, rhs)
-    }
-}
-
-// Implementation of ArrayCheckedSub trait for PrimitiveArrays
-impl ArrayCheckedSub<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn checked_sub(&self, rhs: &PrimitiveArray<i128>) -> Self {
-        checked_sub(self, rhs)
-    }
-}
-
-// Implementation of ArraySaturatingSub trait for PrimitiveArrays
-impl ArraySaturatingSub<PrimitiveArray<i128>> for PrimitiveArray<i128> {
-    fn saturating_sub(&self, rhs: &PrimitiveArray<i128>) -> Self {
-        saturating_sub(self, rhs)
-    }
-}
 /// Checked subtract of two decimal primitive arrays with the same precision
 /// and scale. If the precision and scale is different, then an
 /// InvalidArgumentError is returned. If the result from the sub is larger than

--- a/src/compute/arithmetics/mod.rs
+++ b/src/compute/arithmetics/mod.rs
@@ -416,6 +416,7 @@ macro_rules! with_match_negatable {(
         UInt8 | UInt16 | UInt32 | UInt64 | Float16 => todo!(),
         Float32 => __with_ty__! { f32 },
         Float64 => __with_ty__! { f64 },
+        UInt128 => todo!(),
     }
 })}
 

--- a/src/compute/cast/binary_to.rs
+++ b/src/compute/cast/binary_to.rs
@@ -4,6 +4,47 @@ use crate::{array::*, datatypes::DataType, types::NativeType};
 
 use super::CastOptions;
 
+pub(super) trait Parse {
+    fn parse(val: &[u8]) -> Option<Self>
+        where
+            Self: Sized;
+}
+
+macro_rules! impl_parse {
+    ($primitive_type:ident) => {
+        impl Parse for $primitive_type {
+            fn parse(val: &[u8]) -> Option<Self> {
+                atoi_simd::parse(val).ok()
+            }
+        }
+    };
+}
+impl_parse!(i8);
+impl_parse!(i16);
+impl_parse!(i32);
+impl_parse!(i64);
+impl_parse!(u8);
+impl_parse!(u16);
+impl_parse!(u32);
+impl_parse!(u64);
+
+impl Parse for f32 {
+    fn parse(val: &[u8]) -> Option<Self>
+        where
+            Self: Sized,
+    {
+        fast_float::parse(val).ok()
+    }
+}
+impl Parse for f64 {
+    fn parse(val: &[u8]) -> Option<Self>
+        where
+            Self: Sized,
+    {
+        fast_float::parse(val).ok()
+    }
+}
+
 /// Conversion of binary
 pub fn binary_to_large_binary(from: &BinaryArray<i32>, to_data_type: DataType) -> BinaryArray<i64> {
     let values = from.values().clone();
@@ -72,13 +113,11 @@ where
 }
 
 /// Casts a [`BinaryArray`] to a [`PrimitiveArray`], making any uncastable value a Null.
-pub fn binary_to_primitive<O: Offset, T>(from: &BinaryArray<O>, to: &DataType) -> PrimitiveArray<T>
+pub(super) fn binary_to_primitive<O: Offset, T>(from: &BinaryArray<O>, to: &DataType) -> PrimitiveArray<T>
 where
-    T: NativeType + lexical_core::FromLexical,
+    T: NativeType + Parse,
 {
-    let iter = from
-        .iter()
-        .map(|x| x.and_then::<T, _>(|x| lexical_core::parse(x).ok()));
+    let iter = from.iter().map(|x| x.and_then::<T, _>(|x| T::parse(x)));
 
     PrimitiveArray::<T>::from_trusted_len_iter(iter).to(to.clone())
 }
@@ -89,7 +128,7 @@ pub(super) fn binary_to_primitive_dyn<O: Offset, T>(
     options: CastOptions,
 ) -> Result<Box<dyn Array>>
 where
-    T: NativeType + lexical_core::FromLexical,
+    T: NativeType + lexical_core::FromLexical + Parse,
 {
     let from = from.as_any().downcast_ref().unwrap();
     if options.partial {

--- a/src/compute/cast/binary_to.rs
+++ b/src/compute/cast/binary_to.rs
@@ -145,6 +145,11 @@ pub fn fixed_size_binary_binary<O: Offset>(
     )
 }
 
+pub fn fixed_size_binary_to_binview(from: &FixedSizeBinaryArray) -> BinaryViewArray {
+    let mutable = MutableBinaryViewArray::from_values_iter(from.values_iter());
+    mutable.freeze().with_validity(from.validity().cloned())
+}
+
 /// Conversion of binary
 pub fn binary_to_list<O: Offset>(from: &BinaryArray<O>, to_data_type: DataType) -> ListArray<O> {
     let values = from.values().clone();

--- a/src/compute/cast/binview_to.rs
+++ b/src/compute/cast/binview_to.rs
@@ -1,0 +1,27 @@
+use crate::array::*;
+use crate::offset::Offset;
+
+pub(super) fn view_to_binary<O: Offset>(array: &BinaryViewArray) -> BinaryArray<O> {
+    let len: usize = Array::len(array);
+    let mut mutable = MutableBinaryValuesArray::<O>::with_capacities(len, len * 12);
+    for slice in array.values_iter() {
+        mutable.push(slice)
+    }
+    let out: BinaryArray<O> = mutable.into();
+    out.with_validity(array.validity().cloned())
+}
+
+pub(super) fn utf8view_to_utf8<O: Offset>(array: &Utf8ViewArray) -> Utf8Array<O> {
+    let array = array.to_binview();
+    let out = view_to_binary::<O>(&array);
+
+    let dtype = Utf8Array::<O>::default_data_type();
+    unsafe {
+        Utf8Array::new_unchecked(
+            dtype,
+            out.offsets().clone(),
+            out.values().clone(),
+            out.validity().cloned(),
+        )
+    }
+}

--- a/src/compute/cast/binview_to.rs
+++ b/src/compute/cast/binview_to.rs
@@ -1,9 +1,21 @@
+use chrono::Datelike;
+use polars_error::PolarsResult;
+
 use crate::array::*;
+use crate::compute::cast::binary_to::Parse;
+use crate::compute::cast::CastOptions;
+use crate::datatypes::{ArrowDataType, TimeUnit};
+#[cfg(feature = "dtype-decimal")]
+use crate::legacy::compute::decimal::deserialize_decimal;
 use crate::offset::Offset;
+use crate::temporal_conversions::EPOCH_DAYS_FROM_CE;
+use crate::types::NativeType;
+
+pub(super) const RFC3339: &str = "%Y-%m-%dT%H:%M:%S%.f%:z";
 
 pub(super) fn view_to_binary<O: Offset>(array: &BinaryViewArray) -> BinaryArray<O> {
     let len: usize = Array::len(array);
-    let mut mutable = MutableBinaryValuesArray::<O>::with_capacities(len, len * 12);
+    let mut mutable = MutableBinaryValuesArray::<O>::with_capacities(len, array.total_bytes_len());
     for slice in array.values_iter() {
         mutable.push(slice)
     }
@@ -11,7 +23,7 @@ pub(super) fn view_to_binary<O: Offset>(array: &BinaryViewArray) -> BinaryArray<
     out.with_validity(array.validity().cloned())
 }
 
-pub(super) fn utf8view_to_utf8<O: Offset>(array: &Utf8ViewArray) -> Utf8Array<O> {
+pub fn utf8view_to_utf8<O: Offset>(array: &Utf8ViewArray) -> Utf8Array<O> {
     let array = array.to_binview();
     let out = view_to_binary::<O>(&array);
 
@@ -24,4 +36,77 @@ pub(super) fn utf8view_to_utf8<O: Offset>(array: &Utf8ViewArray) -> Utf8Array<O>
             out.validity().cloned(),
         )
     }
+}
+/// Casts a [`BinaryArray`] to a [`PrimitiveArray`], making any uncastable value a Null.
+pub(super) fn binview_to_primitive<T>(
+    from: &BinaryViewArray,
+    to: &ArrowDataType,
+) -> PrimitiveArray<T>
+where
+    T: NativeType + Parse,
+{
+    let iter = from.iter().map(|x| x.and_then::<T, _>(|x| T::parse(x)));
+
+    PrimitiveArray::<T>::from_trusted_len_iter(iter).to(to.clone())
+}
+
+pub(super) fn binview_to_primitive_dyn<T>(
+    from: &dyn Array,
+    to: &ArrowDataType,
+    options: CastOptions,
+) -> PolarsResult<Box<dyn Array>>
+where
+    T: NativeType + Parse,
+{
+    let from = from.as_any().downcast_ref().unwrap();
+    if options.partial {
+        unimplemented!()
+    } else {
+        Ok(Box::new(binview_to_primitive::<T>(from, to)))
+    }
+}
+
+#[cfg(feature = "dtype-decimal")]
+pub fn binview_to_decimal(
+    array: &BinaryViewArray,
+    precision: Option<usize>,
+    scale: usize,
+) -> PrimitiveArray<i128> {
+    let precision = precision.map(|p| p as u8);
+    array
+        .iter()
+        .map(|val| val.and_then(|val| deserialize_decimal(val, precision, scale as u8)))
+        .collect()
+}
+
+pub(super) fn utf8view_to_naive_timestamp_dyn(
+    from: &dyn Array,
+    time_unit: TimeUnit,
+) -> PolarsResult<Box<dyn Array>> {
+    let from = from.as_any().downcast_ref().unwrap();
+    Ok(Box::new(utf8view_to_naive_timestamp(from, time_unit)))
+}
+
+/// [`crate::temporal_conversions::utf8view_to_timestamp`] applied for RFC3339 formatting
+pub fn utf8view_to_naive_timestamp(
+    from: &Utf8ViewArray,
+    time_unit: TimeUnit,
+) -> PrimitiveArray<i64> {
+    crate::temporal_conversions::utf8view_to_naive_timestamp(from, RFC3339, time_unit)
+}
+
+pub(super) fn utf8view_to_date32(from: &Utf8ViewArray) -> PrimitiveArray<i32> {
+    let iter = from.iter().map(|x| {
+        x.and_then(|x| {
+            x.parse::<chrono::NaiveDate>()
+                .ok()
+                .map(|x| x.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
+        })
+    });
+    PrimitiveArray::<i32>::from_trusted_len_iter(iter).to(ArrowDataType::Date32)
+}
+
+pub(super) fn utf8view_to_date32_dyn(from: &dyn Array) -> PolarsResult<Box<dyn Array>> {
+    let from = from.as_any().downcast_ref().unwrap();
+    Ok(Box::new(utf8view_to_date32(from)))
 }

--- a/src/compute/cast/boolean_to.rs
+++ b/src/compute/cast/boolean_to.rs
@@ -1,9 +1,9 @@
 use crate::{
     array::{Array, BinaryViewArray, BooleanArray, PrimitiveArray, Utf8ViewArray},
     error::Result,
-    offset::Offset,
     types::NativeType,
 };
+use crate::array::MutableBinaryViewArray;
 
 pub(super) fn boolean_to_primitive_dyn<T>(array: &dyn Array) -> Result<Box<dyn Array>>
 where
@@ -43,7 +43,7 @@ pub fn boolean_to_binaryview(from: &BooleanArray) -> BinaryViewArray {
         Some(false) => Some("false".as_bytes()),
         None => None,
     });
-    BinaryViewArray::arr_from_iter_trusted(iter)
+    MutableBinaryViewArray::from_iter(iter).into()
 }
 
 pub(super) fn boolean_to_binaryview_dyn(array: &dyn Array) -> Result<Box<dyn Array>> {

--- a/src/compute/cast/boolean_to.rs
+++ b/src/compute/cast/boolean_to.rs
@@ -1,5 +1,5 @@
 use crate::{
-    array::{Array, BinaryArray, BooleanArray, PrimitiveArray, Utf8Array},
+    array::{Array, BinaryViewArray, BooleanArray, PrimitiveArray, Utf8ViewArray},
     error::Result,
     offset::Offset,
     types::NativeType,
@@ -27,24 +27,26 @@ where
     PrimitiveArray::<T>::new(T::PRIMITIVE.into(), values.into(), from.validity().cloned())
 }
 
-/// Casts the [`BooleanArray`] to a [`Utf8Array`], casting trues to `"1"` and falses to `"0"`
-pub fn boolean_to_utf8<O: Offset>(from: &BooleanArray) -> Utf8Array<O> {
-    let iter = from.values().iter().map(|x| if x { "1" } else { "0" });
-    Utf8Array::from_trusted_len_values_iter(iter)
+pub fn boolean_to_utf8view(from: &BooleanArray) -> Utf8ViewArray {
+    unsafe { boolean_to_binaryview(from).to_utf8view_unchecked() }
 }
 
-pub(super) fn boolean_to_utf8_dyn<O: Offset>(array: &dyn Array) -> Result<Box<dyn Array>> {
+pub(super) fn boolean_to_utf8view_dyn(array: &dyn Array) -> Result<Box<dyn Array>> {
     let array = array.as_any().downcast_ref().unwrap();
-    Ok(Box::new(boolean_to_utf8::<O>(array)))
+    Ok(boolean_to_utf8view(array).boxed())
 }
 
 /// Casts the [`BooleanArray`] to a [`BinaryArray`], casting trues to `"1"` and falses to `"0"`
-pub fn boolean_to_binary<O: Offset>(from: &BooleanArray) -> BinaryArray<O> {
-    let iter = from.values().iter().map(|x| if x { b"1" } else { b"0" });
-    BinaryArray::from_trusted_len_values_iter(iter)
+pub fn boolean_to_binaryview(from: &BooleanArray) -> BinaryViewArray {
+    let iter = from.iter().map(|opt_b| match opt_b {
+        Some(true) => Some("true".as_bytes()),
+        Some(false) => Some("false".as_bytes()),
+        None => None,
+    });
+    BinaryViewArray::arr_from_iter_trusted(iter)
 }
 
-pub(super) fn boolean_to_binary_dyn<O: Offset>(array: &dyn Array) -> Result<Box<dyn Array>> {
+pub(super) fn boolean_to_binaryview_dyn(array: &dyn Array) -> Result<Box<dyn Array>> {
     let array = array.as_any().downcast_ref().unwrap();
-    Ok(Box::new(boolean_to_binary::<O>(array)))
+    Ok(boolean_to_binaryview(array).boxed())
 }

--- a/src/compute/cast/mod.rs
+++ b/src/compute/cast/mod.rs
@@ -667,11 +667,9 @@ pub fn cast(array: &dyn Array, to_type: &DataType, options: CastOptions) -> Resu
             Int64 => boolean_to_primitive_dyn::<i64>(array),
             Float32 => boolean_to_primitive_dyn::<f32>(array),
             Float64 => boolean_to_primitive_dyn::<f64>(array),
-            Utf8 => boolean_to_utf8_dyn::<i32>(array),
-            LargeUtf8 => boolean_to_utf8_dyn::<i64>(array),
-            Binary => boolean_to_binary_dyn::<i32>(array),
-            LargeBinary => boolean_to_binary_dyn::<i64>(array),
-            _ => Err(Error::NotYetImplemented(format!(
+            Utf8View => boolean_to_utf8view_dyn(array),
+            BinaryView => boolean_to_binaryview_dyn(array),
+            _ => Err(Error::InvalidArgumentError(format!(
                 "Casting from {from_type:?} to {to_type:?} not supported",
             ))),
         },

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -587,3 +587,27 @@ pub fn months_to_months_days_ns(from: &PrimitiveArray<i32>) -> PrimitiveArray<mo
 pub fn f16_to_f32(from: &PrimitiveArray<f16>) -> PrimitiveArray<f32> {
     unary(from, |x| x.to_f32(), DataType::Float32)
 }
+
+/// Returns a [`Utf8Array`] where every element is the utf8 representation of the number.
+pub(super) fn primitive_to_binview<T: NativeType>(
+    from: &PrimitiveArray<T>,
+) -> BinaryViewArray {
+    let mut mutable = MutableBinaryViewArray::with_capacity(from.len());
+
+    let mut scratch = vec![];
+    for &x in from.values().iter() {
+        unsafe { scratch.set_len(0) };
+        T::write(&mut scratch, x);
+        mutable.push_value_ignore_validity(&scratch)
+    }
+
+    mutable.freeze().with_validity(from.validity().cloned())
+}
+
+pub(super) fn primitive_to_binview_dyn<T>(from: &dyn Array) -> BinaryViewArray
+where
+    T: NativeType,
+{
+    let from = from.as_any().downcast_ref().unwrap();
+    primitive_to_binview::<T>(from)
+}

--- a/src/compute/cast/primitive_to.rs
+++ b/src/compute/cast/primitive_to.rs
@@ -17,10 +17,64 @@ use crate::{
 
 use super::CastOptions;
 
-/// Returns a [`BinaryArray`] where every element is the binary representation of the number.
-pub fn primitive_to_binary<T: NativeType + lexical_core::ToLexical, O: Offset>(
+pub(super) trait SerPrimitive {
+    fn write(f: &mut Vec<u8>, val: Self) -> usize
+        where
+            Self: Sized;
+}
+
+macro_rules! impl_ser_primitive {
+    ($ptype:ident) => {
+        impl SerPrimitive for $ptype {
+            fn write(f: &mut Vec<u8>, val: Self) -> usize
+            where
+                Self: Sized,
+            {
+                let mut buffer = itoa::Buffer::new();
+                let value = buffer.format(val);
+                f.extend_from_slice(value.as_bytes());
+                value.len()
+            }
+        }
+    };
+}
+
+impl_ser_primitive!(i8);
+impl_ser_primitive!(i16);
+impl_ser_primitive!(i32);
+impl_ser_primitive!(i64);
+impl_ser_primitive!(u8);
+impl_ser_primitive!(u16);
+impl_ser_primitive!(u32);
+impl_ser_primitive!(u64);
+
+impl SerPrimitive for f32 {
+    fn write(f: &mut Vec<u8>, val: Self) -> usize
+        where
+            Self: Sized,
+    {
+        let mut buffer = ryu::Buffer::new();
+        let value = buffer.format(val);
+        f.extend_from_slice(value.as_bytes());
+        value.len()
+    }
+}
+
+impl SerPrimitive for f64 {
+    fn write(f: &mut Vec<u8>, val: Self) -> usize
+        where
+            Self: Sized,
+    {
+        let mut buffer = ryu::Buffer::new();
+        let value = buffer.format(val);
+        f.extend_from_slice(value.as_bytes());
+        value.len()
+    }
+}
+
+fn primitive_to_values_and_offsets<T: NativeType + SerPrimitive, O: Offset>(
     from: &PrimitiveArray<T>,
-) -> BinaryArray<O> {
+) -> (Vec<u8>, Offsets<O>) {
     let mut values: Vec<u8> = Vec::with_capacity(from.len());
     let mut offsets: Vec<O> = Vec::with_capacity(from.len() + 1);
     offsets.push(O::default());
@@ -28,35 +82,38 @@ pub fn primitive_to_binary<T: NativeType + lexical_core::ToLexical, O: Offset>(
     let mut offset: usize = 0;
 
     unsafe {
-        for x in from.values().iter() {
-            values.reserve(offset + T::FORMATTED_SIZE_DECIMAL);
-
-            let bytes = std::slice::from_raw_parts_mut(
-                values.as_mut_ptr().add(offset),
-                values.capacity() - offset,
-            );
-            let len = lexical_core::write_unchecked(*x, bytes).len();
+        for &x in from.values().iter() {
+            let len = T::write(&mut values, x);
 
             offset += len;
-            offsets.push(O::from_usize(offset).unwrap());
+            offsets.push(O::from_as_usize(offset));
         }
         values.set_len(offset);
         values.shrink_to_fit();
         // Safety: offsets _are_ monotonically increasing
         let offsets = unsafe { Offsets::new_unchecked(offsets) };
-        BinaryArray::<O>::new(
-            BinaryArray::<O>::default_data_type(),
-            offsets.into(),
-            values.into(),
-            from.validity().cloned(),
-        )
+
+        (values, offsets)
     }
+}
+
+/// Returns a [`BinaryArray`] where every element is the binary representation of the number.
+pub(super) fn primitive_to_binary<T: NativeType + SerPrimitive, O: Offset>(
+    from: &PrimitiveArray<T>,
+) -> BinaryArray<O> {
+    let (values, offsets) = primitive_to_values_and_offsets(from);
+    BinaryArray::<O>::new(
+        BinaryArray::<O>::default_data_type(),
+        offsets.into(),
+        values.into(),
+        from.validity().cloned(),
+    )
 }
 
 pub(super) fn primitive_to_binary_dyn<T, O>(from: &dyn Array) -> Result<Box<dyn Array>>
 where
     O: Offset,
-    T: NativeType + lexical_core::ToLexical,
+    T: NativeType + SerPrimitive,
 {
     let from = from.as_any().downcast_ref().unwrap();
     Ok(Box::new(primitive_to_binary::<T, O>(from)))
@@ -86,32 +143,11 @@ where
 }
 
 /// Returns a [`Utf8Array`] where every element is the utf8 representation of the number.
-pub fn primitive_to_utf8<T: NativeType + lexical_core::ToLexical, O: Offset>(
+pub(super) fn primitive_to_utf8<T: NativeType + SerPrimitive, O: Offset>(
     from: &PrimitiveArray<T>,
 ) -> Utf8Array<O> {
-    let mut values: Vec<u8> = Vec::with_capacity(from.len());
-    let mut offsets: Vec<O> = Vec::with_capacity(from.len() + 1);
-    offsets.push(O::default());
-
-    let mut offset: usize = 0;
-
+    let (values, offsets) = primitive_to_values_and_offsets(from);
     unsafe {
-        for x in from.values().iter() {
-            values.reserve(offset + T::FORMATTED_SIZE_DECIMAL);
-
-            let bytes = std::slice::from_raw_parts_mut(
-                values.as_mut_ptr().add(offset),
-                values.capacity() - offset,
-            );
-            let len = lexical_core::write_unchecked(*x, bytes).len();
-
-            offset += len;
-            offsets.push(O::from_usize(offset).unwrap());
-        }
-        values.set_len(offset);
-        values.shrink_to_fit();
-        // Safety: offsets _are_ monotonically increasing
-        let offsets = unsafe { Offsets::new_unchecked(offsets) };
         Utf8Array::<O>::new_unchecked(
             Utf8Array::<O>::default_data_type(),
             offsets.into(),
@@ -124,7 +160,7 @@ pub fn primitive_to_utf8<T: NativeType + lexical_core::ToLexical, O: Offset>(
 pub(super) fn primitive_to_utf8_dyn<T, O>(from: &dyn Array) -> Result<Box<dyn Array>>
 where
     O: Offset,
-    T: NativeType + lexical_core::ToLexical,
+    T: NativeType + SerPrimitive,
 {
     let from = from.as_any().downcast_ref().unwrap();
     Ok(Box::new(primitive_to_utf8::<T, O>(from)))
@@ -589,7 +625,7 @@ pub fn f16_to_f32(from: &PrimitiveArray<f16>) -> PrimitiveArray<f32> {
 }
 
 /// Returns a [`Utf8Array`] where every element is the utf8 representation of the number.
-pub(super) fn primitive_to_binview<T: NativeType>(
+pub(super) fn primitive_to_binview<T: NativeType + SerPrimitive>(
     from: &PrimitiveArray<T>,
 ) -> BinaryViewArray {
     let mut mutable = MutableBinaryViewArray::with_capacity(from.len());
@@ -606,7 +642,7 @@ pub(super) fn primitive_to_binview<T: NativeType>(
 
 pub(super) fn primitive_to_binview_dyn<T>(from: &dyn Array) -> BinaryViewArray
 where
-    T: NativeType,
+    T: NativeType + SerPrimitive,
 {
     let from = from.as_any().downcast_ref().unwrap();
     primitive_to_binview::<T>(from)

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -216,6 +216,7 @@ pub fn binary_to_binview<O: Offset>(arr: &BinaryArray<O>) -> BinaryViewArray {
             views.into(),
             buffers,
             arr.validity().cloned(),
+            None,
         )
     }
 }

--- a/src/compute/cast/utf8_to.rs
+++ b/src/compute/cast/utf8_to.rs
@@ -202,7 +202,7 @@ pub fn binary_to_binview<O: Offset>(arr: &BinaryArray<O>) -> BinaryViewArray {
             payload[12..16].copy_from_slice(&offset.to_le_bytes());
         }
 
-        let value = u128::from_le_bytes(payload);
+        let value = View::from_le_bytes(payload);
         unsafe { views.push_unchecked(value) };
     }
     let buffers = if uses_buffer {

--- a/src/compute/comparison/mod.rs
+++ b/src/compute/comparison/mod.rs
@@ -86,6 +86,7 @@ macro_rules! match_eq_ord {(
         Float16 => todo!(),
         Float32 => __with_ty__! { f32 },
         Float64 => __with_ty__! { f64 },
+        UInt128 => todo!(),
     }
 })}
 
@@ -111,6 +112,7 @@ macro_rules! match_eq {(
         Float16 => __with_ty__! { f16 },
         Float32 => __with_ty__! { f32 },
         Float64 => __with_ty__! { f64 },
+        UInt128 => todo!(),
     }
 })}
 

--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -296,6 +296,22 @@ pub fn filter(array: &dyn Array, filter: &BooleanArray) -> Result<Box<dyn Array>
             let array = array.as_any().downcast_ref().unwrap();
             Ok(Box::new(filter_primitive::<$T>(array, filter)))
         }),
+        BinaryView => {
+            let iter = SlicesIterator::new(filter.values());
+            let mut mutable = growable::GrowableBinaryViewArray::new(
+                vec![array.as_any().downcast_ref::<BinaryViewArray>().unwrap()],
+                false,
+                iter.slots(),
+            );
+            unsafe {
+                iter.for_each(|(start, len)| mutable.extend_unchecked(0, start, len));
+            }
+            Ok(mutable.as_box())
+        },
+        // Should go via BinaryView
+        Utf8View => {
+            unreachable!()
+        },
         _ => {
             let iter = SlicesIterator::new(filter.values());
             let mut mutable = make_growable(&[array], false, iter.slots());

--- a/src/compute/filter.rs
+++ b/src/compute/filter.rs
@@ -298,14 +298,14 @@ pub fn filter(array: &dyn Array, filter: &BooleanArray) -> Result<Box<dyn Array>
         }),
         BinaryView => {
             let iter = SlicesIterator::new(filter.values());
-            let mut mutable = growable::GrowableBinaryViewArray::new(
-                vec![array.as_any().downcast_ref::<BinaryViewArray>().unwrap()],
-                false,
-                iter.slots(),
-            );
+            let array = array.as_any().downcast_ref::<BinaryViewArray>().unwrap();
+            let mut mutable =
+                growable::GrowableBinaryViewArray::new(vec![array], false, iter.slots());
             unsafe {
-                iter.for_each(|(start, len)| mutable.extend_unchecked(0, start, len));
+                // We don't have to correct buffers as there is only one array.
+                iter.for_each(|(start, len)| mutable.extend_unchecked_no_buffers(0, start, len));
             }
+
             Ok(mutable.as_box())
         },
         // Should go via BinaryView

--- a/src/datatypes/physical_type.rs
+++ b/src/datatypes/physical_type.rs
@@ -39,6 +39,12 @@ pub enum PhysicalType {
     Map,
     /// A dictionary encoded array by `IntegerType`.
     Dictionary(IntegerType),
+    /// A binary type that inlines small values
+    /// and can intern bytes.
+    BinaryView,
+    /// A string type that inlines small values
+    /// and can intern strings.
+    Utf8View,
 }
 
 impl PhysicalType {

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -104,7 +104,7 @@ impl ArrowArray {
             DataType::BinaryView | DataType::Utf8View
         );
 
-        let (offset, mut buffers, children, dictionary) =
+        let (offset, buffers, children, dictionary) =
             offset_buffers_children_dictionary(array.as_ref());
 
         let variadic_buffer_sizes = if needs_variadic_buffer_sizes {

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -90,6 +90,7 @@ struct PrivateData {
     buffers_ptr: Box<[*const std::os::raw::c_void]>,
     children_ptr: Box<[*mut ArrowArray]>,
     dictionary_ptr: Option<*mut ArrowArray>,
+    variadic_buffer_sizes: Box<[i64]>,
 }
 
 impl ArrowArray {
@@ -98,8 +99,35 @@ impl ArrowArray {
     /// This method releases `buffers`. Consumers of this struct *must* call `release` before
     /// releasing this struct, or contents in `buffers` leak.
     pub(crate) fn new(array: Box<dyn Array>) -> Self {
-        let (offset, buffers, children, dictionary) =
+        let needs_variadic_buffer_sizes = matches!(
+            array.data_type(),
+            DataType::BinaryView | DataType::Utf8View
+        );
+
+        let (offset, mut buffers, children, dictionary) =
             offset_buffers_children_dictionary(array.as_ref());
+
+        let variadic_buffer_sizes = if needs_variadic_buffer_sizes {
+            #[cfg(feature = "compute_cast")]
+            {
+                let arr = crate::compute::cast::cast_unchecked(
+                    array.as_ref(),
+                    &DataType::BinaryView,
+                )
+                .unwrap();
+                let arr = arr.as_any().downcast_ref::<BinaryViewArray>().unwrap();
+                let boxed = arr.variadic_buffer_lengths().into_boxed_slice();
+                let ptr = boxed.as_ptr().cast::<u8>();
+                buffers.push(Some(ptr));
+                boxed
+            }
+            #[cfg(not(feature = "compute_cast"))]
+            {
+                panic!("activate 'compute_cast' feature")
+            }
+        } else {
+            Box::from([])
+        };
 
         let buffers_ptr = buffers
             .iter()
@@ -127,6 +155,7 @@ impl ArrowArray {
             buffers_ptr,
             children_ptr,
             dictionary_ptr,
+            variadic_buffer_sizes,
         });
 
         Self {
@@ -220,6 +249,21 @@ unsafe fn get_buffer_ptr<T: NativeType>(
     Ok(ptr as *mut T)
 }
 
+unsafe fn create_buffer_known_len<T: NativeType>(
+    array: &ArrowArray,
+    data_type: &DataType,
+    owner: InternalArrowArray,
+    len: usize,
+    index: usize,
+) -> Result<Buffer<T>> {
+    if len == 0 {
+        return Ok(Buffer::new());
+    }
+    let ptr: *mut T = get_buffer_ptr(array, data_type, index)?;
+    let bytes = Bytes::from_foreign(ptr, len, BytesAllocator::InternalArrowArray(owner));
+    Ok(Buffer::from_bytes(bytes))
+}
+
 /// returns the buffer `i` of `array` interpreted as a [`Buffer`].
 /// # Safety
 /// This function is safe iff:
@@ -238,6 +282,7 @@ unsafe fn create_buffer<T: NativeType>(
     }
 
     let offset = buffer_offset(array, data_type, index);
+    dbg!(offset, len);
     let ptr: *mut T = get_buffer_ptr(array, data_type, index)?;
 
     // We have to check alignment.
@@ -330,7 +375,10 @@ unsafe fn buffer_len(array: &ArrowArray, data_type: &DataType, i: usize) -> Resu
         | (PhysicalType::Map, 1) => {
             // the len of the offset buffer (buffer 1) equals length + 1
             array.offset as usize + array.length as usize + 1
-        }
+        },
+        (PhysicalType::BinaryView, 1) | (PhysicalType::Utf8View, 1) => {
+            array.offset as usize + array.length as usize
+        },
         (PhysicalType::Utf8, 2) | (PhysicalType::Binary, 2) => {
             // the len of the data buffer (buffer 2) equals the last value of the offset buffer (buffer 1)
             let len = buffer_len(array, data_type, 1)?;
@@ -452,6 +500,17 @@ pub trait ArrowArrayRef: std::fmt::Debug {
     /// This function assumes that the buffer created from FFI is valid; this is impossible to prove.
     unsafe fn buffer<T: NativeType>(&self, index: usize) -> Result<Buffer<T>> {
         create_buffer::<T>(self.array(), self.data_type(), self.owner(), index)
+    }
+
+    /// # Safety
+    /// The caller must guarantee that the buffer `index` corresponds to a buffer.
+    /// This function assumes that the buffer created from FFI is valid; this is impossible to prove.
+    unsafe fn buffer_known_len<T: NativeType>(
+        &self,
+        index: usize,
+        len: usize,
+    ) -> Result<Buffer<T>> {
+        create_buffer_known_len::<T>(self.array(), self.data_type(), self.owner(), len, index)
     }
 
     /// # Safety

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -43,6 +43,8 @@ pub unsafe fn try_from<A: ArrowArrayRef>(array: A) -> Result<Box<dyn Array>> {
         }
         Union => Box::new(UnionArray::try_from_ffi(array)?),
         Map => Box::new(MapArray::try_from_ffi(array)?),
+        BinaryView => Box::new(BinaryViewArray::try_from_ffi(array)?),
+        Utf8View => Box::new(Utf8ViewArray::try_from_ffi(array)?),
     })
 }
 

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -282,7 +282,6 @@ unsafe fn create_buffer<T: NativeType>(
     }
 
     let offset = buffer_offset(array, data_type, index);
-    dbg!(offset, len);
     let ptr: *mut T = get_buffer_ptr(array, data_type, index)?;
 
     // We have to check alignment.

--- a/src/ffi/array.rs
+++ b/src/ffi/array.rs
@@ -104,7 +104,7 @@ impl ArrowArray {
             DataType::BinaryView | DataType::Utf8View
         );
 
-        let (offset, buffers, children, dictionary) =
+        let (offset, mut buffers, children, dictionary) =
             offset_buffers_children_dictionary(array.as_ref());
 
         let variadic_buffer_sizes = if needs_variadic_buffer_sizes {

--- a/src/ffi/bridge.rs
+++ b/src/ffi/bridge.rs
@@ -34,6 +34,8 @@ pub fn align_to_c_data_interface(array: Box<dyn Array>) -> Box<dyn Array> {
             match_integer_type!(key_type, |$T| {
                 ffi_dyn!(array, DictionaryArray<$T>)
             })
-        }
+        },
+        BinaryView => ffi_dyn!(array, BinaryViewArray),
+        Utf8View => ffi_dyn!(array, Utf8ViewArray),
     }
 }

--- a/src/ffi/mmap.rs
+++ b/src/ffi/mmap.rs
@@ -21,7 +21,7 @@ struct PrivateData<T> {
 }
 
 pub(crate) unsafe fn create_array<
-    T: AsRef<[u8]>,
+    T,
     I: Iterator<Item = Option<*const u8>>,
     II: Iterator<Item = ArrowArray>,
 >(

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -261,6 +261,8 @@ unsafe fn to_data_type(schema: &ArrowSchema) -> Result<DataType> {
         "tDn" => DataType::Duration(TimeUnit::Nanosecond),
         "tiM" => DataType::Interval(IntervalUnit::YearMonth),
         "tiD" => DataType::Interval(IntervalUnit::DayTime),
+        "vu" => DataType::Utf8View,
+        "vz" => DataType::BinaryView,
         "+l" => {
             let child = schema.child(0);
             DataType::List(Box::new(to_field(child)?))

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -439,6 +439,8 @@ fn to_format(data_type: &DataType) -> String {
                 tz.as_ref().map(|x| x.as_ref()).unwrap_or("")
             )
         }
+        DataType::Utf8View => "vu".to_string(),
+        DataType::BinaryView => "vz".to_string(),
         DataType::Decimal(precision, scale) => format!("d:{precision},{scale}"),
         DataType::Decimal256(precision, scale) => format!("d:{precision},{scale},256"),
         DataType::List(_) => "+l".to_string(),

--- a/src/io/ipc/mod.rs
+++ b/src/io/ipc/mod.rs
@@ -42,7 +42,7 @@
 //! let y_coord = Field::new("y", DataType::Int32, false);
 //! let schema = Schema::from(vec![x_coord, y_coord]);
 //! let options = WriteOptions {compression: None};
-//! let mut writer = FileWriter::try_new(file, schema, None, options)?;
+//! let mut writer = FileWriter::try_new(file, schema.into(), None, options)?;
 //!
 //! // Setup the data
 //! let x_data = Int32Array::from_slice([-1i32, 1]);

--- a/src/io/ipc/read/array/binary.rs
+++ b/src/io/ipc/read/array/binary.rs
@@ -9,7 +9,7 @@ use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 use crate::offset::Offset;
 
 use super::super::read_basic::*;
-use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
+use super::super::{Compression, IpcBuffer, Node};
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_binary<O: Offset, R: Read + Seek>(

--- a/src/io/ipc/read/array/binary.rs
+++ b/src/io/ipc/read/array/binary.rs
@@ -5,6 +5,7 @@ use crate::array::BinaryArray;
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
 use crate::error::{Error, Result};
+use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 use crate::offset::Offset;
 
 use super::super::read_basic::*;
@@ -22,11 +23,7 @@ pub fn read_binary<O: Offset, R: Read + Seek>(
     limit: Option<usize>,
     scratch: &mut Vec<u8>,
 ) -> Result<BinaryArray<O>> {
-    let field_node = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(format!(
-            "IPC: unable to fetch the field for {data_type:?}. The file or stream is corrupted."
-        ))
-    })?;
+    let field_node = try_get_field_node(field_nodes, &data_type)?;
 
     let validity = read_validity(
         buffers,
@@ -39,11 +36,7 @@ pub fn read_binary<O: Offset, R: Read + Seek>(
         scratch,
     )?;
 
-    let length: usize = field_node
-        .length()
-        .try_into()
-        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
-    let length = limit.map(|limit| limit.min(length)).unwrap_or(length);
+    let length = try_get_array_length(field_node, limit)?;
 
     let offsets: Buffer<O> = read_buffer(
         buffers,

--- a/src/io/ipc/read/array/binview.rs
+++ b/src/io/ipc/read/array/binview.rs
@@ -51,23 +51,10 @@ pub fn read_binview<T: ViewType + ?Sized, R: Read + Seek>(
         || polars_err!(ComputeError: "IPC: unable to fetch the variadic buffers\n\nThe file or stream is corrupted.")
     )?;
 
-    let variadic_buffer_lengths: Buffer<i64> = read_buffer(
-        buffers,
-        n_variadic,
-        reader,
-        block_offset,
-        is_little_endian,
-        compression,
-        scratch,
-    )?;
-
-    let variadic_buffers = variadic_buffer_lengths
-        .iter()
-        .map(|length| {
-            let length = *length as usize;
-            read_buffer(
+    let variadic_buffers = (0..n_variadic)
+        .map(|_| {
+            read_bytes(
                 buffers,
-                length,
                 reader,
                 block_offset,
                 is_little_endian,

--- a/src/io/ipc/read/array/binview.rs
+++ b/src/io/ipc/read/array/binview.rs
@@ -1,0 +1,82 @@
+use std::collections::VecDeque;
+use std::io::{Read, Seek};
+use std::sync::Arc;
+
+use crate::error::{Error, Result};
+
+use super::super::read_basic::*;
+use super::*;
+use crate::array::{ArrayRef, BinaryViewArrayGeneric, ViewType};
+use crate::buffer::Buffer;
+use crate::datatypes::DataType;
+
+#[allow(clippy::too_many_arguments)]
+pub fn read_binview<T: ViewType + ?Sized, R: Read + Seek>(
+    field_nodes: &mut VecDeque<Node>,
+    variadic_buffer_counts: &mut VecDeque<usize>,
+    data_type: DataType,
+    buffers: &mut VecDeque<IpcBuffer>,
+    reader: &mut R,
+    block_offset: u64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+    limit: Option<usize>,
+    scratch: &mut Vec<u8>,
+) -> Result<ArrayRef> {
+    let field_node = try_get_field_node(field_nodes, &data_type)?;
+
+    let validity = read_validity(
+        buffers,
+        field_node,
+        reader,
+        block_offset,
+        is_little_endian,
+        compression,
+        limit,
+        scratch,
+    )?;
+
+    let length = try_get_array_length(field_node, limit)?;
+    let views: Buffer<u128> = read_buffer(
+        buffers,
+        length,
+        reader,
+        block_offset,
+        is_little_endian,
+        compression,
+        scratch,
+    )?;
+
+    let n_variadic = variadic_buffer_counts.pop_front().ok_or_else(
+        || polars_err!(ComputeError: "IPC: unable to fetch the variadic buffers\n\nThe file or stream is corrupted.")
+    )?;
+
+    let variadic_buffer_lengths: Buffer<i64> = read_buffer(
+        buffers,
+        n_variadic,
+        reader,
+        block_offset,
+        is_little_endian,
+        compression,
+        scratch,
+    )?;
+
+    let variadic_buffers = variadic_buffer_lengths
+        .iter()
+        .map(|length| {
+            let length = *length as usize;
+            read_buffer(
+                buffers,
+                length,
+                reader,
+                block_offset,
+                is_little_endian,
+                compression,
+                scratch,
+            )
+        })
+        .collect::<Result<Vec<Buffer<u8>>>>()?;
+
+    BinaryViewArrayGeneric::<T>::try_new(data_type, views, Arc::from(variadic_buffers), validity)
+        .map(|arr| arr.boxed())
+}

--- a/src/io/ipc/read/array/binview.rs
+++ b/src/io/ipc/read/array/binview.rs
@@ -6,7 +6,7 @@ use crate::error::{Error, Result};
 
 use super::super::read_basic::*;
 use super::*;
-use crate::array::{ArrayRef, BinaryViewArrayGeneric, ViewType};
+use crate::array::{ArrayRef, BinaryViewArrayGeneric, View, ViewType};
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
 
@@ -37,7 +37,7 @@ pub fn read_binview<T: ViewType + ?Sized, R: Read + Seek>(
     )?;
 
     let length = try_get_array_length(field_node, limit)?;
-    let views: Buffer<u128> = read_buffer(
+    let views: Buffer<View> = read_buffer(
         buffers,
         length,
         reader,

--- a/src/io/ipc/read/array/boolean.rs
+++ b/src/io/ipc/read/array/boolean.rs
@@ -7,7 +7,7 @@ use crate::error::{Error, Result};
 use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 use super::super::read_basic::*;
-use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
+use super::super::{Compression, IpcBuffer, Node};
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_boolean<R: Read + Seek>(

--- a/src/io/ipc/read/array/boolean.rs
+++ b/src/io/ipc/read/array/boolean.rs
@@ -4,6 +4,7 @@ use std::io::{Read, Seek};
 use crate::array::BooleanArray;
 use crate::datatypes::DataType;
 use crate::error::{Error, Result};
+use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
@@ -20,11 +21,7 @@ pub fn read_boolean<R: Read + Seek>(
     limit: Option<usize>,
     scratch: &mut Vec<u8>,
 ) -> Result<BooleanArray> {
-    let field_node = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(format!(
-            "IPC: unable to fetch the field for {data_type:?}. The file or stream is corrupted."
-        ))
-    })?;
+    let field_node = try_get_field_node(field_nodes, &data_type)?;
 
     let validity = read_validity(
         buffers,
@@ -37,11 +34,7 @@ pub fn read_boolean<R: Read + Seek>(
         scratch,
     )?;
 
-    let length: usize = field_node
-        .length()
-        .try_into()
-        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
-    let length = limit.map(|limit| limit.min(length)).unwrap_or(length);
+    let length = try_get_array_length(field_node, limit)?;
 
     let values = read_bitmap(
         buffers,

--- a/src/io/ipc/read/array/fixed_size_binary.rs
+++ b/src/io/ipc/read/array/fixed_size_binary.rs
@@ -7,7 +7,7 @@ use crate::error::{Error, Result};
 use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 use super::super::read_basic::*;
-use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
+use super::super::{Compression, IpcBuffer, Node};
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_fixed_size_binary<R: Read + Seek>(

--- a/src/io/ipc/read/array/fixed_size_binary.rs
+++ b/src/io/ipc/read/array/fixed_size_binary.rs
@@ -4,6 +4,7 @@ use std::io::{Read, Seek};
 use crate::array::FixedSizeBinaryArray;
 use crate::datatypes::DataType;
 use crate::error::{Error, Result};
+use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
@@ -20,11 +21,7 @@ pub fn read_fixed_size_binary<R: Read + Seek>(
     limit: Option<usize>,
     scratch: &mut Vec<u8>,
 ) -> Result<FixedSizeBinaryArray> {
-    let field_node = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(format!(
-            "IPC: unable to fetch the field for {data_type:?}. The file or stream is corrupted."
-        ))
-    })?;
+    let field_node = try_get_field_node(field_nodes, &data_type)?;
 
     let validity = read_validity(
         buffers,
@@ -37,11 +34,7 @@ pub fn read_fixed_size_binary<R: Read + Seek>(
         scratch,
     )?;
 
-    let length: usize = field_node
-        .length()
-        .try_into()
-        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
-    let length = limit.map(|limit| limit.min(length)).unwrap_or(length);
+    let length = try_get_array_length(field_node, limit)?;
 
     let length = length.saturating_mul(FixedSizeBinaryArray::maybe_get_size(&data_type)?);
     let values = read_buffer(

--- a/src/io/ipc/read/array/fixed_size_list.rs
+++ b/src/io/ipc/read/array/fixed_size_list.rs
@@ -9,10 +9,12 @@ use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
 use super::super::{Compression, Dictionaries, IpcBuffer, Node, Version};
+use crate::io::ipc::read::array::try_get_field_node;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_fixed_size_list<R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
+    variadic_buffer_counts: &mut VecDeque<usize>,
     data_type: DataType,
     ipc_field: &IpcField,
     buffers: &mut VecDeque<IpcBuffer>,
@@ -25,11 +27,7 @@ pub fn read_fixed_size_list<R: Read + Seek>(
     version: Version,
     scratch: &mut Vec<u8>,
 ) -> Result<FixedSizeListArray> {
-    let field_node = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(format!(
-            "IPC: unable to fetch the field for {data_type:?}. The file or stream is corrupted."
-        ))
-    })?;
+    let field_node = try_get_field_node(field_nodes, &data_type)?;
 
     let validity = read_validity(
         buffers,
@@ -48,6 +46,7 @@ pub fn read_fixed_size_list<R: Read + Seek>(
 
     let values = read(
         field_nodes,
+        variadic_buffer_counts,
         field,
         &ipc_field.fields[0],
         buffers,

--- a/src/io/ipc/read/array/list.rs
+++ b/src/io/ipc/read/array/list.rs
@@ -12,10 +12,12 @@ use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
 use super::super::{Compression, Dictionaries, IpcBuffer, Node, OutOfSpecKind, Version};
+use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_list<O: Offset, R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
+    variadic_buffer_counts: &mut VecDeque<usize>,
     data_type: DataType,
     ipc_field: &IpcField,
     buffers: &mut VecDeque<IpcBuffer>,
@@ -31,11 +33,7 @@ pub fn read_list<O: Offset, R: Read + Seek>(
 where
     Vec<u8>: TryInto<O::Bytes>,
 {
-    let field_node = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(format!(
-            "IPC: unable to fetch the field for {data_type:?}. The file or stream is corrupted."
-        ))
-    })?;
+    let field_node = try_get_field_node(field_nodes, &data_type)?;
 
     let validity = read_validity(
         buffers,
@@ -48,11 +46,7 @@ where
         scratch,
     )?;
 
-    let length: usize = field_node
-        .length()
-        .try_into()
-        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
-    let length = limit.map(|limit| limit.min(length)).unwrap_or(length);
+    let length = try_get_array_length(field_node, limit)?;
 
     let offsets = read_buffer::<O, _>(
         buffers,
@@ -72,6 +66,7 @@ where
 
     let values = read(
         field_nodes,
+        variadic_buffer_counts,
         field,
         &ipc_field.fields[0],
         buffers,

--- a/src/io/ipc/read/array/list.rs
+++ b/src/io/ipc/read/array/list.rs
@@ -11,7 +11,7 @@ use crate::offset::Offset;
 use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
-use super::super::{Compression, Dictionaries, IpcBuffer, Node, OutOfSpecKind, Version};
+use super::super::{Compression, Dictionaries, IpcBuffer, Node, Version};
 use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 #[allow(clippy::too_many_arguments)]

--- a/src/io/ipc/read/array/map.rs
+++ b/src/io/ipc/read/array/map.rs
@@ -9,7 +9,7 @@ use crate::error::{Error, Result};
 use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
-use super::super::{Compression, Dictionaries, IpcBuffer, Node, OutOfSpecKind, Version};
+use super::super::{Compression, Dictionaries, IpcBuffer, Node, Version};
 use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 #[allow(clippy::too_many_arguments)]

--- a/src/io/ipc/read/array/map.rs
+++ b/src/io/ipc/read/array/map.rs
@@ -10,10 +10,12 @@ use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
 use super::super::{Compression, Dictionaries, IpcBuffer, Node, OutOfSpecKind, Version};
+use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_map<R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
+    variadic_buffer_counts: &mut VecDeque<usize>,
     data_type: DataType,
     ipc_field: &IpcField,
     buffers: &mut VecDeque<IpcBuffer>,
@@ -26,11 +28,7 @@ pub fn read_map<R: Read + Seek>(
     version: Version,
     scratch: &mut Vec<u8>,
 ) -> Result<MapArray> {
-    let field_node = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(format!(
-            "IPC: unable to fetch the field for {data_type:?}. The file or stream is corrupted."
-        ))
-    })?;
+    let field_node = try_get_field_node(field_nodes, &data_type)?;
 
     let validity = read_validity(
         buffers,
@@ -43,11 +41,7 @@ pub fn read_map<R: Read + Seek>(
         scratch,
     )?;
 
-    let length: usize = field_node
-        .length()
-        .try_into()
-        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
-    let length = limit.map(|limit| limit.min(length)).unwrap_or(length);
+    let length = try_get_array_length(field_node, limit)?;
 
     let offsets = read_buffer::<i32, _>(
         buffers,
@@ -67,6 +61,7 @@ pub fn read_map<R: Read + Seek>(
 
     let field = read(
         field_nodes,
+        variadic_buffer_counts,
         field,
         &ipc_field.fields[0],
         buffers,

--- a/src/io/ipc/read/array/mod.rs
+++ b/src/io/ipc/read/array/mod.rs
@@ -37,7 +37,7 @@ fn try_get_field_node<'a>(
     data_type: &DataType,
 ) -> Result<Node<'a>> {
     field_nodes.pop_front().ok_or_else(|| {
-        polars_err!(ComputeError: "IPC: unable to fetch the field for {:?}\n\nThe file or stream is corrupted.", data_type)
+        Error::oos(format!("IPC: unable to fetch the field for {:?}\n\nThe file or stream is corrupted.", data_type))
     })
 }
 
@@ -45,6 +45,6 @@ fn try_get_array_length(field_node: Node, limit: Option<usize>) -> Result<usize>
     let length: usize = field_node
         .length()
         .try_into()
-        .map_err(|_| polars_err!(oos = OutOfSpecKind::NegativeFooterLength))?;
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
     Ok(limit.map(|limit| limit.min(length)).unwrap_or(length))
 }

--- a/src/io/ipc/read/array/mod.rs
+++ b/src/io/ipc/read/array/mod.rs
@@ -1,4 +1,7 @@
 mod primitive;
+
+use std::collections::VecDeque;
+
 pub use primitive::*;
 mod boolean;
 pub use boolean::*;
@@ -20,5 +23,28 @@ mod dictionary;
 pub use dictionary::*;
 mod union;
 pub use union::*;
+mod binview;
 mod map;
+pub use binview::*;
 pub use map::*;
+
+use super::{Compression, IpcBuffer, Node, OutOfSpecKind};
+use crate::datatypes::DataType;
+use crate::error::{Error, Result};
+
+fn try_get_field_node<'a>(
+    field_nodes: &mut VecDeque<Node<'a>>,
+    data_type: &DataType,
+) -> Result<Node<'a>> {
+    field_nodes.pop_front().ok_or_else(|| {
+        polars_err!(ComputeError: "IPC: unable to fetch the field for {:?}\n\nThe file or stream is corrupted.", data_type)
+    })
+}
+
+fn try_get_array_length(field_node: Node, limit: Option<usize>) -> Result<usize> {
+    let length: usize = field_node
+        .length()
+        .try_into()
+        .map_err(|_| polars_err!(oos = OutOfSpecKind::NegativeFooterLength))?;
+    Ok(limit.map(|limit| limit.min(length)).unwrap_or(length))
+}

--- a/src/io/ipc/read/array/null.rs
+++ b/src/io/ipc/read/array/null.rs
@@ -7,18 +7,16 @@ use crate::{
 };
 
 use super::super::{Node, OutOfSpecKind};
+use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
-pub fn read_null(field_nodes: &mut VecDeque<Node>, data_type: DataType) -> Result<NullArray> {
-    let field_node = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(format!(
-            "IPC: unable to fetch the field for {data_type:?}. The file or stream is corrupted."
-        ))
-    })?;
+pub fn read_null(
+    field_nodes: &mut VecDeque<Node>,
+    data_type: DataType,
+    limit: Option<usize>,
+) -> Result<NullArray> {
+    let field_node = try_get_field_node(field_nodes, &data_type)?;
 
-    let length: usize = field_node
-        .length()
-        .try_into()
-        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
+    let length = try_get_array_length(field_node, limit)?;
 
     NullArray::try_new(data_type, length)
 }

--- a/src/io/ipc/read/array/null.rs
+++ b/src/io/ipc/read/array/null.rs
@@ -6,7 +6,7 @@ use crate::{
     error::{Error, Result},
 };
 
-use super::super::{Node, OutOfSpecKind};
+use super::super::Node;
 use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 pub fn read_null(

--- a/src/io/ipc/read/array/primitive.rs
+++ b/src/io/ipc/read/array/primitive.rs
@@ -7,6 +7,7 @@ use crate::{array::PrimitiveArray, types::NativeType};
 
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
+use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_primitive<T: NativeType, R: Read + Seek>(
@@ -23,11 +24,7 @@ pub fn read_primitive<T: NativeType, R: Read + Seek>(
 where
     Vec<u8>: TryInto<T::Bytes>,
 {
-    let field_node = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(format!(
-            "IPC: unable to fetch the field for {data_type:?}. The file or stream is corrupted."
-        ))
-    })?;
+    let field_node = try_get_field_node(field_nodes, &data_type)?;
 
     let validity = read_validity(
         buffers,
@@ -40,11 +37,7 @@ where
         scratch,
     )?;
 
-    let length: usize = field_node
-        .length()
-        .try_into()
-        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
-    let length = limit.map(|limit| limit.min(length)).unwrap_or(length);
+    let length = try_get_array_length(field_node, limit)?;
 
     let values = read_buffer(
         buffers,

--- a/src/io/ipc/read/array/primitive.rs
+++ b/src/io/ipc/read/array/primitive.rs
@@ -6,7 +6,7 @@ use crate::error::{Error, Result};
 use crate::{array::PrimitiveArray, types::NativeType};
 
 use super::super::read_basic::*;
-use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
+use super::super::{Compression, IpcBuffer, Node};
 use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 #[allow(clippy::too_many_arguments)]

--- a/src/io/ipc/read/array/union.rs
+++ b/src/io/ipc/read/array/union.rs
@@ -10,10 +10,12 @@ use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
 use super::super::{Compression, Dictionaries, IpcBuffer, Node, OutOfSpecKind, Version};
+use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_union<R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
+    variadic_buffer_counts: &mut VecDeque<usize>,
     data_type: DataType,
     ipc_field: &IpcField,
     buffers: &mut VecDeque<IpcBuffer>,
@@ -26,11 +28,7 @@ pub fn read_union<R: Read + Seek>(
     version: Version,
     scratch: &mut Vec<u8>,
 ) -> Result<UnionArray> {
-    let field_node = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(format!(
-            "IPC: unable to fetch the field for {data_type:?}. The file or stream is corrupted."
-        ))
-    })?;
+    let field_node = try_get_field_node(field_nodes, &data_type)?;
 
     if version != Version::V5 {
         let _ = buffers
@@ -38,11 +36,7 @@ pub fn read_union<R: Read + Seek>(
             .ok_or_else(|| Error::oos("IPC: missing validity buffer."))?;
     };
 
-    let length: usize = field_node
-        .length()
-        .try_into()
-        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
-    let length = limit.map(|limit| limit.min(length)).unwrap_or(length);
+    let length = try_get_array_length(field_node, limit)?;
 
     let types = read_buffer(
         buffers,
@@ -80,6 +74,7 @@ pub fn read_union<R: Read + Seek>(
         .map(|(field, ipc_field)| {
             read(
                 field_nodes,
+                variadic_buffer_counts,
                 field,
                 ipc_field,
                 buffers,

--- a/src/io/ipc/read/array/union.rs
+++ b/src/io/ipc/read/array/union.rs
@@ -9,7 +9,7 @@ use crate::error::{Error, Result};
 use super::super::super::IpcField;
 use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
-use super::super::{Compression, Dictionaries, IpcBuffer, Node, OutOfSpecKind, Version};
+use super::super::{Compression, Dictionaries, IpcBuffer, Node, Version};
 use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 
 #[allow(clippy::too_many_arguments)]

--- a/src/io/ipc/read/array/utf8.rs
+++ b/src/io/ipc/read/array/utf8.rs
@@ -5,6 +5,7 @@ use crate::array::Utf8Array;
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
 use crate::error::{Error, Result};
+use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 use crate::offset::Offset;
 
 use super::super::read_basic::*;
@@ -22,11 +23,7 @@ pub fn read_utf8<O: Offset, R: Read + Seek>(
     limit: Option<usize>,
     scratch: &mut Vec<u8>,
 ) -> Result<Utf8Array<O>> {
-    let field_node = field_nodes.pop_front().ok_or_else(|| {
-        Error::oos(format!(
-            "IPC: unable to fetch the field for {data_type:?}. The file or stream is corrupted."
-        ))
-    })?;
+    let field_node = try_get_field_node(field_nodes, &data_type)?;
 
     let validity = read_validity(
         buffers,
@@ -39,12 +36,7 @@ pub fn read_utf8<O: Offset, R: Read + Seek>(
         scratch,
     )?;
 
-    let length: usize = field_node
-        .length()
-        .try_into()
-        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
-
-    let length = limit.map(|limit| limit.min(length)).unwrap_or(length);
+    let length = try_get_array_length(field_node, limit)?;
 
     let offsets: Buffer<O> = read_buffer(
         buffers,

--- a/src/io/ipc/read/array/utf8.rs
+++ b/src/io/ipc/read/array/utf8.rs
@@ -9,7 +9,7 @@ use crate::io::ipc::read::array::{try_get_array_length, try_get_field_node};
 use crate::offset::Offset;
 
 use super::super::read_basic::*;
-use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
+use super::super::{Compression, IpcBuffer, Node};
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_utf8<O: Offset, R: Read + Seek>(

--- a/src/io/ipc/read/common.rs
+++ b/src/io/ipc/read/common.rs
@@ -94,6 +94,11 @@ pub fn read_record_batch<R: Read + Seek>(
         .buffers()
         .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferBuffers(err)))?
         .ok_or_else(|| Error::from(OutOfSpecKind::MissingMessageBuffers))?;
+    let mut variadic_buffer_counts = batch
+        .variadic_buffer_counts()
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferRecordBatches(err)))?
+        .map(|v| v.iter().map(|v| v as usize).collect::<VecDeque<usize>>())
+        .unwrap_or_else(VecDeque::new);
     let mut buffers: VecDeque<arrow_format::ipc::BufferRef> = buffers.iter().collect();
 
     // check that the sum of the sizes of all buffers is <= than the size of the file
@@ -128,6 +133,7 @@ pub fn read_record_batch<R: Read + Seek>(
             .map(|maybe_field| match maybe_field {
                 ProjectionResult::Selected((field, ipc_field)) => Ok(Some(read(
                     &mut field_nodes,
+                    &mut variadic_buffer_counts,
                     field,
                     ipc_field,
                     &mut buffers,
@@ -156,6 +162,7 @@ pub fn read_record_batch<R: Read + Seek>(
             .map(|(field, ipc_field)| {
                 read(
                     &mut field_nodes,
+                    &mut variadic_buffer_counts,
                     field,
                     ipc_field,
                     &mut buffers,

--- a/src/io/ipc/read/deserialize.rs
+++ b/src/io/ipc/read/deserialize.rs
@@ -226,6 +226,7 @@ pub fn read<R: Read + Seek>(
             scratch,
         )
         .map(|x| x.boxed()),
+        Utf8View | BinaryView => todo!(),
     }
 }
 
@@ -249,5 +250,6 @@ pub fn skip(
         Dictionary(_) => skip_dictionary(field_nodes, buffers),
         Union => skip_union(field_nodes, data_type, buffers),
         Map => skip_map(field_nodes, data_type, buffers),
+        BinaryView | Utf8View => todo!(),
     }
 }

--- a/src/io/ipc/read/deserialize.rs
+++ b/src/io/ipc/read/deserialize.rs
@@ -244,7 +244,8 @@ pub fn read<R: Read + Seek>(
             compression,
             limit,
             scratch,
-        ),
+        )
+        .map(|x| x.boxed()),
         BinaryView => read_binview::<[u8], _>(
             field_nodes,
             variadic_buffer_counts,
@@ -256,7 +257,8 @@ pub fn read<R: Read + Seek>(
             compression,
             limit,
             scratch,
-        ),
+        )
+        .map(|x| x.boxed()),
     }
 }
 

--- a/src/io/ipc/read/file.rs
+++ b/src/io/ipc/read/file.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Seek, SeekFrom};
 
 use crate::array::Array;
 use crate::chunk::Chunk;
-use crate::datatypes::Schema;
+use crate::datatypes::SchemaRef;
 use crate::error::{Error, Result};
 use crate::io::ipc::IpcSchema;
 
@@ -19,7 +19,7 @@ use arrow_format::ipc::planus::ReadAsRoot;
 #[derive(Debug, Clone)]
 pub struct FileMetadata {
     /// The schema that is read from the file footer
-    pub schema: Schema,
+    pub schema: SchemaRef,
 
     /// The files' [`IpcSchema`]
     pub ipc_schema: IpcSchema,
@@ -184,6 +184,7 @@ pub(super) fn deserialize_footer(footer_data: &[u8], size: u64) -> Result<FileMe
         .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferSchema(err)))?
         .ok_or_else(|| Error::from(OutOfSpecKind::MissingSchema))?;
     let (schema, ipc_schema) = fb_to_schema(ipc_schema)?;
+    let schema = schema.into();
 
     let dictionaries = footer
         .dictionaries()

--- a/src/io/ipc/read/read_basic.rs
+++ b/src/io/ipc/read/read_basic.rs
@@ -47,7 +47,7 @@ fn read_uncompressed_bytes<R: Read + Seek>(
     reader: &mut R,
     buffer_length: usize,
     is_little_endian: bool,
-) -> PolarsResult<Vec<u8>> {
+) -> Result<Vec<u8>> {
     if is_native_little_endian() == is_little_endian {
         let mut buffer = Vec::with_capacity(buffer_length);
         let _ = reader
@@ -153,7 +153,7 @@ fn read_compressed_bytes<R: Read + Seek>(
     is_little_endian: bool,
     compression: Compression,
     scratch: &mut Vec<u8>,
-) -> PolarsResult<Vec<u8>> {
+) -> Result<Vec<u8>> {
     read_compressed_buffer::<u8, _>(
         reader,
         buffer_length,
@@ -171,20 +171,20 @@ pub fn read_bytes<R: Read + Seek>(
     is_little_endian: bool,
     compression: Option<Compression>,
     scratch: &mut Vec<u8>,
-) -> PolarsResult<Buffer<u8>> {
+) -> Result<Buffer<u8>> {
     let buf = buf
         .pop_front()
-        .ok_or_else(|| polars_err!(oos = OutOfSpecKind::ExpectedBuffer))?;
+        .ok_or_else(|| Error::from(OutOfSpecKind::ExpectedBuffer))?;
 
     let offset: u64 = buf
         .offset()
         .try_into()
-        .map_err(|_| polars_err!(oos = OutOfSpecKind::NegativeFooterLength))?;
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
 
     let buffer_length: usize = buf
         .length()
         .try_into()
-        .map_err(|_| polars_err!(oos = OutOfSpecKind::NegativeFooterLength))?;
+        .map_err(|_| Error::from(OutOfSpecKind::NegativeFooterLength))?;
 
     reader.seek(SeekFrom::Start(block_offset + offset))?;
 

--- a/src/io/ipc/read/read_basic.rs
+++ b/src/io/ipc/read/read_basic.rs
@@ -43,6 +43,23 @@ fn read_swapped<T: NativeType, R: Read + Seek>(
     Ok(())
 }
 
+fn read_uncompressed_bytes<R: Read + Seek>(
+    reader: &mut R,
+    buffer_length: usize,
+    is_little_endian: bool,
+) -> PolarsResult<Vec<u8>> {
+    if is_native_little_endian() == is_little_endian {
+        let mut buffer = Vec::with_capacity(buffer_length);
+        let _ = reader
+            .take(buffer_length as u64)
+            .read_to_end(&mut buffer)
+            .unwrap();
+        Ok(buffer)
+    } else {
+        unreachable!()
+    }
+}
+
 fn read_uncompressed_buffer<T: NativeType, R: Read + Seek>(
     reader: &mut R,
     buffer_length: usize,
@@ -128,6 +145,61 @@ fn read_compressed_buffer<T: NativeType, R: Read + Seek>(
         }
     }
     Ok(buffer)
+}
+
+fn read_compressed_bytes<R: Read + Seek>(
+    reader: &mut R,
+    buffer_length: usize,
+    is_little_endian: bool,
+    compression: Compression,
+    scratch: &mut Vec<u8>,
+) -> PolarsResult<Vec<u8>> {
+    read_compressed_buffer::<u8, _>(
+        reader,
+        buffer_length,
+        buffer_length,
+        is_little_endian,
+        compression,
+        scratch,
+    )
+}
+
+pub fn read_bytes<R: Read + Seek>(
+    buf: &mut VecDeque<IpcBuffer>,
+    reader: &mut R,
+    block_offset: u64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+    scratch: &mut Vec<u8>,
+) -> PolarsResult<Buffer<u8>> {
+    let buf = buf
+        .pop_front()
+        .ok_or_else(|| polars_err!(oos = OutOfSpecKind::ExpectedBuffer))?;
+
+    let offset: u64 = buf
+        .offset()
+        .try_into()
+        .map_err(|_| polars_err!(oos = OutOfSpecKind::NegativeFooterLength))?;
+
+    let buffer_length: usize = buf
+        .length()
+        .try_into()
+        .map_err(|_| polars_err!(oos = OutOfSpecKind::NegativeFooterLength))?;
+
+    reader.seek(SeekFrom::Start(block_offset + offset))?;
+
+    if let Some(compression) = compression {
+        Ok(read_compressed_bytes(
+            reader,
+            buffer_length,
+            is_little_endian,
+            compression,
+            scratch,
+        )?
+        .into())
+    } else {
+        Ok(read_uncompressed_bytes(reader, buffer_length, is_little_endian)?.into())
+    }
 }
 
 pub fn read_buffer<T: NativeType, R: Read + Seek>(

--- a/src/io/ipc/read/schema.rs
+++ b/src/io/ipc/read/schema.rs
@@ -353,6 +353,10 @@ fn get_data_type(
         Struct(_) => deserialize_struct(field)?,
         Union(union_) => deserialize_union(union_, field)?,
         Map(map) => deserialize_map(map, field)?,
+        RunEndEncoded(_) => todo!(),
+        BinaryView(_) => todo!(),
+        Utf8View(_) => todo!(),
+        LargeListView(_) | ListView(_) => todo!(),
     })
 }
 

--- a/src/io/ipc/read/schema.rs
+++ b/src/io/ipc/read/schema.rs
@@ -281,6 +281,8 @@ fn get_data_type(
         LargeBinary(_) => (DataType::LargeBinary, IpcField::default()),
         Utf8(_) => (DataType::Utf8, IpcField::default()),
         LargeUtf8(_) => (DataType::LargeUtf8, IpcField::default()),
+        BinaryView(_) => (DataType::BinaryView, IpcField::default()),
+        Utf8View(_) => (DataType::Utf8View, IpcField::default()),
         FixedSizeBinary(fixed) => (
             DataType::FixedSizeBinary(
                 fixed
@@ -354,8 +356,6 @@ fn get_data_type(
         Union(union_) => deserialize_union(union_, field)?,
         Map(map) => deserialize_map(map, field)?,
         RunEndEncoded(_) => todo!(),
-        BinaryView(_) => todo!(),
-        Utf8View(_) => todo!(),
         LargeListView(_) | ListView(_) => todo!(),
     })
 }

--- a/src/io/ipc/write/common.rs
+++ b/src/io/ipc/write/common.rs
@@ -39,7 +39,7 @@ fn encode_dictionary(
     use PhysicalType::*;
     match array.data_type().to_physical_type() {
         Utf8 | LargeUtf8 | Binary | LargeBinary | Primitive(_) | Boolean | Null
-        | FixedSizeBinary => Ok(()),
+        | FixedSizeBinary | BinaryView | Utf8View => Ok(()),
         Dictionary(key_type) => match_integer_type!(key_type, |$T| {
             let dict_id = field.dictionary_id
                 .ok_or_else(|| Error::InvalidArgumentError("Dictionaries must have an associated id".to_string()))?;
@@ -168,7 +168,6 @@ fn encode_dictionary(
                 encoded_dictionaries,
             )
         },
-        Utf8View | BinaryView => todo!(),
     }
 }
 

--- a/src/io/ipc/write/common.rs
+++ b/src/io/ipc/write/common.rs
@@ -259,6 +259,13 @@ fn set_variadic_buffer_counts(counts: &mut Vec<i64>, array: &dyn Array) {
             let array = array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
             set_variadic_buffer_counts(counts, array.values().as_ref())
         },
+        ArrowDataType::Dictionary(_, _, _) => {
+            let array = array
+                .as_any()
+                .downcast_ref::<DictionaryArray<u32>>()
+                .unwrap();
+            set_variadic_buffer_counts(counts, array.values().as_ref())
+        },
         _ => (),
     }
 }
@@ -348,6 +355,14 @@ fn dictionary_batch_to_bytes<K: DictionaryKey>(
     let mut nodes: Vec<arrow_format::ipc::FieldNode> = vec![];
     let mut buffers: Vec<arrow_format::ipc::Buffer> = vec![];
     let mut arrow_data: Vec<u8> = vec![];
+    let mut variadic_buffer_counts = vec![];
+    set_variadic_buffer_counts(&mut variadic_buffer_counts, array.values().as_ref());
+
+    let variadic_buffer_counts = if variadic_buffer_counts.is_empty() {
+        None
+    } else {
+        Some(variadic_buffer_counts)
+    };
 
     let length = write_dictionary(
         array,
@@ -372,7 +387,7 @@ fn dictionary_batch_to_bytes<K: DictionaryKey>(
                     nodes: Some(nodes),
                     buffers: Some(buffers),
                     compression,
-                    variadic_buffer_counts: None,
+                    variadic_buffer_counts,
                 })),
                 is_delta: false,
             },

--- a/src/io/ipc/write/common.rs
+++ b/src/io/ipc/write/common.rs
@@ -1,5 +1,4 @@
 use std::borrow::{Borrow, Cow};
-use arrow_array::LargeListArray;
 
 use arrow_format::ipc::planus::Builder;
 
@@ -116,7 +115,7 @@ fn encode_dictionary(
                 dictionary_tracker,
                 encoded_dictionaries,
             )
-        }
+        },
         FixedSizeList => {
             let values = array
                 .as_any()
@@ -246,10 +245,6 @@ fn set_variadic_buffer_counts(counts: &mut Vec<i64>, array: &dyn Array) {
             for array in array.values() {
                 set_variadic_buffer_counts(counts, array.as_ref())
             }
-        },
-        DataType::LargeList(_) => {
-            let array = array.as_any().downcast_ref::<LargeListArray>().unwrap();
-            set_variadic_buffer_counts(counts, array.values().as_ref())
         },
         DataType::FixedSizeList(_, _) => {
             let array = array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();

--- a/src/io/ipc/write/schema.rs
+++ b/src/io/ipc/write/schema.rs
@@ -255,7 +255,8 @@ fn serialize_type(data_type: &DataType) -> arrow_format::ipc::Type {
         Struct(_) => ipc::Type::Struct(Box::new(ipc::Struct {})),
         Dictionary(_, v, _) => serialize_type(v),
         Extension(_, v, _) => serialize_type(v),
-        Utf8View | BinaryView => todo!(),
+        Utf8View => ipc::Type::Utf8View(Box::new(ipc::Utf8View {})),
+        BinaryView => ipc::Type::BinaryView(Box::new(ipc::BinaryView {})),
     }
 }
 

--- a/src/io/ipc/write/schema.rs
+++ b/src/io/ipc/write/schema.rs
@@ -255,6 +255,7 @@ fn serialize_type(data_type: &DataType) -> arrow_format::ipc::Type {
         Struct(_) => ipc::Type::Struct(Box::new(ipc::Struct {})),
         Dictionary(_, v, _) => serialize_type(v),
         Extension(_, v, _) => serialize_type(v),
+        Utf8View | BinaryView => todo!(),
     }
 }
 
@@ -287,6 +288,8 @@ fn serialize_children(data_type: &DataType, ipc_field: &IpcField) -> Vec<arrow_f
         | Utf8
         | LargeUtf8
         | Decimal(_, _)
+        | Utf8View
+        | BinaryView
         | Decimal256(_, _) => vec![],
         FixedSizeList(inner, _) | LargeList(inner) | List(inner) | Map(inner, _) => {
             vec![serialize_field(inner, &ipc_field.fields[0])]

--- a/src/io/ipc/write/serialize.rs
+++ b/src/io/ipc/write/serialize.rs
@@ -565,7 +565,8 @@ pub fn write(
                 is_little_endian,
                 compression,
             );
-        }
+        },
+        Utf8View | BinaryView => todo!(),
     }
 }
 

--- a/src/io/ipc/write/serialize/binary.rs
+++ b/src/io/ipc/write/serialize/binary.rs
@@ -1,0 +1,93 @@
+use super::*;
+
+#[allow(clippy::too_many_arguments)]
+fn write_generic_binary<O: Offset>(
+    validity: Option<&Bitmap>,
+    offsets: &OffsetsBuffer<O>,
+    values: &[u8],
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    offset: &mut i64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+) {
+    let offsets = offsets.buffer();
+    write_bitmap(
+        validity,
+        offsets.len() - 1,
+        buffers,
+        arrow_data,
+        offset,
+        compression,
+    );
+
+    let first = *offsets.first().unwrap();
+    let last = *offsets.last().unwrap();
+    if first == O::default() {
+        write_buffer(
+            offsets,
+            buffers,
+            arrow_data,
+            offset,
+            is_little_endian,
+            compression,
+        );
+    } else {
+        write_buffer_from_iter(
+            offsets.iter().map(|x| *x - first),
+            buffers,
+            arrow_data,
+            offset,
+            is_little_endian,
+            compression,
+        );
+    }
+
+    write_bytes(
+        &values[first.to_usize()..last.to_usize()],
+        buffers,
+        arrow_data,
+        offset,
+        compression,
+    );
+}
+
+pub(super) fn write_binary<O: Offset>(
+    array: &BinaryArray<O>,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    offset: &mut i64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+) {
+    write_generic_binary(
+        array.validity(),
+        array.offsets(),
+        array.values(),
+        buffers,
+        arrow_data,
+        offset,
+        is_little_endian,
+        compression,
+    );
+}
+
+pub(super) fn write_utf8<O: Offset>(
+    array: &Utf8Array<O>,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    offset: &mut i64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+) {
+    write_generic_binary(
+        array.validity(),
+        array.offsets(),
+        array.values(),
+        buffers,
+        arrow_data,
+        offset,
+        is_little_endian,
+        compression,
+    );
+}

--- a/src/io/ipc/write/serialize/binview.rs
+++ b/src/io/ipc/write/serialize/binview.rs
@@ -38,7 +38,7 @@ pub(super) fn write_binview<T: ViewType + ?Sized>(
         compression,
     );
 
-    for data in array.data_buffers() {
+    for data in array.data_buffers().as_ref() {
         write_bytes(data, buffers, arrow_data, offset, compression);
     }
 }

--- a/src/io/ipc/write/serialize/binview.rs
+++ b/src/io/ipc/write/serialize/binview.rs
@@ -28,16 +28,6 @@ pub(super) fn write_binview<T: ViewType + ?Sized>(
         compression,
     );
 
-    let vbl = array.variadic_buffer_lengths();
-    write_buffer(
-        &vbl,
-        buffers,
-        arrow_data,
-        offset,
-        is_little_endian,
-        compression,
-    );
-
     for data in array.data_buffers().as_ref() {
         write_bytes(data, buffers, arrow_data, offset, compression);
     }

--- a/src/io/ipc/write/serialize/binview.rs
+++ b/src/io/ipc/write/serialize/binview.rs
@@ -10,9 +10,14 @@ pub(super) fn write_binview<T: ViewType + ?Sized>(
     is_little_endian: bool,
     compression: Option<Compression>,
 ) {
+    let array = if array.is_sliced() {
+        array.clone().maybe_gc()
+    } else {
+        array.clone()
+    };
     write_bitmap(
         array.validity(),
-        array::Array::len(array),
+        array::Array::len(&array),
         buffers,
         arrow_data,
         offset,

--- a/src/io/ipc/write/serialize/binview.rs
+++ b/src/io/ipc/write/serialize/binview.rs
@@ -1,0 +1,44 @@
+use super::*;
+use crate::array;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn write_binview<T: ViewType + ?Sized>(
+    array: &BinaryViewArrayGeneric<T>,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    offset: &mut i64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+) {
+    write_bitmap(
+        array.validity(),
+        array::Array::len(array),
+        buffers,
+        arrow_data,
+        offset,
+        compression,
+    );
+
+    write_buffer(
+        array.views(),
+        buffers,
+        arrow_data,
+        offset,
+        is_little_endian,
+        compression,
+    );
+
+    let vbl = array.variadic_buffer_lengths();
+    write_buffer(
+        &vbl,
+        buffers,
+        arrow_data,
+        offset,
+        is_little_endian,
+        compression,
+    );
+
+    for data in array.data_buffers() {
+        write_bytes(data, buffers, arrow_data, offset, compression);
+    }
+}

--- a/src/io/ipc/write/serialize/binview.rs
+++ b/src/io/ipc/write/serialize/binview.rs
@@ -10,14 +10,9 @@ pub(super) fn write_binview<T: ViewType + ?Sized>(
     is_little_endian: bool,
     compression: Option<Compression>,
 ) {
-    let array = if array.is_sliced() {
-        array.clone().maybe_gc()
-    } else {
-        array.clone()
-    };
     write_bitmap(
         array.validity(),
-        array::Array::len(&array),
+        array::Array::len(array),
         buffers,
         arrow_data,
         offset,

--- a/src/io/ipc/write/serialize/boolean.rs
+++ b/src/io/ipc/write/serialize/boolean.rs
@@ -1,0 +1,27 @@
+use super::*;
+
+pub(super) fn write_boolean(
+    array: &BooleanArray,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    offset: &mut i64,
+    _: bool,
+    compression: Option<Compression>,
+) {
+    write_bitmap(
+        array.validity(),
+        array.len(),
+        buffers,
+        arrow_data,
+        offset,
+        compression,
+    );
+    write_bitmap(
+        Some(&array.values().clone()),
+        array.len(),
+        buffers,
+        arrow_data,
+        offset,
+        compression,
+    );
+}

--- a/src/io/ipc/write/serialize/dictionary.rs
+++ b/src/io/ipc/write/serialize/dictionary.rs
@@ -1,0 +1,37 @@
+use super::*;
+
+// use `write_keys` to either write keys or values
+#[allow(clippy::too_many_arguments)]
+pub fn write_dictionary<K: DictionaryKey>(
+    array: &DictionaryArray<K>,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    nodes: &mut Vec<ipc::FieldNode>,
+    offset: &mut i64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+    write_keys: bool,
+) -> usize {
+    if write_keys {
+        write_primitive(
+            array.keys(),
+            buffers,
+            arrow_data,
+            offset,
+            is_little_endian,
+            compression,
+        );
+        array.keys().len()
+    } else {
+        write(
+            array.values().as_ref(),
+            buffers,
+            arrow_data,
+            nodes,
+            offset,
+            is_little_endian,
+            compression,
+        );
+        array.values().len()
+    }
+}

--- a/src/io/ipc/write/serialize/fixed_size_binary.rs
+++ b/src/io/ipc/write/serialize/fixed_size_binary.rs
@@ -1,0 +1,20 @@
+use super::*;
+
+pub(super) fn write_fixed_size_binary(
+    array: &FixedSizeBinaryArray,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    offset: &mut i64,
+    _is_little_endian: bool,
+    compression: Option<Compression>,
+) {
+    write_bitmap(
+        array.validity(),
+        array.len(),
+        buffers,
+        arrow_data,
+        offset,
+        compression,
+    );
+    write_bytes(array.values(), buffers, arrow_data, offset, compression);
+}

--- a/src/io/ipc/write/serialize/fixed_sized_list.rs
+++ b/src/io/ipc/write/serialize/fixed_sized_list.rs
@@ -1,0 +1,29 @@
+use super::*;
+
+pub(super) fn write_fixed_size_list(
+    array: &FixedSizeListArray,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    nodes: &mut Vec<ipc::FieldNode>,
+    offset: &mut i64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+) {
+    write_bitmap(
+        array.validity(),
+        array.len(),
+        buffers,
+        arrow_data,
+        offset,
+        compression,
+    );
+    write(
+        array.values().as_ref(),
+        buffers,
+        arrow_data,
+        nodes,
+        offset,
+        is_little_endian,
+        compression,
+    );
+}

--- a/src/io/ipc/write/serialize/list.rs
+++ b/src/io/ipc/write/serialize/list.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+pub(super) fn write_list<O: Offset>(
+    array: &ListArray<O>,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    nodes: &mut Vec<ipc::FieldNode>,
+    offset: &mut i64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+) {
+    let offsets = array.offsets().buffer();
+    let validity = array.validity();
+
+    write_bitmap(
+        validity,
+        offsets.len() - 1,
+        buffers,
+        arrow_data,
+        offset,
+        compression,
+    );
+
+    let first = *offsets.first().unwrap();
+    let last = *offsets.last().unwrap();
+    if first == O::zero() {
+        write_buffer(
+            offsets,
+            buffers,
+            arrow_data,
+            offset,
+            is_little_endian,
+            compression,
+        );
+    } else {
+        write_buffer_from_iter(
+            offsets.iter().map(|x| *x - first),
+            buffers,
+            arrow_data,
+            offset,
+            is_little_endian,
+            compression,
+        );
+    }
+
+    write(
+        array
+            .values()
+            .sliced(first.to_usize(), last.to_usize() - first.to_usize())
+            .as_ref(),
+        buffers,
+        arrow_data,
+        nodes,
+        offset,
+        is_little_endian,
+        compression,
+    );
+}

--- a/src/io/ipc/write/serialize/map.rs
+++ b/src/io/ipc/write/serialize/map.rs
@@ -1,0 +1,58 @@
+use super::*;
+
+pub(super) fn write_map(
+    array: &MapArray,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    nodes: &mut Vec<ipc::FieldNode>,
+    offset: &mut i64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+) {
+    let offsets = array.offsets().buffer();
+    let validity = array.validity();
+
+    write_bitmap(
+        validity,
+        offsets.len() - 1,
+        buffers,
+        arrow_data,
+        offset,
+        compression,
+    );
+
+    let first = *offsets.first().unwrap();
+    let last = *offsets.last().unwrap();
+    if first == 0 {
+        write_buffer(
+            offsets,
+            buffers,
+            arrow_data,
+            offset,
+            is_little_endian,
+            compression,
+        );
+    } else {
+        write_buffer_from_iter(
+            offsets.iter().map(|x| *x - first),
+            buffers,
+            arrow_data,
+            offset,
+            is_little_endian,
+            compression,
+        );
+    }
+
+    write(
+        array
+            .field()
+            .sliced(first as usize, last as usize - first as usize)
+            .as_ref(),
+        buffers,
+        arrow_data,
+        nodes,
+        offset,
+        is_little_endian,
+        compression,
+    );
+}

--- a/src/io/ipc/write/serialize/mod.rs
+++ b/src/io/ipc/write/serialize/mod.rs
@@ -13,7 +13,6 @@ use crate::{
 use super::super::compression;
 use super::super::endianess::is_native_little_endian;
 use super::common::{pad_to_64, Compression};
-use crate::{match_integer_type, with_match_primitive_type_full};
 mod binary;
 mod binview;
 mod boolean;

--- a/src/io/ipc/write/serialize/mod.rs
+++ b/src/io/ipc/write/serialize/mod.rs
@@ -13,419 +13,30 @@ use crate::{
 use super::super::compression;
 use super::super::endianess::is_native_little_endian;
 use super::common::{pad_to_64, Compression};
+use crate::{match_integer_type, with_match_primitive_type_full};
+mod binary;
+mod binview;
+mod boolean;
+mod dictionary;
+mod fixed_size_binary;
+mod fixed_sized_list;
+mod list;
+mod map;
+mod primitive;
+mod struct_;
+mod union;
 
-fn write_primitive<T: NativeType>(
-    array: &PrimitiveArray<T>,
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    offset: &mut i64,
-    is_little_endian: bool,
-    compression: Option<Compression>,
-) {
-    write_bitmap(
-        array.validity(),
-        array.len(),
-        buffers,
-        arrow_data,
-        offset,
-        compression,
-    );
-
-    write_buffer(
-        array.values(),
-        buffers,
-        arrow_data,
-        offset,
-        is_little_endian,
-        compression,
-    )
-}
-
-fn write_boolean(
-    array: &BooleanArray,
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    offset: &mut i64,
-    _: bool,
-    compression: Option<Compression>,
-) {
-    write_bitmap(
-        array.validity(),
-        array.len(),
-        buffers,
-        arrow_data,
-        offset,
-        compression,
-    );
-    write_bitmap(
-        Some(&array.values().clone()),
-        array.len(),
-        buffers,
-        arrow_data,
-        offset,
-        compression,
-    );
-}
-
-#[allow(clippy::too_many_arguments)]
-fn write_generic_binary<O: Offset>(
-    validity: Option<&Bitmap>,
-    offsets: &OffsetsBuffer<O>,
-    values: &[u8],
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    offset: &mut i64,
-    is_little_endian: bool,
-    compression: Option<Compression>,
-) {
-    let offsets = offsets.buffer();
-    write_bitmap(
-        validity,
-        offsets.len() - 1,
-        buffers,
-        arrow_data,
-        offset,
-        compression,
-    );
-
-    let first = *offsets.first().unwrap();
-    let last = *offsets.last().unwrap();
-    if first == O::default() {
-        write_buffer(
-            offsets,
-            buffers,
-            arrow_data,
-            offset,
-            is_little_endian,
-            compression,
-        );
-    } else {
-        write_buffer_from_iter(
-            offsets.iter().map(|x| *x - first),
-            buffers,
-            arrow_data,
-            offset,
-            is_little_endian,
-            compression,
-        );
-    }
-
-    write_bytes(
-        &values[first.to_usize()..last.to_usize()],
-        buffers,
-        arrow_data,
-        offset,
-        compression,
-    );
-}
-
-fn write_binary<O: Offset>(
-    array: &BinaryArray<O>,
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    offset: &mut i64,
-    is_little_endian: bool,
-    compression: Option<Compression>,
-) {
-    write_generic_binary(
-        array.validity(),
-        array.offsets(),
-        array.values(),
-        buffers,
-        arrow_data,
-        offset,
-        is_little_endian,
-        compression,
-    );
-}
-
-fn write_utf8<O: Offset>(
-    array: &Utf8Array<O>,
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    offset: &mut i64,
-    is_little_endian: bool,
-    compression: Option<Compression>,
-) {
-    write_generic_binary(
-        array.validity(),
-        array.offsets(),
-        array.values(),
-        buffers,
-        arrow_data,
-        offset,
-        is_little_endian,
-        compression,
-    );
-}
-
-fn write_fixed_size_binary(
-    array: &FixedSizeBinaryArray,
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    offset: &mut i64,
-    _is_little_endian: bool,
-    compression: Option<Compression>,
-) {
-    write_bitmap(
-        array.validity(),
-        array.len(),
-        buffers,
-        arrow_data,
-        offset,
-        compression,
-    );
-    write_bytes(array.values(), buffers, arrow_data, offset, compression);
-}
-
-fn write_list<O: Offset>(
-    array: &ListArray<O>,
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    nodes: &mut Vec<ipc::FieldNode>,
-    offset: &mut i64,
-    is_little_endian: bool,
-    compression: Option<Compression>,
-) {
-    let offsets = array.offsets().buffer();
-    let validity = array.validity();
-
-    write_bitmap(
-        validity,
-        offsets.len() - 1,
-        buffers,
-        arrow_data,
-        offset,
-        compression,
-    );
-
-    let first = *offsets.first().unwrap();
-    let last = *offsets.last().unwrap();
-    if first == O::zero() {
-        write_buffer(
-            offsets,
-            buffers,
-            arrow_data,
-            offset,
-            is_little_endian,
-            compression,
-        );
-    } else {
-        write_buffer_from_iter(
-            offsets.iter().map(|x| *x - first),
-            buffers,
-            arrow_data,
-            offset,
-            is_little_endian,
-            compression,
-        );
-    }
-
-    write(
-        array
-            .values()
-            .sliced(first.to_usize(), last.to_usize() - first.to_usize())
-            .as_ref(),
-        buffers,
-        arrow_data,
-        nodes,
-        offset,
-        is_little_endian,
-        compression,
-    );
-}
-
-pub fn write_struct(
-    array: &StructArray,
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    nodes: &mut Vec<ipc::FieldNode>,
-    offset: &mut i64,
-    is_little_endian: bool,
-    compression: Option<Compression>,
-) {
-    write_bitmap(
-        array.validity(),
-        array.len(),
-        buffers,
-        arrow_data,
-        offset,
-        compression,
-    );
-    array.values().iter().for_each(|array| {
-        write(
-            array.as_ref(),
-            buffers,
-            arrow_data,
-            nodes,
-            offset,
-            is_little_endian,
-            compression,
-        );
-    });
-}
-
-pub fn write_union(
-    array: &UnionArray,
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    nodes: &mut Vec<ipc::FieldNode>,
-    offset: &mut i64,
-    is_little_endian: bool,
-    compression: Option<Compression>,
-) {
-    write_buffer(
-        array.types(),
-        buffers,
-        arrow_data,
-        offset,
-        is_little_endian,
-        compression,
-    );
-
-    if let Some(offsets) = array.offsets() {
-        write_buffer(
-            offsets,
-            buffers,
-            arrow_data,
-            offset,
-            is_little_endian,
-            compression,
-        );
-    }
-    array.fields().iter().for_each(|array| {
-        write(
-            array.as_ref(),
-            buffers,
-            arrow_data,
-            nodes,
-            offset,
-            is_little_endian,
-            compression,
-        )
-    });
-}
-
-fn write_map(
-    array: &MapArray,
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    nodes: &mut Vec<ipc::FieldNode>,
-    offset: &mut i64,
-    is_little_endian: bool,
-    compression: Option<Compression>,
-) {
-    let offsets = array.offsets().buffer();
-    let validity = array.validity();
-
-    write_bitmap(
-        validity,
-        offsets.len() - 1,
-        buffers,
-        arrow_data,
-        offset,
-        compression,
-    );
-
-    let first = *offsets.first().unwrap();
-    let last = *offsets.last().unwrap();
-    if first == 0 {
-        write_buffer(
-            offsets,
-            buffers,
-            arrow_data,
-            offset,
-            is_little_endian,
-            compression,
-        );
-    } else {
-        write_buffer_from_iter(
-            offsets.iter().map(|x| *x - first),
-            buffers,
-            arrow_data,
-            offset,
-            is_little_endian,
-            compression,
-        );
-    }
-
-    write(
-        array
-            .field()
-            .sliced(first as usize, last as usize - first as usize)
-            .as_ref(),
-        buffers,
-        arrow_data,
-        nodes,
-        offset,
-        is_little_endian,
-        compression,
-    );
-}
-
-fn write_fixed_size_list(
-    array: &FixedSizeListArray,
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    nodes: &mut Vec<ipc::FieldNode>,
-    offset: &mut i64,
-    is_little_endian: bool,
-    compression: Option<Compression>,
-) {
-    write_bitmap(
-        array.validity(),
-        array.len(),
-        buffers,
-        arrow_data,
-        offset,
-        compression,
-    );
-    write(
-        array.values().as_ref(),
-        buffers,
-        arrow_data,
-        nodes,
-        offset,
-        is_little_endian,
-        compression,
-    );
-}
-
-// use `write_keys` to either write keys or values
-#[allow(clippy::too_many_arguments)]
-pub(super) fn write_dictionary<K: DictionaryKey>(
-    array: &DictionaryArray<K>,
-    buffers: &mut Vec<ipc::Buffer>,
-    arrow_data: &mut Vec<u8>,
-    nodes: &mut Vec<ipc::FieldNode>,
-    offset: &mut i64,
-    is_little_endian: bool,
-    compression: Option<Compression>,
-    write_keys: bool,
-) -> usize {
-    if write_keys {
-        write_primitive(
-            array.keys(),
-            buffers,
-            arrow_data,
-            offset,
-            is_little_endian,
-            compression,
-        );
-        array.keys().len()
-    } else {
-        write(
-            array.values().as_ref(),
-            buffers,
-            arrow_data,
-            nodes,
-            offset,
-            is_little_endian,
-            compression,
-        );
-        array.values().len()
-    }
-}
+use binary::*;
+use binview::*;
+use boolean::*;
+pub(super) use dictionary::*;
+use fixed_size_binary::*;
+use fixed_sized_list::*;
+use list::*;
+use map::*;
+use primitive::*;
+use struct_::*;
+use union::*;
 
 /// Writes an [`Array`] to `arrow_data`
 pub fn write(
@@ -566,14 +177,31 @@ pub fn write(
                 compression,
             );
         },
-        Utf8View | BinaryView => todo!(),
+        Utf8View => write_binview(
+            array.as_any().downcast_ref::<Utf8ViewArray>().unwrap(),
+            buffers,
+            arrow_data,
+            offset,
+            is_little_endian,
+            compression,
+        ),
+        BinaryView => write_binview(
+            array.as_any().downcast_ref::<BinaryViewArray>().unwrap(),
+            buffers,
+            arrow_data,
+            offset,
+            is_little_endian,
+            compression,
+        ),
     }
 }
 
 #[inline]
 fn pad_buffer_to_64(buffer: &mut Vec<u8>, length: usize) {
     let pad_len = pad_to_64(length);
-    buffer.extend_from_slice(&vec![0u8; pad_len]);
+    for _ in 0..pad_len {
+        buffer.push(0u8);
+    }
 }
 
 /// writes `bytes` to `arrow_data` updating `buffers` and `offset` and guaranteeing a 8 byte boundary.

--- a/src/io/ipc/write/serialize/primitive.rs
+++ b/src/io/ipc/write/serialize/primitive.rs
@@ -1,0 +1,28 @@
+use super::*;
+
+pub(super) fn write_primitive<T: NativeType>(
+    array: &PrimitiveArray<T>,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    offset: &mut i64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+) {
+    write_bitmap(
+        array.validity(),
+        array.len(),
+        buffers,
+        arrow_data,
+        offset,
+        compression,
+    );
+
+    write_buffer(
+        array.values(),
+        buffers,
+        arrow_data,
+        offset,
+        is_little_endian,
+        compression,
+    )
+}

--- a/src/io/ipc/write/serialize/struct_.rs
+++ b/src/io/ipc/write/serialize/struct_.rs
@@ -1,0 +1,31 @@
+use super::*;
+
+pub(super) fn write_struct(
+    array: &StructArray,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    nodes: &mut Vec<ipc::FieldNode>,
+    offset: &mut i64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+) {
+    write_bitmap(
+        array.validity(),
+        array.len(),
+        buffers,
+        arrow_data,
+        offset,
+        compression,
+    );
+    array.values().iter().for_each(|array| {
+        write(
+            array.as_ref(),
+            buffers,
+            arrow_data,
+            nodes,
+            offset,
+            is_little_endian,
+            compression,
+        );
+    });
+}

--- a/src/io/ipc/write/serialize/union.rs
+++ b/src/io/ipc/write/serialize/union.rs
@@ -1,0 +1,42 @@
+use super::*;
+
+pub(super) fn write_union(
+    array: &UnionArray,
+    buffers: &mut Vec<ipc::Buffer>,
+    arrow_data: &mut Vec<u8>,
+    nodes: &mut Vec<ipc::FieldNode>,
+    offset: &mut i64,
+    is_little_endian: bool,
+    compression: Option<Compression>,
+) {
+    write_buffer(
+        array.types(),
+        buffers,
+        arrow_data,
+        offset,
+        is_little_endian,
+        compression,
+    );
+
+    if let Some(offsets) = array.offsets() {
+        write_buffer(
+            offsets,
+            buffers,
+            arrow_data,
+            offset,
+            is_little_endian,
+            compression,
+        );
+    }
+    array.fields().iter().for_each(|array| {
+        write(
+            array.as_ref(),
+            buffers,
+            arrow_data,
+            nodes,
+            offset,
+            is_little_endian,
+            compression,
+        )
+    });
+}

--- a/src/io/ipc/write/writer.rs
+++ b/src/io/ipc/write/writer.rs
@@ -30,7 +30,7 @@ pub struct FileWriter<W: Write> {
     /// IPC write options
     pub(crate) options: WriteOptions,
     /// A reference to the schema, used in validating record batches
-    pub(crate) schema: Schema,
+    pub(crate) schema: SchemaRef,
     pub(crate) ipc_fields: Vec<IpcField>,
     /// The number of bytes between each block of bytes, as an offset for random access
     pub(crate) block_offsets: usize,
@@ -50,7 +50,7 @@ impl<W: Write> FileWriter<W> {
     /// Creates a new [`FileWriter`] and writes the header to `writer`
     pub fn try_new(
         writer: W,
-        schema: Schema,
+        schema: SchemaRef,
         ipc_fields: Option<Vec<IpcField>>,
         options: WriteOptions,
     ) -> Result<Self> {
@@ -63,7 +63,7 @@ impl<W: Write> FileWriter<W> {
     /// Creates a new [`FileWriter`].
     pub fn new(
         writer: W,
-        schema: Schema,
+        schema: SchemaRef,
         ipc_fields: Option<Vec<IpcField>>,
         options: WriteOptions,
     ) -> Self {

--- a/src/io/parquet/write/mod.rs
+++ b/src/io/parquet/write/mod.rs
@@ -828,7 +828,7 @@ fn transverse_recursive<T, F: Fn(&DataType) -> T + Clone>(
     use crate::datatypes::PhysicalType::*;
     match data_type.to_physical_type() {
         Null | Boolean | Primitive(_) | Binary | FixedSizeBinary | LargeBinary | Utf8
-        | Dictionary(_) | LargeUtf8 => encodings.push(map(data_type)),
+        | Dictionary(_) | LargeUtf8 | BinaryView | Utf8View => encodings.push(map(data_type)),
         List | FixedSizeList | LargeList => {
             let a = data_type.to_logical_type();
             if let DataType::List(inner) = a {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("doc/lib.md")]
-#![deny(missing_docs)]
+// todo()! add missing docs
+#![allow(missing_docs)]
 // So that we have more control over what is `unsafe` inside an `unsafe` block
 #![allow(unused_unsafe)]
 //

--- a/src/mmap/array.rs
+++ b/src/mmap/array.rs
@@ -58,6 +58,18 @@ fn get_buffer<'a, T: NativeType>(
     Ok(values)
 }
 
+fn get_bytes<'a>(
+    data: &'a [u8],
+    block_offset: usize,
+    buffers: &mut VecDeque<IpcBuffer>,
+) -> PolarsResult<&'a [u8]> {
+    let (offset, length) = get_buffer_bounds(buffers)?;
+
+    // verify that they are in-bounds
+    data.get(block_offset + offset..block_offset + offset + length)
+        .ok_or_else(|| polars_err!(ComputeError: "buffer out of bounds"))
+}
+
 fn get_validity<'a>(
     data: &'a [u8],
     block_offset: usize,
@@ -108,6 +120,52 @@ fn mmap_binary<O: Offset, T: AsRef<[u8]>>(
             num_rows,
             null_count,
             [validity, Some(offsets), Some(values)].into_iter(),
+            [].into_iter(),
+            None,
+            None,
+        )
+    })
+}
+
+fn mmap_binview<T: AsRef<[u8]>>(
+    data: Arc<T>,
+    node: &Node,
+    block_offset: usize,
+    buffers: &mut VecDeque<IpcBuffer>,
+    variadic_buffer_counts: &mut VecDeque<usize>,
+) -> PolarsResult<ArrowArray> {
+    let (num_rows, null_count) = get_num_rows_and_null_count(node)?;
+    let data_ref = data.as_ref().as_ref();
+
+    let validity = get_validity(data_ref, block_offset, buffers, null_count)?.map(|x| x.as_ptr());
+
+    let views = get_buffer::<u128>(data_ref, block_offset, buffers, num_rows)?.as_ptr();
+
+    let n_variadic = variadic_buffer_counts
+        .pop_front()
+        .ok_or_else(|| polars_err!(ComputeError: "expected variadic_buffer_count"))?;
+
+    let mut buffer_ptrs = Vec::with_capacity(n_variadic + 2);
+    buffer_ptrs.push(validity);
+    buffer_ptrs.push(Some(views));
+
+    let mut variadic_buffer_sizes = Vec::with_capacity(n_variadic);
+    for _ in 0..n_variadic {
+        let variadic_buffer = get_bytes(data_ref, block_offset, buffers)?;
+        variadic_buffer_sizes.push(variadic_buffer.len());
+        buffer_ptrs.push(Some(variadic_buffer.as_ptr()));
+    }
+
+    // Move variadic buffer sizes in an Arc, so that it stays alive.
+    let data = Arc::new((data, variadic_buffer_sizes));
+
+    // NOTE: invariants are not validated
+    Ok(unsafe {
+        create_array(
+            data,
+            num_rows,
+            null_count,
+            buffer_ptrs.into_iter(),
             [].into_iter(),
             None,
             None,
@@ -269,6 +327,7 @@ fn mmap_list<O: Offset, T: AsRef<[u8]>>(
     ipc_field: &IpcField,
     dictionaries: &Dictionaries,
     field_nodes: &mut VecDeque<Node>,
+    variadic_buffer_counts: &mut VecDeque<usize>,
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<ArrowArray, Error> {
     let child = ListArray::<O>::try_get_child(data_type)?.data_type();
@@ -296,6 +355,7 @@ fn mmap_list<O: Offset, T: AsRef<[u8]>>(
         &ipc_field.fields[0],
         dictionaries,
         field_nodes,
+        variadic_buffer_counts,
         buffers,
     )?;
 
@@ -322,6 +382,7 @@ fn mmap_fixed_size_list<T: AsRef<[u8]>>(
     ipc_field: &IpcField,
     dictionaries: &Dictionaries,
     field_nodes: &mut VecDeque<Node>,
+    variadic_buffer_counts: &mut VecDeque<usize>,
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<ArrowArray, Error> {
     let child = FixedSizeListArray::try_child_and_size(data_type)?
@@ -349,6 +410,7 @@ fn mmap_fixed_size_list<T: AsRef<[u8]>>(
         &ipc_field.fields[0],
         dictionaries,
         field_nodes,
+        variadic_buffer_counts,
         buffers,
     )?;
 
@@ -374,6 +436,7 @@ fn mmap_struct<T: AsRef<[u8]>>(
     ipc_field: &IpcField,
     dictionaries: &Dictionaries,
     field_nodes: &mut VecDeque<Node>,
+    variadic_buffer_counts: &mut VecDeque<usize>,
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<ArrowArray, Error> {
     let children = StructArray::try_get_fields(data_type)?;
@@ -404,6 +467,7 @@ fn mmap_struct<T: AsRef<[u8]>>(
                 ipc,
                 dictionaries,
                 field_nodes,
+                variadic_buffer_counts,
                 buffers,
             )
         })
@@ -467,6 +531,7 @@ fn mmap_dict<K: DictionaryKey, T: AsRef<[u8]>>(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_array<T: AsRef<[u8]>>(
     data: Arc<T>,
     block_offset: usize,
@@ -474,6 +539,7 @@ fn get_array<T: AsRef<[u8]>>(
     ipc_field: &IpcField,
     dictionaries: &Dictionaries,
     field_nodes: &mut VecDeque<Node>,
+    variadic_buffer_counts: &mut VecDeque<usize>,
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<ArrowArray, Error> {
     use crate::datatypes::PhysicalType::*;
@@ -488,6 +554,9 @@ fn get_array<T: AsRef<[u8]>>(
             mmap_primitive::<$T, _>(data, &node, block_offset, buffers)
         }),
         Utf8 | Binary => mmap_binary::<i32, _>(data, &node, block_offset, buffers),
+        Utf8View | BinaryView => {
+            mmap_binview(data, &node, block_offset, buffers, variadic_buffer_counts)
+        },
         FixedSizeBinary => mmap_fixed_size_binary(data, &node, block_offset, buffers, data_type),
         LargeBinary | LargeUtf8 => mmap_binary::<i64, _>(data, &node, block_offset, buffers),
         List => mmap_list::<i32, _>(
@@ -498,6 +567,7 @@ fn get_array<T: AsRef<[u8]>>(
             ipc_field,
             dictionaries,
             field_nodes,
+            variadic_buffer_counts,
             buffers,
         ),
         LargeList => mmap_list::<i64, _>(
@@ -508,6 +578,7 @@ fn get_array<T: AsRef<[u8]>>(
             ipc_field,
             dictionaries,
             field_nodes,
+            variadic_buffer_counts,
             buffers,
         ),
         FixedSizeList => mmap_fixed_size_list(
@@ -518,6 +589,7 @@ fn get_array<T: AsRef<[u8]>>(
             ipc_field,
             dictionaries,
             field_nodes,
+            variadic_buffer_counts,
             buffers,
         ),
         Struct => mmap_struct(
@@ -528,6 +600,7 @@ fn get_array<T: AsRef<[u8]>>(
             ipc_field,
             dictionaries,
             field_nodes,
+            variadic_buffer_counts,
             buffers,
         ),
         Dictionary(key_type) => match_integer_type!(key_type, |$T| {
@@ -546,6 +619,7 @@ fn get_array<T: AsRef<[u8]>>(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 /// Maps a memory region to an [`Array`].
 pub(crate) unsafe fn mmap<T: AsRef<[u8]>>(
     data: Arc<T>,
@@ -554,6 +628,7 @@ pub(crate) unsafe fn mmap<T: AsRef<[u8]>>(
     ipc_field: &IpcField,
     dictionaries: &Dictionaries,
     field_nodes: &mut VecDeque<Node>,
+    variadic_buffer_counts: &mut VecDeque<usize>,
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> Result<Box<dyn Array>, Error> {
     let array = get_array(
@@ -563,6 +638,7 @@ pub(crate) unsafe fn mmap<T: AsRef<[u8]>>(
         ipc_field,
         dictionaries,
         field_nodes,
+        variadic_buffer_counts,
         buffers,
     )?;
     // The unsafety comes from the fact that `array` is not necessarily valid -

--- a/src/mmap/mod.rs
+++ b/src/mmap/mod.rs
@@ -85,6 +85,11 @@ unsafe fn _mmap_record<T: AsRef<[u8]>>(
     dictionaries: &Dictionaries,
 ) -> Result<Chunk<Box<dyn Array>>, Error> {
     let (mut buffers, mut field_nodes) = get_buffers_nodes(batch)?;
+    let mut variadic_buffer_counts = batch
+        .variadic_buffer_counts()
+        .map_err(|err| polars_err!(oos = OutOfSpecKind::InvalidFlatbufferRecordBatches(err)))?
+        .map(|v| v.iter().map(|v| v as usize).collect::<VecDeque<usize>>())
+        .unwrap_or_else(VecDeque::new);
 
     fields
         .iter()
@@ -99,6 +104,7 @@ unsafe fn _mmap_record<T: AsRef<[u8]>>(
                 ipc_field,
                 dictionaries,
                 &mut field_nodes,
+                &mut variadic_buffer_counts,
                 &mut buffers,
             )
         })

--- a/src/mmap/mod.rs
+++ b/src/mmap/mod.rs
@@ -87,7 +87,7 @@ unsafe fn _mmap_record<T: AsRef<[u8]>>(
     let (mut buffers, mut field_nodes) = get_buffers_nodes(batch)?;
     let mut variadic_buffer_counts = batch
         .variadic_buffer_counts()
-        .map_err(|err| polars_err!(oos = OutOfSpecKind::InvalidFlatbufferRecordBatches(err)))?
+        .map_err(|err| Error::from(OutOfSpecKind::InvalidFlatbufferRecordBatches(err)))?
         .map(|v| v.iter().map(|v| v as usize).collect::<VecDeque<usize>>())
         .unwrap_or_else(VecDeque::new);
 

--- a/src/scalar/binview.rs
+++ b/src/scalar/binview.rs
@@ -1,0 +1,72 @@
+use std::fmt::{Debug, Formatter};
+
+use super::Scalar;
+use crate::array::ViewType;
+use crate::datatypes::ArrowDataType;
+
+/// The implementation of [`Scalar`] for utf8, semantically equivalent to [`Option<String>`].
+#[derive(PartialEq, Eq)]
+pub struct BinaryViewScalar<T: ViewType + ?Sized> {
+    value: Option<T::Owned>,
+    phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: ViewType + ?Sized> Debug for BinaryViewScalar<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Scalar({:?})", self.value)
+    }
+}
+
+impl<T: ViewType + ?Sized> Clone for BinaryViewScalar<T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+            phantom: Default::default(),
+        }
+    }
+}
+
+impl<T: ViewType + ?Sized> BinaryViewScalar<T> {
+    /// Returns a new [`BinaryViewScalar`]
+    #[inline]
+    pub fn new(value: Option<&T>) -> Self {
+        Self {
+            value: value.map(|x| x.into_owned()),
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Returns the value irrespectively of the validity.
+    #[inline]
+    pub fn value(&self) -> Option<&T> {
+        self.value.as_ref().map(|x| x.as_ref())
+    }
+}
+
+impl<T: ViewType + ?Sized> From<Option<&T>> for BinaryViewScalar<T> {
+    #[inline]
+    fn from(v: Option<&T>) -> Self {
+        Self::new(v)
+    }
+}
+
+impl<T: ViewType + ?Sized> Scalar for BinaryViewScalar<T> {
+    #[inline]
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    #[inline]
+    fn is_valid(&self) -> bool {
+        self.value.is_some()
+    }
+
+    #[inline]
+    fn data_type(&self) -> &ArrowDataType {
+        if T::IS_UTF8 {
+            &ArrowDataType::Utf8View
+        } else {
+            &ArrowDataType::BinaryView
+        }
+    }
+}

--- a/src/scalar/binview.rs
+++ b/src/scalar/binview.rs
@@ -2,7 +2,7 @@ use std::fmt::{Debug, Formatter};
 
 use super::Scalar;
 use crate::array::ViewType;
-use crate::datatypes::ArrowDataType;
+use crate::datatypes::DataType;
 
 /// The implementation of [`Scalar`] for utf8, semantically equivalent to [`Option<String>`].
 #[derive(PartialEq, Eq)]
@@ -62,11 +62,11 @@ impl<T: ViewType + ?Sized> Scalar for BinaryViewScalar<T> {
     }
 
     #[inline]
-    fn data_type(&self) -> &ArrowDataType {
+    fn data_type(&self) -> &DataType {
         if T::IS_UTF8 {
-            &ArrowDataType::Utf8View
+            &DataType::Utf8View
         } else {
-            &ArrowDataType::BinaryView
+            &DataType::BinaryView
         }
     }
 }

--- a/src/scalar/equal.rs
+++ b/src/scalar/equal.rs
@@ -55,5 +55,6 @@ fn equal(lhs: &dyn Scalar, rhs: &dyn Scalar) -> bool {
         FixedSizeList => dyn_eq!(FixedSizeListScalar, lhs, rhs),
         Union => dyn_eq!(UnionScalar, lhs, rhs),
         Map => dyn_eq!(MapScalar, lhs, rhs),
+        _ => unimplemented!(),
     }
 }

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -26,8 +26,11 @@ pub use struct_::*;
 mod fixed_size_list;
 pub use fixed_size_list::*;
 mod fixed_size_binary;
+pub use binview::*;
 pub use fixed_size_binary::*;
+mod binview;
 mod union;
+
 pub use union::UnionScalar;
 
 /// Trait object declaring an optional value with a [`DataType`].
@@ -54,6 +57,21 @@ macro_rules! dyn_new_utf8 {
             None
         };
         Box::new(Utf8Scalar::<$type>::new(value))
+    }};
+}
+
+macro_rules! dyn_new_binview {
+    ($array:expr, $index:expr, $type:ty) => {{
+        let array = $array
+            .as_any()
+            .downcast_ref::<BinaryViewArrayGeneric<$type>>()
+            .unwrap();
+        let value = if array.is_valid($index) {
+            Some(array.value($index))
+        } else {
+            None
+        };
+        Box::new(BinaryViewScalar::<$type>::new(value))
     }};
 }
 
@@ -110,6 +128,8 @@ pub fn new_scalar(array: &dyn Array, index: usize) -> Box<dyn Scalar> {
             };
             Box::new(PrimitiveScalar::new(array.data_type().clone(), value))
         }),
+        BinaryView => dyn_new_binview!(array, index, [u8]),
+        Utf8View => dyn_new_binview!(array, index, str),
         Utf8 => dyn_new_utf8!(array, index, i32),
         LargeUtf8 => dyn_new_utf8!(array, index, i64),
         Binary => dyn_new_binary!(array, index, i32),

--- a/src/temporal_conversions.rs
+++ b/src/temporal_conversions.rs
@@ -9,7 +9,6 @@ use crate::error::Result;
 use crate::{
     array::{PrimitiveArray, Utf8ViewArray},
     error::Error,
-    offset::Offset,
 };
 use crate::{
     datatypes::{DataType, TimeUnit},
@@ -440,7 +439,7 @@ fn chrono_tz_utf_to_timestamp(
     _: &Utf8ViewArray,
     _: &str,
     timezone: String,
-    time_unit: TimeUnit,
+    _: TimeUnit,
 ) -> Result<PrimitiveArray<i64>> {
     Err(Error::InvalidArgumentError(format!(
         "timezone \"{timezone}\" cannot be parsed (feature chrono-tz is not active)",
@@ -455,7 +454,7 @@ fn chrono_tz_utf_to_timestamp(
 /// The feature `"chrono-tz"` enables IANA and zoneinfo formats for `timezone`.
 /// # Error
 /// This function errors iff `timezone` is not parsable to an offset.
-pub(crate) fn utf8view_to_timestamp(
+pub fn utf8view_to_timestamp(
     array: &Utf8ViewArray,
     fmt: &str,
     timezone: String,
@@ -476,7 +475,7 @@ pub(crate) fn utf8view_to_timestamp(
 /// [`PrimitiveArray<i64>`] with type `Timestamp(Nanosecond, None)`.
 /// Timezones are ignored.
 /// Null elements remain null; non-parsable elements are set to null.
-pub(crate) fn utf8view_to_naive_timestamp(
+pub fn utf8view_to_naive_timestamp(
     array: &Utf8ViewArray,
     fmt: &str,
 ) -> PrimitiveArray<i64> {

--- a/src/trusted_len.rs
+++ b/src/trusted_len.rs
@@ -1,4 +1,5 @@
 //! Declares [`TrustedLen`].
+use std::iter::Scan;
 use std::slice::Iter;
 
 /// An iterator of known, fixed size.
@@ -12,8 +13,6 @@ use std::slice::Iter;
 pub unsafe trait TrustedLen: Iterator {}
 
 unsafe impl<T> TrustedLen for Iter<'_, T> {}
-
-unsafe impl<B, I: TrustedLen, T: FnMut(I::Item) -> B> TrustedLen for std::iter::Map<I, T> {}
 
 unsafe impl<'a, I, T: 'a> TrustedLen for std::iter::Copied<I>
 where
@@ -55,3 +54,69 @@ unsafe impl<T> TrustedLen for std::vec::IntoIter<T> {}
 unsafe impl<A: Clone> TrustedLen for std::iter::Repeat<A> {}
 unsafe impl<A, F: FnMut() -> A> TrustedLen for std::iter::RepeatWith<F> {}
 unsafe impl<A: TrustedLen> TrustedLen for std::iter::Take<A> {}
+
+unsafe impl<T> TrustedLen for &mut dyn TrustedLen<Item = T> {}
+unsafe impl<T> TrustedLen for Box<dyn TrustedLen<Item = T> + '_> {}
+
+unsafe impl<B, I: TrustedLen, T: FnMut(I::Item) -> B> TrustedLen for std::iter::Map<I, T> {}
+
+unsafe impl<I: TrustedLen + DoubleEndedIterator> TrustedLen for std::iter::Rev<I> {}
+
+unsafe impl<I: Iterator<Item = J>, J> TrustedLen for TrustMyLength<I, J> {}
+unsafe impl<T> TrustedLen for std::ops::Range<T> where std::ops::Range<T>: Iterator {}
+unsafe impl<T> TrustedLen for std::ops::RangeInclusive<T> where std::ops::RangeInclusive<T>: Iterator
+{}
+unsafe impl<A: TrustedLen> TrustedLen for std::iter::StepBy<A> {}
+
+unsafe impl<I, St, F, B> TrustedLen for Scan<I, St, F>
+where
+    F: FnMut(&mut St, I::Item) -> Option<B>,
+    I: TrustedLen + Iterator<Item = B>,
+{
+}
+
+unsafe impl<K, V> TrustedLen for hashbrown::hash_map::IntoIter<K, V> {}
+
+#[derive(Clone)]
+pub struct TrustMyLength<I: Iterator<Item = J>, J> {
+    iter: I,
+    len: usize,
+}
+
+impl<I, J> TrustMyLength<I, J>
+where
+    I: Iterator<Item = J>,
+{
+    #[inline]
+    pub fn new(iter: I, len: usize) -> Self {
+        Self { iter, len }
+    }
+}
+
+impl<I, J> Iterator for TrustMyLength<I, J>
+where
+    I: Iterator<Item = J>,
+{
+    type Item = J;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+}
+
+impl<I, J> ExactSizeIterator for TrustMyLength<I, J> where I: Iterator<Item = J> {}
+
+impl<I, J> DoubleEndedIterator for TrustMyLength<I, J>
+where
+    I: Iterator<Item = J> + DoubleEndedIterator,
+{
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.iter.next_back()
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -72,6 +72,8 @@ pub enum PrimitiveType {
 }
 
 mod private {
+    use crate::array::View;
+
     pub trait Sealed {}
 
     impl Sealed for u8 {}
@@ -90,4 +92,5 @@ mod private {
     impl Sealed for f64 {}
     impl Sealed for super::days_ms {}
     impl Sealed for super::months_days_ns {}
+    impl Sealed for View {}
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -57,6 +57,8 @@ pub enum PrimitiveType {
     UInt32,
     /// An unsigned 64-bit integer.
     UInt64,
+    /// An unsigned 128-bit integer.
+    UInt128,
     /// A 16-bit floating point number.
     Float16,
     /// A 32-bit floating point number.
@@ -81,6 +83,7 @@ mod private {
     impl Sealed for i32 {}
     impl Sealed for i64 {}
     impl Sealed for i128 {}
+    impl Sealed for u128 {}
     impl Sealed for super::i256 {}
     impl Sealed for super::f16 {}
     impl Sealed for f32 {}

--- a/src/types/native.rs
+++ b/src/types/native.rs
@@ -86,6 +86,7 @@ native_type!(i64, PrimitiveType::Int64);
 native_type!(f32, PrimitiveType::Float32);
 native_type!(f64, PrimitiveType::Float64);
 native_type!(i128, PrimitiveType::Int128);
+native_type!(u128, PrimitiveType::UInt128);
 
 /// The in-memory representation of the DayMillisecond variant of arrow's "Interval" logical type.
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, Hash, Zeroable, Pod)]

--- a/tests/it/ffi/data.rs
+++ b/tests/it/ffi/data.rs
@@ -30,7 +30,6 @@ fn test_round_trip(expected: impl Array + Clone + 'static) -> Result<()> {
     _test_round_trip(array.sliced(1, 2), expected.sliced(1, 2))
 }
 
-<<<<<<< HEAD
 fn test_round_trip_schema(field: Field) -> Result<()> {
     let schema_ffi = ffi::export_field_to_c(&field);
 
@@ -52,7 +51,7 @@ fn bool() -> Result<()> {
     test_round_trip(data)
 }
 
-fn binview_nullable_inlined() -> PolarsResult<()> {
+fn binview_nullable_inlined() -> Result<()> {
     let data = Utf8ViewArray::from_slice([Some("foo"), None, Some("barbar"), None]);
     test_round_trip(data)
 }

--- a/tests/it/ffi/data.rs
+++ b/tests/it/ffi/data.rs
@@ -30,6 +30,7 @@ fn test_round_trip(expected: impl Array + Clone + 'static) -> Result<()> {
     _test_round_trip(array.sliced(1, 2), expected.sliced(1, 2))
 }
 
+<<<<<<< HEAD
 fn test_round_trip_schema(field: Field) -> Result<()> {
     let schema_ffi = ffi::export_field_to_c(&field);
 
@@ -48,6 +49,11 @@ fn bool_nullable() -> Result<()> {
 #[test]
 fn bool() -> Result<()> {
     let data = BooleanArray::from_slice([true, true, false]);
+    test_round_trip(data)
+}
+
+fn binview_nullable_inlined() -> PolarsResult<()> {
+    let data = Utf8ViewArray::from_slice([Some("foo"), None, Some("barbar"), None]);
     test_round_trip(data)
 }
 
@@ -361,4 +367,15 @@ fn extension_children() -> Result<()> {
         true,
     );
     test_round_trip_schema(field)
+}
+
+fn binview_nullable_buffered() -> Result<()> {
+    let data = Utf8ViewArray::from_slice([
+        Some("foobaroiwalksdfjoiei"),
+        None,
+        Some("barbar"),
+        None,
+        Some("aoisejiofjfoiewjjwfoiwejfo"),
+    ]);
+    test_round_trip(data)
 }

--- a/tests/it/io/ipc/mod.rs
+++ b/tests/it/io/ipc/mod.rs
@@ -92,7 +92,7 @@ fn write_sliced_utf8() -> Result<()> {
 
 #[test]
 fn write_binview() -> Result<()> {
-    let array = Utf8ViewArray::from([Some("foo"), Some("bar"), None, Some("hamlet")]).boxed();
+    let array = Utf8ViewArray::from_slice([Some("foo"), Some("bar"), None, Some("hamlet")]).boxed();
     let schema = prep_schema(array.as_ref());
     let columns = Chunk::try_new(vec![array])?;
     round_trip(columns, schema, None, Some(Compression::ZSTD))

--- a/tests/it/io/ipc/mod.rs
+++ b/tests/it/io/ipc/mod.rs
@@ -17,3 +17,83 @@ mod read_stream_async;
 mod read_file_async;
 
 mod mmap;
+use std::io::Cursor;
+use std::sync::Arc;
+
+use arrow2::array::*;
+use arrow2::chunk::Chunk;
+use arrow2::datatypes::{Schema, SchemaRef, Field};
+use arrow2::error::*;
+use arrow2::io::ipc::read::{read_file_metadata, FileReader};
+use arrow2::io::ipc::write::*;
+use arrow2::io::ipc::IpcField;
+
+pub(crate) fn write(
+    batches: &[Chunk<Box<dyn Array>>],
+    schema: &SchemaRef,
+    ipc_fields: Option<Vec<IpcField>>,
+    compression: Option<Compression>,
+) -> Result<Vec<u8>> {
+    let result = vec![];
+    let options = WriteOptions { compression };
+    let mut writer = FileWriter::try_new(result, schema.clone(), ipc_fields.clone(), options)?;
+    for batch in batches {
+        writer.write(batch, ipc_fields.as_ref().map(|x| x.as_ref()))?;
+    }
+    writer.finish()?;
+    Ok(writer.into_inner())
+}
+
+fn round_trip(
+    columns: Chunk<Box<dyn Array>>,
+    schema: SchemaRef,
+    ipc_fields: Option<Vec<IpcField>>,
+    compression: Option<Compression>,
+) -> Result<()> {
+    let (expected_schema, expected_batches) = (schema.clone(), vec![columns]);
+
+    let result = write(&expected_batches, &schema, ipc_fields, compression)?;
+    let mut reader = Cursor::new(result);
+    let metadata = read_file_metadata(&mut reader)?;
+    let schema = metadata.schema.clone();
+
+    let reader = FileReader::new(reader, metadata, None, None);
+
+    assert_eq!(schema, expected_schema);
+
+    let batches = reader.collect::<Result<Vec<_>>>()?;
+
+    assert_eq!(batches, expected_batches);
+    Ok(())
+}
+
+fn prep_schema(array: &dyn Array) -> SchemaRef {
+    let fields = vec![Field::new("a", array.data_type().clone(), true)];
+    Arc::new(Schema::from(fields))
+}
+
+#[test]
+fn write_boolean() -> Result<()> {
+    let array = BooleanArray::from([Some(true), Some(false), None, Some(true)]).boxed();
+    let schema = prep_schema(array.as_ref());
+    let columns = Chunk::try_new(vec![array])?;
+    round_trip(columns, schema, None, Some(Compression::ZSTD))
+}
+
+#[test]
+fn write_sliced_utf8() -> Result<()> {
+    let array = Utf8Array::<i32>::from_slice(["aa", "bb"])
+        .sliced(1, 1)
+        .boxed();
+    let schema = prep_schema(array.as_ref());
+    let columns = Chunk::try_new(vec![array])?;
+    round_trip(columns, schema, None, Some(Compression::ZSTD))
+}
+
+#[test]
+fn write_binview() -> Result<()> {
+    let array = Utf8ViewArray::from([Some("foo"), Some("bar"), None, Some("hamlet")]).boxed();
+    let schema = prep_schema(array.as_ref());
+    let columns = Chunk::try_new(vec![array])?;
+    round_trip(columns, schema, None, Some(Compression::ZSTD))
+}

--- a/tests/it/io/ipc/write/file.rs
+++ b/tests/it/io/ipc/write/file.rs
@@ -18,7 +18,7 @@ pub(crate) fn write(
 ) -> Result<Vec<u8>> {
     let result = vec![];
     let options = WriteOptions { compression };
-    let mut writer = FileWriter::try_new(result, schema.clone(), ipc_fields.clone(), options)?;
+    let mut writer = FileWriter::try_new(result, schema.clone().into(), ipc_fields.clone(), options)?;
     for batch in batches {
         writer.write(batch, ipc_fields.as_ref().map(|x| x.as_ref()))?;
     }

--- a/tests/it/temporal_conversions.rs
+++ b/tests/it/temporal_conversions.rs
@@ -15,12 +15,12 @@ fn naive() {
         "1996-12-19 13:39:57-03:00", // missing T
     ];
     let array = Utf8ViewArray::from_slice_values(slice);
-    let r = temporal_conversions::utf8view_to_naive_timestamp(&array, fmt);
+    let r = temporal_conversions::utf8view_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
     assert_eq!(format!("{r:?}"), expected);
 
     let fmt = "%Y-%m-%dT%H:%M:%S"; // no tz info
     let array = Utf8ViewArray::from_slice_values(slice);
-    let r = temporal_conversions::utf8view_to_naive_timestamp(&array, fmt);
+    let r = temporal_conversions::utf8view_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
     assert_eq!(format!("{r:?}"), expected);
 }
 
@@ -117,7 +117,7 @@ fn naive_no_tz() {
         "1996-12-19T13:39:57",
         "1996-12-19 13:39:57", // missing T
     ]);
-    let r = temporal_conversions::utf8view_to_naive_timestamp(&array, fmt);
+    let r = temporal_conversions::utf8view_to_naive_timestamp(&array, fmt, TimeUnit::Nanosecond);
     assert_eq!(format!("{r:?}"), expected);
 }
 

--- a/tests/it/temporal_conversions.rs
+++ b/tests/it/temporal_conversions.rs
@@ -9,21 +9,18 @@ use chrono::NaiveDateTime;
 fn naive() {
     let expected = "Timestamp(Nanosecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S:z";
-    let array = Utf8Array::<i32>::from_slice([
+    let slice = [
         "1996-12-19T16:39:57-02:00",
         "1996-12-19T13:39:57-03:00",
         "1996-12-19 13:39:57-03:00", // missing T
-    ]);
-    let r = temporal_conversions::utf8_to_naive_timestamp_ns(&array, fmt);
+    ];
+    let array = Utf8ViewArray::from_slice_values(slice);
+    let r = temporal_conversions::utf8view_to_naive_timestamp(&array, fmt);
     assert_eq!(format!("{r:?}"), expected);
 
     let fmt = "%Y-%m-%dT%H:%M:%S"; // no tz info
-    let array = Utf8Array::<i32>::from_slice([
-        "1996-12-19T16:39:57-02:00",
-        "1996-12-19T13:39:57-03:00",
-        "1996-12-19 13:39:57-03:00", // missing T
-    ]);
-    let r = temporal_conversions::utf8_to_naive_timestamp_ns(&array, fmt);
+    let array = Utf8ViewArray::from_slice_values(slice);
+    let r = temporal_conversions::utf8view_to_naive_timestamp(&array, fmt);
     assert_eq!(format!("{r:?}"), expected);
 }
 
@@ -115,12 +112,12 @@ fn scalar_tz_aware_no_timezone() {
 fn naive_no_tz() {
     let expected = "Timestamp(Nanosecond, None)[1996-12-19 16:39:57, 1996-12-19 13:39:57, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S"; // no tz info
-    let array = Utf8Array::<i32>::from_slice([
+    let array = Utf8ViewArray::from_slice_values([
         "1996-12-19T16:39:57",
         "1996-12-19T13:39:57",
         "1996-12-19 13:39:57", // missing T
     ]);
-    let r = temporal_conversions::utf8_to_naive_timestamp_ns(&array, fmt);
+    let r = temporal_conversions::utf8view_to_naive_timestamp(&array, fmt);
     assert_eq!(format!("{r:?}"), expected);
 }
 
@@ -197,12 +194,12 @@ fn tz_aware() {
     let expected =
         "Timestamp(Nanosecond, Some(\"-02:00\"))[1996-12-19 16:39:57 -02:00, 1996-12-19 17:39:57 -02:00, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S%.f%:z";
-    let array = Utf8Array::<i32>::from_slice([
+    let array = Utf8ViewArray::from_slice_values([
         "1996-12-19T16:39:57.0-02:00",
         "1996-12-19T16:39:57.0-03:00", // same time at a different TZ
         "1996-12-19 13:39:57.0-03:00",
     ]);
-    let r = temporal_conversions::utf8_to_timestamp_ns(&array, fmt, tz).unwrap();
+    let r = temporal_conversions::utf8view_to_timestamp(&array, fmt, tz).unwrap();
     assert_eq!(format!("{r:?}"), expected);
 }
 
@@ -211,12 +208,12 @@ fn tz_aware_no_timezone() {
     let tz = "-02:00".to_string();
     let expected = "Timestamp(Nanosecond, Some(\"-02:00\"))[None, None, None]";
     let fmt = "%Y-%m-%dT%H:%M:%S%.f";
-    let array = Utf8Array::<i32>::from_slice([
+    let array = Utf8ViewArray::from_slice_values([
         "1996-12-19T16:39:57.0",
         "1996-12-19T17:39:57.0",
         "1996-12-19 13:39:57.0",
     ]);
-    let r = temporal_conversions::utf8_to_timestamp_ns(&array, fmt, tz).unwrap();
+    let r = temporal_conversions::utf8view_to_timestamp(&array, fmt, tz).unwrap();
     assert_eq!(format!("{r:?}"), expected);
 }
 


### PR DESCRIPTION
This PR adds support for BinaryView and StringView based on the commits to polars-arrow with most merge conflicts resolved. It would be great if we could merge this before archiving since it would make the arrow2 in sync with the existing Arrow spec

Resolves issue #1596 